### PR TITLE
 Fix warnings in generated Dart code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Fixed missing imports for collections of "external" types in Swift.
   * Fixed missing imports for constants in Dart.
   * Added missing Dart overloads validation for functions/constructors of structs.
+  * Fixed Dart warnings from "dart analyze" static analysis tool.
 
 ## 8.13.1
 Release date: 2021-04-28

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CamelCaseNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CamelCaseNameResolver.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.common
+
+internal class CamelCaseNameResolver(private val mainResolver: NameResolver, upper: Boolean = false) : NameResolver {
+
+    val camelCase = if (upper) NameHelper::toUpperCamelCase else NameHelper::toLowerCamelCase
+
+    override fun resolveName(element: Any): String =
+        when (element) {
+            is String -> camelCase(element)
+            else -> camelCase(mainResolver.resolveName(element))
+        }
+}

--- a/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
@@ -29,33 +29,33 @@ import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
 
 // Blob
 
-final _Blob_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
   >('{{libraryName}}_blob_create_handle'));
-final _Blob_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_blob_release_handle'));
-final _Blob_get_length = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobGetLength = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('{{libraryName}}_blob_get_length'));
-final _Blob_get_data_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobGetDataPointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Uint8> Function(Pointer<Void>),
     Pointer<Uint8> Function(Pointer<Void>)
 >('{{libraryName}}_blob_get_data_pointer'));
 
 Pointer<Void> Blob_toFfi(Uint8List list) {
-  final result = _Blob_create_handle(list.length);
-  (_Blob_get_data_pointer(result) as Pointer<Uint8>).asTypedList(list.length).setRange(0, list.length, list);
+  final result = _blobCreateHandle(list.length);
+  (_blobGetDataPointer(result) as Pointer<Uint8>).asTypedList(list.length).setRange(0, list.length, list);
   return result;
 }
 
 Uint8List Blob_fromFfi(Pointer<Void> handle) =>
-  Uint8List.fromList((_Blob_get_data_pointer(handle) as Pointer<Uint8>).asTypedList(_Blob_get_length(handle)));
+  Uint8List.fromList((_blobGetDataPointer(handle) as Pointer<Uint8>).asTypedList(_blobGetLength(handle)));
 
-void Blob_releaseFfiHandle(Pointer<Void> handle) => _Blob_release_handle(handle);
+void Blob_releaseFfiHandle(Pointer<Void> handle) => _blobReleaseHandle(handle);
 
 // Boolean
 
@@ -75,53 +75,53 @@ void Date_releaseFfiHandle(int handle) {}
 
 // String
 
-final _String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _StringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>)
   >('{{libraryName}}_std_string_create_handle'));
-final _String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _StringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_std_string_release_handle'));
-final _String_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _StringGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
   >('{{libraryName}}_std_string_get_value'));
 
 Pointer<Void> String_toFfi(String value) {
   final cValue = Utf8.toUtf8(value);
-  final result = _String_create_handle(cValue);
+  final result = _StringCreateHandle(cValue);
   free(cValue);
   return result;
 }
 
-String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_String_get_value(handle));
+String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_StringGetValue(handle));
 
-void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(handle);
+void String_releaseFfiHandle(Pointer<Void> handle) => _StringReleaseHandle(handle);
 
 // Locale
 
-final _Locale_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _LocaleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
   >('{{libraryName}}_locale_create_handle'));
-final _Locale_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _LocaleReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_locale_release_handle'));
-final _Locale_get_language_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final LocaleGetLanguageCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('{{libraryName}}_locale_get_language_code'));
-final _Locale_get_country_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final LocaleGetCountryCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('{{libraryName}}_locale_get_country_code'));
-final _Locale_get_script_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final LocaleGetScriptCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('{{libraryName}}_locale_get_script_code'));
-final _Locale_get_language_tag = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _LocaleGetLanguageTag = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('{{libraryName}}_locale_get_language_tag'));
@@ -134,7 +134,7 @@ Pointer<Void> Locale_toFfi(Locale locale) {
     locale.scriptCode != null ? Utf8.toUtf8(locale.scriptCode) : Pointer<Utf8>.fromAddress(0);
   final cLanguageTag = Utf8.toUtf8(locale.toLanguageTag());
 
-  final result = _Locale_create_handle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
+  final result = _LocaleCreateHandle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
 
   free(cLanguageCode);
   if (cCountryCode.address != 0) free(cCountryCode);
@@ -145,15 +145,15 @@ Pointer<Void> Locale_toFfi(Locale locale) {
 }
 
 Locale Locale_fromFfi(Pointer<Void> handle) {
-  final languageTagCstring = _Locale_get_language_tag(handle);
+  final Pointer<Utf8> languageTagCstring = _LocaleGetLanguageTag(handle);
   if (languageTagCstring.address != 0) {
     // BCP 47 language tag takes precedence if present.
     return Locale.parse(Utf8.fromUtf8(languageTagCstring));
   }
 
-  final languageCodeCstring = _Locale_get_language_code(handle);
-  final countryCodeCstring = _Locale_get_country_code(handle);
-  final scriptCodeCstring = _Locale_get_script_code(handle);
+  final Pointer<Utf8> languageCodeCstring = LocaleGetLanguageCode(handle);
+  final Pointer<Utf8> countryCodeCstring = LocaleGetCountryCode(handle);
+  final Pointer<Utf8> scriptCodeCstring = LocaleGetScriptCode(handle);
 
   return Locale.fromSubtags(
     languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,
@@ -162,20 +162,20 @@ Locale Locale_fromFfi(Pointer<Void> handle) {
   );
 }
 
-void Locale_releaseFfiHandle(Pointer<Void> handle) => _Locale_release_handle(handle);
+void Locale_releaseFfiHandle(Pointer<Void> handle) => _LocaleReleaseHandle(handle);
 
 {{#builtInTypes}}
 // Nullable {{this}}
 
-final _{{this}}_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName toString "FfiCamelCase"}}CreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{resolveName "FfiApiTypes"}}),
     Pointer<Void> Function({{resolveName "FfiDartTypes"}})
   >('{{libraryName}}_{{this}}_create_handle_nullable'));
-final _{{this}}_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName toString "FfiCamelCase"}}ReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{this}}_release_handle_nullable'));
-final _{{this}}_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName toString "FfiCamelCase"}}GetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{this}}_get_value_nullable'));
@@ -183,19 +183,19 @@ final _{{this}}_get_value_nullable = __lib.catchArgumentError(() => __lib.native
 Pointer<Void> {{this}}_toFfi_nullable({{resolveName}} value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = {{#unless isNumericType}}{{this}}_toFfi{{/unless}}(value);
-  final result = _{{this}}_create_handle_nullable(_handle);{{#unless isNumericType}}
+  final result = _{{resolveName toString "FfiCamelCase"}}CreateHandleNullable(_handle);{{#unless isNumericType}}
   {{this}}_releaseFfiHandle(_handle);{{/unless}}
   return result;
 }
 
 {{resolveName}} {{this}}_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _{{this}}_get_value_nullable(handle);
+  final _handle = _{{resolveName toString "FfiCamelCase"}}GetValueNullable(handle);
   final result = {{#unless isNumericType}}{{this}}_fromFfi{{/unless}}(_handle);{{#unless isNumericType}}
   {{this}}_releaseFfiHandle(_handle);{{/unless}}
   return result;
 }
 
-void {{this}}_releaseFfiHandle_nullable(Pointer<Void> handle) => _{{this}}_release_handle_nullable(handle);
+void {{this}}_releaseFfiHandle_nullable(Pointer<Void> handle) => _{{resolveName toString "FfiCamelCase"}}ReleaseHandleNullable(handle);
 
 {{/builtInTypes}}

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -63,18 +63,18 @@
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}CopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle'));
-final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}ReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
 {{#if attributes.equatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}
 {{#if this.parent visibility.isOpen logic="or"}}
-final _{{resolveName "Ffi"}}_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}GetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_get_type_id'));
@@ -95,8 +95,8 @@ class {{resolveName}}$Impl extends {{#if hasClassParent}}{{resolveName parent}}$
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _{{resolveName "Ffi"}}_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
     handle = null;
   }
 
@@ -128,30 +128,30 @@ class {{resolveName}}$Impl extends {{#if hasClassParent}}{{resolveName parent}}$
 }
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) =>
-  _{{resolveName "Ffi"}}_copy_handle((value as __lib.NativeBase).handle);
+  _{{resolveName "FfiCamelCase"}}CopyHandle((value as __lib.NativeBase).handle);
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as {{resolveName}};
   if (instance != null) return instance;
 
 {{#if this.parent visibility.isOpen logic="or"}}
-  final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
+  final _typeIdHandle = _{{resolveName "FfiCamelCase"}}GetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
 
 {{/if}}
-  final _copied_handle = _{{resolveName "Ffi"}}_copy_handle(handle);
+  final _copiedHandle = _{{resolveName "FfiCamelCase"}}CopyHandle(handle);
   final result = {{#if this.parent visibility.isOpen logic="or"}}factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : {{/if}}{{resolveName}}$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : {{/if}}{{resolveName}}$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) =>
-  _{{resolveName "Ffi"}}_release_handle(handle);
+  _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
   value != null ? {{resolveName "Ffi"}}_toFfi(value) : Pointer<Void>.fromAddress(0);
@@ -160,7 +160,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
   handle.address != 0 ? {{resolveName "Ffi"}}_fromFfi(handle) : null;
 
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _{{resolveName "Ffi"}}_release_handle(handle);
+  _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 // End of {{resolveName}} "private" section.{{!!
 
@@ -169,7 +169,7 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) {
   final result = {{resolveName parent}}$Impl({{!!
   }}_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
-  __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(result));
+  __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(result));
   return result;
 }
 {{/if}}{{!!
@@ -177,31 +177,31 @@ void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
 {{resolveName parent}}$Impl.{{resolveName visibility}}{{resolveName}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) : {{!!
 }}super(_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})) {
-  __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+  __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
 }
 {{/unless}}{{/dartConstructor}}{{!!
 
 }}{{+dartCachedProperty}}
-{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}{{resolveName typeRef}} _cache_{{resolveName}};
-{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}bool _is_cached_{{resolveName}} = false;
+{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}/*late*/ {{resolveName typeRef}} _{{resolveName}}Cache;
+{{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}bool _{{resolveName}}IsCached = false;
 {{#unless isStatic}}@override
 {{/unless}}
 {{#if isStatic}}{{#unless testableMode}}static {{/unless}}{{/if}}{{!!
 }}{{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} {
-  if (!_is_cached_{{resolveName}}) {
-    final _{{resolveName getter}}_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<{{!!
+  if (!_{{resolveName}}IsCached) {
+    final _{{resolveName getter}}Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<{{!!
     }}{{resolveName typeRef "FfiApiTypes"}} Function({{#unless isStatic}}Pointer<Void>, {{/unless}}Int32), {{!!
     }}{{resolveName typeRef "FfiDartTypes"}} Function({{#unless isStatic}}Pointer<Void>, {{/unless}}int)>{{!!
     }}('{{libraryName}}_{{resolveName getter "Ffi"}}'));
-    final __result_handle = _{{resolveName getter}}_ffi({{!!
+    final __resultHandle = _{{resolveName getter}}Ffi({{!!
     }}{{#unless isStatic}}this.handle, {{/unless}}__lib.LibraryContext.isolateId);
     try {
-      _cache_{{resolveName}} = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+      _{{resolveName}}Cache = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
     } finally {
-      {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+      {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
     }
-    _is_cached_{{resolveName}} = true;
+    _{{resolveName}}IsCached = true;
   }
-  return _cache_{{resolveName}};
+  return _{{resolveName}}Cache;
 }
 {{/dartCachedProperty}}

--- a/gluecodium/src/main/resources/templates/dart/DartEqualityOperator.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEqualityOperator.mustache
@@ -22,5 +22,5 @@
 bool operator ==(dynamic other) {
   if (identical(this, other)) return true;
   if (other is! {{resolveName}}$Impl) return false;
-  return __are_equal((this as {{resolveName}}$Impl).handle, other.handle) != 0;
+  return __areEqual((this as {{resolveName}}$Impl).handle, other.handle) != 0;
 }

--- a/gluecodium/src/main/resources/templates/dart/DartFfiEqualityFunction.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFfiEqualityFunction.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-final __are_equal = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final __areEqual = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_are_equal'));

--- a/gluecodium/src/main/resources/templates/dart/DartFile.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFile.mustache
@@ -25,7 +25,6 @@
 {{/imports}}
 
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 
 import 'package:{{libraryName}}/src/_library_context.dart' as __lib;

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -19,36 +19,36 @@
   !
   !}}
  {
-  final _{{resolveName}}_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{libraryName}}_{{resolveName "Ffi"}}'));
+  final _{{resolveName}}Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{libraryName}}_{{resolveName "Ffi"}}'));
 {{#parameters}}
-  final _{{resolveName}}_handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
+  final _{{resolveName}}Handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#unless isStatic}}
   final _handle = {{#if isStruct}}{{resolveName parent "Ffi"}}_toFfi(this){{/if}}{{!!
   }}{{#unless isStruct}}this.handle{{/unless}};
 {{/unless}}
-  final __{{#if thrownType}}call_{{/if}}result_handle = _{{resolveName}}_ffi({{!!
+  final __{{#if thrownType}}callResult{{/if}}{{#unless thrownType}}result{{/unless}}Handle = _{{resolveName}}Ffi({{!!
   }}{{#unless isStatic}}_handle, {{/unless}}__lib.LibraryContext.isolateId{{#if parameters}}, {{/if}}{{!!
-  }}{{#parameters}}_{{resolveName}}_handle{{#if iter.hasNext}}, {{/if}}{{/parameters}});
+  }}{{#parameters}}_{{resolveName}}Handle{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{#if isStruct}}{{#unless isStatic}}  {{resolveName parent "Ffi"}}_releaseFfiHandle(_handle);
 {{/unless}}{{/if}}{{!!
 }}{{#parameters}}
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
+  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle);
 {{/parameters}}
 {{#if thrownType}}
-  if (_{{resolveName}}_return_has_error(__call_result_handle) != 0) {
-      final __error_handle = _{{resolveName}}_return_get_error(__call_result_handle);
-      _{{resolveName}}_return_release_handle(__call_result_handle);
+  if (_{{resolveName}}ReturnHasError(__callResultHandle) != 0) {
+      final __errorHandle = _{{resolveName}}ReturnGetError(__callResultHandle);
+      _{{resolveName}}ReturnReleaseHandle(__callResultHandle);
       try {
-        throw {{resolveName exception}}({{#set call="fromFfi" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__error_handle));
+        throw {{resolveName exception}}({{#set call="fromFfi" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__errorHandle));
       } finally {
-        {{#set call="releaseFfiHandle" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__error_handle);
+        {{#set call="releaseFfiHandle" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__errorHandle);
       }
   }
-  final __result_handle = _{{resolveName}}_return_get_result(__call_result_handle);
-  _{{resolveName}}_return_release_handle(__call_result_handle);
+  final __resultHandle = _{{resolveName}}ReturnGetResult(__callResultHandle);
+  _{{resolveName}}ReturnReleaseHandle(__callResultHandle);
 {{/if}}
 {{#if isConstructor}}{{#if isStruct}}{{>ffiReturnConversion}}{{/if}}{{!!
-}}{{#unless isStruct}}  return __result_handle;{{/unless}}{{/if}}{{!!
+}}{{#unless isStruct}}  return __resultHandle;{{/unless}}{{/if}}{{!!
 }}{{#unless isConstructor}}{{>ffiReturnConversion}}{{/unless}}
 }{{!!
 
@@ -65,11 +65,11 @@
 }}{{+ffiReturnConversion}}{{!!
 }}  {{#returnType}}{{#if typeRef.attributes.optimized}}{{!!
 }}{{#set elementType=typeRef.type.actualType.elementType.type.actualType typeRef=typeRef.type.actualType.elementType}}{{!!
-    }}return {{#set varName="__result_handle"}}{{prefixPartial "dart/InitLazyList" "    " skipFirstLine=true}}{{/set}};{{/set}}
+    }}return {{#set varName="__resultHandle"}}{{prefixPartial "dart/InitLazyList" "    " skipFirstLine=true}}{{/set}};{{/set}}
 {{/if}}{{#unless typeRef.attributes.optimized}}try {
-    return {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+    return {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
   } finally {
-    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__result_handle);
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
   }
 {{/unless}}{{/returnType}}{{!!
 }}{{/ffiReturnConversion}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
@@ -19,20 +19,20 @@
   !
   !}}
 {{#if thrownType}}
-final _{{resolveName}}_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}ReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_return_release_handle'));
-final _{{resolveName}}_return_get_result = {{#unless returnType.isVoid}}__lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}ReturnGetResult = {{#unless returnType.isVoid}}__lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName returnType.typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName returnType.typeRef "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_result'));{{/unless}}{{!!
     }}{{#if returnType.isVoid}}(Pointer) {};{{/if}}
-final _{{resolveName}}_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}ReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName exception.errorType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName exception.errorType "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_return_get_error'));
-final _{{resolveName}}_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}ReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_return_has_error'));

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -25,115 +25,115 @@
 {{/imports}}
 
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 
 import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
 
 {{#genericTypes}}
-final _{{resolveName "Ffi"}}_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}CreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle'));
-final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}ReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
 {{#instanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}Put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, {{resolveName keyType "FfiApiTypes"}}, {{resolveName valueType "FfiApiTypes"}}),
     void Function(Pointer<Void>, {{resolveName keyType "FfiDartTypes"}}, {{resolveName valueType "FfiDartTypes"}})
   >('{{libraryName}}_{{resolveName "Ffi"}}_put'));
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}Insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, {{resolveName elementType "FfiApiTypes"}}),
     void Function(Pointer<Void>, {{resolveName elementType "FfiDartTypes"}})
   >('{{libraryName}}_{{resolveName "Ffi"}}_insert'));
 {{/notInstanceOf}}
-final _{{resolveName "Ffi"}}_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}Iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('{{libraryName}}_{{resolveName "Ffi"}}_iterator'));
-final _{{resolveName "Ffi"}}_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}IteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('{{libraryName}}_{{resolveName "Ffi"}}_iterator_release_handle'));
-final _{{resolveName "Ffi"}}_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}IteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('{{libraryName}}_{{resolveName "Ffi"}}_iterator_is_valid'));
-final _{{resolveName "Ffi"}}_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}IteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('{{libraryName}}_{{resolveName "Ffi"}}_iterator_increment'));
 {{#instanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}IteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName keyType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName keyType "FfiDartTypes"}} Function(Pointer<Void>)
 >('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_key'));
-final _{{resolveName "Ffi"}}_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}IteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName valueType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName valueType "FfiDartTypes"}} Function(Pointer<Void>)
 >('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get_value'));
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
-final _{{resolveName "Ffi"}}_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}IteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName elementType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName elementType "FfiDartTypes"}} Function(Pointer<Void>)
 >('{{libraryName}}_{{resolveName "Ffi"}}_iterator_get'));
 {{/notInstanceOf}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  final _result = _{{resolveName "Ffi"}}_create_handle();
+  final _result = _{{resolveName "FfiCamelCase"}}CreateHandle();
 {{#instanceOf this "LimeMap"}}
   for (final entry in value.entries) {
-    final _key_handle = {{#set typeRef=keyType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(entry.key);
-    final _value_handle = {{#set typeRef=valueType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(entry.value);
-    _{{resolveName "Ffi"}}_put(_result, _key_handle, _value_handle);
-    {{#set typeRef=keyType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_key_handle);
-    {{#set typeRef=valueType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value_handle);
+    final _keyHandle = {{#set typeRef=keyType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(entry.key);
+    final _valueHandle = {{#set typeRef=valueType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(entry.value);
+    _{{resolveName "FfiCamelCase"}}Put(_result, _keyHandle, _valueHandle);
+    {{#set typeRef=keyType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_keyHandle);
+    {{#set typeRef=valueType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_valueHandle);
   }
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
   for (final element in value) {
-    final _element_handle = {{#set typeRef=elementType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(element);
-    _{{resolveName "Ffi"}}_insert(_result, _element_handle);
-    {{#set typeRef=elementType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_element_handle);
+    final _elementHandle = {{#set typeRef=elementType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(element);
+    _{{resolveName "FfiCamelCase"}}Insert(_result, _elementHandle);
+    {{#set typeRef=elementType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_elementHandle);
   }
 {{/notInstanceOf}}
   return _result;
 }
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
-  final result = {{resolveName}}();
-  final _iterator_handle = _{{resolveName "Ffi"}}_iterator(handle);
-  while (_{{resolveName "Ffi"}}_iterator_is_valid(handle, _iterator_handle) != 0) {
+  final result = {{resolveName}}{{#instanceOf this "LimeList"}}.empty(growable: true){{/instanceOf}}{{!!
+  }}{{#notInstanceOf this "LimeList"}}(){{/notInstanceOf}};
+  final _iteratorHandle = _{{resolveName "FfiCamelCase"}}Iterator(handle);
+  while (_{{resolveName "FfiCamelCase"}}IteratorIsValid(handle, _iteratorHandle) != 0) {
 {{#instanceOf this "LimeMap"}}
-    final _key_handle = _{{resolveName "Ffi"}}_iterator_get_key(_iterator_handle);
-    final _value_handle = _{{resolveName "Ffi"}}_iterator_get_value(_iterator_handle);
+    final _keyHandle = _{{resolveName "FfiCamelCase"}}IteratorGetKey(_iteratorHandle);
+    final _valueHandle = _{{resolveName "FfiCamelCase"}}IteratorGetValue(_iteratorHandle);
     try {
-      result[{{#set typeRef=keyType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_key_handle)] =
-        {{#set typeRef=valueType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value_handle);
+      result[{{#set typeRef=keyType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_keyHandle)] =
+        {{#set typeRef=valueType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_valueHandle);
     } finally {
-      {{#set typeRef=keyType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_key_handle);
-      {{#set typeRef=valueType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value_handle);
+      {{#set typeRef=keyType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_keyHandle);
+      {{#set typeRef=valueType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_valueHandle);
     }
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
-    final _element_handle = _{{resolveName "Ffi"}}_iterator_get(_iterator_handle);
+    final _elementHandle = _{{resolveName "FfiCamelCase"}}IteratorGet(_iteratorHandle);
     try {
-      result.add({{#set typeRef=elementType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_element_handle));
+      result.add({{#set typeRef=elementType call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_elementHandle));
     } finally {
-      {{#set typeRef=elementType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_element_handle);
+      {{#set typeRef=elementType call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_elementHandle);
     }
 {{/notInstanceOf}}
-    _{{resolveName "Ffi"}}_iterator_increment(_iterator_handle);
+    _{{resolveName "FfiCamelCase"}}IteratorIncrement(_iteratorHandle);
   }
-  _{{resolveName "Ffi"}}_iterator_release_handle(_iterator_handle);
+  _{{resolveName "FfiCamelCase"}}IteratorReleaseHandle(_iteratorHandle);
   return result;
 }
 
-void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveName "Ffi"}}_release_handle(handle);
+void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 {{#set self=this internalPrefix=""}}{{#self}}{{>dart/DartNullableTypeConversion}}{{/self}}{{/set}}
 

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -21,7 +21,7 @@
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
-  {{resolveName}}() {}
+  {{resolveName}}();
 
   factory {{resolveName}}.fromLambdas({
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
@@ -79,20 +79,20 @@ abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}CopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle'));
-final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}ReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
-final _{{resolveName "Ffi"}}_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}CreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer{{>ffiFunctionPointers}}),
     Pointer<Void> Function(int, int, Pointer{{>ffiFunctionPointers}})
   >('{{libraryName}}_{{resolveName "Ffi"}}_create_proxy'));
 {{#if attributes.equatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}
-final _{{resolveName "Ffi"}}_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}GetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_get_type_id'));
@@ -151,8 +151,8 @@ class {{resolveName}}$Impl extends __lib.NativeBase implements {{resolveName}} {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _{{resolveName "Ffi"}}_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
     handle = null;
   }
 
@@ -175,24 +175,24 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}{{!!
 }}{{#if thrownType}}, Pointer<{{resolveName exception.errorType "FfiApiTypes"}}> _error{{/if}}) {
 {{#if thrownType}}
-  bool _error_flag = false;
+  bool _errorFlag = false;
 {{/if}}{{#unless returnType.isVoid}}
-  {{resolveName returnType.typeRef}} _result_object = null;{{/unless}}
+  {{resolveName returnType.typeRef}} _resultObject = null;{{/unless}}
   try {
-    {{#unless returnType.isVoid}}_result_object = {{/unless}}{{!!
+    {{#unless returnType.isVoid}}_resultObject = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#unless returnType.isVoid}}
-    _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
+    _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_resultObject);{{/unless}}
 {{#if thrownType}}
   } on {{resolveName exception}} catch(e) {
-    _error_flag = true;
-    final _error_object = e.error;
-    _error.value = {{#set typeRef=exception.errorType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_error_object);
+    _errorFlag = true;
+    final _errorObject = e.error;
+    _error.value = {{#set typeRef=exception.errorType call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_errorObject);
 {{#instanceOf exception.errorType.type.actualType "LimeClass"}}
-    if (_error_object != null) _error_object.release();
+    if (_errorObject != null) _errorObject.release();
 {{/instanceOf}}{{#instanceOf exception.errorType.type.actualType "LimeInterface"}}
-    if (_error_object != null) _error_object.release();
+    if (_errorObject != null) _errorObject.release();
 {{/instanceOf}}
 {{/if}}
   } finally {
@@ -200,12 +200,12 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
     {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{!!
 }}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
-    if (_result_object != null) _result_object.release();
+    if (_resultObject != null) _resultObject.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
-    if (_result_object != null) _result_object.release();
+    if (_resultObject != null) _resultObject.release();
 {{/instanceOf}}
   }
-  return{{#if thrownType}} _error_flag ? 1 :{{/if}} 0;
+  return{{#if thrownType}} _errorFlag ? 1 :{{/if}} 0;
 }
 {{/unless}}{{/each}}
 
@@ -230,9 +230,9 @@ int _{{resolveName parent}}_{{resolveName}}_set_static(int _token, {{resolveName
 {{/unless}}{{/each}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  if (value is __lib.NativeBase) return _{{resolveName "Ffi"}}_copy_handle((value as __lib.NativeBase).handle);
+  if (value is __lib.NativeBase) return _{{resolveName "FfiCamelCase"}}CopyHandle((value as __lib.NativeBase).handle);
 
-  final result = _{{resolveName "Ffi"}}_create_proxy(
+  final result = _{{resolveName "FfiCamelCase"}}CreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi{{#set parent=this}}{{#each inheritedFunctions functions}}{{#unless isStatic}},
@@ -248,24 +248,24 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as {{resolveName}};
   if (instance != null) return instance;
 
-  final _type_id_handle = _{{resolveName "Ffi"}}_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
+  final _typeIdHandle = _{{resolveName "FfiCamelCase"}}GetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
 
-  final _copied_handle = _{{resolveName "Ffi"}}_copy_handle(handle);
+  final _copiedHandle = _{{resolveName "FfiCamelCase"}}CopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : {{resolveName}}$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : {{resolveName}}$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) =>
-  _{{resolveName "Ffi"}}_release_handle(handle);
+  _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
   value != null ? {{resolveName "Ffi"}}_toFfi(value) : Pointer<Void>.fromAddress(0);
@@ -274,7 +274,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName}} value) =>
   handle.address != 0 ? {{resolveName "Ffi"}}_fromFfi(handle) : null;
 
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _{{resolveName "Ffi"}}_release_handle(handle);
+  _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 // End of {{resolveName}} "private" section.{{!!
 

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -23,15 +23,15 @@ typedef {{resolveName}} = {{>dart/DartLambdaType}};
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}CopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_copy_handle'));
-final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}ReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
-final _{{resolveName "Ffi"}}_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}CreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('{{libraryName}}_{{resolveName "Ffi"}}_create_proxy'));
@@ -41,7 +41,7 @@ class {{resolveName}}$Impl {
   final Pointer<Void> handle;
   {{resolveName}}$Impl(this.handle);
 
-  void release() => _{{resolveName "Ffi"}}_release_handle(handle);
+  void release() => _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 {{#set parent=this}}{{#asFunction}}
 {{prefixPartial "dart/DartFunction" "  "}}
@@ -53,20 +53,20 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}) {
-  {{#unless returnType.isVoid}}{{resolveName returnType.typeRef}} _result_object;{{/unless}}
+  {{#unless returnType.isVoid}}{{resolveName returnType.typeRef}} _resultObject;{{/unless}}
   try {
-    {{#unless returnType.isVoid}}_result_object = {{/unless}}{{!!
+    {{#unless returnType.isVoid}}_resultObject = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}})({{#parameters}}{{!!
   }}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#unless returnType.isVoid}}
-    _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_result_object);{{/unless}}
+    _result.value = {{#returnType}}{{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_resultObject);{{/unless}}
   } finally {
 {{#parameters}}
     {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
-    if (_result_object != null) _result_object.release();
+    if (_resultObject != null) _resultObject.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
-    if (_result_object != null) _result_object.release();
+    if (_resultObject != null) _resultObject.release();
 {{/instanceOf}}
   }
   return 0;
@@ -74,7 +74,7 @@ int _{{resolveName parent}}_{{resolveName}}_static({{!!
 {{/asFunction}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
-  final result = _{{resolveName "Ffi"}}_create_proxy(
+  final result = _{{resolveName "FfiCamelCase"}}CreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,{{#set parent=this}}{{#asFunction}}
@@ -85,7 +85,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 }
 
 {{resolveName}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
-  final _impl = {{resolveName}}$Impl(_{{resolveName "Ffi"}}_copy_handle(handle));
+  final _impl = {{resolveName}}$Impl(_{{resolveName "FfiCamelCase"}}CopyHandle(handle));
   return ({{#asFunction}}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{/asFunction}}){{!!
   }} {
     final _result =_impl.{{#asFunction}}{{resolveName visibility}}{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{/asFunction}});
@@ -95,7 +95,7 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName}} value) {
 }
 
 void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) =>
-  _{{resolveName "Ffi"}}_release_handle(handle);
+  _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 // Nullable {{resolveName}}
 

--- a/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
@@ -30,7 +30,7 @@ class _LazyIterator<E> extends Iterator<E> {
   int position;
 
   _LazyIterator(this.list, [int start = -1, int step = 1])
-    : step = step, length = list.length, position = start {}
+    : step = step, length = list.length, position = start;
 
   bool moveNext() {
     position += step;
@@ -49,7 +49,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   final E Function(int) _elementGetter;
   final void Function() _releaser;
 
-  LazyList(this.handle, int length, this._elementGetter, this._releaser) : _length = length {}
+  LazyList(this.handle, int length, this._elementGetter, this._releaser) : _length = length;
 
   void release() => _releaser();
 
@@ -66,7 +66,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   List<E> operator +(List<E> other) => cast<E>() + other;
   Map<int, E> asMap() => cast<E>().asMap();
   Iterable<E> getRange(int start, int end) => cast<E>().getRange(start, end);
-  List<E> sublist(int start, [int end = null]) => cast<E>().sublist(start, end);
+  List<E> sublist(int start, [int end]) => cast<E>().sublist(start, end);
   Iterable<E> get reversed => cast<E>().reversed;
 
   // Methods relying on the iterator
@@ -81,9 +81,9 @@ class LazyList<E> extends Iterable<E> implements List<E> {
     return -1;
   }
 
-  int lastIndexOf(E element, [int start = null]) => lastIndexWhere((it) => element == it, start);
+  int lastIndexOf(E element, [int start]) => lastIndexWhere((it) => element == it, start);
 
-  int lastIndexWhere(bool test(E element), [int start = null]) {
+  int lastIndexWhere(bool test(E element), [int start]) {
     final iterator = _LazyIterator(this, start ?? length, -1);
     while (iterator.moveNext()) {
       if (test(iterator.current)) return iterator.position;
@@ -111,7 +111,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   void setRange(int start, int end, Iterable<E> iterable, [int skipCount = 0]) => throw UnsupportedError(_cannotModify);
   void shuffle([Random random]) => throw UnsupportedError(_cannotModify);
   void sort([int compare(E a, E b)]) => throw UnsupportedError(_cannotModify);
-  void set first(E value) => throw UnsupportedError(_cannotModify);
-  void set last(E value) => throw UnsupportedError(_cannotModify);
+  set first(E value) => throw UnsupportedError(_cannotModify);
+  set last(E value) => throw UnsupportedError(_cannotModify);
   set length(int newLength) => throw UnsupportedError(_cannotModify);
 }

--- a/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLibraryContext.mustache
@@ -37,9 +37,9 @@ DynamicLibrary _loadNativeLibrary(String nativeLibraryPath) {
 }
 
 String _getLibraryPath(String nativeLibraryName) {
-  if (Platform.isWindows) return 'lib${nativeLibraryName}.dll';
-  if (Platform.isMacOS || Platform.isIOS) return 'lib${nativeLibraryName}.dylib';
-  return 'lib${nativeLibraryName}.so';
+  if (Platform.isWindows) return 'lib$nativeLibraryName.dll';
+  if (Platform.isMacOS || Platform.isIOS) return 'lib$nativeLibraryName.dylib';
+  return 'lib$nativeLibraryName.so';
 }
 
 dynamic catchArgumentError(Function f) {
@@ -50,19 +50,19 @@ dynamic catchArgumentError(Function f) {
   }
 }
 
-final _library_callbacks_queue_init = catchArgumentError(() => nativeLibrary.lookupFunction<
+final _libraryCallbacksQueueInit = catchArgumentError(() => nativeLibrary.lookupFunction<
     Int32 Function(Uint8),
     int Function(int)
   >('{{libraryName}}_library_callbacks_queue_init'));
-final _library_callbacks_queue_release = catchArgumentError(() => nativeLibrary.lookupFunction<
+final _libraryCallbacksQueueRelease = catchArgumentError(() => nativeLibrary.lookupFunction<
     Void Function(Int32),
     void Function(int)
   >('{{libraryName}}_library_callbacks_queue_release'));
-final _library_wait_for_callbacks = catchArgumentError(() => nativeLibrary.lookupFunction<
+final _libraryWaitForCallbacks = catchArgumentError(() => nativeLibrary.lookupFunction<
     Uint8 Function(Int32),
     int Function(int)
   >('{{libraryName}}_library_wait_for_callbacks'));
-final _library_execute_callbacks = catchArgumentError(() => nativeLibrary.lookupFunction<
+final _libraryExecuteCallbacks = catchArgumentError(() => nativeLibrary.lookupFunction<
     Void Function(Int32),
     void Function(int)
   >('{{libraryName}}_library_execute_callbacks'));
@@ -96,16 +96,16 @@ class LibraryContext {
   /// fails, current process is used as a native library instead.
   static void init(IsolateOrigin isolateOrigin, {String nativeLibraryPath}) {
     _loadCustomLibrary(nativeLibraryPath);
-    _isolateId = _library_callbacks_queue_init(isolateOrigin == IsolateOrigin.main ? 1 : 0);
+    _isolateId = _libraryCallbacksQueueInit(isolateOrigin == IsolateOrigin.main ? 1 : 0);
 
     final receivePort = ReceivePort();
     Isolate.spawn(_sentryIsolate, _SentryIsolateMessage(receivePort.sendPort, isolateId, nativeLibraryPath));
-    _callbackStream = receivePort.listen((dynamic _) { _library_execute_callbacks(isolateId); });
+    _callbackStream = receivePort.listen((dynamic _) { _libraryExecuteCallbacks(isolateId); });
   }
 
   static void release() {
     _callbackStream.cancel();
-    _library_callbacks_queue_release(isolateId);
+    _libraryCallbacksQueueRelease(isolateId);
   }
 
   static void _sentryIsolate(_SentryIsolateMessage message) {
@@ -113,7 +113,7 @@ class LibraryContext {
 
     WaitCallbackResult waitResult = WaitCallbackResult.stopped;
     do {
-      waitResult = WaitCallbackResult.values[_library_wait_for_callbacks(message.isolateId)];
+      waitResult = WaitCallbackResult.values[_libraryWaitForCallbacks(message.isolateId)];
       if (waitResult == WaitCallbackResult.hasIncoming) {
         message.port.send(1);
       }
@@ -121,7 +121,7 @@ class LibraryContext {
     message.port.send(0);
   }
 
-  static DynamicLibrary _loadCustomLibrary(String nativeLibraryPath) {
+  static void _loadCustomLibrary(String nativeLibraryPath) {
     if (nativeLibraryPath != null) _nativeLibrary = _loadNativeLibrary(nativeLibraryPath);
   }
 }

--- a/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
@@ -21,7 +21,6 @@
 {{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
 
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 
 /// @nodoc

--- a/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
@@ -18,15 +18,15 @@
   ! License-Filename: LICENSE
   !
   !}}
-final _{{resolveName "Ffi"}}_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}CreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{resolveName "FfiApiTypes"}}),
     Pointer<Void> Function({{resolveName "FfiDartTypes"}})
   >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_create_handle_nullable'));
-final _{{resolveName "Ffi"}}_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}ReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_release_handle_nullable'));
-final _{{resolveName "Ffi"}}_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "Ffi"}}GetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{internalPrefix}}{{resolveName "Ffi"}}_get_value_nullable'));
@@ -34,18 +34,18 @@ final _{{resolveName "Ffi"}}_get_value_nullable = __lib.catchArgumentError(() =>
 Pointer<Void> {{resolveName "Ffi"}}_toFfi_nullable({{resolveName this "" "ref"}} value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = {{resolveName "Ffi"}}_toFfi(value);
-  final result = _{{resolveName "Ffi"}}_create_handle_nullable(_handle);
+  final result = _{{resolveName "Ffi"}}CreateHandleNullable(_handle);
   {{resolveName "Ffi"}}_releaseFfiHandle(_handle);
   return result;
 }
 
 {{resolveName this "" "ref"}} {{resolveName "Ffi"}}_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _{{resolveName "Ffi"}}_get_value_nullable(handle);
+  final _handle = _{{resolveName "Ffi"}}GetValueNullable(handle);
   final result = {{resolveName "Ffi"}}_fromFfi(_handle);
   {{resolveName "Ffi"}}_releaseFfiHandle(_handle);
   return result;
 }
 
 void {{resolveName "Ffi"}}_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _{{resolveName "Ffi"}}_release_handle_nullable(handle);
+  _{{resolveName "Ffi"}}ReleaseHandleNullable(handle);

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -94,16 +94,16 @@ class {{resolveName}}{{#if external.dart.converter}}_internal{{/if}}{{#if testab
 
 // {{resolveName}} "private" section, not exported.
 
-final _{{resolveName "Ffi"}}_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}CreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{#fields}}{{resolveName typeRef "FfiApiTypes"}}{{#if iter.hasNext}}, {{/if}}{{/fields}}),
     Pointer<Void> Function({{#fields}}{{resolveName typeRef "FfiDartTypes"}}{{#if iter.hasNext}}, {{/if}}{{/fields}})
   >('{{libraryName}}_{{resolveName "Ffi"}}_create_handle'));
-final _{{resolveName "Ffi"}}_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName "FfiCamelCase"}}ReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "Ffi"}}_release_handle'));
 {{#set parent=this}}{{#fields}}
-final _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}} = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName parent "FfiCamelCase"}}GetField{{resolveName "Ffi"}} = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName typeRef "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}'));
@@ -116,29 +116,30 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName this "" "ref"}} value{{#
   final value = {{external.dart.converter}}.convertToInternal(value_ext);
 {{/if}}
 {{#fields}}{{#if typeRef.attributes.optimized}}
-  final _{{resolveName}}_handle = (value.{{resolveName visibility}}{{resolveName}} as __lib.LazyList).handle;
+  final _{{resolveName}}Handle = (value.{{resolveName visibility}}{{resolveName}} as __lib.LazyList).handle;
 {{/if}}{{#unless typeRef.attributes.optimized}}
-  final _{{resolveName}}_handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(value.{{resolveName visibility}}{{resolveName}});
+  final _{{resolveName}}Handle = {{#set call="toFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(value.{{resolveName visibility}}{{resolveName}});
 {{/unless}}{{/fields}}
-  final _result = _{{resolveName "Ffi"}}_create_handle({{#fields}}_{{resolveName}}_handle{{#if iter.hasNext}}, {{/if}}{{/fields}});
+  final _result = _{{resolveName "FfiCamelCase"}}CreateHandle({{#fields}}_{{resolveName}}Handle{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{#fields}}{{#unless typeRef.attributes.optimized}}
-  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
+  {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle);
 {{/unless}}{{/fields}}
   return _result;
 }
 
 {{resolveName this "" "ref"}} {{resolveName "Ffi"}}_fromFfi(Pointer<Void> handle) {
 {{#set parent=this}}{{#fields}}
-  final _{{resolveName}}_handle = _{{resolveName parent "Ffi"}}_get_field_{{resolveName "Ffi"}}(handle);
+  final _{{resolveName}}Handle = {{!!
+  }}_{{resolveName parent "FfiCamelCase"}}GetField{{resolveName "Ffi"}}(handle);
 {{/fields}}{{/set}}
   try {
 {{#if external.dart.converter}}
-    final result_internal = {{resolveName}}_internal{{#if constructors}}._{{/if}}(
+    final resultInternal = {{resolveName}}_internal{{#if constructors}}._{{/if}}(
 {{#set container=this}}{{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}{{/set}}
     );
-    return {{external.dart.converter}}.convertFromInternal(result_internal);
+    return {{external.dart.converter}}.convertFromInternal(resultInternal);
 {{/if}}{{#unless external.dart.converter}}
     return {{resolveName this "" "ref"}}{{#if constructors}}._{{/if}}(
 {{#set container=this}}{{#if attributes.dart.positionalDefaults initializedFields}}
@@ -155,12 +156,12 @@ Pointer<Void> {{resolveName "Ffi"}}_toFfi({{resolveName this "" "ref"}} value{{#
 {{/unless}}
   } finally {
 {{#fields}}{{#unless typeRef.attributes.optimized}}
-    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle);
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle);
 {{/unless}}{{/fields}}
   }
 }
 
-void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveName "Ffi"}}_release_handle(handle);
+void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveName "FfiCamelCase"}}ReleaseHandle(handle);
 
 // Nullable {{resolveName}}
 
@@ -227,11 +228,11 @@ void {{resolveName "Ffi"}}_releaseFfiHandle(Pointer<Void> handle) => _{{resolveN
 
 }}{{+fromFfiFieldInit}}{{!!
 }}      {{#if typeRef.attributes.optimized}}{{!!
-}}{{#resolveName}}{{#setJoin "varName" "" this "handle" delimiter="_"}}{{!!
+}}{{#resolveName}}{{#setJoin "varName" "_" this "Handle" delimiter=""}}{{!!
 }}{{#set elementType=typeRef.type.actualType.elementType.type.actualType typeRef=typeRef.type.actualType.elementType}}{{!!
 }}{{prefixPartial "dart/InitLazyList" "      " skipFirstLine=true}}{{/set}}{{/setJoin}}{{/resolveName}}{{/if}}{{!!
 }}{{#unless typeRef.attributes.optimized}}{{!!
-}}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}_handle){{/unless}}{{#if iter.hasNext}}, {{/if}}
+}}{{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle){{/unless}}{{#if iter.hasNext}}, {{/if}}
 {{/fromFfiFieldInit}}{{!!
 
 }}{{+constPrefix}}{{#set type=typeRef.type.actualType}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTokenCache.mustache
@@ -21,7 +21,6 @@
 {{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
 
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 
 import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
 
@@ -53,15 +52,15 @@ void uncacheObject(Object object) {
 
 final uncacheObjectFfi = Pointer.fromFunction<Void Function(Uint64)>(uncacheObjectByToken);
 
-final ffi_get_cached_token = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final ffiGetCachedToken = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Uint64 Function(Pointer<Void>, Int32),
       int Function(Pointer<Void>, int)
     >('{{libraryName}}_get_cached_token'));
-final ffi_cache_token = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final ffiCacheToken = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Void Function(Pointer<Void>, Int32, Uint64),
       void Function(Pointer<Void>, int, int)
     >('{{libraryName}}_cache_token'));
-final ffi_uncache_token = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final ffiUncacheToken = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Void Function(Pointer<Void>, Int32),
       void Function(Pointer<Void>, int)
     >('{{libraryName}}_uncache_token'));

--- a/gluecodium/src/main/resources/templates/dart/DartTypeRepository.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTypeRepository.mustache
@@ -24,9 +24,6 @@
 {{>dart/DartImport}}
 {{/imports}}
 
-import 'dart:ffi';
-import 'package:ffi/ffi.dart';
-
 final Map<String, Function> typeRepository = { {{#typeRepositories}}
   "{{resolveName "Ffi"}}": (handle) => {{resolveName}}$Impl(handle),
 {{/typeRepositories}} };

--- a/gluecodium/src/main/resources/templates/dart/InitLazyList.mustache
+++ b/gluecodium/src/main/resources/templates/dart/InitLazyList.mustache
@@ -22,10 +22,10 @@ __lib.LazyList(
   {{varName}},
   _{{resolveName container "Ffi"}}_{{resolveName elementType "Ffi"}}LazyList_get_size({{varName}}),
   (index) {
-    final __element_handle = _{{resolveName container "Ffi"}}_{{resolveName elementType "Ffi"}}LazyList_get({{varName}}, index);
-    final __element_result = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__element_handle);
-    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__element_handle);
-    return __element_result;
+    final __elementHandle = _{{resolveName container "Ffi"}}_{{resolveName elementType "Ffi"}}LazyList_get({{varName}}, index);
+    final __elementResult = {{#set call="fromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__elementHandle);
+    {{#set call="releaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__elementHandle);
+    return __elementResult;
   },
   () => _{{resolveName container "Ffi"}}_{{resolveName elementType "Ffi"}}LazyList_release_handle({{varName}})
 )

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnClass
@@ -22,11 +21,11 @@ abstract class AttributesClass {
   set prop(String value);
 }
 // AttributesClass "private" section, not exported.
-final _smoke_AttributesClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesClass_copy_handle'));
-final _smoke_AttributesClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesClass_release_handle'));
@@ -36,68 +35,68 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_AttributesClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeAttributesclassReleaseHandle(handle);
     handle = null;
   }
   @override
   veryFun(@OnParameterInClass String param) {
-    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_veryFun__String'));
-    final _param_handle = String_toFfi(param);
+    final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_veryFun__String'));
+    final _paramHandle = String_toFfi(param);
     final _handle = this.handle;
-    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId, _param_handle);
-    String_releaseFfiHandle(_param_handle);
+    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
+    String_releaseFfiHandle(_paramHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @OnPropertyInClass
   @override
   String get prop {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesClass_prop_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesClass_prop_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @OnPropertyInClass
   @override
   set prop(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_prop_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_prop_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_AttributesClass_toFfi(AttributesClass value) =>
-  _smoke_AttributesClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeAttributesclassCopyHandle((value as __lib.NativeBase).handle);
 AttributesClass smoke_AttributesClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as AttributesClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_AttributesClass_copy_handle(handle);
-  final result = AttributesClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeAttributesclassCopyHandle(handle);
+  final result = AttributesClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_AttributesClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_AttributesClass_release_handle(handle);
+  _smokeAttributesclassReleaseHandle(handle);
 Pointer<Void> smoke_AttributesClass_toFfi_nullable(AttributesClass value) =>
   value != null ? smoke_AttributesClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 AttributesClass smoke_AttributesClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesClass_fromFfi(handle) : null;
 void smoke_AttributesClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesClass_release_handle(handle);
+  _smokeAttributesclassReleaseHandle(handle);
 // End of AttributesClass "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnException

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnEnumeration
@@ -27,32 +26,32 @@ AttributesEnum smoke_AttributesEnum_fromFfi(int handle) {
   }
 }
 void smoke_AttributesEnum_releaseFfiHandle(int handle) {}
-final _smoke_AttributesEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_AttributesEnum_create_handle_nullable'));
-final _smoke_AttributesEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesEnum_release_handle_nullable'));
-final _smoke_AttributesEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_AttributesEnum_get_value_nullable'));
 Pointer<Void> smoke_AttributesEnum_toFfi_nullable(AttributesEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesEnum_toFfi(value);
-  final result = _smoke_AttributesEnum_create_handle_nullable(_handle);
+  final result = _smoke_AttributesEnumCreateHandleNullable(_handle);
   smoke_AttributesEnum_releaseFfiHandle(_handle);
   return result;
 }
 AttributesEnum smoke_AttributesEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_AttributesEnum_get_value_nullable(handle);
+  final _handle = _smoke_AttributesEnumGetValueNullable(handle);
   final result = smoke_AttributesEnum_fromFfi(_handle);
   smoke_AttributesEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_AttributesEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesEnum_release_handle_nullable(handle);
+  _smoke_AttributesEnumReleaseHandleNullable(handle);
 // End of AttributesEnum "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -3,12 +3,11 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnInterface
 abstract class AttributesInterface {
-  AttributesInterface() {}
+  AttributesInterface();
   factory AttributesInterface.fromLambdas({
     @required void Function(String) lambda_veryFun,
     @required String Function() lambda_prop_get,
@@ -33,19 +32,19 @@ abstract class AttributesInterface {
   set prop(String value);
 }
 // AttributesInterface "private" section, not exported.
-final _smoke_AttributesInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesInterface_copy_handle'));
-final _smoke_AttributesInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesInterface_release_handle'));
-final _smoke_AttributesInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_AttributesInterface_create_proxy'));
-final _smoke_AttributesInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesInterface_get_type_id'));
@@ -74,45 +73,45 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_AttributesInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeAttributesinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   veryFun(@OnParameterInInterface String param) {
-    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_veryFun__String'));
-    final _param_handle = String_toFfi(param);
+    final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_veryFun__String'));
+    final _paramHandle = String_toFfi(param);
     final _handle = this.handle;
-    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId, _param_handle);
-    String_releaseFfiHandle(_param_handle);
+    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
+    String_releaseFfiHandle(_paramHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @OnPropertyInInterface
   String get prop {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesInterface_prop_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesInterface_prop_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @OnPropertyInInterface
   set prop(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_prop_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_prop_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -138,8 +137,8 @@ int _AttributesInterface_prop_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_AttributesInterface_toFfi(AttributesInterface value) {
-  if (value is __lib.NativeBase) return _smoke_AttributesInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_AttributesInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeAttributesinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeAttributesinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -151,25 +150,25 @@ Pointer<Void> smoke_AttributesInterface_toFfi(AttributesInterface value) {
 }
 AttributesInterface smoke_AttributesInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as AttributesInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_AttributesInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_AttributesInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeAttributesinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeAttributesinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : AttributesInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : AttributesInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_AttributesInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_AttributesInterface_release_handle(handle);
+  _smokeAttributesinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_AttributesInterface_toFfi_nullable(AttributesInterface value) =>
   value != null ? smoke_AttributesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 AttributesInterface smoke_AttributesInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesInterface_fromFfi(handle) : null;
 void smoke_AttributesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesInterface_release_handle(handle);
+  _smokeAttributesinterfaceReleaseHandle(handle);
 // End of AttributesInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -1,21 +1,20 @@
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnLambda
 typedef AttributesLambda = void Function();
 // AttributesLambda "private" section, not exported.
-final _smoke_AttributesLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeslambdaCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesLambda_copy_handle'));
-final _smoke_AttributesLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeslambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesLambda_release_handle'));
-final _smoke_AttributesLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeslambdaCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_AttributesLambda_create_proxy'));
@@ -23,15 +22,15 @@ class AttributesLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   AttributesLambda$Impl(this.handle);
-  void release() => _smoke_AttributesLambda_release_handle(handle);
+  void release() => _smokeAttributeslambdaReleaseHandle(handle);
   call() {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesLambda_call'));
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesLambda_call'));
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -43,7 +42,7 @@ int _AttributesLambda_call_static(int _token) {
   return 0;
 }
 Pointer<Void> smoke_AttributesLambda_toFfi(AttributesLambda value) {
-  final result = _smoke_AttributesLambda_create_proxy(
+  final result = _smokeAttributeslambdaCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -52,7 +51,7 @@ Pointer<Void> smoke_AttributesLambda_toFfi(AttributesLambda value) {
   return result;
 }
 AttributesLambda smoke_AttributesLambda_fromFfi(Pointer<Void> handle) {
-  final _impl = AttributesLambda$Impl(_smoke_AttributesLambda_copy_handle(handle));
+  final _impl = AttributesLambda$Impl(_smokeAttributeslambdaCopyHandle(handle));
   return () {
     final _result =_impl.call();
     _impl.release();
@@ -60,34 +59,34 @@ AttributesLambda smoke_AttributesLambda_fromFfi(Pointer<Void> handle) {
   };
 }
 void smoke_AttributesLambda_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_AttributesLambda_release_handle(handle);
+  _smokeAttributeslambdaReleaseHandle(handle);
 // Nullable AttributesLambda
-final _smoke_AttributesLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesLambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesLambda_create_handle_nullable'));
-final _smoke_AttributesLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesLambdaReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesLambda_release_handle_nullable'));
-final _smoke_AttributesLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesLambdaGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesLambda_get_value_nullable'));
 Pointer<Void> smoke_AttributesLambda_toFfi_nullable(AttributesLambda value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesLambda_toFfi(value);
-  final result = _smoke_AttributesLambda_create_handle_nullable(_handle);
+  final result = _smoke_AttributesLambdaCreateHandleNullable(_handle);
   smoke_AttributesLambda_releaseFfiHandle(_handle);
   return result;
 }
 AttributesLambda smoke_AttributesLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_AttributesLambda_get_value_nullable(handle);
+  final _handle = _smoke_AttributesLambdaGetValueNullable(handle);
   final result = smoke_AttributesLambda_fromFfi(_handle);
   smoke_AttributesLambda_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_AttributesLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesLambda_release_handle_nullable(handle);
+  _smoke_AttributesLambdaReleaseHandleNullable(handle);
 // End of AttributesLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnStruct
@@ -12,76 +11,76 @@ class AttributesStruct {
   static final bool pi = false;
   @OnFunctionInStruct
   veryFun(@OnParameterInStruct String param) {
-    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesStruct_veryFun__String'));
-    final _param_handle = String_toFfi(param);
+    final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesStruct_veryFun__String'));
+    final _paramHandle = String_toFfi(param);
     final _handle = smoke_AttributesStruct_toFfi(this);
-    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId, _param_handle);
+    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
     smoke_AttributesStruct_releaseFfiHandle(_handle);
-    String_releaseFfiHandle(_param_handle);
+    String_releaseFfiHandle(_paramHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 // AttributesStruct "private" section, not exported.
-final _smoke_AttributesStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesStruct_create_handle'));
-final _smoke_AttributesStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesStruct_release_handle'));
-final _smoke_AttributesStruct_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributesstructGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesStruct_get_field_field'));
 Pointer<Void> smoke_AttributesStruct_toFfi(AttributesStruct value) {
-  final _field_handle = String_toFfi(value.field);
-  final _result = _smoke_AttributesStruct_create_handle(_field_handle);
-  String_releaseFfiHandle(_field_handle);
+  final _fieldHandle = String_toFfi(value.field);
+  final _result = _smokeAttributesstructCreateHandle(_fieldHandle);
+  String_releaseFfiHandle(_fieldHandle);
   return _result;
 }
 AttributesStruct smoke_AttributesStruct_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_AttributesStruct_get_field_field(handle);
+  final _fieldHandle = _smokeAttributesstructGetFieldfield(handle);
   try {
     return AttributesStruct(
-      String_fromFfi(_field_handle)
+      String_fromFfi(_fieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_field_handle);
+    String_releaseFfiHandle(_fieldHandle);
   }
 }
-void smoke_AttributesStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_AttributesStruct_release_handle(handle);
+void smoke_AttributesStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeAttributesstructReleaseHandle(handle);
 // Nullable AttributesStruct
-final _smoke_AttributesStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesStruct_create_handle_nullable'));
-final _smoke_AttributesStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesStruct_release_handle_nullable'));
-final _smoke_AttributesStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesStruct_get_value_nullable'));
 Pointer<Void> smoke_AttributesStruct_toFfi_nullable(AttributesStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesStruct_toFfi(value);
-  final result = _smoke_AttributesStruct_create_handle_nullable(_handle);
+  final result = _smoke_AttributesStructCreateHandleNullable(_handle);
   smoke_AttributesStruct_releaseFfiHandle(_handle);
   return result;
 }
 AttributesStruct smoke_AttributesStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_AttributesStruct_get_value_nullable(handle);
+  final _handle = _smoke_AttributesStructGetValueNullable(handle);
   final result = smoke_AttributesStruct_fromFfi(_handle);
   smoke_AttributesStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_AttributesStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesStruct_release_handle_nullable(handle);
+  _smoke_AttributesStructReleaseHandleNullable(handle);
 // End of AttributesStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// Class comment
@@ -34,71 +33,71 @@ class AttributesWithComments_SomeStruct {
   AttributesWithComments_SomeStruct(this.field);
 }
 // AttributesWithComments_SomeStruct "private" section, not exported.
-final _smoke_AttributesWithComments_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithcommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_create_handle'));
-final _smoke_AttributesWithComments_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithcommentsSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_release_handle'));
-final _smoke_AttributesWithComments_SomeStruct_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithcommentsSomestructGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_get_field_field'));
 Pointer<Void> smoke_AttributesWithComments_SomeStruct_toFfi(AttributesWithComments_SomeStruct value) {
-  final _field_handle = String_toFfi(value.field);
-  final _result = _smoke_AttributesWithComments_SomeStruct_create_handle(_field_handle);
-  String_releaseFfiHandle(_field_handle);
+  final _fieldHandle = String_toFfi(value.field);
+  final _result = _smokeAttributeswithcommentsSomestructCreateHandle(_fieldHandle);
+  String_releaseFfiHandle(_fieldHandle);
   return _result;
 }
 AttributesWithComments_SomeStruct smoke_AttributesWithComments_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_AttributesWithComments_SomeStruct_get_field_field(handle);
+  final _fieldHandle = _smokeAttributeswithcommentsSomestructGetFieldfield(handle);
   try {
     return AttributesWithComments_SomeStruct(
-      String_fromFfi(_field_handle)
+      String_fromFfi(_fieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_field_handle);
+    String_releaseFfiHandle(_fieldHandle);
   }
 }
-void smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_AttributesWithComments_SomeStruct_release_handle(handle);
+void smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeAttributeswithcommentsSomestructReleaseHandle(handle);
 // Nullable AttributesWithComments_SomeStruct
-final _smoke_AttributesWithComments_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesWithComments_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_create_handle_nullable'));
-final _smoke_AttributesWithComments_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesWithComments_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_release_handle_nullable'));
-final _smoke_AttributesWithComments_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesWithComments_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_AttributesWithComments_SomeStruct_toFfi_nullable(AttributesWithComments_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesWithComments_SomeStruct_toFfi(value);
-  final result = _smoke_AttributesWithComments_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_AttributesWithComments_SomeStructCreateHandleNullable(_handle);
   smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 AttributesWithComments_SomeStruct smoke_AttributesWithComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_AttributesWithComments_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_AttributesWithComments_SomeStructGetValueNullable(handle);
   final result = smoke_AttributesWithComments_SomeStruct_fromFfi(_handle);
   smoke_AttributesWithComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_AttributesWithComments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesWithComments_SomeStruct_release_handle_nullable(handle);
+  _smoke_AttributesWithComments_SomeStructReleaseHandleNullable(handle);
 // End of AttributesWithComments_SomeStruct "private" section.
 // AttributesWithComments "private" section, not exported.
-final _smoke_AttributesWithComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithcommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_copy_handle'));
-final _smoke_AttributesWithComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithcommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_release_handle'));
@@ -108,66 +107,66 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_AttributesWithComments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeAttributeswithcommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   veryFun() {
-    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_veryFun'));
+    final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_veryFun'));
     final _handle = this.handle;
-    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @OnPropertyInClass
   @override
   String get prop {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_prop_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_prop_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @OnPropertyInClass
   @override
   set prop(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithComments_prop_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithComments_prop_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_AttributesWithComments_toFfi(AttributesWithComments value) =>
-  _smoke_AttributesWithComments_copy_handle((value as __lib.NativeBase).handle);
+  _smokeAttributeswithcommentsCopyHandle((value as __lib.NativeBase).handle);
 AttributesWithComments smoke_AttributesWithComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as AttributesWithComments;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_AttributesWithComments_copy_handle(handle);
-  final result = AttributesWithComments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeAttributeswithcommentsCopyHandle(handle);
+  final result = AttributesWithComments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_AttributesWithComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_AttributesWithComments_release_handle(handle);
+  _smokeAttributeswithcommentsReleaseHandle(handle);
 Pointer<Void> smoke_AttributesWithComments_toFfi_nullable(AttributesWithComments value) =>
   value != null ? smoke_AttributesWithComments_toFfi(value) : Pointer<Void>.fromAddress(0);
 AttributesWithComments smoke_AttributesWithComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesWithComments_fromFfi(handle) : null;
 void smoke_AttributesWithComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesWithComments_release_handle(handle);
+  _smokeAttributeswithcommentsReleaseHandle(handle);
 // End of AttributesWithComments "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("")
@@ -33,71 +32,71 @@ class AttributesWithDeprecated_SomeStruct {
   AttributesWithDeprecated_SomeStruct(this.field);
 }
 // AttributesWithDeprecated_SomeStruct "private" section, not exported.
-final _smoke_AttributesWithDeprecated_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithdeprecatedSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_create_handle'));
-final _smoke_AttributesWithDeprecated_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithdeprecatedSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_release_handle'));
-final _smoke_AttributesWithDeprecated_SomeStruct_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithdeprecatedSomestructGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_get_field_field'));
 Pointer<Void> smoke_AttributesWithDeprecated_SomeStruct_toFfi(AttributesWithDeprecated_SomeStruct value) {
-  final _field_handle = String_toFfi(value.field);
-  final _result = _smoke_AttributesWithDeprecated_SomeStruct_create_handle(_field_handle);
-  String_releaseFfiHandle(_field_handle);
+  final _fieldHandle = String_toFfi(value.field);
+  final _result = _smokeAttributeswithdeprecatedSomestructCreateHandle(_fieldHandle);
+  String_releaseFfiHandle(_fieldHandle);
   return _result;
 }
 AttributesWithDeprecated_SomeStruct smoke_AttributesWithDeprecated_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_AttributesWithDeprecated_SomeStruct_get_field_field(handle);
+  final _fieldHandle = _smokeAttributeswithdeprecatedSomestructGetFieldfield(handle);
   try {
     return AttributesWithDeprecated_SomeStruct(
-      String_fromFfi(_field_handle)
+      String_fromFfi(_fieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_field_handle);
+    String_releaseFfiHandle(_fieldHandle);
   }
 }
-void smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_AttributesWithDeprecated_SomeStruct_release_handle(handle);
+void smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeAttributeswithdeprecatedSomestructReleaseHandle(handle);
 // Nullable AttributesWithDeprecated_SomeStruct
-final _smoke_AttributesWithDeprecated_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesWithDeprecated_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_create_handle_nullable'));
-final _smoke_AttributesWithDeprecated_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesWithDeprecated_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_release_handle_nullable'));
-final _smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_AttributesWithDeprecated_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_AttributesWithDeprecated_SomeStruct_toFfi_nullable(AttributesWithDeprecated_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_AttributesWithDeprecated_SomeStruct_toFfi(value);
-  final result = _smoke_AttributesWithDeprecated_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_AttributesWithDeprecated_SomeStructCreateHandleNullable(_handle);
   smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 AttributesWithDeprecated_SomeStruct smoke_AttributesWithDeprecated_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_AttributesWithDeprecated_SomeStructGetValueNullable(handle);
   final result = smoke_AttributesWithDeprecated_SomeStruct_fromFfi(_handle);
   smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_AttributesWithDeprecated_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesWithDeprecated_SomeStruct_release_handle_nullable(handle);
+  _smoke_AttributesWithDeprecated_SomeStructReleaseHandleNullable(handle);
 // End of AttributesWithDeprecated_SomeStruct "private" section.
 // AttributesWithDeprecated "private" section, not exported.
-final _smoke_AttributesWithDeprecated_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithdeprecatedCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_copy_handle'));
-final _smoke_AttributesWithDeprecated_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeAttributeswithdeprecatedReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_release_handle'));
@@ -107,66 +106,66 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_AttributesWithDeprecated_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeAttributeswithdeprecatedReleaseHandle(handle);
     handle = null;
   }
   @override
   veryFun() {
-    final _veryFun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_veryFun'));
+    final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_veryFun'));
     final _handle = this.handle;
-    final __result_handle = _veryFun_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @OnPropertyInClass
   @override
   String get prop {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_prop_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_prop_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @OnPropertyInClass
   @override
   set prop(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithDeprecated_prop_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithDeprecated_prop_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_AttributesWithDeprecated_toFfi(AttributesWithDeprecated value) =>
-  _smoke_AttributesWithDeprecated_copy_handle((value as __lib.NativeBase).handle);
+  _smokeAttributeswithdeprecatedCopyHandle((value as __lib.NativeBase).handle);
 AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as AttributesWithDeprecated;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_AttributesWithDeprecated_copy_handle(handle);
-  final result = AttributesWithDeprecated$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeAttributeswithdeprecatedCopyHandle(handle);
+  final result = AttributesWithDeprecated$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_AttributesWithDeprecated_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_AttributesWithDeprecated_release_handle(handle);
+  _smokeAttributeswithdeprecatedReleaseHandle(handle);
 Pointer<Void> smoke_AttributesWithDeprecated_toFfi_nullable(AttributesWithDeprecated value) =>
   value != null ? smoke_AttributesWithDeprecated_toFfi(value) : Pointer<Void>.fromAddress(0);
 AttributesWithDeprecated smoke_AttributesWithDeprecated_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_AttributesWithDeprecated_fromFfi(handle) : null;
 void smoke_AttributesWithDeprecated_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_AttributesWithDeprecated_release_handle(handle);
+  _smokeAttributeswithdeprecatedReleaseHandle(handle);
 // End of AttributesWithDeprecated "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class MultipleAttributesDart {
@@ -33,11 +32,11 @@ abstract class MultipleAttributesDart {
   twoLists();
 }
 // MultipleAttributesDart "private" section, not exported.
-final _smoke_MultipleAttributesDart_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMultipleattributesdartCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MultipleAttributesDart_copy_handle'));
-final _smoke_MultipleAttributesDart_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMultipleattributesdartReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MultipleAttributesDart_release_handle'));
@@ -47,84 +46,84 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_MultipleAttributesDart_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeMultipleattributesdartReleaseHandle(handle);
     handle = null;
   }
   @override
   noLists2() {
-    final _noLists2_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists2'));
+    final _noLists2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists2'));
     final _handle = this.handle;
-    final __result_handle = _noLists2_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _noLists2Ffi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   noLists3() {
-    final _noLists3_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists3'));
+    final _noLists3Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists3'));
     final _handle = this.handle;
-    final __result_handle = _noLists3_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _noLists3Ffi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   listFirst() {
-    final _listFirst_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listFirst'));
+    final _listFirstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listFirst'));
     final _handle = this.handle;
-    final __result_handle = _listFirst_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _listFirstFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   listSecond() {
-    final _listSecond_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listSecond'));
+    final _listSecondFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listSecond'));
     final _handle = this.handle;
-    final __result_handle = _listSecond_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _listSecondFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   twoLists() {
-    final _twoLists_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_twoLists'));
+    final _twoListsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_twoLists'));
     final _handle = this.handle;
-    final __result_handle = _twoLists_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _twoListsFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_MultipleAttributesDart_toFfi(MultipleAttributesDart value) =>
-  _smoke_MultipleAttributesDart_copy_handle((value as __lib.NativeBase).handle);
+  _smokeMultipleattributesdartCopyHandle((value as __lib.NativeBase).handle);
 MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as MultipleAttributesDart;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_MultipleAttributesDart_copy_handle(handle);
-  final result = MultipleAttributesDart$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeMultipleattributesdartCopyHandle(handle);
+  final result = MultipleAttributesDart$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_MultipleAttributesDart_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_MultipleAttributesDart_release_handle(handle);
+  _smokeMultipleattributesdartReleaseHandle(handle);
 Pointer<Void> smoke_MultipleAttributesDart_toFfi_nullable(MultipleAttributesDart value) =>
   value != null ? smoke_MultipleAttributesDart_toFfi(value) : Pointer<Void>.fromAddress(0);
 MultipleAttributesDart smoke_MultipleAttributesDart_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MultipleAttributesDart_fromFfi(handle) : null;
 void smoke_MultipleAttributesDart_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_MultipleAttributesDart_release_handle(handle);
+  _smokeMultipleattributesdartReleaseHandle(handle);
 // End of MultipleAttributesDart "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SpecialAttributes {
@@ -17,11 +16,11 @@ abstract class SpecialAttributes {
   withLineBreak();
 }
 // SpecialAttributes "private" section, not exported.
-final _smoke_SpecialAttributes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSpecialattributesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SpecialAttributes_copy_handle'));
-final _smoke_SpecialAttributes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSpecialattributesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialAttributes_release_handle'));
@@ -31,51 +30,51 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SpecialAttributes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSpecialattributesReleaseHandle(handle);
     handle = null;
   }
   @override
   withEscaping() {
-    final _withEscaping_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withEscaping'));
+    final _withEscapingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withEscaping'));
     final _handle = this.handle;
-    final __result_handle = _withEscaping_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _withEscapingFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   withLineBreak() {
-    final _withLineBreak_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withLineBreak'));
+    final _withLineBreakFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withLineBreak'));
     final _handle = this.handle;
-    final __result_handle = _withLineBreak_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _withLineBreakFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_SpecialAttributes_toFfi(SpecialAttributes value) =>
-  _smoke_SpecialAttributes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSpecialattributesCopyHandle((value as __lib.NativeBase).handle);
 SpecialAttributes smoke_SpecialAttributes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SpecialAttributes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SpecialAttributes_copy_handle(handle);
-  final result = SpecialAttributes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSpecialattributesCopyHandle(handle);
+  final result = SpecialAttributes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SpecialAttributes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SpecialAttributes_release_handle(handle);
+  _smokeSpecialattributesReleaseHandle(handle);
 Pointer<Void> smoke_SpecialAttributes_toFfi_nullable(SpecialAttributes value) =>
   value != null ? smoke_SpecialAttributes_toFfi(value) : Pointer<Void>.fromAddress(0);
 SpecialAttributes smoke_SpecialAttributes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SpecialAttributes_fromFfi(handle) : null;
 void smoke_SpecialAttributes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SpecialAttributes_release_handle(handle);
+  _smokeSpecialattributesReleaseHandle(handle);
 // End of SpecialAttributes "private" section.

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
@@ -4,30 +4,30 @@ import 'package:ffi/ffi.dart';
 import 'package:intl/locale.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // Blob
-final _Blob_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
   >('library_blob_create_handle'));
-final _Blob_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_blob_release_handle'));
-final _Blob_get_length = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobGetLength = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_blob_get_length'));
-final _Blob_get_data_pointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobGetDataPointer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Uint8> Function(Pointer<Void>),
     Pointer<Uint8> Function(Pointer<Void>)
 >('library_blob_get_data_pointer'));
 Pointer<Void> Blob_toFfi(Uint8List list) {
-  final result = _Blob_create_handle(list.length);
-  (_Blob_get_data_pointer(result) as Pointer<Uint8>).asTypedList(list.length).setRange(0, list.length, list);
+  final result = _blobCreateHandle(list.length);
+  (_blobGetDataPointer(result) as Pointer<Uint8>).asTypedList(list.length).setRange(0, list.length, list);
   return result;
 }
 Uint8List Blob_fromFfi(Pointer<Void> handle) =>
-  Uint8List.fromList((_Blob_get_data_pointer(handle) as Pointer<Uint8>).asTypedList(_Blob_get_length(handle)));
-void Blob_releaseFfiHandle(Pointer<Void> handle) => _Blob_release_handle(handle);
+  Uint8List.fromList((_blobGetDataPointer(handle) as Pointer<Uint8>).asTypedList(_blobGetLength(handle)));
+void Blob_releaseFfiHandle(Pointer<Void> handle) => _blobReleaseHandle(handle);
 // Boolean
 int Boolean_toFfi(bool value) => value ? 1 : 0;
 bool Boolean_fromFfi(int handle) => handle != 0;
@@ -37,48 +37,48 @@ int Date_toFfi(DateTime value) => value.microsecondsSinceEpoch;
 DateTime Date_fromFfi(int us) => DateTime.fromMicrosecondsSinceEpoch(us, isUtc: true);
 void Date_releaseFfiHandle(int handle) {}
 // String
-final _String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _StringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>)
   >('library_std_string_create_handle'));
-final _String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _StringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_std_string_release_handle'));
-final _String_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _StringGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
   >('library_std_string_get_value'));
 Pointer<Void> String_toFfi(String value) {
   final cValue = Utf8.toUtf8(value);
-  final result = _String_create_handle(cValue);
+  final result = _StringCreateHandle(cValue);
   free(cValue);
   return result;
 }
-String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_String_get_value(handle));
-void String_releaseFfiHandle(Pointer<Void> handle) => _String_release_handle(handle);
+String String_fromFfi(Pointer<Void> handle) => Utf8.fromUtf8(_StringGetValue(handle));
+void String_releaseFfiHandle(Pointer<Void> handle) => _StringReleaseHandle(handle);
 // Locale
-final _Locale_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _LocaleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
     Pointer<Void> Function(Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>)
   >('library_locale_create_handle'));
-final _Locale_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _LocaleReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_locale_release_handle'));
-final _Locale_get_language_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final LocaleGetLanguageCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_language_code'));
-final _Locale_get_country_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final LocaleGetCountryCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_country_code'));
-final _Locale_get_script_code = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final LocaleGetScriptCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_script_code'));
-final _Locale_get_language_tag = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _LocaleGetLanguageTag = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_language_tag'));
@@ -89,7 +89,7 @@ Pointer<Void> Locale_toFfi(Locale locale) {
   final cScriptCode =
     locale.scriptCode != null ? Utf8.toUtf8(locale.scriptCode) : Pointer<Utf8>.fromAddress(0);
   final cLanguageTag = Utf8.toUtf8(locale.toLanguageTag());
-  final result = _Locale_create_handle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
+  final result = _LocaleCreateHandle(cLanguageCode, cCountryCode, cScriptCode, cLanguageTag);
   free(cLanguageCode);
   if (cCountryCode.address != 0) free(cCountryCode);
   if (cScriptCode.address != 0) free(cScriptCode);
@@ -97,418 +97,418 @@ Pointer<Void> Locale_toFfi(Locale locale) {
   return result;
 }
 Locale Locale_fromFfi(Pointer<Void> handle) {
-  final languageTagCstring = _Locale_get_language_tag(handle);
+  final Pointer<Utf8> languageTagCstring = _LocaleGetLanguageTag(handle);
   if (languageTagCstring.address != 0) {
     // BCP 47 language tag takes precedence if present.
     return Locale.parse(Utf8.fromUtf8(languageTagCstring));
   }
-  final languageCodeCstring = _Locale_get_language_code(handle);
-  final countryCodeCstring = _Locale_get_country_code(handle);
-  final scriptCodeCstring = _Locale_get_script_code(handle);
+  final Pointer<Utf8> languageCodeCstring = LocaleGetLanguageCode(handle);
+  final Pointer<Utf8> countryCodeCstring = LocaleGetCountryCode(handle);
+  final Pointer<Utf8> scriptCodeCstring = LocaleGetScriptCode(handle);
   return Locale.fromSubtags(
     languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,
     countryCode: countryCodeCstring.address != 0 ? Utf8.fromUtf8(countryCodeCstring) : null,
     scriptCode: scriptCodeCstring.address != 0 ? Utf8.fromUtf8(scriptCodeCstring) : null
   );
 }
-void Locale_releaseFfiHandle(Pointer<Void> handle) => _Locale_release_handle(handle);
+void Locale_releaseFfiHandle(Pointer<Void> handle) => _LocaleReleaseHandle(handle);
 // Nullable Byte
-final _Byte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _byteCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8),
     Pointer<Void> Function(int)
   >('library_Byte_create_handle_nullable'));
-final _Byte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _byteReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Byte_release_handle_nullable'));
-final _Byte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _byteGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Byte_get_value_nullable'));
 Pointer<Void> Byte_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _Byte_create_handle_nullable(_handle);
+  final result = _byteCreateHandleNullable(_handle);
   return result;
 }
 int Byte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Byte_get_value_nullable(handle);
+  final _handle = _byteGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void Byte_releaseFfiHandle_nullable(Pointer<Void> handle) => _Byte_release_handle_nullable(handle);
+void Byte_releaseFfiHandle_nullable(Pointer<Void> handle) => _byteReleaseHandleNullable(handle);
 // Nullable UByte
-final _UByte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uByteCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
   >('library_UByte_create_handle_nullable'));
-final _UByte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uByteReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_UByte_release_handle_nullable'));
-final _UByte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uByteGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_UByte_get_value_nullable'));
 Pointer<Void> UByte_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _UByte_create_handle_nullable(_handle);
+  final result = _uByteCreateHandleNullable(_handle);
   return result;
 }
 int UByte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _UByte_get_value_nullable(handle);
+  final _handle = _uByteGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void UByte_releaseFfiHandle_nullable(Pointer<Void> handle) => _UByte_release_handle_nullable(handle);
+void UByte_releaseFfiHandle_nullable(Pointer<Void> handle) => _uByteReleaseHandleNullable(handle);
 // Nullable Short
-final _Short_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _shortCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int16),
     Pointer<Void> Function(int)
   >('library_Short_create_handle_nullable'));
-final _Short_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _shortReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Short_release_handle_nullable'));
-final _Short_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _shortGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Short_get_value_nullable'));
 Pointer<Void> Short_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _Short_create_handle_nullable(_handle);
+  final result = _shortCreateHandleNullable(_handle);
   return result;
 }
 int Short_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Short_get_value_nullable(handle);
+  final _handle = _shortGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void Short_releaseFfiHandle_nullable(Pointer<Void> handle) => _Short_release_handle_nullable(handle);
+void Short_releaseFfiHandle_nullable(Pointer<Void> handle) => _shortReleaseHandleNullable(handle);
 // Nullable UShort
-final _UShort_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uShortCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint16),
     Pointer<Void> Function(int)
   >('library_UShort_create_handle_nullable'));
-final _UShort_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uShortReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_UShort_release_handle_nullable'));
-final _UShort_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uShortGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_UShort_get_value_nullable'));
 Pointer<Void> UShort_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _UShort_create_handle_nullable(_handle);
+  final result = _uShortCreateHandleNullable(_handle);
   return result;
 }
 int UShort_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _UShort_get_value_nullable(handle);
+  final _handle = _uShortGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void UShort_releaseFfiHandle_nullable(Pointer<Void> handle) => _UShort_release_handle_nullable(handle);
+void UShort_releaseFfiHandle_nullable(Pointer<Void> handle) => _uShortReleaseHandleNullable(handle);
 // Nullable Int
-final _Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _intCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32),
     Pointer<Void> Function(int)
   >('library_Int_create_handle_nullable'));
-final _Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _intReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Int_release_handle_nullable'));
-final _Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _intGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Int_get_value_nullable'));
 Pointer<Void> Int_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _Int_create_handle_nullable(_handle);
+  final result = _intCreateHandleNullable(_handle);
   return result;
 }
 int Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Int_get_value_nullable(handle);
+  final _handle = _intGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void Int_releaseFfiHandle_nullable(Pointer<Void> handle) => _Int_release_handle_nullable(handle);
+void Int_releaseFfiHandle_nullable(Pointer<Void> handle) => _intReleaseHandleNullable(handle);
 // Nullable UInt
-final _UInt_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uIntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_UInt_create_handle_nullable'));
-final _UInt_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uIntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_UInt_release_handle_nullable'));
-final _UInt_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uIntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_UInt_get_value_nullable'));
 Pointer<Void> UInt_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _UInt_create_handle_nullable(_handle);
+  final result = _uIntCreateHandleNullable(_handle);
   return result;
 }
 int UInt_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _UInt_get_value_nullable(handle);
+  final _handle = _uIntGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void UInt_releaseFfiHandle_nullable(Pointer<Void> handle) => _UInt_release_handle_nullable(handle);
+void UInt_releaseFfiHandle_nullable(Pointer<Void> handle) => _uIntReleaseHandleNullable(handle);
 // Nullable Long
-final _Long_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _longCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int64),
     Pointer<Void> Function(int)
   >('library_Long_create_handle_nullable'));
-final _Long_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _longReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Long_release_handle_nullable'));
-final _Long_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _longGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Long_get_value_nullable'));
 Pointer<Void> Long_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _Long_create_handle_nullable(_handle);
+  final result = _longCreateHandleNullable(_handle);
   return result;
 }
 int Long_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Long_get_value_nullable(handle);
+  final _handle = _longGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void Long_releaseFfiHandle_nullable(Pointer<Void> handle) => _Long_release_handle_nullable(handle);
+void Long_releaseFfiHandle_nullable(Pointer<Void> handle) => _longReleaseHandleNullable(handle);
 // Nullable ULong
-final _ULong_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uLongCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
   >('library_ULong_create_handle_nullable'));
-final _ULong_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uLongReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_ULong_release_handle_nullable'));
-final _ULong_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _uLongGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_ULong_get_value_nullable'));
 Pointer<Void> ULong_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _ULong_create_handle_nullable(_handle);
+  final result = _uLongCreateHandleNullable(_handle);
   return result;
 }
 int ULong_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _ULong_get_value_nullable(handle);
+  final _handle = _uLongGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void ULong_releaseFfiHandle_nullable(Pointer<Void> handle) => _ULong_release_handle_nullable(handle);
+void ULong_releaseFfiHandle_nullable(Pointer<Void> handle) => _uLongReleaseHandleNullable(handle);
 // Nullable Float
-final _Float_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _floatCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Float),
     Pointer<Void> Function(double)
   >('library_Float_create_handle_nullable'));
-final _Float_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _floatReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Float_release_handle_nullable'));
-final _Float_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _floatGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_Float_get_value_nullable'));
 Pointer<Void> Float_toFfi_nullable(double value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _Float_create_handle_nullable(_handle);
+  final result = _floatCreateHandleNullable(_handle);
   return result;
 }
 double Float_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Float_get_value_nullable(handle);
+  final _handle = _floatGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void Float_releaseFfiHandle_nullable(Pointer<Void> handle) => _Float_release_handle_nullable(handle);
+void Float_releaseFfiHandle_nullable(Pointer<Void> handle) => _floatReleaseHandleNullable(handle);
 // Nullable Double
-final _Double_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doubleCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_Double_create_handle_nullable'));
-final _Double_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doubleReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Double_release_handle_nullable'));
-final _Double_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doubleGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_Double_get_value_nullable'));
 Pointer<Void> Double_toFfi_nullable(double value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = (value);
-  final result = _Double_create_handle_nullable(_handle);
+  final result = _doubleCreateHandleNullable(_handle);
   return result;
 }
 double Double_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Double_get_value_nullable(handle);
+  final _handle = _doubleGetValueNullable(handle);
   final result = (_handle);
   return result;
 }
-void Double_releaseFfiHandle_nullable(Pointer<Void> handle) => _Double_release_handle_nullable(handle);
+void Double_releaseFfiHandle_nullable(Pointer<Void> handle) => _doubleReleaseHandleNullable(handle);
 // Nullable Boolean
-final _Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _booleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
   >('library_Boolean_create_handle_nullable'));
-final _Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _booleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Boolean_release_handle_nullable'));
-final _Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _booleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Boolean_get_value_nullable'));
 Pointer<Void> Boolean_toFfi_nullable(bool value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Boolean_toFfi(value);
-  final result = _Boolean_create_handle_nullable(_handle);
+  final result = _booleanCreateHandleNullable(_handle);
   Boolean_releaseFfiHandle(_handle);
   return result;
 }
 bool Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Boolean_get_value_nullable(handle);
+  final _handle = _booleanGetValueNullable(handle);
   final result = Boolean_fromFfi(_handle);
   Boolean_releaseFfiHandle(_handle);
   return result;
 }
-void Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) => _Boolean_release_handle_nullable(handle);
+void Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) => _booleanReleaseHandleNullable(handle);
 // Nullable String
-final _String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _stringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_String_create_handle_nullable'));
-final _String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _stringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_String_release_handle_nullable'));
-final _String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _stringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_String_get_value_nullable'));
 Pointer<Void> String_toFfi_nullable(String value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = String_toFfi(value);
-  final result = _String_create_handle_nullable(_handle);
+  final result = _stringCreateHandleNullable(_handle);
   String_releaseFfiHandle(_handle);
   return result;
 }
 String String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _String_get_value_nullable(handle);
+  final _handle = _stringGetValueNullable(handle);
   final result = String_fromFfi(_handle);
   String_releaseFfiHandle(_handle);
   return result;
 }
-void String_releaseFfiHandle_nullable(Pointer<Void> handle) => _String_release_handle_nullable(handle);
+void String_releaseFfiHandle_nullable(Pointer<Void> handle) => _stringReleaseHandleNullable(handle);
 // Nullable Blob
-final _Blob_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_Blob_create_handle_nullable'));
-final _Blob_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Blob_release_handle_nullable'));
-final _Blob_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _blobGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_Blob_get_value_nullable'));
 Pointer<Void> Blob_toFfi_nullable(Uint8List value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Blob_toFfi(value);
-  final result = _Blob_create_handle_nullable(_handle);
+  final result = _blobCreateHandleNullable(_handle);
   Blob_releaseFfiHandle(_handle);
   return result;
 }
 Uint8List Blob_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Blob_get_value_nullable(handle);
+  final _handle = _blobGetValueNullable(handle);
   final result = Blob_fromFfi(_handle);
   Blob_releaseFfiHandle(_handle);
   return result;
 }
-void Blob_releaseFfiHandle_nullable(Pointer<Void> handle) => _Blob_release_handle_nullable(handle);
+void Blob_releaseFfiHandle_nullable(Pointer<Void> handle) => _blobReleaseHandleNullable(handle);
 // Nullable Date
-final _Date_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _dateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
   >('library_Date_create_handle_nullable'));
-final _Date_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _dateReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Date_release_handle_nullable'));
-final _Date_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _dateGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_Date_get_value_nullable'));
 Pointer<Void> Date_toFfi_nullable(DateTime value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Date_toFfi(value);
-  final result = _Date_create_handle_nullable(_handle);
+  final result = _dateCreateHandleNullable(_handle);
   Date_releaseFfiHandle(_handle);
   return result;
 }
 DateTime Date_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Date_get_value_nullable(handle);
+  final _handle = _dateGetValueNullable(handle);
   final result = Date_fromFfi(_handle);
   Date_releaseFfiHandle(_handle);
   return result;
 }
-void Date_releaseFfiHandle_nullable(Pointer<Void> handle) => _Date_release_handle_nullable(handle);
+void Date_releaseFfiHandle_nullable(Pointer<Void> handle) => _dateReleaseHandleNullable(handle);
 // Nullable Locale
-final _Locale_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_Locale_create_handle_nullable'));
-final _Locale_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_Locale_release_handle_nullable'));
-final _Locale_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_Locale_get_value_nullable'));
 Pointer<Void> Locale_toFfi_nullable(Locale value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = Locale_toFfi(value);
-  final result = _Locale_create_handle_nullable(_handle);
+  final result = _localeCreateHandleNullable(_handle);
   Locale_releaseFfiHandle(_handle);
   return result;
 }
 Locale Locale_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _Locale_get_value_nullable(handle);
+  final _handle = _localeGetValueNullable(handle);
   final result = Locale_fromFfi(_handle);
   Locale_releaseFfiHandle(_handle);
   return result;
 }
-void Locale_releaseFfiHandle_nullable(Pointer<Void> handle) => _Locale_release_handle_nullable(handle);
+void Locale_releaseFfiHandle_nullable(Pointer<Void> handle) => _localeReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class BasicTypes {
@@ -25,11 +24,11 @@ abstract class BasicTypes {
   static int ulongFunction(int input) => BasicTypes$Impl.ulongFunction(input);
 }
 // BasicTypes "private" section, not exported.
-final _smoke_BasicTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeBasictypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_BasicTypes_copy_handle'));
-final _smoke_BasicTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeBasictypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_BasicTypes_release_handle'));
@@ -39,161 +38,161 @@ class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_BasicTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeBasictypesReleaseHandle(handle);
     handle = null;
   }
   static String stringFunction(String input) {
-    final _stringFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String'));
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _stringFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final _stringFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String'));
+    final _inputHandle = String_toFfi(input);
+    final __resultHandle = _stringFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   static bool boolFunction(bool input) {
-    final _boolFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_boolFunction__Boolean'));
-    final _input_handle = Boolean_toFfi(input);
-    final __result_handle = _boolFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    Boolean_releaseFfiHandle(_input_handle);
+    final _boolFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_boolFunction__Boolean'));
+    final _inputHandle = Boolean_toFfi(input);
+    final __resultHandle = _boolFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   static double floatFunction(double input) {
-    final _floatFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Int32, Float), double Function(int, double)>('library_smoke_BasicTypes_floatFunction__Float'));
-    final _input_handle = (input);
-    final __result_handle = _floatFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _floatFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Int32, Float), double Function(int, double)>('library_smoke_BasicTypes_floatFunction__Float'));
+    final _inputHandle = (input);
+    final __resultHandle = _floatFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static double doubleFunction(double input) {
-    final _doubleFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_BasicTypes_doubleFunction__Double'));
-    final _input_handle = (input);
-    final __result_handle = _doubleFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _doubleFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_BasicTypes_doubleFunction__Double'));
+    final _inputHandle = (input);
+    final __resultHandle = _doubleFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int byteFunction(int input) {
-    final _byteFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int8 Function(Int32, Int8), int Function(int, int)>('library_smoke_BasicTypes_byteFunction__Byte'));
-    final _input_handle = (input);
-    final __result_handle = _byteFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _byteFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int8 Function(Int32, Int8), int Function(int, int)>('library_smoke_BasicTypes_byteFunction__Byte'));
+    final _inputHandle = (input);
+    final __resultHandle = _byteFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int shortFunction(int input) {
-    final _shortFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int16 Function(Int32, Int16), int Function(int, int)>('library_smoke_BasicTypes_shortFunction__Short'));
-    final _input_handle = (input);
-    final __result_handle = _shortFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _shortFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int16 Function(Int32, Int16), int Function(int, int)>('library_smoke_BasicTypes_shortFunction__Short'));
+    final _inputHandle = (input);
+    final __resultHandle = _shortFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int intFunction(int input) {
-    final _intFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('library_smoke_BasicTypes_intFunction__Int'));
-    final _input_handle = (input);
-    final __result_handle = _intFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _intFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('library_smoke_BasicTypes_intFunction__Int'));
+    final _inputHandle = (input);
+    final __resultHandle = _intFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int longFunction(int input) {
-    final _longFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int64 Function(Int32, Int64), int Function(int, int)>('library_smoke_BasicTypes_longFunction__Long'));
-    final _input_handle = (input);
-    final __result_handle = _longFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _longFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int64 Function(Int32, Int64), int Function(int, int)>('library_smoke_BasicTypes_longFunction__Long'));
+    final _inputHandle = (input);
+    final __resultHandle = _longFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int ubyteFunction(int input) {
-    final _ubyteFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_ubyteFunction__UByte'));
-    final _input_handle = (input);
-    final __result_handle = _ubyteFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _ubyteFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_ubyteFunction__UByte'));
+    final _inputHandle = (input);
+    final __resultHandle = _ubyteFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int ushortFunction(int input) {
-    final _ushortFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint16 Function(Int32, Uint16), int Function(int, int)>('library_smoke_BasicTypes_ushortFunction__UShort'));
-    final _input_handle = (input);
-    final __result_handle = _ushortFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _ushortFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint16 Function(Int32, Uint16), int Function(int, int)>('library_smoke_BasicTypes_ushortFunction__UShort'));
+    final _inputHandle = (input);
+    final __resultHandle = _ushortFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int uintFunction(int input) {
-    final _uintFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_BasicTypes_uintFunction__UInt'));
-    final _input_handle = (input);
-    final __result_handle = _uintFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _uintFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_BasicTypes_uintFunction__UInt'));
+    final _inputHandle = (input);
+    final __resultHandle = _uintFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static int ulongFunction(int input) {
-    final _ulongFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Int32, Uint64), int Function(int, int)>('library_smoke_BasicTypes_ulongFunction__ULong'));
-    final _input_handle = (input);
-    final __result_handle = _ulongFunction_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _ulongFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Int32, Uint64), int Function(int, int)>('library_smoke_BasicTypes_ulongFunction__ULong'));
+    final _inputHandle = (input);
+    final __resultHandle = _ulongFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_BasicTypes_toFfi(BasicTypes value) =>
-  _smoke_BasicTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeBasictypesCopyHandle((value as __lib.NativeBase).handle);
 BasicTypes smoke_BasicTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as BasicTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_BasicTypes_copy_handle(handle);
-  final result = BasicTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeBasictypesCopyHandle(handle);
+  final result = BasicTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_BasicTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_BasicTypes_release_handle(handle);
+  _smokeBasictypesReleaseHandle(handle);
 Pointer<Void> smoke_BasicTypes_toFfi_nullable(BasicTypes value) =>
   value != null ? smoke_BasicTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 BasicTypes smoke_BasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_BasicTypes_fromFfi(handle) : null;
 void smoke_BasicTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_BasicTypes_release_handle(handle);
+  _smokeBasictypesReleaseHandle(handle);
 // End of BasicTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
@@ -100,34 +99,34 @@ Comments_SomeEnum smoke_Comments_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_Comments_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_Comments_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Comments_SomeEnum_create_handle_nullable'));
-final _smoke_Comments_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_SomeEnum_release_handle_nullable'));
-final _smoke_Comments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_Comments_SomeEnum_toFfi_nullable(Comments_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeEnum_toFfi(value);
-  final result = _smoke_Comments_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_Comments_SomeEnumCreateHandleNullable(_handle);
   smoke_Comments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 Comments_SomeEnum smoke_Comments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Comments_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_Comments_SomeEnumGetValueNullable(handle);
   final result = smoke_Comments_SomeEnum_fromFfi(_handle);
   smoke_Comments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Comments_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Comments_SomeEnum_release_handle_nullable(handle);
+  _smoke_Comments_SomeEnumReleaseHandleNullable(handle);
 // End of Comments_SomeEnum "private" section.
 /// This is some very useful exception.
 class Comments_SomethingWrongException implements Exception {
@@ -148,86 +147,86 @@ class Comments_SomeStruct {
   Comments_SomeStruct(this.someField, this.nullableField);
 }
 // Comments_SomeStruct "private" section, not exported.
-final _smoke_Comments_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_create_handle'));
-final _smoke_Comments_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_release_handle'));
-final _smoke_Comments_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsSomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_get_field_someField'));
-final _smoke_Comments_SomeStruct_get_field_nullableField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsSomestructGetFieldnullableField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_get_field_nullableField'));
 Pointer<Void> smoke_Comments_SomeStruct_toFfi(Comments_SomeStruct value) {
-  final _someField_handle = Boolean_toFfi(value.someField);
-  final _nullableField_handle = String_toFfi_nullable(value.nullableField);
-  final _result = _smoke_Comments_SomeStruct_create_handle(_someField_handle, _nullableField_handle);
-  Boolean_releaseFfiHandle(_someField_handle);
-  String_releaseFfiHandle_nullable(_nullableField_handle);
+  final _someFieldHandle = Boolean_toFfi(value.someField);
+  final _nullableFieldHandle = String_toFfi_nullable(value.nullableField);
+  final _result = _smokeCommentsSomestructCreateHandle(_someFieldHandle, _nullableFieldHandle);
+  Boolean_releaseFfiHandle(_someFieldHandle);
+  String_releaseFfiHandle_nullable(_nullableFieldHandle);
   return _result;
 }
 Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_Comments_SomeStruct_get_field_someField(handle);
-  final _nullableField_handle = _smoke_Comments_SomeStruct_get_field_nullableField(handle);
+  final _someFieldHandle = _smokeCommentsSomestructGetFieldsomeField(handle);
+  final _nullableFieldHandle = _smokeCommentsSomestructGetFieldnullableField(handle);
   try {
     return Comments_SomeStruct(
-      Boolean_fromFfi(_someField_handle),
-      String_fromFfi_nullable(_nullableField_handle)
+      Boolean_fromFfi(_someFieldHandle),
+      String_fromFfi_nullable(_nullableFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle(_someField_handle);
-    String_releaseFfiHandle_nullable(_nullableField_handle);
+    Boolean_releaseFfiHandle(_someFieldHandle);
+    String_releaseFfiHandle_nullable(_nullableFieldHandle);
   }
 }
-void smoke_Comments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Comments_SomeStruct_release_handle(handle);
+void smoke_Comments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeCommentsSomestructReleaseHandle(handle);
 // Nullable Comments_SomeStruct
-final _smoke_Comments_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_create_handle_nullable'));
-final _smoke_Comments_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_release_handle_nullable'));
-final _smoke_Comments_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_Comments_SomeStruct_toFfi_nullable(Comments_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeStruct_toFfi(value);
-  final result = _smoke_Comments_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_Comments_SomeStructCreateHandleNullable(_handle);
   smoke_Comments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 Comments_SomeStruct smoke_Comments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Comments_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_Comments_SomeStructGetValueNullable(handle);
   final result = smoke_Comments_SomeStruct_fromFfi(_handle);
   smoke_Comments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Comments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Comments_SomeStruct_release_handle_nullable(handle);
+  _smoke_Comments_SomeStructReleaseHandleNullable(handle);
 // End of Comments_SomeStruct "private" section.
 /// This is some very useful lambda that does it.
 typedef Comments_SomeLambda = double Function(String, int);
 // Comments_SomeLambda "private" section, not exported.
-final _smoke_Comments_SomeLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsSomelambdaCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeLambda_copy_handle'));
-final _smoke_Comments_SomeLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsSomelambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_SomeLambda_release_handle'));
-final _smoke_Comments_SomeLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsSomelambdaCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Comments_SomeLambda_create_proxy'));
@@ -235,27 +234,27 @@ class Comments_SomeLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Comments_SomeLambda$Impl(this.handle);
-  void release() => _smoke_Comments_SomeLambda_release_handle(handle);
+  void release() => _smokeCommentsSomelambdaReleaseHandle(handle);
   double call(String p0, int p1) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_Comments_SomeLambda_call__String_Int'));
-    final _p0_handle = String_toFfi(p0);
-    final _p1_handle = (p1);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_Comments_SomeLambda_call__String_Int'));
+    final _p0Handle = String_toFfi(p0);
+    final _p1Handle = (p1);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle, _p1_handle);
-    String_releaseFfiHandle(_p0_handle);
-    (_p1_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
+    String_releaseFfiHandle(_p0Handle);
+    (_p1Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _Comments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
-  double _result_object;
+  double _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as Comments_SomeLambda)(String_fromFfi(p0), (p1));
-    _result.value = (_result_object);
+    _resultObject = (__lib.instanceCache[_token] as Comments_SomeLambda)(String_fromFfi(p0), (p1));
+    _result.value = (_resultObject);
   } finally {
     String_releaseFfiHandle(p0);
     (p1);
@@ -263,7 +262,7 @@ int _Comments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Point
   return 0;
 }
 Pointer<Void> smoke_Comments_SomeLambda_toFfi(Comments_SomeLambda value) {
-  final result = _smoke_Comments_SomeLambda_create_proxy(
+  final result = _smokeCommentsSomelambdaCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -272,7 +271,7 @@ Pointer<Void> smoke_Comments_SomeLambda_toFfi(Comments_SomeLambda value) {
   return result;
 }
 Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi(Pointer<Void> handle) {
-  final _impl = Comments_SomeLambda$Impl(_smoke_Comments_SomeLambda_copy_handle(handle));
+  final _impl = Comments_SomeLambda$Impl(_smokeCommentsSomelambdaCopyHandle(handle));
   return (String p0, int p1) {
     final _result =_impl.call(p0, p1);
     _impl.release();
@@ -280,59 +279,59 @@ Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi(Pointer<Void> handle) {
   };
 }
 void smoke_Comments_SomeLambda_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Comments_SomeLambda_release_handle(handle);
+  _smokeCommentsSomelambdaReleaseHandle(handle);
 // Nullable Comments_SomeLambda
-final _smoke_Comments_SomeLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeLambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeLambda_create_handle_nullable'));
-final _smoke_Comments_SomeLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeLambdaReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_SomeLambda_release_handle_nullable'));
-final _smoke_Comments_SomeLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Comments_SomeLambdaGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeLambda_get_value_nullable'));
 Pointer<Void> smoke_Comments_SomeLambda_toFfi_nullable(Comments_SomeLambda value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Comments_SomeLambda_toFfi(value);
-  final result = _smoke_Comments_SomeLambda_create_handle_nullable(_handle);
+  final result = _smoke_Comments_SomeLambdaCreateHandleNullable(_handle);
   smoke_Comments_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
 Comments_SomeLambda smoke_Comments_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Comments_SomeLambda_get_value_nullable(handle);
+  final _handle = _smoke_Comments_SomeLambdaGetValueNullable(handle);
   final result = smoke_Comments_SomeLambda_fromFfi(_handle);
   smoke_Comments_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Comments_SomeLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Comments_SomeLambda_release_handle_nullable(handle);
+  _smoke_Comments_SomeLambdaReleaseHandleNullable(handle);
 // End of Comments_SomeLambda "private" section.
 // Comments "private" section, not exported.
-final _smoke_Comments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_copy_handle'));
-final _smoke_Comments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_release_handle'));
-final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error'));
@@ -342,214 +341,214 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Comments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeCommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   bool someMethodWithAllComments(String inputParameter) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String'));
-    final _inputParameter_handle = String_toFfi(inputParameter);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String'));
+    final _inputParameterHandle = String_toFfi(inputParameter);
     final _handle = this.handle;
-    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _inputParameter_handle);
-    String_releaseFfiHandle(_inputParameter_handle);
-    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
-        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
+    String_releaseFfiHandle(_inputParameterHandle);
+    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
         try {
-          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__error_handle));
+          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+          smoke_Comments_SomeEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
-    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithInputComments(String input) {
-    final _someMethodWithInputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithInputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithInputCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithOutputComments(String input) {
-    final _someMethodWithOutputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithOutputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithOutputCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithNoComments(String input) {
-    final _someMethodWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeWithAllComments(String input) {
-    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeWithNoComments(String input) {
-    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
-    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments'));
+    final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutInputParametersWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
-    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments'));
+    final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutInputParametersWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   someMethodWithNothing() {
-    final _someMethodWithNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing'));
+    final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithNothing_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
-    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters'));
+    final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String oneParameterCommentOnly(String undocumented, String documented) {
-    final _oneParameterCommentOnly_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String'));
-    final _undocumented_handle = String_toFfi(undocumented);
-    final _documented_handle = String_toFfi(documented);
+    final _oneParameterCommentOnlyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String'));
+    final _undocumentedHandle = String_toFfi(undocumented);
+    final _documentedHandle = String_toFfi(documented);
     final _handle = this.handle;
-    final __result_handle = _oneParameterCommentOnly_ffi(_handle, __lib.LibraryContext.isolateId, _undocumented_handle, _documented_handle);
-    String_releaseFfiHandle(_undocumented_handle);
-    String_releaseFfiHandle(_documented_handle);
+    final __resultHandle = _oneParameterCommentOnlyFfi(_handle, __lib.LibraryContext.isolateId, _undocumentedHandle, _documentedHandle);
+    String_releaseFfiHandle(_undocumentedHandle);
+    String_releaseFfiHandle(_documentedHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   String returnCommentOnly(String undocumented) {
-    final _returnCommentOnly_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String'));
-    final _undocumented_handle = String_toFfi(undocumented);
+    final _returnCommentOnlyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String'));
+    final _undocumentedHandle = String_toFfi(undocumented);
     final _handle = this.handle;
-    final __result_handle = _returnCommentOnly_ffi(_handle, __lib.LibraryContext.isolateId, _undocumented_handle);
-    String_releaseFfiHandle(_undocumented_handle);
+    final __resultHandle = _returnCommentOnlyFfi(_handle, __lib.LibraryContext.isolateId, _undocumentedHandle);
+    String_releaseFfiHandle(_undocumentedHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool get isSomeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Comments_toFfi(Comments value) =>
-  _smoke_Comments_copy_handle((value as __lib.NativeBase).handle);
+  _smokeCommentsCopyHandle((value as __lib.NativeBase).handle);
 Comments smoke_Comments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Comments;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Comments_copy_handle(handle);
-  final result = Comments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeCommentsCopyHandle(handle);
+  final result = Comments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Comments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Comments_release_handle(handle);
+  _smokeCommentsReleaseHandle(handle);
 Pointer<Void> smoke_Comments_toFfi_nullable(Comments value) =>
   value != null ? smoke_Comments_toFfi(value) : Pointer<Void>.fromAddress(0);
 Comments smoke_Comments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Comments_fromFfi(handle) : null;
 void smoke_Comments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Comments_release_handle(handle);
+  _smokeCommentsReleaseHandle(handle);
 // End of Comments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -3,12 +3,11 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 abstract class CommentsInterface {
-  CommentsInterface() {}
+  CommentsInterface();
   factory CommentsInterface.fromLambdas({
     @required bool Function(String) lambda_someMethodWithAllComments,
     @required bool Function(String) lambda_someMethodWithInputComments,
@@ -121,34 +120,34 @@ CommentsInterface_SomeEnum smoke_CommentsInterface_SomeEnum_fromFfi(int handle) 
   }
 }
 void smoke_CommentsInterface_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_CommentsInterface_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_CommentsInterface_SomeEnum_create_handle_nullable'));
-final _smoke_CommentsInterface_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeEnum_release_handle_nullable'));
-final _smoke_CommentsInterface_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_CommentsInterface_SomeEnum_toFfi_nullable(CommentsInterface_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsInterface_SomeEnum_toFfi(value);
-  final result = _smoke_CommentsInterface_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_CommentsInterface_SomeEnumCreateHandleNullable(_handle);
   smoke_CommentsInterface_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 CommentsInterface_SomeEnum smoke_CommentsInterface_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_CommentsInterface_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_CommentsInterface_SomeEnumGetValueNullable(handle);
   final result = smoke_CommentsInterface_SomeEnum_fromFfi(_handle);
   smoke_CommentsInterface_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_CommentsInterface_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CommentsInterface_SomeEnum_release_handle_nullable(handle);
+  _smoke_CommentsInterface_SomeEnumReleaseHandleNullable(handle);
 // End of CommentsInterface_SomeEnum "private" section.
 /// This is some very useful struct.
 class CommentsInterface_SomeStruct {
@@ -157,79 +156,79 @@ class CommentsInterface_SomeStruct {
   CommentsInterface_SomeStruct(this.someField);
 }
 // CommentsInterface_SomeStruct "private" section, not exported.
-final _smoke_CommentsInterface_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsinterfaceSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
   >('library_smoke_CommentsInterface_SomeStruct_create_handle'));
-final _smoke_CommentsInterface_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsinterfaceSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_release_handle'));
-final _smoke_CommentsInterface_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsinterfaceSomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi(CommentsInterface_SomeStruct value) {
-  final _someField_handle = Boolean_toFfi(value.someField);
-  final _result = _smoke_CommentsInterface_SomeStruct_create_handle(_someField_handle);
-  Boolean_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = Boolean_toFfi(value.someField);
+  final _result = _smokeCommentsinterfaceSomestructCreateHandle(_someFieldHandle);
+  Boolean_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 CommentsInterface_SomeStruct smoke_CommentsInterface_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_CommentsInterface_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeCommentsinterfaceSomestructGetFieldsomeField(handle);
   try {
     return CommentsInterface_SomeStruct(
-      Boolean_fromFfi(_someField_handle)
+      Boolean_fromFfi(_someFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle(_someField_handle);
+    Boolean_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_CommentsInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsInterface_SomeStruct_release_handle(handle);
+void smoke_CommentsInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeCommentsinterfaceSomestructReleaseHandle(handle);
 // Nullable CommentsInterface_SomeStruct
-final _smoke_CommentsInterface_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_create_handle_nullable'));
-final _smoke_CommentsInterface_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_release_handle_nullable'));
-final _smoke_CommentsInterface_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsInterface_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_CommentsInterface_SomeStruct_toFfi_nullable(CommentsInterface_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsInterface_SomeStruct_toFfi(value);
-  final result = _smoke_CommentsInterface_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_CommentsInterface_SomeStructCreateHandleNullable(_handle);
   smoke_CommentsInterface_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 CommentsInterface_SomeStruct smoke_CommentsInterface_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_CommentsInterface_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_CommentsInterface_SomeStructGetValueNullable(handle);
   final result = smoke_CommentsInterface_SomeStruct_fromFfi(_handle);
   smoke_CommentsInterface_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_CommentsInterface_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CommentsInterface_SomeStruct_release_handle_nullable(handle);
+  _smoke_CommentsInterface_SomeStructReleaseHandleNullable(handle);
 // End of CommentsInterface_SomeStruct "private" section.
 // CommentsInterface "private" section, not exported.
-final _smoke_CommentsInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_copy_handle'));
-final _smoke_CommentsInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_release_handle'));
-final _smoke_CommentsInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_CommentsInterface_create_proxy'));
-final _smoke_CommentsInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_get_type_id'));
@@ -303,192 +302,192 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_CommentsInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeCommentsinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithInputComments(String input) {
-    final _someMethodWithInputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithInputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithInputCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithOutputComments(String input) {
-    final _someMethodWithOutputComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithOutputComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithOutputCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithNoComments(String input) {
-    final _someMethodWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeWithAllComments(String input) {
-    final _someMethodWithoutReturnTypeWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeWithNoComments(String input) {
-    final _someMethodWithoutReturnTypeWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
-    final _someMethodWithoutInputParametersWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments'));
+    final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutInputParametersWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutInputParametersWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
-    final _someMethodWithoutInputParametersWithNoComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments'));
+    final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutInputParametersWithNoComments_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutInputParametersWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   someMethodWithNothing() {
-    final _someMethodWithNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing'));
+    final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithNothing_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
-    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters'));
+    final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   /// Gets some very useful property.
   bool get isSomeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   /// Sets some very useful property.
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _CommentsInterface_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(String_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 int _CommentsInterface_someMethodWithInputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(String_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 int _CommentsInterface_someMethodWithOutputComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(String_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 int _CommentsInterface_someMethodWithNoComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(String_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
@@ -511,19 +510,19 @@ int _CommentsInterface_someMethodWithoutReturnTypeWithNoComments_static(int _tok
   return 0;
 }
 int _CommentsInterface_someMethodWithoutInputParametersWithAllComments_static(int _token, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 int _CommentsInterface_someMethodWithoutInputParametersWithNoComments_static(int _token, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
   }
   return 0;
@@ -556,8 +555,8 @@ int _CommentsInterface_isSomeProperty_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {
-  if (value is __lib.NativeBase) return _smoke_CommentsInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_CommentsInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeCommentsinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeCommentsinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -578,25 +577,25 @@ Pointer<Void> smoke_CommentsInterface_toFfi(CommentsInterface value) {
 }
 CommentsInterface smoke_CommentsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as CommentsInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_CommentsInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_CommentsInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeCommentsinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeCommentsinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : CommentsInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : CommentsInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_CommentsInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_CommentsInterface_release_handle(handle);
+  _smokeCommentsinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_CommentsInterface_toFfi_nullable(CommentsInterface value) =>
   value != null ? smoke_CommentsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 CommentsInterface smoke_CommentsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CommentsInterface_fromFfi(handle) : null;
 void smoke_CommentsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CommentsInterface_release_handle(handle);
+  _smokeCommentsinterfaceReleaseHandle(handle);
 // End of CommentsInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// The nested types like [CommentsLinks.randomMethod2] don't need full name prefix, but it's
@@ -74,87 +73,87 @@ class CommentsLinks_RandomStruct {
   CommentsLinks_RandomStruct(this.randomField);
 }
 // CommentsLinks_RandomStruct "private" section, not exported.
-final _smoke_CommentsLinks_RandomStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentslinksRandomstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_create_handle'));
-final _smoke_CommentsLinks_RandomStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentslinksRandomstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_release_handle'));
-final _smoke_CommentsLinks_RandomStruct_get_field_randomField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentslinksRandomstructGetFieldrandomField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_get_field_randomField'));
 Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi(CommentsLinks_RandomStruct value) {
-  final _randomField_handle = smoke_Comments_SomeStruct_toFfi(value.randomField);
-  final _result = _smoke_CommentsLinks_RandomStruct_create_handle(_randomField_handle);
-  smoke_Comments_SomeStruct_releaseFfiHandle(_randomField_handle);
+  final _randomFieldHandle = smoke_Comments_SomeStruct_toFfi(value.randomField);
+  final _result = _smokeCommentslinksRandomstructCreateHandle(_randomFieldHandle);
+  smoke_Comments_SomeStruct_releaseFfiHandle(_randomFieldHandle);
   return _result;
 }
 CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi(Pointer<Void> handle) {
-  final _randomField_handle = _smoke_CommentsLinks_RandomStruct_get_field_randomField(handle);
+  final _randomFieldHandle = _smokeCommentslinksRandomstructGetFieldrandomField(handle);
   try {
     return CommentsLinks_RandomStruct(
-      smoke_Comments_SomeStruct_fromFfi(_randomField_handle)
+      smoke_Comments_SomeStruct_fromFfi(_randomFieldHandle)
     );
   } finally {
-    smoke_Comments_SomeStruct_releaseFfiHandle(_randomField_handle);
+    smoke_Comments_SomeStruct_releaseFfiHandle(_randomFieldHandle);
   }
 }
-void smoke_CommentsLinks_RandomStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CommentsLinks_RandomStruct_release_handle(handle);
+void smoke_CommentsLinks_RandomStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeCommentslinksRandomstructReleaseHandle(handle);
 // Nullable CommentsLinks_RandomStruct
-final _smoke_CommentsLinks_RandomStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsLinks_RandomStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_create_handle_nullable'));
-final _smoke_CommentsLinks_RandomStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsLinks_RandomStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_release_handle_nullable'));
-final _smoke_CommentsLinks_RandomStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CommentsLinks_RandomStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_get_value_nullable'));
 Pointer<Void> smoke_CommentsLinks_RandomStruct_toFfi_nullable(CommentsLinks_RandomStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CommentsLinks_RandomStruct_toFfi(value);
-  final result = _smoke_CommentsLinks_RandomStruct_create_handle_nullable(_handle);
+  final result = _smoke_CommentsLinks_RandomStructCreateHandleNullable(_handle);
   smoke_CommentsLinks_RandomStruct_releaseFfiHandle(_handle);
   return result;
 }
 CommentsLinks_RandomStruct smoke_CommentsLinks_RandomStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_CommentsLinks_RandomStruct_get_value_nullable(handle);
+  final _handle = _smoke_CommentsLinks_RandomStructGetValueNullable(handle);
   final result = smoke_CommentsLinks_RandomStruct_fromFfi(_handle);
   smoke_CommentsLinks_RandomStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_CommentsLinks_RandomStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CommentsLinks_RandomStruct_release_handle_nullable(handle);
+  _smoke_CommentsLinks_RandomStructReleaseHandleNullable(handle);
 // End of CommentsLinks_RandomStruct "private" section.
 // CommentsLinks "private" section, not exported.
-final _smoke_CommentsLinks_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentslinksCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_copy_handle'));
-final _smoke_CommentsLinks_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentslinksReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_release_handle'));
-final _randomMethod_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_release_handle'));
-final _randomMethod_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_result'));
-final _randomMethod_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_error'));
-final _randomMethod_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error'));
@@ -164,68 +163,68 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_CommentsLinks_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeCommentslinksReleaseHandle(handle);
     handle = null;
   }
   @override
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
-    final _randomMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Uint32), Pointer<Void> Function(Pointer<Void>, int, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum'));
-    final _inputParameter_handle = smoke_Comments_SomeEnum_toFfi(inputParameter);
+    final _randomMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Uint32), Pointer<Void> Function(Pointer<Void>, int, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum'));
+    final _inputParameterHandle = smoke_Comments_SomeEnum_toFfi(inputParameter);
     final _handle = this.handle;
-    final __call_result_handle = _randomMethod_ffi(_handle, __lib.LibraryContext.isolateId, _inputParameter_handle);
-    smoke_Comments_SomeEnum_releaseFfiHandle(_inputParameter_handle);
-    if (_randomMethod_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _randomMethod_return_get_error(__call_result_handle);
-        _randomMethod_return_release_handle(__call_result_handle);
+    final __callResultHandle = _randomMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
+    smoke_Comments_SomeEnum_releaseFfiHandle(_inputParameterHandle);
+    if (_randomMethodReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _randomMethodReturnGetError(__callResultHandle);
+        _randomMethodReturnReleaseHandle(__callResultHandle);
         try {
-          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__error_handle));
+          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+          smoke_Comments_SomeEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _randomMethod_return_get_result(__call_result_handle);
-    _randomMethod_return_release_handle(__call_result_handle);
+    final __resultHandle = _randomMethodReturnGetResult(__callResultHandle);
+    _randomMethodReturnReleaseHandle(__callResultHandle);
     try {
-      return smoke_Comments_SomeEnum_fromFfi(__result_handle);
+      return smoke_Comments_SomeEnum_fromFfi(__resultHandle);
     } finally {
-      smoke_Comments_SomeEnum_releaseFfiHandle(__result_handle);
+      smoke_Comments_SomeEnum_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   randomMethod2(String text, bool flag) {
-    final _randomMethod2_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__String_Boolean'));
-    final _text_handle = String_toFfi(text);
-    final _flag_handle = Boolean_toFfi(flag);
+    final _randomMethod2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__String_Boolean'));
+    final _textHandle = String_toFfi(text);
+    final _flagHandle = Boolean_toFfi(flag);
     final _handle = this.handle;
-    final __result_handle = _randomMethod2_ffi(_handle, __lib.LibraryContext.isolateId, _text_handle, _flag_handle);
-    String_releaseFfiHandle(_text_handle);
-    Boolean_releaseFfiHandle(_flag_handle);
+    final __resultHandle = _randomMethod2Ffi(_handle, __lib.LibraryContext.isolateId, _textHandle, _flagHandle);
+    String_releaseFfiHandle(_textHandle);
+    Boolean_releaseFfiHandle(_flagHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_CommentsLinks_toFfi(CommentsLinks value) =>
-  _smoke_CommentsLinks_copy_handle((value as __lib.NativeBase).handle);
+  _smokeCommentslinksCopyHandle((value as __lib.NativeBase).handle);
 CommentsLinks smoke_CommentsLinks_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as CommentsLinks;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_CommentsLinks_copy_handle(handle);
-  final result = CommentsLinks$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeCommentslinksCopyHandle(handle);
+  final result = CommentsLinks$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_CommentsLinks_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_CommentsLinks_release_handle(handle);
+  _smokeCommentslinksReleaseHandle(handle);
 Pointer<Void> smoke_CommentsLinks_toFfi_nullable(CommentsLinks value) =>
   value != null ? smoke_CommentsLinks_toFfi(value) : Pointer<Void>.fromAddress(0);
 CommentsLinks smoke_CommentsLinks_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CommentsLinks_fromFfi(handle) : null;
 void smoke_CommentsLinks_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CommentsLinks_release_handle(handle);
+  _smokeCommentslinksReleaseHandle(handle);
 // End of CommentsLinks "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// First line.
@@ -37,11 +36,11 @@ abstract class CommentsMarkdown {
   void release();
 }
 // CommentsMarkdown "private" section, not exported.
-final _smoke_CommentsMarkdown_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsmarkdownCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsMarkdown_copy_handle'));
-final _smoke_CommentsMarkdown_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCommentsmarkdownReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsMarkdown_release_handle'));
@@ -51,29 +50,29 @@ class CommentsMarkdown$Impl extends __lib.NativeBase implements CommentsMarkdown
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_CommentsMarkdown_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeCommentsmarkdownReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_CommentsMarkdown_toFfi(CommentsMarkdown value) =>
-  _smoke_CommentsMarkdown_copy_handle((value as __lib.NativeBase).handle);
+  _smokeCommentsmarkdownCopyHandle((value as __lib.NativeBase).handle);
 CommentsMarkdown smoke_CommentsMarkdown_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as CommentsMarkdown;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_CommentsMarkdown_copy_handle(handle);
-  final result = CommentsMarkdown$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeCommentsmarkdownCopyHandle(handle);
+  final result = CommentsMarkdown$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_CommentsMarkdown_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_CommentsMarkdown_release_handle(handle);
+  _smokeCommentsmarkdownReleaseHandle(handle);
 Pointer<Void> smoke_CommentsMarkdown_toFfi_nullable(CommentsMarkdown value) =>
   value != null ? smoke_CommentsMarkdown_toFfi(value) : Pointer<Void>.fromAddress(0);
 CommentsMarkdown smoke_CommentsMarkdown_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CommentsMarkdown_fromFfi(handle) : null;
 void smoke_CommentsMarkdown_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CommentsMarkdown_release_handle(handle);
+  _smokeCommentsmarkdownReleaseHandle(handle);
 // End of CommentsMarkdown "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("")
@@ -9,62 +8,62 @@ class DeprecatedWithNoMessage {
   DeprecatedWithNoMessage(this.field);
 }
 // DeprecatedWithNoMessage "private" section, not exported.
-final _smoke_DeprecatedWithNoMessage_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecatedwithnomessageCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_create_handle'));
-final _smoke_DeprecatedWithNoMessage_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecatedwithnomessageReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_release_handle'));
-final _smoke_DeprecatedWithNoMessage_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecatedwithnomessageGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_get_field_field'));
 Pointer<Void> smoke_DeprecatedWithNoMessage_toFfi(DeprecatedWithNoMessage value) {
-  final _field_handle = String_toFfi(value.field);
-  final _result = _smoke_DeprecatedWithNoMessage_create_handle(_field_handle);
-  String_releaseFfiHandle(_field_handle);
+  final _fieldHandle = String_toFfi(value.field);
+  final _result = _smokeDeprecatedwithnomessageCreateHandle(_fieldHandle);
+  String_releaseFfiHandle(_fieldHandle);
   return _result;
 }
 DeprecatedWithNoMessage smoke_DeprecatedWithNoMessage_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_DeprecatedWithNoMessage_get_field_field(handle);
+  final _fieldHandle = _smokeDeprecatedwithnomessageGetFieldfield(handle);
   try {
     return DeprecatedWithNoMessage(
-      String_fromFfi(_field_handle)
+      String_fromFfi(_fieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_field_handle);
+    String_releaseFfiHandle(_fieldHandle);
   }
 }
-void smoke_DeprecatedWithNoMessage_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecatedWithNoMessage_release_handle(handle);
+void smoke_DeprecatedWithNoMessage_releaseFfiHandle(Pointer<Void> handle) => _smokeDeprecatedwithnomessageReleaseHandle(handle);
 // Nullable DeprecatedWithNoMessage
-final _smoke_DeprecatedWithNoMessage_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecatedWithNoMessageCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_create_handle_nullable'));
-final _smoke_DeprecatedWithNoMessage_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecatedWithNoMessageReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_release_handle_nullable'));
-final _smoke_DeprecatedWithNoMessage_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecatedWithNoMessageGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_get_value_nullable'));
 Pointer<Void> smoke_DeprecatedWithNoMessage_toFfi_nullable(DeprecatedWithNoMessage value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecatedWithNoMessage_toFfi(value);
-  final result = _smoke_DeprecatedWithNoMessage_create_handle_nullable(_handle);
+  final result = _smoke_DeprecatedWithNoMessageCreateHandleNullable(_handle);
   smoke_DeprecatedWithNoMessage_releaseFfiHandle(_handle);
   return result;
 }
 DeprecatedWithNoMessage smoke_DeprecatedWithNoMessage_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DeprecatedWithNoMessage_get_value_nullable(handle);
+  final _handle = _smoke_DeprecatedWithNoMessageGetValueNullable(handle);
   final result = smoke_DeprecatedWithNoMessage_fromFfi(_handle);
   smoke_DeprecatedWithNoMessage_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DeprecatedWithNoMessage_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DeprecatedWithNoMessage_release_handle_nullable(handle);
+  _smoke_DeprecatedWithNoMessageReleaseHandleNullable(handle);
 // End of DeprecatedWithNoMessage "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -3,13 +3,12 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 abstract class DeprecationComments {
-  DeprecationComments() {}
+  DeprecationComments();
   factory DeprecationComments.fromLambdas({
     @required bool Function(String) lambda_someMethodWithAllComments,
     @required bool Function() lambda_isSomeProperty_get,
@@ -78,34 +77,34 @@ DeprecationComments_SomeEnum smoke_DeprecationComments_SomeEnum_fromFfi(int hand
   }
 }
 void smoke_DeprecationComments_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_DeprecationComments_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_DeprecationComments_SomeEnum_create_handle_nullable'));
-final _smoke_DeprecationComments_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeEnum_release_handle_nullable'));
-final _smoke_DeprecationComments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_DeprecationComments_SomeEnum_toFfi_nullable(DeprecationComments_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationComments_SomeEnum_toFfi(value);
-  final result = _smoke_DeprecationComments_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_DeprecationComments_SomeEnumCreateHandleNullable(_handle);
   smoke_DeprecationComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 DeprecationComments_SomeEnum smoke_DeprecationComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DeprecationComments_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_DeprecationComments_SomeEnumGetValueNullable(handle);
   final result = smoke_DeprecationComments_SomeEnum_fromFfi(_handle);
   smoke_DeprecationComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DeprecationComments_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DeprecationComments_SomeEnum_release_handle_nullable(handle);
+  _smoke_DeprecationComments_SomeEnumReleaseHandleNullable(handle);
 // End of DeprecationComments_SomeEnum "private" section.
 @Deprecated("Unfortunately, this exception is deprecated, please use [Comments_SomethingWrongException] instead.")
 class DeprecationComments_SomethingWrongException implements Exception {
@@ -121,79 +120,79 @@ class DeprecationComments_SomeStruct {
   DeprecationComments_SomeStruct(this.someField);
 }
 // DeprecationComments_SomeStruct "private" section, not exported.
-final _smoke_DeprecationComments_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
   >('library_smoke_DeprecationComments_SomeStruct_create_handle'));
-final _smoke_DeprecationComments_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_release_handle'));
-final _smoke_DeprecationComments_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsSomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi(DeprecationComments_SomeStruct value) {
-  final _someField_handle = Boolean_toFfi(value.someField);
-  final _result = _smoke_DeprecationComments_SomeStruct_create_handle(_someField_handle);
-  Boolean_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = Boolean_toFfi(value.someField);
+  final _result = _smokeDeprecationcommentsSomestructCreateHandle(_someFieldHandle);
+  Boolean_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 DeprecationComments_SomeStruct smoke_DeprecationComments_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_DeprecationComments_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeDeprecationcommentsSomestructGetFieldsomeField(handle);
   try {
     return DeprecationComments_SomeStruct(
-      Boolean_fromFfi(_someField_handle)
+      Boolean_fromFfi(_someFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle(_someField_handle);
+    Boolean_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_DeprecationComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationComments_SomeStruct_release_handle(handle);
+void smoke_DeprecationComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeDeprecationcommentsSomestructReleaseHandle(handle);
 // Nullable DeprecationComments_SomeStruct
-final _smoke_DeprecationComments_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_create_handle_nullable'));
-final _smoke_DeprecationComments_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_release_handle_nullable'));
-final _smoke_DeprecationComments_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationComments_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_DeprecationComments_SomeStruct_toFfi_nullable(DeprecationComments_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationComments_SomeStruct_toFfi(value);
-  final result = _smoke_DeprecationComments_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_DeprecationComments_SomeStructCreateHandleNullable(_handle);
   smoke_DeprecationComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 DeprecationComments_SomeStruct smoke_DeprecationComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DeprecationComments_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_DeprecationComments_SomeStructGetValueNullable(handle);
   final result = smoke_DeprecationComments_SomeStruct_fromFfi(_handle);
   smoke_DeprecationComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DeprecationComments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DeprecationComments_SomeStruct_release_handle_nullable(handle);
+  _smoke_DeprecationComments_SomeStructReleaseHandleNullable(handle);
 // End of DeprecationComments_SomeStruct "private" section.
 // DeprecationComments "private" section, not exported.
-final _smoke_DeprecationComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_copy_handle'));
-final _smoke_DeprecationComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_release_handle'));
-final _smoke_DeprecationComments_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_DeprecationComments_create_proxy'));
-final _smoke_DeprecationComments_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_get_type_id'));
@@ -230,80 +229,80 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_DeprecationComments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeDeprecationcommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   bool get isSomeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   /// Gets the property but not accessors.
   @Deprecated("Will be removed in v3.2.1.")
   String get propertyButNotAccessors {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_propertyButNotAccessors_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_propertyButNotAccessors_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @Deprecated("Will be removed in v3.2.1.")
   set propertyButNotAccessors(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_propertyButNotAccessors_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_propertyButNotAccessors_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _DeprecationComments_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(String_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
@@ -336,8 +335,8 @@ int _DeprecationComments_propertyButNotAccessors_set_static(int _token, Pointer<
   return 0;
 }
 Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
-  if (value is __lib.NativeBase) return _smoke_DeprecationComments_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_DeprecationComments_create_proxy(
+  if (value is __lib.NativeBase) return _smokeDeprecationcommentsCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeDeprecationcommentsCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -351,25 +350,25 @@ Pointer<Void> smoke_DeprecationComments_toFfi(DeprecationComments value) {
 }
 DeprecationComments smoke_DeprecationComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as DeprecationComments;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_DeprecationComments_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_DeprecationComments_copy_handle(handle);
+  final _typeIdHandle = _smokeDeprecationcommentsGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeDeprecationcommentsCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : DeprecationComments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : DeprecationComments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_DeprecationComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_DeprecationComments_release_handle(handle);
+  _smokeDeprecationcommentsReleaseHandle(handle);
 Pointer<Void> smoke_DeprecationComments_toFfi_nullable(DeprecationComments value) =>
   value != null ? smoke_DeprecationComments_toFfi(value) : Pointer<Void>.fromAddress(0);
 DeprecationComments smoke_DeprecationComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_DeprecationComments_fromFfi(handle) : null;
 void smoke_DeprecationComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DeprecationComments_release_handle(handle);
+  _smokeDeprecationcommentsReleaseHandle(handle);
 // End of DeprecationComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -3,12 +3,11 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("Unfortunately, this interface is deprecated.")
 abstract class DeprecationCommentsOnly {
-  DeprecationCommentsOnly() {}
+  DeprecationCommentsOnly();
   factory DeprecationCommentsOnly.fromLambdas({
     @required bool Function(String) lambda_someMethodWithAllComments,
     @required bool Function() lambda_isSomeProperty_get,
@@ -61,34 +60,34 @@ DeprecationCommentsOnly_SomeEnum smoke_DeprecationCommentsOnly_SomeEnum_fromFfi(
   }
 }
 void smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable'));
-final _smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable'));
-final _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_DeprecationCommentsOnly_SomeEnum_toFfi_nullable(DeprecationCommentsOnly_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationCommentsOnly_SomeEnum_toFfi(value);
-  final result = _smoke_DeprecationCommentsOnly_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_DeprecationCommentsOnly_SomeEnumCreateHandleNullable(_handle);
   smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 DeprecationCommentsOnly_SomeEnum smoke_DeprecationCommentsOnly_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_DeprecationCommentsOnly_SomeEnumGetValueNullable(handle);
   final result = smoke_DeprecationCommentsOnly_SomeEnum_fromFfi(_handle);
   smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DeprecationCommentsOnly_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DeprecationCommentsOnly_SomeEnum_release_handle_nullable(handle);
+  _smoke_DeprecationCommentsOnly_SomeEnumReleaseHandleNullable(handle);
 // End of DeprecationCommentsOnly_SomeEnum "private" section.
 @Deprecated("Unfortunately, this struct is deprecated.")
 class DeprecationCommentsOnly_SomeStruct {
@@ -97,79 +96,79 @@ class DeprecationCommentsOnly_SomeStruct {
   DeprecationCommentsOnly_SomeStruct(this.someField);
 }
 // DeprecationCommentsOnly_SomeStruct "private" section, not exported.
-final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsonlySomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle'));
-final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsonlySomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle'));
-final _smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsonlySomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi(DeprecationCommentsOnly_SomeStruct value) {
-  final _someField_handle = Boolean_toFfi(value.someField);
-  final _result = _smoke_DeprecationCommentsOnly_SomeStruct_create_handle(_someField_handle);
-  Boolean_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = Boolean_toFfi(value.someField);
+  final _result = _smokeDeprecationcommentsonlySomestructCreateHandle(_someFieldHandle);
+  Boolean_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 DeprecationCommentsOnly_SomeStruct smoke_DeprecationCommentsOnly_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeDeprecationcommentsonlySomestructGetFieldsomeField(handle);
   try {
     return DeprecationCommentsOnly_SomeStruct(
-      Boolean_fromFfi(_someField_handle)
+      Boolean_fromFfi(_someFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle(_someField_handle);
+    Boolean_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_DeprecationCommentsOnly_SomeStruct_release_handle(handle);
+void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeDeprecationcommentsonlySomestructReleaseHandle(handle);
 // Nullable DeprecationCommentsOnly_SomeStruct
-final _smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable'));
-final _smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable'));
-final _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DeprecationCommentsOnly_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_DeprecationCommentsOnly_SomeStruct_toFfi_nullable(DeprecationCommentsOnly_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DeprecationCommentsOnly_SomeStruct_toFfi(value);
-  final result = _smoke_DeprecationCommentsOnly_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_DeprecationCommentsOnly_SomeStructCreateHandleNullable(_handle);
   smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 DeprecationCommentsOnly_SomeStruct smoke_DeprecationCommentsOnly_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_DeprecationCommentsOnly_SomeStructGetValueNullable(handle);
   final result = smoke_DeprecationCommentsOnly_SomeStruct_fromFfi(_handle);
   smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DeprecationCommentsOnly_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DeprecationCommentsOnly_SomeStruct_release_handle_nullable(handle);
+  _smoke_DeprecationCommentsOnly_SomeStructReleaseHandleNullable(handle);
 // End of DeprecationCommentsOnly_SomeStruct "private" section.
 // DeprecationCommentsOnly "private" section, not exported.
-final _smoke_DeprecationCommentsOnly_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsonlyCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_copy_handle'));
-final _smoke_DeprecationCommentsOnly_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsonlyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_release_handle'));
-final _smoke_DeprecationCommentsOnly_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsonlyCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_DeprecationCommentsOnly_create_proxy'));
-final _smoke_DeprecationCommentsOnly_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDeprecationcommentsonlyGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_get_type_id'));
@@ -198,53 +197,53 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_DeprecationCommentsOnly_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeDeprecationcommentsonlyReleaseHandle(handle);
     handle = null;
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @Deprecated("Unfortunately, this property's getter is deprecated.")
   bool get isSomeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @Deprecated("Unfortunately, this property's setter is deprecated.")
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _DeprecationCommentsOnly_someMethodWithAllComments_static(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(String_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(String_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
@@ -264,8 +263,8 @@ int _DeprecationCommentsOnly_isSomeProperty_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value) {
-  if (value is __lib.NativeBase) return _smoke_DeprecationCommentsOnly_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_DeprecationCommentsOnly_create_proxy(
+  if (value is __lib.NativeBase) return _smokeDeprecationcommentsonlyCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeDeprecationcommentsonlyCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -277,25 +276,25 @@ Pointer<Void> smoke_DeprecationCommentsOnly_toFfi(DeprecationCommentsOnly value)
 }
 DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as DeprecationCommentsOnly;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_DeprecationCommentsOnly_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_DeprecationCommentsOnly_copy_handle(handle);
+  final _typeIdHandle = _smokeDeprecationcommentsonlyGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeDeprecationcommentsonlyCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : DeprecationCommentsOnly$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : DeprecationCommentsOnly$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_DeprecationCommentsOnly_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_DeprecationCommentsOnly_release_handle(handle);
+  _smokeDeprecationcommentsonlyReleaseHandle(handle);
 Pointer<Void> smoke_DeprecationCommentsOnly_toFfi_nullable(DeprecationCommentsOnly value) =>
   value != null ? smoke_DeprecationCommentsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
 DeprecationCommentsOnly smoke_DeprecationCommentsOnly_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_DeprecationCommentsOnly_fromFfi(handle) : null;
 void smoke_DeprecationCommentsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DeprecationCommentsOnly_release_handle(handle);
+  _smokeDeprecationcommentsonlyReleaseHandle(handle);
 // End of DeprecationCommentsOnly "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful class.
@@ -64,34 +63,34 @@ ExcludedComments_SomeEnum smoke_ExcludedComments_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_ExcludedComments_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_ExcludedComments_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ExcludedComments_SomeEnum_create_handle_nullable'));
-final _smoke_ExcludedComments_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeEnum_release_handle_nullable'));
-final _smoke_ExcludedComments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_ExcludedComments_SomeEnum_toFfi_nullable(ExcludedComments_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedComments_SomeEnum_toFfi(value);
-  final result = _smoke_ExcludedComments_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_ExcludedComments_SomeEnumCreateHandleNullable(_handle);
   smoke_ExcludedComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 ExcludedComments_SomeEnum smoke_ExcludedComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExcludedComments_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_ExcludedComments_SomeEnumGetValueNullable(handle);
   final result = smoke_ExcludedComments_SomeEnum_fromFfi(_handle);
   smoke_ExcludedComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExcludedComments_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedComments_SomeEnum_release_handle_nullable(handle);
+  _smoke_ExcludedComments_SomeEnumReleaseHandleNullable(handle);
 // End of ExcludedComments_SomeEnum "private" section.
 /// This is some very useful exception.
 /// @nodoc
@@ -112,78 +111,78 @@ class ExcludedComments_SomeStruct {
   ExcludedComments_SomeStruct(this.someField);
 }
 // ExcludedComments_SomeStruct "private" section, not exported.
-final _smoke_ExcludedComments_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
   >('library_smoke_ExcludedComments_SomeStruct_create_handle'));
-final _smoke_ExcludedComments_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_release_handle'));
-final _smoke_ExcludedComments_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsSomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_ExcludedComments_SomeStruct_toFfi(ExcludedComments_SomeStruct value) {
-  final _someField_handle = Boolean_toFfi(value.someField);
-  final _result = _smoke_ExcludedComments_SomeStruct_create_handle(_someField_handle);
-  Boolean_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = Boolean_toFfi(value.someField);
+  final _result = _smokeExcludedcommentsSomestructCreateHandle(_someFieldHandle);
+  Boolean_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 ExcludedComments_SomeStruct smoke_ExcludedComments_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_ExcludedComments_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeExcludedcommentsSomestructGetFieldsomeField(handle);
   try {
     return ExcludedComments_SomeStruct(
-      Boolean_fromFfi(_someField_handle)
+      Boolean_fromFfi(_someFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle(_someField_handle);
+    Boolean_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_ExcludedComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExcludedComments_SomeStruct_release_handle(handle);
+void smoke_ExcludedComments_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeExcludedcommentsSomestructReleaseHandle(handle);
 // Nullable ExcludedComments_SomeStruct
-final _smoke_ExcludedComments_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_create_handle_nullable'));
-final _smoke_ExcludedComments_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_release_handle_nullable'));
-final _smoke_ExcludedComments_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_ExcludedComments_SomeStruct_toFfi_nullable(ExcludedComments_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedComments_SomeStruct_toFfi(value);
-  final result = _smoke_ExcludedComments_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_ExcludedComments_SomeStructCreateHandleNullable(_handle);
   smoke_ExcludedComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 ExcludedComments_SomeStruct smoke_ExcludedComments_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExcludedComments_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_ExcludedComments_SomeStructGetValueNullable(handle);
   final result = smoke_ExcludedComments_SomeStruct_fromFfi(_handle);
   smoke_ExcludedComments_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExcludedComments_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedComments_SomeStruct_release_handle_nullable(handle);
+  _smoke_ExcludedComments_SomeStructReleaseHandleNullable(handle);
 // End of ExcludedComments_SomeStruct "private" section.
 /// This is some very useful lambda that does it.
 /// @nodoc
 typedef ExcludedComments_SomeLambda = double Function(String, int);
 // ExcludedComments_SomeLambda "private" section, not exported.
-final _smoke_ExcludedComments_SomeLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsSomelambdaCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeLambda_copy_handle'));
-final _smoke_ExcludedComments_SomeLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsSomelambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeLambda_release_handle'));
-final _smoke_ExcludedComments_SomeLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsSomelambdaCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_ExcludedComments_SomeLambda_create_proxy'));
@@ -191,27 +190,27 @@ class ExcludedComments_SomeLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   ExcludedComments_SomeLambda$Impl(this.handle);
-  void release() => _smoke_ExcludedComments_SomeLambda_release_handle(handle);
+  void release() => _smokeExcludedcommentsSomelambdaReleaseHandle(handle);
   double call(String p0, int p1) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_ExcludedComments_SomeLambda_call__String_Int'));
-    final _p0_handle = String_toFfi(p0);
-    final _p1_handle = (p1);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_ExcludedComments_SomeLambda_call__String_Int'));
+    final _p0Handle = String_toFfi(p0);
+    final _p1Handle = (p1);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle, _p1_handle);
-    String_releaseFfiHandle(_p0_handle);
-    (_p1_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
+    String_releaseFfiHandle(_p0Handle);
+    (_p1Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _ExcludedComments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
-  double _result_object;
+  double _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as ExcludedComments_SomeLambda)(String_fromFfi(p0), (p1));
-    _result.value = (_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ExcludedComments_SomeLambda)(String_fromFfi(p0), (p1));
+    _result.value = (_resultObject);
   } finally {
     String_releaseFfiHandle(p0);
     (p1);
@@ -219,7 +218,7 @@ int _ExcludedComments_SomeLambda_call_static(int _token, Pointer<Void> p0, int p
   return 0;
 }
 Pointer<Void> smoke_ExcludedComments_SomeLambda_toFfi(ExcludedComments_SomeLambda value) {
-  final result = _smoke_ExcludedComments_SomeLambda_create_proxy(
+  final result = _smokeExcludedcommentsSomelambdaCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -228,7 +227,7 @@ Pointer<Void> smoke_ExcludedComments_SomeLambda_toFfi(ExcludedComments_SomeLambd
   return result;
 }
 ExcludedComments_SomeLambda smoke_ExcludedComments_SomeLambda_fromFfi(Pointer<Void> handle) {
-  final _impl = ExcludedComments_SomeLambda$Impl(_smoke_ExcludedComments_SomeLambda_copy_handle(handle));
+  final _impl = ExcludedComments_SomeLambda$Impl(_smokeExcludedcommentsSomelambdaCopyHandle(handle));
   return (String p0, int p1) {
     final _result =_impl.call(p0, p1);
     _impl.release();
@@ -236,59 +235,59 @@ ExcludedComments_SomeLambda smoke_ExcludedComments_SomeLambda_fromFfi(Pointer<Vo
   };
 }
 void smoke_ExcludedComments_SomeLambda_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExcludedComments_SomeLambda_release_handle(handle);
+  _smokeExcludedcommentsSomelambdaReleaseHandle(handle);
 // Nullable ExcludedComments_SomeLambda
-final _smoke_ExcludedComments_SomeLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeLambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeLambda_create_handle_nullable'));
-final _smoke_ExcludedComments_SomeLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeLambdaReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeLambda_release_handle_nullable'));
-final _smoke_ExcludedComments_SomeLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedComments_SomeLambdaGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeLambda_get_value_nullable'));
 Pointer<Void> smoke_ExcludedComments_SomeLambda_toFfi_nullable(ExcludedComments_SomeLambda value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedComments_SomeLambda_toFfi(value);
-  final result = _smoke_ExcludedComments_SomeLambda_create_handle_nullable(_handle);
+  final result = _smoke_ExcludedComments_SomeLambdaCreateHandleNullable(_handle);
   smoke_ExcludedComments_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
 ExcludedComments_SomeLambda smoke_ExcludedComments_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExcludedComments_SomeLambda_get_value_nullable(handle);
+  final _handle = _smoke_ExcludedComments_SomeLambdaGetValueNullable(handle);
   final result = smoke_ExcludedComments_SomeLambda_fromFfi(_handle);
   smoke_ExcludedComments_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExcludedComments_SomeLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedComments_SomeLambda_release_handle_nullable(handle);
+  _smoke_ExcludedComments_SomeLambdaReleaseHandleNullable(handle);
 // End of ExcludedComments_SomeLambda "private" section.
 // ExcludedComments "private" section, not exported.
-final _smoke_ExcludedComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_copy_handle'));
-final _smoke_ExcludedComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_release_handle'));
-final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_has_error'));
@@ -298,88 +297,88 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ExcludedComments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeExcludedcommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   bool someMethodWithAllComments(String inputParameter) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedComments_someMethodWithAllComments__String'));
-    final _inputParameter_handle = String_toFfi(inputParameter);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedComments_someMethodWithAllComments__String'));
+    final _inputParameterHandle = String_toFfi(inputParameter);
     final _handle = this.handle;
-    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _inputParameter_handle);
-    String_releaseFfiHandle(_inputParameter_handle);
-    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
-        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
+    String_releaseFfiHandle(_inputParameterHandle);
+    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
         try {
-          throw ExcludedComments_SomethingWrongException(smoke_ExcludedComments_SomeEnum_fromFfi(__error_handle));
+          throw ExcludedComments_SomethingWrongException(smoke_ExcludedComments_SomeEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_ExcludedComments_SomeEnum_releaseFfiHandle(__error_handle);
+          smoke_ExcludedComments_SomeEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
-    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
-    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_someMethodWithoutReturnTypeOrInputParameters'));
+    final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool get isSomeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_isSomeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_isSomeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedComments_isSomeProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedComments_isSomeProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ExcludedComments_toFfi(ExcludedComments value) =>
-  _smoke_ExcludedComments_copy_handle((value as __lib.NativeBase).handle);
+  _smokeExcludedcommentsCopyHandle((value as __lib.NativeBase).handle);
 ExcludedComments smoke_ExcludedComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ExcludedComments;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_ExcludedComments_copy_handle(handle);
-  final result = ExcludedComments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeExcludedcommentsCopyHandle(handle);
+  final result = ExcludedComments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ExcludedComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExcludedComments_release_handle(handle);
+  _smokeExcludedcommentsReleaseHandle(handle);
 Pointer<Void> smoke_ExcludedComments_toFfi_nullable(ExcludedComments value) =>
   value != null ? smoke_ExcludedComments_toFfi(value) : Pointer<Void>.fromAddress(0);
 ExcludedComments smoke_ExcludedComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExcludedComments_fromFfi(handle) : null;
 void smoke_ExcludedComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedComments_release_handle(handle);
+  _smokeExcludedcommentsReleaseHandle(handle);
 // End of ExcludedComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
@@ -16,19 +15,19 @@ abstract class ExcludedCommentsInterface {
   void release() {}
 }
 // ExcludedCommentsInterface "private" section, not exported.
-final _smoke_ExcludedCommentsInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsInterface_copy_handle'));
-final _smoke_ExcludedCommentsInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsInterface_release_handle'));
-final _smoke_ExcludedCommentsInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
   >('library_smoke_ExcludedCommentsInterface_create_proxy'));
-final _smoke_ExcludedCommentsInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsInterface_get_type_id'));
@@ -38,14 +37,14 @@ class ExcludedCommentsInterface$Impl extends __lib.NativeBase implements Exclude
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ExcludedCommentsInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeExcludedcommentsinterfaceReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_ExcludedCommentsInterface_toFfi(ExcludedCommentsInterface value) {
-  if (value is __lib.NativeBase) return _smoke_ExcludedCommentsInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_ExcludedCommentsInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeExcludedcommentsinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeExcludedcommentsinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi
@@ -54,25 +53,25 @@ Pointer<Void> smoke_ExcludedCommentsInterface_toFfi(ExcludedCommentsInterface va
 }
 ExcludedCommentsInterface smoke_ExcludedCommentsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ExcludedCommentsInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ExcludedCommentsInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ExcludedCommentsInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeExcludedcommentsinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeExcludedcommentsinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ExcludedCommentsInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ExcludedCommentsInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ExcludedCommentsInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsInterface_release_handle(handle);
+  _smokeExcludedcommentsinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_ExcludedCommentsInterface_toFfi_nullable(ExcludedCommentsInterface value) =>
   value != null ? smoke_ExcludedCommentsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 ExcludedCommentsInterface smoke_ExcludedCommentsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExcludedCommentsInterface_fromFfi(handle) : null;
 void smoke_ExcludedCommentsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsInterface_release_handle(handle);
+  _smokeExcludedcommentsinterfaceReleaseHandle(handle);
 // End of ExcludedCommentsInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
@@ -48,34 +47,34 @@ ExcludedCommentsOnly_SomeEnum smoke_ExcludedCommentsOnly_SomeEnum_fromFfi(int ha
   }
 }
 void smoke_ExcludedCommentsOnly_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_ExcludedCommentsOnly_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ExcludedCommentsOnly_SomeEnum_create_handle_nullable'));
-final _smoke_ExcludedCommentsOnly_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeEnum_release_handle_nullable'));
-final _smoke_ExcludedCommentsOnly_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_ExcludedCommentsOnly_SomeEnum_toFfi_nullable(ExcludedCommentsOnly_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedCommentsOnly_SomeEnum_toFfi(value);
-  final result = _smoke_ExcludedCommentsOnly_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_ExcludedCommentsOnly_SomeEnumCreateHandleNullable(_handle);
   smoke_ExcludedCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 ExcludedCommentsOnly_SomeEnum smoke_ExcludedCommentsOnly_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExcludedCommentsOnly_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_ExcludedCommentsOnly_SomeEnumGetValueNullable(handle);
   final result = smoke_ExcludedCommentsOnly_SomeEnum_fromFfi(_handle);
   smoke_ExcludedCommentsOnly_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExcludedCommentsOnly_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsOnly_SomeEnum_release_handle_nullable(handle);
+  _smoke_ExcludedCommentsOnly_SomeEnumReleaseHandleNullable(handle);
 // End of ExcludedCommentsOnly_SomeEnum "private" section.
 /// @nodoc
 class ExcludedCommentsOnly_SomethingWrongException implements Exception {
@@ -89,77 +88,77 @@ class ExcludedCommentsOnly_SomeStruct {
   ExcludedCommentsOnly_SomeStruct(this.someField);
 }
 // ExcludedCommentsOnly_SomeStruct "private" section, not exported.
-final _smoke_ExcludedCommentsOnly_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlySomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_create_handle'));
-final _smoke_ExcludedCommentsOnly_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlySomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_release_handle'));
-final _smoke_ExcludedCommentsOnly_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlySomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_ExcludedCommentsOnly_SomeStruct_toFfi(ExcludedCommentsOnly_SomeStruct value) {
-  final _someField_handle = Boolean_toFfi(value.someField);
-  final _result = _smoke_ExcludedCommentsOnly_SomeStruct_create_handle(_someField_handle);
-  Boolean_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = Boolean_toFfi(value.someField);
+  final _result = _smokeExcludedcommentsonlySomestructCreateHandle(_someFieldHandle);
+  Boolean_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 ExcludedCommentsOnly_SomeStruct smoke_ExcludedCommentsOnly_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_ExcludedCommentsOnly_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeExcludedcommentsonlySomestructGetFieldsomeField(handle);
   try {
     return ExcludedCommentsOnly_SomeStruct(
-      Boolean_fromFfi(_someField_handle)
+      Boolean_fromFfi(_someFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle(_someField_handle);
+    Boolean_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_ExcludedCommentsOnly_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExcludedCommentsOnly_SomeStruct_release_handle(handle);
+void smoke_ExcludedCommentsOnly_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeExcludedcommentsonlySomestructReleaseHandle(handle);
 // Nullable ExcludedCommentsOnly_SomeStruct
-final _smoke_ExcludedCommentsOnly_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_create_handle_nullable'));
-final _smoke_ExcludedCommentsOnly_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_release_handle_nullable'));
-final _smoke_ExcludedCommentsOnly_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_ExcludedCommentsOnly_SomeStruct_toFfi_nullable(ExcludedCommentsOnly_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedCommentsOnly_SomeStruct_toFfi(value);
-  final result = _smoke_ExcludedCommentsOnly_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_ExcludedCommentsOnly_SomeStructCreateHandleNullable(_handle);
   smoke_ExcludedCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 ExcludedCommentsOnly_SomeStruct smoke_ExcludedCommentsOnly_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExcludedCommentsOnly_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_ExcludedCommentsOnly_SomeStructGetValueNullable(handle);
   final result = smoke_ExcludedCommentsOnly_SomeStruct_fromFfi(_handle);
   smoke_ExcludedCommentsOnly_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExcludedCommentsOnly_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsOnly_SomeStruct_release_handle_nullable(handle);
+  _smoke_ExcludedCommentsOnly_SomeStructReleaseHandleNullable(handle);
 // End of ExcludedCommentsOnly_SomeStruct "private" section.
 /// @nodoc
 typedef ExcludedCommentsOnly_SomeLambda = double Function(String, int);
 // ExcludedCommentsOnly_SomeLambda "private" section, not exported.
-final _smoke_ExcludedCommentsOnly_SomeLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlySomelambdaCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_copy_handle'));
-final _smoke_ExcludedCommentsOnly_SomeLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlySomelambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_release_handle'));
-final _smoke_ExcludedCommentsOnly_SomeLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlySomelambdaCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_create_proxy'));
@@ -167,27 +166,27 @@ class ExcludedCommentsOnly_SomeLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   ExcludedCommentsOnly_SomeLambda$Impl(this.handle);
-  void release() => _smoke_ExcludedCommentsOnly_SomeLambda_release_handle(handle);
+  void release() => _smokeExcludedcommentsonlySomelambdaReleaseHandle(handle);
   double call(String p0, int p1) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_SomeLambda_call__String_Int'));
-    final _p0_handle = String_toFfi(p0);
-    final _p1_handle = (p1);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_SomeLambda_call__String_Int'));
+    final _p0Handle = String_toFfi(p0);
+    final _p1Handle = (p1);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle, _p1_handle);
-    String_releaseFfiHandle(_p0_handle);
-    (_p1_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
+    String_releaseFfiHandle(_p0Handle);
+    (_p1Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _ExcludedCommentsOnly_SomeLambda_call_static(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
-  double _result_object;
+  double _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as ExcludedCommentsOnly_SomeLambda)(String_fromFfi(p0), (p1));
-    _result.value = (_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ExcludedCommentsOnly_SomeLambda)(String_fromFfi(p0), (p1));
+    _result.value = (_resultObject);
   } finally {
     String_releaseFfiHandle(p0);
     (p1);
@@ -195,7 +194,7 @@ int _ExcludedCommentsOnly_SomeLambda_call_static(int _token, Pointer<Void> p0, i
   return 0;
 }
 Pointer<Void> smoke_ExcludedCommentsOnly_SomeLambda_toFfi(ExcludedCommentsOnly_SomeLambda value) {
-  final result = _smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(
+  final result = _smokeExcludedcommentsonlySomelambdaCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -204,7 +203,7 @@ Pointer<Void> smoke_ExcludedCommentsOnly_SomeLambda_toFfi(ExcludedCommentsOnly_S
   return result;
 }
 ExcludedCommentsOnly_SomeLambda smoke_ExcludedCommentsOnly_SomeLambda_fromFfi(Pointer<Void> handle) {
-  final _impl = ExcludedCommentsOnly_SomeLambda$Impl(_smoke_ExcludedCommentsOnly_SomeLambda_copy_handle(handle));
+  final _impl = ExcludedCommentsOnly_SomeLambda$Impl(_smokeExcludedcommentsonlySomelambdaCopyHandle(handle));
   return (String p0, int p1) {
     final _result =_impl.call(p0, p1);
     _impl.release();
@@ -212,59 +211,59 @@ ExcludedCommentsOnly_SomeLambda smoke_ExcludedCommentsOnly_SomeLambda_fromFfi(Po
   };
 }
 void smoke_ExcludedCommentsOnly_SomeLambda_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsOnly_SomeLambda_release_handle(handle);
+  _smokeExcludedcommentsonlySomelambdaReleaseHandle(handle);
 // Nullable ExcludedCommentsOnly_SomeLambda
-final _smoke_ExcludedCommentsOnly_SomeLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeLambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_create_handle_nullable'));
-final _smoke_ExcludedCommentsOnly_SomeLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeLambdaReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_release_handle_nullable'));
-final _smoke_ExcludedCommentsOnly_SomeLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExcludedCommentsOnly_SomeLambdaGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_get_value_nullable'));
 Pointer<Void> smoke_ExcludedCommentsOnly_SomeLambda_toFfi_nullable(ExcludedCommentsOnly_SomeLambda value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExcludedCommentsOnly_SomeLambda_toFfi(value);
-  final result = _smoke_ExcludedCommentsOnly_SomeLambda_create_handle_nullable(_handle);
+  final result = _smoke_ExcludedCommentsOnly_SomeLambdaCreateHandleNullable(_handle);
   smoke_ExcludedCommentsOnly_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
 ExcludedCommentsOnly_SomeLambda smoke_ExcludedCommentsOnly_SomeLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExcludedCommentsOnly_SomeLambda_get_value_nullable(handle);
+  final _handle = _smoke_ExcludedCommentsOnly_SomeLambdaGetValueNullable(handle);
   final result = smoke_ExcludedCommentsOnly_SomeLambda_fromFfi(_handle);
   smoke_ExcludedCommentsOnly_SomeLambda_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExcludedCommentsOnly_SomeLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsOnly_SomeLambda_release_handle_nullable(handle);
+  _smoke_ExcludedCommentsOnly_SomeLambdaReleaseHandleNullable(handle);
 // End of ExcludedCommentsOnly_SomeLambda "private" section.
 // ExcludedCommentsOnly "private" section, not exported.
-final _smoke_ExcludedCommentsOnly_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlyCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_copy_handle'));
-final _smoke_ExcludedCommentsOnly_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExcludedcommentsonlyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_release_handle'));
-final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_has_error'));
@@ -274,88 +273,88 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ExcludedCommentsOnly_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeExcludedcommentsonlyReleaseHandle(handle);
     handle = null;
   }
   @override
   bool someMethodWithAllComments(String inputParameter) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String'));
-    final _inputParameter_handle = String_toFfi(inputParameter);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String'));
+    final _inputParameterHandle = String_toFfi(inputParameter);
     final _handle = this.handle;
-    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _inputParameter_handle);
-    String_releaseFfiHandle(_inputParameter_handle);
-    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
-        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
+    String_releaseFfiHandle(_inputParameterHandle);
+    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
         try {
-          throw ExcludedCommentsOnly_SomethingWrongException(smoke_ExcludedCommentsOnly_SomeEnum_fromFfi(__error_handle));
+          throw ExcludedCommentsOnly_SomethingWrongException(smoke_ExcludedCommentsOnly_SomeEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_ExcludedCommentsOnly_SomeEnum_releaseFfiHandle(__error_handle);
+          smoke_ExcludedCommentsOnly_SomeEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
-    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   someMethodWithoutReturnTypeOrInputParameters() {
-    final _someMethodWithoutReturnTypeOrInputParameters_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_someMethodWithoutReturnTypeOrInputParameters'));
+    final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __result_handle = _someMethodWithoutReturnTypeOrInputParameters_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool get isSomeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set isSomeProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ExcludedCommentsOnly_toFfi(ExcludedCommentsOnly value) =>
-  _smoke_ExcludedCommentsOnly_copy_handle((value as __lib.NativeBase).handle);
+  _smokeExcludedcommentsonlyCopyHandle((value as __lib.NativeBase).handle);
 ExcludedCommentsOnly smoke_ExcludedCommentsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ExcludedCommentsOnly;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_ExcludedCommentsOnly_copy_handle(handle);
-  final result = ExcludedCommentsOnly$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeExcludedcommentsonlyCopyHandle(handle);
+  final result = ExcludedCommentsOnly$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ExcludedCommentsOnly_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsOnly_release_handle(handle);
+  _smokeExcludedcommentsonlyReleaseHandle(handle);
 Pointer<Void> smoke_ExcludedCommentsOnly_toFfi_nullable(ExcludedCommentsOnly value) =>
   value != null ? smoke_ExcludedCommentsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
 ExcludedCommentsOnly smoke_ExcludedCommentsOnly_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExcludedCommentsOnly_fromFfi(handle) : null;
 void smoke_ExcludedCommentsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExcludedCommentsOnly_release_handle(handle);
+  _smokeExcludedcommentsonlyReleaseHandle(handle);
 // End of ExcludedCommentsOnly "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This looks internal
@@ -19,11 +18,11 @@ abstract class InternalClassWithComments {
   internal_doNothing();
 }
 // InternalClassWithComments "private" section, not exported.
-final _smoke_InternalClassWithComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclasswithcommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalClassWithComments_copy_handle'));
-final _smoke_InternalClassWithComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclasswithcommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithComments_release_handle'));
@@ -33,40 +32,40 @@ class InternalClassWithComments$Impl extends __lib.NativeBase implements Interna
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_InternalClassWithComments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeInternalclasswithcommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   internal_doNothing() {
-    final _doNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));
+    final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));
     final _handle = this.handle;
-    final __result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_InternalClassWithComments_toFfi(InternalClassWithComments value) =>
-  _smoke_InternalClassWithComments_copy_handle((value as __lib.NativeBase).handle);
+  _smokeInternalclasswithcommentsCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithComments smoke_InternalClassWithComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as InternalClassWithComments;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_InternalClassWithComments_copy_handle(handle);
-  final result = InternalClassWithComments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeInternalclasswithcommentsCopyHandle(handle);
+  final result = InternalClassWithComments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_InternalClassWithComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_InternalClassWithComments_release_handle(handle);
+  _smokeInternalclasswithcommentsReleaseHandle(handle);
 Pointer<Void> smoke_InternalClassWithComments_toFfi_nullable(InternalClassWithComments value) =>
   value != null ? smoke_InternalClassWithComments_toFfi(value) : Pointer<Void>.fromAddress(0);
 InternalClassWithComments smoke_InternalClassWithComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClassWithComments_fromFfi(handle) : null;
 void smoke_InternalClassWithComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_InternalClassWithComments_release_handle(handle);
+  _smokeInternalclasswithcommentsReleaseHandle(handle);
 // End of InternalClassWithComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// Referencing some type [MapScene.loadSceneWithInt].
@@ -17,15 +16,15 @@ abstract class MapScene {
 }
 typedef MapScene_LoadSceneCallback = void Function(String);
 // MapScene_LoadSceneCallback "private" section, not exported.
-final _smoke_MapScene_LoadSceneCallback_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMapsceneLoadscenecallbackCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MapScene_LoadSceneCallback_copy_handle'));
-final _smoke_MapScene_LoadSceneCallback_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMapsceneLoadscenecallbackReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MapScene_LoadSceneCallback_release_handle'));
-final _smoke_MapScene_LoadSceneCallback_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMapsceneLoadscenecallbackCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_MapScene_LoadSceneCallback_create_proxy'));
@@ -33,17 +32,17 @@ class MapScene_LoadSceneCallback$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   MapScene_LoadSceneCallback$Impl(this.handle);
-  void release() => _smoke_MapScene_LoadSceneCallback_release_handle(handle);
+  void release() => _smokeMapsceneLoadscenecallbackReleaseHandle(handle);
   call(String p0) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MapScene_LoadSceneCallback_call__String'));
-    final _p0_handle = String_toFfi_nullable(p0);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MapScene_LoadSceneCallback_call__String'));
+    final _p0Handle = String_toFfi_nullable(p0);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
-    String_releaseFfiHandle_nullable(_p0_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    String_releaseFfiHandle_nullable(_p0Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -56,7 +55,7 @@ int _MapScene_LoadSceneCallback_call_static(int _token, Pointer<Void> p0) {
   return 0;
 }
 Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi(MapScene_LoadSceneCallback value) {
-  final result = _smoke_MapScene_LoadSceneCallback_create_proxy(
+  final result = _smokeMapsceneLoadscenecallbackCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -65,7 +64,7 @@ Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi(MapScene_LoadSceneCallback 
   return result;
 }
 MapScene_LoadSceneCallback smoke_MapScene_LoadSceneCallback_fromFfi(Pointer<Void> handle) {
-  final _impl = MapScene_LoadSceneCallback$Impl(_smoke_MapScene_LoadSceneCallback_copy_handle(handle));
+  final _impl = MapScene_LoadSceneCallback$Impl(_smokeMapsceneLoadscenecallbackCopyHandle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -73,43 +72,43 @@ MapScene_LoadSceneCallback smoke_MapScene_LoadSceneCallback_fromFfi(Pointer<Void
   };
 }
 void smoke_MapScene_LoadSceneCallback_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_MapScene_LoadSceneCallback_release_handle(handle);
+  _smokeMapsceneLoadscenecallbackReleaseHandle(handle);
 // Nullable MapScene_LoadSceneCallback
-final _smoke_MapScene_LoadSceneCallback_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_MapScene_LoadSceneCallbackCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MapScene_LoadSceneCallback_create_handle_nullable'));
-final _smoke_MapScene_LoadSceneCallback_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_MapScene_LoadSceneCallbackReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MapScene_LoadSceneCallback_release_handle_nullable'));
-final _smoke_MapScene_LoadSceneCallback_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_MapScene_LoadSceneCallbackGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MapScene_LoadSceneCallback_get_value_nullable'));
 Pointer<Void> smoke_MapScene_LoadSceneCallback_toFfi_nullable(MapScene_LoadSceneCallback value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_MapScene_LoadSceneCallback_toFfi(value);
-  final result = _smoke_MapScene_LoadSceneCallback_create_handle_nullable(_handle);
+  final result = _smoke_MapScene_LoadSceneCallbackCreateHandleNullable(_handle);
   smoke_MapScene_LoadSceneCallback_releaseFfiHandle(_handle);
   return result;
 }
 MapScene_LoadSceneCallback smoke_MapScene_LoadSceneCallback_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_MapScene_LoadSceneCallback_get_value_nullable(handle);
+  final _handle = _smoke_MapScene_LoadSceneCallbackGetValueNullable(handle);
   final result = smoke_MapScene_LoadSceneCallback_fromFfi(_handle);
   smoke_MapScene_LoadSceneCallback_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_MapScene_LoadSceneCallback_release_handle_nullable(handle);
+  _smoke_MapScene_LoadSceneCallbackReleaseHandleNullable(handle);
 // End of MapScene_LoadSceneCallback "private" section.
 // MapScene "private" section, not exported.
-final _smoke_MapScene_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMapsceneCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MapScene_copy_handle'));
-final _smoke_MapScene_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMapsceneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MapScene_release_handle'));
@@ -119,59 +118,59 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_MapScene_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeMapsceneReleaseHandle(handle);
     handle = null;
   }
   @override
   loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback callback) {
-    final _loadSceneWithInt_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_MapScene_loadScene__Int_LoadSceneCallback'));
-    final _mapScheme_handle = (mapScheme);
-    final _callback_handle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
+    final _loadSceneWithIntFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_MapScene_loadScene__Int_LoadSceneCallback'));
+    final _mapSchemeHandle = (mapScheme);
+    final _callbackHandle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
     final _handle = this.handle;
-    final __result_handle = _loadSceneWithInt_ffi(_handle, __lib.LibraryContext.isolateId, _mapScheme_handle, _callback_handle);
-    (_mapScheme_handle);
-    smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(_callback_handle);
+    final __resultHandle = _loadSceneWithIntFfi(_handle, __lib.LibraryContext.isolateId, _mapSchemeHandle, _callbackHandle);
+    (_mapSchemeHandle);
+    smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(_callbackHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback callback) {
-    final _loadSceneWithString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MapScene_loadScene__String_LoadSceneCallback'));
-    final _configurationFile_handle = String_toFfi(configurationFile);
-    final _callback_handle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
+    final _loadSceneWithStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MapScene_loadScene__String_LoadSceneCallback'));
+    final _configurationFileHandle = String_toFfi(configurationFile);
+    final _callbackHandle = smoke_MapScene_LoadSceneCallback_toFfi_nullable(callback);
     final _handle = this.handle;
-    final __result_handle = _loadSceneWithString_ffi(_handle, __lib.LibraryContext.isolateId, _configurationFile_handle, _callback_handle);
-    String_releaseFfiHandle(_configurationFile_handle);
-    smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(_callback_handle);
+    final __resultHandle = _loadSceneWithStringFfi(_handle, __lib.LibraryContext.isolateId, _configurationFileHandle, _callbackHandle);
+    String_releaseFfiHandle(_configurationFileHandle);
+    smoke_MapScene_LoadSceneCallback_releaseFfiHandle_nullable(_callbackHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_MapScene_toFfi(MapScene value) =>
-  _smoke_MapScene_copy_handle((value as __lib.NativeBase).handle);
+  _smokeMapsceneCopyHandle((value as __lib.NativeBase).handle);
 MapScene smoke_MapScene_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as MapScene;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_MapScene_copy_handle(handle);
-  final result = MapScene$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeMapsceneCopyHandle(handle);
+  final result = MapScene$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_MapScene_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_MapScene_release_handle(handle);
+  _smokeMapsceneReleaseHandle(handle);
 Pointer<Void> smoke_MapScene_toFfi_nullable(MapScene value) =>
   value != null ? smoke_MapScene_toFfi(value) : Pointer<Void>.fromAddress(0);
 MapScene smoke_MapScene_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MapScene_fromFfi(handle) : null;
 void smoke_MapScene_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_MapScene_release_handle(handle);
+  _smokeMapsceneReleaseHandle(handle);
 // End of MapScene "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
@@ -46,11 +45,11 @@ abstract class MultiLineComments {
   double someMethodWithLongComment(String input, double ratio);
 }
 // MultiLineComments "private" section, not exported.
-final _smoke_MultiLineComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMultilinecommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MultiLineComments_copy_handle'));
-final _smoke_MultiLineComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMultilinecommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MultiLineComments_release_handle'));
@@ -60,44 +59,44 @@ class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineCommen
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_MultiLineComments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeMultilinecommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   double someMethodWithLongComment(String input, double ratio) {
-    final _someMethodWithLongComment_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32, Pointer<Void>, Double), double Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_MultiLineComments_someMethodWithLongComment__String_Double'));
-    final _input_handle = String_toFfi(input);
-    final _ratio_handle = (ratio);
+    final _someMethodWithLongCommentFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32, Pointer<Void>, Double), double Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_MultiLineComments_someMethodWithLongComment__String_Double'));
+    final _inputHandle = String_toFfi(input);
+    final _ratioHandle = (ratio);
     final _handle = this.handle;
-    final __result_handle = _someMethodWithLongComment_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle, _ratio_handle);
-    String_releaseFfiHandle(_input_handle);
-    (_ratio_handle);
+    final __resultHandle = _someMethodWithLongCommentFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle, _ratioHandle);
+    String_releaseFfiHandle(_inputHandle);
+    (_ratioHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_MultiLineComments_toFfi(MultiLineComments value) =>
-  _smoke_MultiLineComments_copy_handle((value as __lib.NativeBase).handle);
+  _smokeMultilinecommentsCopyHandle((value as __lib.NativeBase).handle);
 MultiLineComments smoke_MultiLineComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as MultiLineComments;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_MultiLineComments_copy_handle(handle);
-  final result = MultiLineComments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeMultilinecommentsCopyHandle(handle);
+  final result = MultiLineComments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_MultiLineComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_MultiLineComments_release_handle(handle);
+  _smokeMultilinecommentsReleaseHandle(handle);
 Pointer<Void> smoke_MultiLineComments_toFfi_nullable(MultiLineComments value) =>
   value != null ? smoke_MultiLineComments_toFfi(value) : Pointer<Void>.fromAddress(0);
 MultiLineComments smoke_MultiLineComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MultiLineComments_fromFfi(handle) : null;
 void smoke_MultiLineComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_MultiLineComments_release_handle(handle);
+  _smokeMultilinecommentsReleaseHandle(handle);
 // End of MultiLineComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PlatformComments {
@@ -59,34 +58,34 @@ PlatformComments_SomeEnum smoke_PlatformComments_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_PlatformComments_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_PlatformComments_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_PlatformComments_SomeEnum_create_handle_nullable'));
-final _smoke_PlatformComments_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_SomeEnum_release_handle_nullable'));
-final _smoke_PlatformComments_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_PlatformComments_SomeEnum_toFfi_nullable(PlatformComments_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformComments_SomeEnum_toFfi(value);
-  final result = _smoke_PlatformComments_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_PlatformComments_SomeEnumCreateHandleNullable(_handle);
   smoke_PlatformComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 PlatformComments_SomeEnum smoke_PlatformComments_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PlatformComments_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_PlatformComments_SomeEnumGetValueNullable(handle);
   final result = smoke_PlatformComments_SomeEnum_fromFfi(_handle);
   smoke_PlatformComments_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PlatformComments_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformComments_SomeEnum_release_handle_nullable(handle);
+  _smoke_PlatformComments_SomeEnumReleaseHandleNullable(handle);
 // End of PlatformComments_SomeEnum "private" section.
 /// An exception when something goes wrong.
 class PlatformComments_SomethingWrongException implements Exception {
@@ -99,87 +98,87 @@ class PlatformComments_Something {
   PlatformComments_Something(this.nothing);
 }
 // PlatformComments_Something "private" section, not exported.
-final _smoke_PlatformComments_Something_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformcommentsSomethingCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_create_handle'));
-final _smoke_PlatformComments_Something_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformcommentsSomethingReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_release_handle'));
-final _smoke_PlatformComments_Something_get_field_nothing = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformcommentsSomethingGetFieldnothing = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_get_field_nothing'));
 Pointer<Void> smoke_PlatformComments_Something_toFfi(PlatformComments_Something value) {
-  final _nothing_handle = String_toFfi(value.nothing);
-  final _result = _smoke_PlatformComments_Something_create_handle(_nothing_handle);
-  String_releaseFfiHandle(_nothing_handle);
+  final _nothingHandle = String_toFfi(value.nothing);
+  final _result = _smokePlatformcommentsSomethingCreateHandle(_nothingHandle);
+  String_releaseFfiHandle(_nothingHandle);
   return _result;
 }
 PlatformComments_Something smoke_PlatformComments_Something_fromFfi(Pointer<Void> handle) {
-  final _nothing_handle = _smoke_PlatformComments_Something_get_field_nothing(handle);
+  final _nothingHandle = _smokePlatformcommentsSomethingGetFieldnothing(handle);
   try {
     return PlatformComments_Something(
-      String_fromFfi(_nothing_handle)
+      String_fromFfi(_nothingHandle)
     );
   } finally {
-    String_releaseFfiHandle(_nothing_handle);
+    String_releaseFfiHandle(_nothingHandle);
   }
 }
-void smoke_PlatformComments_Something_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformComments_Something_release_handle(handle);
+void smoke_PlatformComments_Something_releaseFfiHandle(Pointer<Void> handle) => _smokePlatformcommentsSomethingReleaseHandle(handle);
 // Nullable PlatformComments_Something
-final _smoke_PlatformComments_Something_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_SomethingCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_create_handle_nullable'));
-final _smoke_PlatformComments_Something_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_SomethingReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_release_handle_nullable'));
-final _smoke_PlatformComments_Something_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformComments_SomethingGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_get_value_nullable'));
 Pointer<Void> smoke_PlatformComments_Something_toFfi_nullable(PlatformComments_Something value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformComments_Something_toFfi(value);
-  final result = _smoke_PlatformComments_Something_create_handle_nullable(_handle);
+  final result = _smoke_PlatformComments_SomethingCreateHandleNullable(_handle);
   smoke_PlatformComments_Something_releaseFfiHandle(_handle);
   return result;
 }
 PlatformComments_Something smoke_PlatformComments_Something_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PlatformComments_Something_get_value_nullable(handle);
+  final _handle = _smoke_PlatformComments_SomethingGetValueNullable(handle);
   final result = smoke_PlatformComments_Something_fromFfi(_handle);
   smoke_PlatformComments_Something_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PlatformComments_Something_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformComments_Something_release_handle_nullable(handle);
+  _smoke_PlatformComments_SomethingReleaseHandleNullable(handle);
 // End of PlatformComments_Something "private" section.
 // PlatformComments "private" section, not exported.
-final _smoke_PlatformComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformcommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_copy_handle'));
-final _smoke_PlatformComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformcommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_release_handle'));
-final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error'));
@@ -189,86 +188,86 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_PlatformComments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokePlatformcommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   doNothing() {
-    final _doNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));
+    final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));
     final _handle = this.handle;
-    final __result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   doMagic() {
-    final _doMagic_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic'));
+    final _doMagicFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic'));
     final _handle = this.handle;
-    final __result_handle = _doMagic_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _doMagicFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
-        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
+    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
         try {
-          throw PlatformComments_SomethingWrongException(smoke_PlatformComments_SomeEnum_fromFfi(__error_handle));
+          throw PlatformComments_SomethingWrongException(smoke_PlatformComments_SomeEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_PlatformComments_SomeEnum_releaseFfiHandle(__error_handle);
+          smoke_PlatformComments_SomeEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
-    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   someDeprecatedMethod() {
-    final _someDeprecatedMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod'));
+    final _someDeprecatedMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod'));
     final _handle = this.handle;
-    final __result_handle = _someDeprecatedMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _someDeprecatedMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_PlatformComments_toFfi(PlatformComments value) =>
-  _smoke_PlatformComments_copy_handle((value as __lib.NativeBase).handle);
+  _smokePlatformcommentsCopyHandle((value as __lib.NativeBase).handle);
 PlatformComments smoke_PlatformComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as PlatformComments;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_PlatformComments_copy_handle(handle);
-  final result = PlatformComments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokePlatformcommentsCopyHandle(handle);
+  final result = PlatformComments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_PlatformComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PlatformComments_release_handle(handle);
+  _smokePlatformcommentsReleaseHandle(handle);
 Pointer<Void> smoke_PlatformComments_toFfi_nullable(PlatformComments value) =>
   value != null ? smoke_PlatformComments_toFfi(value) : Pointer<Void>.fromAddress(0);
 PlatformComments smoke_PlatformComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PlatformComments_fromFfi(handle) : null;
 void smoke_PlatformComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformComments_release_handle(handle);
+  _smokePlatformcommentsReleaseHandle(handle);
 // End of PlatformComments "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UnicodeComments {
@@ -23,27 +22,27 @@ abstract class UnicodeComments {
   bool someMethodWithAllComments(String input);
 }
 // UnicodeComments "private" section, not exported.
-final _smoke_UnicodeComments_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUnicodecommentsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_copy_handle'));
-final _smoke_UnicodeComments_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUnicodecommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_release_handle'));
-final _someMethodWithAllComments_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllComments_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllComments_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllComments_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error'));
@@ -53,53 +52,53 @@ class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_UnicodeComments_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeUnicodecommentsReleaseHandle(handle);
     handle = null;
   }
   @override
   bool someMethodWithAllComments(String input) {
-    final _someMethodWithAllComments_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));
-    final _input_handle = String_toFfi(input);
+    final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __call_result_handle = _someMethodWithAllComments_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    if (_someMethodWithAllComments_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _someMethodWithAllComments_return_get_error(__call_result_handle);
-        _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
+    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
         try {
-          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__error_handle));
+          throw Comments_SomethingWrongException(smoke_Comments_SomeEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_Comments_SomeEnum_releaseFfiHandle(__error_handle);
+          smoke_Comments_SomeEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _someMethodWithAllComments_return_get_result(__call_result_handle);
-    _someMethodWithAllComments_return_release_handle(__call_result_handle);
+    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_UnicodeComments_toFfi(UnicodeComments value) =>
-  _smoke_UnicodeComments_copy_handle((value as __lib.NativeBase).handle);
+  _smokeUnicodecommentsCopyHandle((value as __lib.NativeBase).handle);
 UnicodeComments smoke_UnicodeComments_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as UnicodeComments;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_UnicodeComments_copy_handle(handle);
-  final result = UnicodeComments$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeUnicodecommentsCopyHandle(handle);
+  final result = UnicodeComments$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_UnicodeComments_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_UnicodeComments_release_handle(handle);
+  _smokeUnicodecommentsReleaseHandle(handle);
 Pointer<Void> smoke_UnicodeComments_toFfi_nullable(UnicodeComments value) =>
   value != null ? smoke_UnicodeComments_toFfi(value) : Pointer<Void>.fromAddress(0);
 UnicodeComments smoke_UnicodeComments_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UnicodeComments_fromFfi(handle) : null;
 void smoke_UnicodeComments_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_UnicodeComments_release_handle(handle);
+  _smokeUnicodecommentsReleaseHandle(handle);
 // End of UnicodeComments "private" section.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class CollectionConstants {
@@ -16,11 +15,11 @@ abstract class CollectionConstants {
   static final Map<List<String>, Set<String>> mixedConstant = {["foo"]: {"bar"}};
 }
 // CollectionConstants "private" section, not exported.
-final _smoke_CollectionConstants_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCollectionconstantsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CollectionConstants_copy_handle'));
-final _smoke_CollectionConstants_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCollectionconstantsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CollectionConstants_release_handle'));
@@ -30,29 +29,29 @@ class CollectionConstants$Impl extends __lib.NativeBase implements CollectionCon
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_CollectionConstants_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeCollectionconstantsReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_CollectionConstants_toFfi(CollectionConstants value) =>
-  _smoke_CollectionConstants_copy_handle((value as __lib.NativeBase).handle);
+  _smokeCollectionconstantsCopyHandle((value as __lib.NativeBase).handle);
 CollectionConstants smoke_CollectionConstants_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as CollectionConstants;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_CollectionConstants_copy_handle(handle);
-  final result = CollectionConstants$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeCollectionconstantsCopyHandle(handle);
+  final result = CollectionConstants$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_CollectionConstants_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_CollectionConstants_release_handle(handle);
+  _smokeCollectionconstantsReleaseHandle(handle);
 Pointer<Void> smoke_CollectionConstants_toFfi_nullable(CollectionConstants value) =>
   value != null ? smoke_CollectionConstants_toFfi(value) : Pointer<Void>.fromAddress(0);
 CollectionConstants smoke_CollectionConstants_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CollectionConstants_fromFfi(handle) : null;
 void smoke_CollectionConstants_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CollectionConstants_release_handle(handle);
+  _smokeCollectionconstantsReleaseHandle(handle);
 // End of CollectionConstants "private" section.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
@@ -1,8 +1,6 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 enum StateEnum {
     off,
     on
@@ -33,34 +31,34 @@ StateEnum smoke_Constants_StateEnum_fromFfi(int handle) {
   }
 }
 void smoke_Constants_StateEnum_releaseFfiHandle(int handle) {}
-final _smoke_Constants_StateEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Constants_StateEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Constants_StateEnum_create_handle_nullable'));
-final _smoke_Constants_StateEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Constants_StateEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Constants_StateEnum_release_handle_nullable'));
-final _smoke_Constants_StateEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Constants_StateEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constants_StateEnum_get_value_nullable'));
 Pointer<Void> smoke_Constants_StateEnum_toFfi_nullable(StateEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Constants_StateEnum_toFfi(value);
-  final result = _smoke_Constants_StateEnum_create_handle_nullable(_handle);
+  final result = _smoke_Constants_StateEnumCreateHandleNullable(_handle);
   smoke_Constants_StateEnum_releaseFfiHandle(_handle);
   return result;
 }
 StateEnum smoke_Constants_StateEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Constants_StateEnum_get_value_nullable(handle);
+  final _handle = _smoke_Constants_StateEnumGetValueNullable(handle);
   final result = smoke_Constants_StateEnum_fromFfi(_handle);
   smoke_Constants_StateEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Constants_StateEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Constants_StateEnum_release_handle_nullable(handle);
+  _smoke_Constants_StateEnumReleaseHandleNullable(handle);
 // End of StateEnum "private" section.
 final bool boolConstant = true;
 final int intConstant = -11;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ConstantsInterface {
@@ -48,41 +47,41 @@ ConstantsInterface_StateEnum smoke_ConstantsInterface_StateEnum_fromFfi(int hand
   }
 }
 void smoke_ConstantsInterface_StateEnum_releaseFfiHandle(int handle) {}
-final _smoke_ConstantsInterface_StateEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ConstantsInterface_StateEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ConstantsInterface_StateEnum_create_handle_nullable'));
-final _smoke_ConstantsInterface_StateEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ConstantsInterface_StateEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_StateEnum_release_handle_nullable'));
-final _smoke_ConstantsInterface_StateEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ConstantsInterface_StateEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_StateEnum_get_value_nullable'));
 Pointer<Void> smoke_ConstantsInterface_StateEnum_toFfi_nullable(ConstantsInterface_StateEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ConstantsInterface_StateEnum_toFfi(value);
-  final result = _smoke_ConstantsInterface_StateEnum_create_handle_nullable(_handle);
+  final result = _smoke_ConstantsInterface_StateEnumCreateHandleNullable(_handle);
   smoke_ConstantsInterface_StateEnum_releaseFfiHandle(_handle);
   return result;
 }
 ConstantsInterface_StateEnum smoke_ConstantsInterface_StateEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ConstantsInterface_StateEnum_get_value_nullable(handle);
+  final _handle = _smoke_ConstantsInterface_StateEnumGetValueNullable(handle);
   final result = smoke_ConstantsInterface_StateEnum_fromFfi(_handle);
   smoke_ConstantsInterface_StateEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ConstantsInterface_StateEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ConstantsInterface_StateEnum_release_handle_nullable(handle);
+  _smoke_ConstantsInterface_StateEnumReleaseHandleNullable(handle);
 // End of ConstantsInterface_StateEnum "private" section.
 // ConstantsInterface "private" section, not exported.
-final _smoke_ConstantsInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeConstantsinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_copy_handle'));
-final _smoke_ConstantsInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeConstantsinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_release_handle'));
@@ -92,29 +91,29 @@ class ConstantsInterface$Impl extends __lib.NativeBase implements ConstantsInter
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ConstantsInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeConstantsinterfaceReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_ConstantsInterface_toFfi(ConstantsInterface value) =>
-  _smoke_ConstantsInterface_copy_handle((value as __lib.NativeBase).handle);
+  _smokeConstantsinterfaceCopyHandle((value as __lib.NativeBase).handle);
 ConstantsInterface smoke_ConstantsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ConstantsInterface;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_ConstantsInterface_copy_handle(handle);
-  final result = ConstantsInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeConstantsinterfaceCopyHandle(handle);
+  final result = ConstantsInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ConstantsInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ConstantsInterface_release_handle(handle);
+  _smokeConstantsinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_ConstantsInterface_toFfi_nullable(ConstantsInterface value) =>
   value != null ? smoke_ConstantsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 ConstantsInterface smoke_ConstantsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ConstantsInterface_fromFfi(handle) : null;
 void smoke_ConstantsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ConstantsInterface_release_handle(handle);
+  _smokeConstantsinterfaceReleaseHandle(handle);
 // End of ConstantsInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/constants.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 final StateEnum fooBar = StateEnum.on;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class StructConstants {
@@ -20,144 +19,144 @@ class StructConstants_SomeStruct {
   StructConstants_SomeStruct(this.stringField, this.floatField);
 }
 // StructConstants_SomeStruct "private" section, not exported.
-final _smoke_StructConstants_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Float),
     Pointer<Void> Function(Pointer<Void>, double)
   >('library_smoke_StructConstants_SomeStruct_create_handle'));
-final _smoke_StructConstants_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_release_handle'));
-final _smoke_StructConstants_SomeStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsSomestructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_get_field_stringField'));
-final _smoke_StructConstants_SomeStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsSomestructGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_get_field_floatField'));
 Pointer<Void> smoke_StructConstants_SomeStruct_toFfi(StructConstants_SomeStruct value) {
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _floatField_handle = (value.floatField);
-  final _result = _smoke_StructConstants_SomeStruct_create_handle(_stringField_handle, _floatField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  (_floatField_handle);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _floatFieldHandle = (value.floatField);
+  final _result = _smokeStructconstantsSomestructCreateHandle(_stringFieldHandle, _floatFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  (_floatFieldHandle);
   return _result;
 }
 StructConstants_SomeStruct smoke_StructConstants_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_StructConstants_SomeStruct_get_field_stringField(handle);
-  final _floatField_handle = _smoke_StructConstants_SomeStruct_get_field_floatField(handle);
+  final _stringFieldHandle = _smokeStructconstantsSomestructGetFieldstringField(handle);
+  final _floatFieldHandle = _smokeStructconstantsSomestructGetFieldfloatField(handle);
   try {
     return StructConstants_SomeStruct(
-      String_fromFfi(_stringField_handle),
-      (_floatField_handle)
+      String_fromFfi(_stringFieldHandle),
+      (_floatFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
-    (_floatField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    (_floatFieldHandle);
   }
 }
-void smoke_StructConstants_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructConstants_SomeStruct_release_handle(handle);
+void smoke_StructConstants_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeStructconstantsSomestructReleaseHandle(handle);
 // Nullable StructConstants_SomeStruct
-final _smoke_StructConstants_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_create_handle_nullable'));
-final _smoke_StructConstants_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_release_handle_nullable'));
-final _smoke_StructConstants_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_StructConstants_SomeStruct_toFfi_nullable(StructConstants_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructConstants_SomeStruct_toFfi(value);
-  final result = _smoke_StructConstants_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_StructConstants_SomeStructCreateHandleNullable(_handle);
   smoke_StructConstants_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 StructConstants_SomeStruct smoke_StructConstants_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructConstants_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_StructConstants_SomeStructGetValueNullable(handle);
   final result = smoke_StructConstants_SomeStruct_fromFfi(_handle);
   smoke_StructConstants_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructConstants_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructConstants_SomeStruct_release_handle_nullable(handle);
+  _smoke_StructConstants_SomeStructReleaseHandleNullable(handle);
 // End of StructConstants_SomeStruct "private" section.
 class StructConstants_NestingStruct {
   StructConstants_SomeStruct structField;
   StructConstants_NestingStruct(this.structField);
 }
 // StructConstants_NestingStruct "private" section, not exported.
-final _smoke_StructConstants_NestingStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsNestingstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_create_handle'));
-final _smoke_StructConstants_NestingStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsNestingstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_release_handle'));
-final _smoke_StructConstants_NestingStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsNestingstructGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_get_field_structField'));
 Pointer<Void> smoke_StructConstants_NestingStruct_toFfi(StructConstants_NestingStruct value) {
-  final _structField_handle = smoke_StructConstants_SomeStruct_toFfi(value.structField);
-  final _result = _smoke_StructConstants_NestingStruct_create_handle(_structField_handle);
-  smoke_StructConstants_SomeStruct_releaseFfiHandle(_structField_handle);
+  final _structFieldHandle = smoke_StructConstants_SomeStruct_toFfi(value.structField);
+  final _result = _smokeStructconstantsNestingstructCreateHandle(_structFieldHandle);
+  smoke_StructConstants_SomeStruct_releaseFfiHandle(_structFieldHandle);
   return _result;
 }
 StructConstants_NestingStruct smoke_StructConstants_NestingStruct_fromFfi(Pointer<Void> handle) {
-  final _structField_handle = _smoke_StructConstants_NestingStruct_get_field_structField(handle);
+  final _structFieldHandle = _smokeStructconstantsNestingstructGetFieldstructField(handle);
   try {
     return StructConstants_NestingStruct(
-      smoke_StructConstants_SomeStruct_fromFfi(_structField_handle)
+      smoke_StructConstants_SomeStruct_fromFfi(_structFieldHandle)
     );
   } finally {
-    smoke_StructConstants_SomeStruct_releaseFfiHandle(_structField_handle);
+    smoke_StructConstants_SomeStruct_releaseFfiHandle(_structFieldHandle);
   }
 }
-void smoke_StructConstants_NestingStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructConstants_NestingStruct_release_handle(handle);
+void smoke_StructConstants_NestingStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeStructconstantsNestingstructReleaseHandle(handle);
 // Nullable StructConstants_NestingStruct
-final _smoke_StructConstants_NestingStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_NestingStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_create_handle_nullable'));
-final _smoke_StructConstants_NestingStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_NestingStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_release_handle_nullable'));
-final _smoke_StructConstants_NestingStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructConstants_NestingStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_get_value_nullable'));
 Pointer<Void> smoke_StructConstants_NestingStruct_toFfi_nullable(StructConstants_NestingStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructConstants_NestingStruct_toFfi(value);
-  final result = _smoke_StructConstants_NestingStruct_create_handle_nullable(_handle);
+  final result = _smoke_StructConstants_NestingStructCreateHandleNullable(_handle);
   smoke_StructConstants_NestingStruct_releaseFfiHandle(_handle);
   return result;
 }
 StructConstants_NestingStruct smoke_StructConstants_NestingStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructConstants_NestingStruct_get_value_nullable(handle);
+  final _handle = _smoke_StructConstants_NestingStructGetValueNullable(handle);
   final result = smoke_StructConstants_NestingStruct_fromFfi(_handle);
   smoke_StructConstants_NestingStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructConstants_NestingStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructConstants_NestingStruct_release_handle_nullable(handle);
+  _smoke_StructConstants_NestingStructReleaseHandleNullable(handle);
 // End of StructConstants_NestingStruct "private" section.
 // StructConstants "private" section, not exported.
-final _smoke_StructConstants_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_copy_handle'));
-final _smoke_StructConstants_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructconstantsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructConstants_release_handle'));
@@ -167,29 +166,29 @@ class StructConstants$Impl extends __lib.NativeBase implements StructConstants {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_StructConstants_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeStructconstantsReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_StructConstants_toFfi(StructConstants value) =>
-  _smoke_StructConstants_copy_handle((value as __lib.NativeBase).handle);
+  _smokeStructconstantsCopyHandle((value as __lib.NativeBase).handle);
 StructConstants smoke_StructConstants_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as StructConstants;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_StructConstants_copy_handle(handle);
-  final result = StructConstants$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeStructconstantsCopyHandle(handle);
+  final result = StructConstants$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_StructConstants_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_StructConstants_release_handle(handle);
+  _smokeStructconstantsReleaseHandle(handle);
 Pointer<Void> smoke_StructConstants_toFfi_nullable(StructConstants value) =>
   value != null ? smoke_StructConstants_toFfi(value) : Pointer<Void>.fromAddress(0);
 StructConstants smoke_StructConstants_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_StructConstants_fromFfi(handle) : null;
 void smoke_StructConstants_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructConstants_release_handle(handle);
+  _smokeStructconstantsReleaseHandle(handle);
 // End of StructConstants "private" section.

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Constructors {
@@ -50,65 +49,65 @@ Constructors_ErrorEnum smoke_Constructors_ErrorEnum_fromFfi(int handle) {
   }
 }
 void smoke_Constructors_ErrorEnum_releaseFfiHandle(int handle) {}
-final _smoke_Constructors_ErrorEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Constructors_ErrorEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Constructors_ErrorEnum_create_handle_nullable'));
-final _smoke_Constructors_ErrorEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Constructors_ErrorEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Constructors_ErrorEnum_release_handle_nullable'));
-final _smoke_Constructors_ErrorEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Constructors_ErrorEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_ErrorEnum_get_value_nullable'));
 Pointer<Void> smoke_Constructors_ErrorEnum_toFfi_nullable(Constructors_ErrorEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Constructors_ErrorEnum_toFfi(value);
-  final result = _smoke_Constructors_ErrorEnum_create_handle_nullable(_handle);
+  final result = _smoke_Constructors_ErrorEnumCreateHandleNullable(_handle);
   smoke_Constructors_ErrorEnum_releaseFfiHandle(_handle);
   return result;
 }
 Constructors_ErrorEnum smoke_Constructors_ErrorEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Constructors_ErrorEnum_get_value_nullable(handle);
+  final _handle = _smoke_Constructors_ErrorEnumGetValueNullable(handle);
   final result = smoke_Constructors_ErrorEnum_fromFfi(_handle);
   smoke_Constructors_ErrorEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Constructors_ErrorEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Constructors_ErrorEnum_release_handle_nullable(handle);
+  _smoke_Constructors_ErrorEnumReleaseHandleNullable(handle);
 // End of Constructors_ErrorEnum "private" section.
 class Constructors_ConstructorExplodedException implements Exception {
   final Constructors_ErrorEnum error;
   Constructors_ConstructorExplodedException(this.error);
 }
 // Constructors "private" section, not exported.
-final _smoke_Constructors_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeConstructorsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_copy_handle'));
-final _smoke_Constructors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeConstructorsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Constructors_release_handle'));
-final _smoke_Constructors_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeConstructorsGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_get_type_id'));
-final _fromString_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_release_handle'));
-final _fromString_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_get_result'));
-final _fromString_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_get_error'));
-final _fromString_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_has_error'));
@@ -118,105 +117,105 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Constructors_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeConstructorsReleaseHandle(handle);
     handle = null;
   }
   Constructors$Impl.$init() : super(_$init()) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   Constructors$Impl.fromOther(Constructors other) : super(_fromOther(other)) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   Constructors$Impl.fromMulti(String foo, int bar) : super(_fromMulti(foo, bar)) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   Constructors$Impl.fromString(String input) : super(_fromString(input)) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   Constructors$Impl.fromList(List<double> input) : super(_fromList(input)) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   Constructors$Impl.create(int input) : super(_create(input)) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _$init() {
-    final _$init_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Constructors_create'));
-    final __result_handle = _$init_ffi(__lib.LibraryContext.isolateId);
-    return __result_handle;
+    final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Constructors_create'));
+    final __resultHandle = _$initFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
   }
   static Pointer<Void> _fromOther(Constructors other) {
-    final _fromOther_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__Constructors'));
-    final _other_handle = smoke_Constructors_toFfi(other);
-    final __result_handle = _fromOther_ffi(__lib.LibraryContext.isolateId, _other_handle);
-    smoke_Constructors_releaseFfiHandle(_other_handle);
-    return __result_handle;
+    final _fromOtherFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__Constructors'));
+    final _otherHandle = smoke_Constructors_toFfi(other);
+    final __resultHandle = _fromOtherFfi(__lib.LibraryContext.isolateId, _otherHandle);
+    smoke_Constructors_releaseFfiHandle(_otherHandle);
+    return __resultHandle;
   }
   static Pointer<Void> _fromMulti(String foo, int bar) {
-    final _fromMulti_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Uint64), Pointer<Void> Function(int, Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong'));
-    final _foo_handle = String_toFfi(foo);
-    final _bar_handle = (bar);
-    final __result_handle = _fromMulti_ffi(__lib.LibraryContext.isolateId, _foo_handle, _bar_handle);
-    String_releaseFfiHandle(_foo_handle);
-    (_bar_handle);
-    return __result_handle;
+    final _fromMultiFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Uint64), Pointer<Void> Function(int, Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong'));
+    final _fooHandle = String_toFfi(foo);
+    final _barHandle = (bar);
+    final __resultHandle = _fromMultiFfi(__lib.LibraryContext.isolateId, _fooHandle, _barHandle);
+    String_releaseFfiHandle(_fooHandle);
+    (_barHandle);
+    return __resultHandle;
   }
   static Pointer<Void> _fromString(String input) {
-    final _fromString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__String'));
-    final _input_handle = String_toFfi(input);
-    final __call_result_handle = _fromString_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
-    if (_fromString_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _fromString_return_get_error(__call_result_handle);
-        _fromString_return_release_handle(__call_result_handle);
+    final _fromStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__String'));
+    final _inputHandle = String_toFfi(input);
+    final __callResultHandle = _fromStringFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
+    if (_fromStringReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _fromStringReturnGetError(__callResultHandle);
+        _fromStringReturnReleaseHandle(__callResultHandle);
         try {
-          throw Constructors_ConstructorExplodedException(smoke_Constructors_ErrorEnum_fromFfi(__error_handle));
+          throw Constructors_ConstructorExplodedException(smoke_Constructors_ErrorEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_Constructors_ErrorEnum_releaseFfiHandle(__error_handle);
+          smoke_Constructors_ErrorEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _fromString_return_get_result(__call_result_handle);
-    _fromString_return_release_handle(__call_result_handle);
-    return __result_handle;
+    final __resultHandle = _fromStringReturnGetResult(__callResultHandle);
+    _fromStringReturnReleaseHandle(__callResultHandle);
+    return __resultHandle;
   }
   static Pointer<Void> _fromList(List<double> input) {
-    final _fromList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double'));
-    final _input_handle = foobar_ListOf_Double_toFfi(input);
-    final __result_handle = _fromList_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_Double_releaseFfiHandle(_input_handle);
-    return __result_handle;
+    final _fromListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__ListOf_1Double'));
+    final _inputHandle = foobar_ListOf_Double_toFfi(input);
+    final __resultHandle = _fromListFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_Double_releaseFfiHandle(_inputHandle);
+    return __resultHandle;
   }
   static Pointer<Void> _create(int input) {
-    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_Constructors_create__ULong'));
-    final _input_handle = (input);
-    final __result_handle = _create_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
-    return __result_handle;
+    final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_Constructors_create__ULong'));
+    final _inputHandle = (input);
+    final __resultHandle = _createFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
+    return __resultHandle;
   }
 }
 Pointer<Void> smoke_Constructors_toFfi(Constructors value) =>
-  _smoke_Constructors_copy_handle((value as __lib.NativeBase).handle);
+  _smokeConstructorsCopyHandle((value as __lib.NativeBase).handle);
 Constructors smoke_Constructors_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Constructors;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_Constructors_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_Constructors_copy_handle(handle);
+  final _typeIdHandle = _smokeConstructorsGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeConstructorsCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : Constructors$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : Constructors$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Constructors_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Constructors_release_handle(handle);
+  _smokeConstructorsReleaseHandle(handle);
 Pointer<Void> smoke_Constructors_toFfi_nullable(Constructors value) =>
   value != null ? smoke_Constructors_toFfi(value) : Pointer<Void>.fromAddress(0);
 Constructors smoke_Constructors_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Constructors_fromFfi(handle) : null;
 void smoke_Constructors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Constructors_release_handle(handle);
+  _smokeConstructorsReleaseHandle(handle);
 // End of Constructors "private" section.

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SingleNamedConstructor {
@@ -13,11 +12,11 @@ abstract class SingleNamedConstructor {
   void release();
 }
 // SingleNamedConstructor "private" section, not exported.
-final _smoke_SingleNamedConstructor_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSinglenamedconstructorCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SingleNamedConstructor_copy_handle'));
-final _smoke_SingleNamedConstructor_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSinglenamedconstructorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SingleNamedConstructor_release_handle'));
@@ -27,37 +26,37 @@ class SingleNamedConstructor$Impl extends __lib.NativeBase implements SingleName
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SingleNamedConstructor_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSinglenamedconstructorReleaseHandle(handle);
     handle = null;
   }
   SingleNamedConstructor$Impl.fooBar() : super(_fooBar()) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamedConstructor_create'));
-    final __result_handle = _fooBar_ffi(__lib.LibraryContext.isolateId);
-    return __result_handle;
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamedConstructor_create'));
+    final __resultHandle = _fooBarFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
   }
 }
 Pointer<Void> smoke_SingleNamedConstructor_toFfi(SingleNamedConstructor value) =>
-  _smoke_SingleNamedConstructor_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSinglenamedconstructorCopyHandle((value as __lib.NativeBase).handle);
 SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SingleNamedConstructor;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SingleNamedConstructor_copy_handle(handle);
-  final result = SingleNamedConstructor$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSinglenamedconstructorCopyHandle(handle);
+  final result = SingleNamedConstructor$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SingleNamedConstructor_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SingleNamedConstructor_release_handle(handle);
+  _smokeSinglenamedconstructorReleaseHandle(handle);
 Pointer<Void> smoke_SingleNamedConstructor_toFfi_nullable(SingleNamedConstructor value) =>
   value != null ? smoke_SingleNamedConstructor_toFfi(value) : Pointer<Void>.fromAddress(0);
 SingleNamedConstructor smoke_SingleNamedConstructor_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SingleNamedConstructor_fromFfi(handle) : null;
 void smoke_SingleNamedConstructor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SingleNamedConstructor_release_handle(handle);
+  _smokeSinglenamedconstructorReleaseHandle(handle);
 // End of SingleNamedConstructor "private" section.

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SingleNamelessConstructor {
@@ -13,11 +12,11 @@ abstract class SingleNamelessConstructor {
   void release();
 }
 // SingleNamelessConstructor "private" section, not exported.
-final _smoke_SingleNamelessConstructor_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSinglenamelessconstructorCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SingleNamelessConstructor_copy_handle'));
-final _smoke_SingleNamelessConstructor_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSinglenamelessconstructorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SingleNamelessConstructor_release_handle'));
@@ -27,37 +26,37 @@ class SingleNamelessConstructor$Impl extends __lib.NativeBase implements SingleN
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SingleNamelessConstructor_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSinglenamelessconstructorReleaseHandle(handle);
     handle = null;
   }
   SingleNamelessConstructor$Impl.create() : super(_create()) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _create() {
-    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamelessConstructor_create'));
-    final __result_handle = _create_ffi(__lib.LibraryContext.isolateId);
-    return __result_handle;
+    final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamelessConstructor_create'));
+    final __resultHandle = _createFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
   }
 }
 Pointer<Void> smoke_SingleNamelessConstructor_toFfi(SingleNamelessConstructor value) =>
-  _smoke_SingleNamelessConstructor_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSinglenamelessconstructorCopyHandle((value as __lib.NativeBase).handle);
 SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SingleNamelessConstructor;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SingleNamelessConstructor_copy_handle(handle);
-  final result = SingleNamelessConstructor$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSinglenamelessconstructorCopyHandle(handle);
+  final result = SingleNamelessConstructor$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SingleNamelessConstructor_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SingleNamelessConstructor_release_handle(handle);
+  _smokeSinglenamelessconstructorReleaseHandle(handle);
 Pointer<Void> smoke_SingleNamelessConstructor_toFfi_nullable(SingleNamelessConstructor value) =>
   value != null ? smoke_SingleNamelessConstructor_toFfi(value) : Pointer<Void>.fromAddress(0);
 SingleNamelessConstructor smoke_SingleNamelessConstructor_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SingleNamelessConstructor_fromFfi(handle) : null;
 void smoke_SingleNamelessConstructor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SingleNamelessConstructor_release_handle(handle);
+  _smokeSinglenamelessconstructorReleaseHandle(handle);
 // End of SingleNamelessConstructor "private" section.

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Dates {
@@ -20,71 +19,71 @@ class Dates_DateStruct {
   Dates_DateStruct(this.dateField);
 }
 // Dates_DateStruct "private" section, not exported.
-final _smoke_Dates_DateStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDatesDatestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
   >('library_smoke_Dates_DateStruct_create_handle'));
-final _smoke_Dates_DateStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDatesDatestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_release_handle'));
-final _smoke_Dates_DateStruct_get_field_dateField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDatesDatestructGetFielddateField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_get_field_dateField'));
 Pointer<Void> smoke_Dates_DateStruct_toFfi(Dates_DateStruct value) {
-  final _dateField_handle = Date_toFfi(value.dateField);
-  final _result = _smoke_Dates_DateStruct_create_handle(_dateField_handle);
-  Date_releaseFfiHandle(_dateField_handle);
+  final _dateFieldHandle = Date_toFfi(value.dateField);
+  final _result = _smokeDatesDatestructCreateHandle(_dateFieldHandle);
+  Date_releaseFfiHandle(_dateFieldHandle);
   return _result;
 }
 Dates_DateStruct smoke_Dates_DateStruct_fromFfi(Pointer<Void> handle) {
-  final _dateField_handle = _smoke_Dates_DateStruct_get_field_dateField(handle);
+  final _dateFieldHandle = _smokeDatesDatestructGetFielddateField(handle);
   try {
     return Dates_DateStruct(
-      Date_fromFfi(_dateField_handle)
+      Date_fromFfi(_dateFieldHandle)
     );
   } finally {
-    Date_releaseFfiHandle(_dateField_handle);
+    Date_releaseFfiHandle(_dateFieldHandle);
   }
 }
-void smoke_Dates_DateStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Dates_DateStruct_release_handle(handle);
+void smoke_Dates_DateStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeDatesDatestructReleaseHandle(handle);
 // Nullable Dates_DateStruct
-final _smoke_Dates_DateStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Dates_DateStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_create_handle_nullable'));
-final _smoke_Dates_DateStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Dates_DateStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_release_handle_nullable'));
-final _smoke_Dates_DateStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Dates_DateStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_get_value_nullable'));
 Pointer<Void> smoke_Dates_DateStruct_toFfi_nullable(Dates_DateStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Dates_DateStruct_toFfi(value);
-  final result = _smoke_Dates_DateStruct_create_handle_nullable(_handle);
+  final result = _smoke_Dates_DateStructCreateHandleNullable(_handle);
   smoke_Dates_DateStruct_releaseFfiHandle(_handle);
   return result;
 }
 Dates_DateStruct smoke_Dates_DateStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Dates_DateStruct_get_value_nullable(handle);
+  final _handle = _smoke_Dates_DateStructGetValueNullable(handle);
   final result = smoke_Dates_DateStruct_fromFfi(_handle);
   smoke_Dates_DateStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Dates_DateStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Dates_DateStruct_release_handle_nullable(handle);
+  _smoke_Dates_DateStructReleaseHandleNullable(handle);
 // End of Dates_DateStruct "private" section.
 // Dates "private" section, not exported.
-final _smoke_Dates_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDatesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Dates_copy_handle'));
-final _smoke_Dates_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDatesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Dates_release_handle'));
@@ -94,66 +93,66 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Dates_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeDatesReleaseHandle(handle);
     handle = null;
   }
   @override
   DateTime dateMethod(DateTime input) {
-    final _dateMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateMethod__Date'));
-    final _input_handle = Date_toFfi(input);
+    final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateMethod__Date'));
+    final _inputHandle = Date_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _dateMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Date_releaseFfiHandle(_input_handle);
+    final __resultHandle = _dateMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Date_releaseFfiHandle(_inputHandle);
     try {
-      return Date_fromFfi(__result_handle);
+      return Date_fromFfi(__resultHandle);
     } finally {
-      Date_releaseFfiHandle(__result_handle);
+      Date_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   DateTime get dateProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Date_fromFfi(__result_handle);
+      return Date_fromFfi(__resultHandle);
     } finally {
-      Date_releaseFfiHandle(__result_handle);
+      Date_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set dateProperty(DateTime value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateProperty_set__Date'));
-    final _value_handle = Date_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateProperty_set__Date'));
+    final _valueHandle = Date_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Date_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Date_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Dates_toFfi(Dates value) =>
-  _smoke_Dates_copy_handle((value as __lib.NativeBase).handle);
+  _smokeDatesCopyHandle((value as __lib.NativeBase).handle);
 Dates smoke_Dates_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Dates;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Dates_copy_handle(handle);
-  final result = Dates$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeDatesCopyHandle(handle);
+  final result = Dates$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Dates_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Dates_release_handle(handle);
+  _smokeDatesReleaseHandle(handle);
 Pointer<Void> smoke_Dates_toFfi_nullable(Dates value) =>
   value != null ? smoke_Dates_toFfi(value) : Pointer<Void>.fromAddress(0);
 Dates smoke_Dates_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Dates_fromFfi(handle) : null;
 void smoke_Dates_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Dates_release_handle(handle);
+  _smokeDatesReleaseHandle(handle);
 // End of Dates "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class DefaultValues {
@@ -44,34 +43,34 @@ DefaultValues_SomeEnum smoke_DefaultValues_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_DefaultValues_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_DefaultValues_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_DefaultValues_SomeEnum_create_handle_nullable'));
-final _smoke_DefaultValues_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_SomeEnum_release_handle_nullable'));
-final _smoke_DefaultValues_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_SomeEnum_toFfi_nullable(DefaultValues_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_SomeEnum_toFfi(value);
-  final result = _smoke_DefaultValues_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_DefaultValues_SomeEnumCreateHandleNullable(_handle);
   smoke_DefaultValues_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 DefaultValues_SomeEnum smoke_DefaultValues_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DefaultValues_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_DefaultValues_SomeEnumGetValueNullable(handle);
   final result = smoke_DefaultValues_SomeEnum_fromFfi(_handle);
   smoke_DefaultValues_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DefaultValues_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_SomeEnum_release_handle_nullable(handle);
+  _smoke_DefaultValues_SomeEnumReleaseHandleNullable(handle);
 // End of DefaultValues_SomeEnum "private" section.
 enum DefaultValues_ExternalEnum {
     oneValue,
@@ -103,34 +102,34 @@ DefaultValues_ExternalEnum smoke_DefaultValues_ExternalEnum_fromFfi(int handle) 
   }
 }
 void smoke_DefaultValues_ExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_DefaultValues_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_ExternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_DefaultValues_ExternalEnum_create_handle_nullable'));
-final _smoke_DefaultValues_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_ExternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_ExternalEnum_release_handle_nullable'));
-final _smoke_DefaultValues_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_ExternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_ExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_ExternalEnum_toFfi_nullable(DefaultValues_ExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_ExternalEnum_toFfi(value);
-  final result = _smoke_DefaultValues_ExternalEnum_create_handle_nullable(_handle);
+  final result = _smoke_DefaultValues_ExternalEnumCreateHandleNullable(_handle);
   smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 DefaultValues_ExternalEnum smoke_DefaultValues_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DefaultValues_ExternalEnum_get_value_nullable(handle);
+  final _handle = _smoke_DefaultValues_ExternalEnumGetValueNullable(handle);
   final result = smoke_DefaultValues_ExternalEnum_fromFfi(_handle);
   smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DefaultValues_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_ExternalEnum_release_handle_nullable(handle);
+  _smoke_DefaultValues_ExternalEnumReleaseHandleNullable(handle);
 // End of DefaultValues_ExternalEnum "private" section.
 class DefaultValues_StructWithDefaults {
   int intField;
@@ -146,127 +145,127 @@ class DefaultValues_StructWithDefaults {
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
 }
 // DefaultValues_StructWithDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32, Uint32),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int, int)
   >('library_smoke_DefaultValues_StructWithDefaults_create_handle'));
-final _smoke_DefaultValues_StructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_release_handle'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_intField'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFielduintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_uintField'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_floatField'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFielddoubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_doubleField'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_boolField'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_stringField'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_enumField'));
-final _smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithdefaultsGetFieldexternalEnumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField'));
 Pointer<Void> smoke_DefaultValues_StructWithDefaults_toFfi(DefaultValues_StructWithDefaults value) {
-  final _intField_handle = (value.intField);
-  final _uintField_handle = (value.uintField);
-  final _floatField_handle = (value.floatField);
-  final _doubleField_handle = (value.doubleField);
-  final _boolField_handle = Boolean_toFfi(value.boolField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _enumField_handle = smoke_DefaultValues_SomeEnum_toFfi(value.enumField);
-  final _externalEnumField_handle = smoke_DefaultValues_ExternalEnum_toFfi(value.externalEnumField);
-  final _result = _smoke_DefaultValues_StructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _doubleField_handle, _boolField_handle, _stringField_handle, _enumField_handle, _externalEnumField_handle);
-  (_intField_handle);
-  (_uintField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
-  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  final _intFieldHandle = (value.intField);
+  final _uintFieldHandle = (value.uintField);
+  final _floatFieldHandle = (value.floatField);
+  final _doubleFieldHandle = (value.doubleField);
+  final _boolFieldHandle = Boolean_toFfi(value.boolField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _enumFieldHandle = smoke_DefaultValues_SomeEnum_toFfi(value.enumField);
+  final _externalEnumFieldHandle = smoke_DefaultValues_ExternalEnum_toFfi(value.externalEnumField);
+  final _result = _smokeDefaultvaluesStructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle, _externalEnumFieldHandle);
+  (_intFieldHandle);
+  (_uintFieldHandle);
+  (_floatFieldHandle);
+  (_doubleFieldHandle);
+  Boolean_releaseFfiHandle(_boolFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumFieldHandle);
+  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumFieldHandle);
   return _result;
 }
 DefaultValues_StructWithDefaults smoke_DefaultValues_StructWithDefaults_fromFfi(Pointer<Void> handle) {
-  final _intField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_intField(handle);
-  final _uintField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_uintField(handle);
-  final _floatField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_floatField(handle);
-  final _doubleField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_doubleField(handle);
-  final _boolField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_boolField(handle);
-  final _stringField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_stringField(handle);
-  final _enumField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_enumField(handle);
-  final _externalEnumField_handle = _smoke_DefaultValues_StructWithDefaults_get_field_externalEnumField(handle);
+  final _intFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldintField(handle);
+  final _uintFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFielduintField(handle);
+  final _floatFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldfloatField(handle);
+  final _doubleFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFielddoubleField(handle);
+  final _boolFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldboolField(handle);
+  final _stringFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldstringField(handle);
+  final _enumFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldenumField(handle);
+  final _externalEnumFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldexternalEnumField(handle);
   try {
     return DefaultValues_StructWithDefaults(
-      (_intField_handle),
-      (_uintField_handle),
-      (_floatField_handle),
-      (_doubleField_handle),
-      Boolean_fromFfi(_boolField_handle),
-      String_fromFfi(_stringField_handle),
-      smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle),
-      smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
+      (_intFieldHandle),
+      (_uintFieldHandle),
+      (_floatFieldHandle),
+      (_doubleFieldHandle),
+      Boolean_fromFfi(_boolFieldHandle),
+      String_fromFfi(_stringFieldHandle),
+      smoke_DefaultValues_SomeEnum_fromFfi(_enumFieldHandle),
+      smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumFieldHandle)
     );
   } finally {
-    (_intField_handle);
-    (_uintField_handle);
-    (_floatField_handle);
-    (_doubleField_handle);
-    Boolean_releaseFfiHandle(_boolField_handle);
-    String_releaseFfiHandle(_stringField_handle);
-    smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
-    smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+    (_intFieldHandle);
+    (_uintFieldHandle);
+    (_floatFieldHandle);
+    (_doubleFieldHandle);
+    Boolean_releaseFfiHandle(_boolFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumFieldHandle);
+    smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumFieldHandle);
   }
 }
-void smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithDefaults_release_handle(handle);
+void smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithdefaultsReleaseHandle(handle);
 // Nullable DefaultValues_StructWithDefaults
-final _smoke_DefaultValues_StructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_create_handle_nullable'));
-final _smoke_DefaultValues_StructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_release_handle_nullable'));
-final _smoke_DefaultValues_StructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithDefaults_toFfi_nullable(DefaultValues_StructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithDefaults_toFfi(value);
-  final result = _smoke_DefaultValues_StructWithDefaults_create_handle_nullable(_handle);
+  final result = _smoke_DefaultValues_StructWithDefaultsCreateHandleNullable(_handle);
   smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 DefaultValues_StructWithDefaults smoke_DefaultValues_StructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DefaultValues_StructWithDefaults_get_value_nullable(handle);
+  final _handle = _smoke_DefaultValues_StructWithDefaultsGetValueNullable(handle);
   final result = smoke_DefaultValues_StructWithDefaults_fromFfi(_handle);
   smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DefaultValues_StructWithDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_StructWithDefaults_release_handle_nullable(handle);
+  _smoke_DefaultValues_StructWithDefaultsReleaseHandleNullable(handle);
 // End of DefaultValues_StructWithDefaults "private" section.
 class DefaultValues_NullableStructWithDefaults {
   int intField;
@@ -280,109 +279,109 @@ class DefaultValues_NullableStructWithDefaults {
     : intField = null, uintField = null, floatField = null, boolField = null, stringField = null, enumField = null;
 }
 // DefaultValues_NullableStructWithDefaults "private" section, not exported.
-final _smoke_DefaultValues_NullableStructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_create_handle'));
-final _smoke_DefaultValues_NullableStructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_release_handle'));
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_intField'));
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsGetFielduintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField'));
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField'));
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField'));
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField'));
-final _smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesNullablestructwithdefaultsGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField'));
 Pointer<Void> smoke_DefaultValues_NullableStructWithDefaults_toFfi(DefaultValues_NullableStructWithDefaults value) {
-  final _intField_handle = Int_toFfi_nullable(value.intField);
-  final _uintField_handle = UInt_toFfi_nullable(value.uintField);
-  final _floatField_handle = Float_toFfi_nullable(value.floatField);
-  final _boolField_handle = Boolean_toFfi_nullable(value.boolField);
-  final _stringField_handle = String_toFfi_nullable(value.stringField);
-  final _enumField_handle = smoke_DefaultValues_SomeEnum_toFfi_nullable(value.enumField);
-  final _result = _smoke_DefaultValues_NullableStructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _boolField_handle, _stringField_handle, _enumField_handle);
-  Int_releaseFfiHandle_nullable(_intField_handle);
-  UInt_releaseFfiHandle_nullable(_uintField_handle);
-  Float_releaseFfiHandle_nullable(_floatField_handle);
-  Boolean_releaseFfiHandle_nullable(_boolField_handle);
-  String_releaseFfiHandle_nullable(_stringField_handle);
-  smoke_DefaultValues_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
+  final _intFieldHandle = Int_toFfi_nullable(value.intField);
+  final _uintFieldHandle = UInt_toFfi_nullable(value.uintField);
+  final _floatFieldHandle = Float_toFfi_nullable(value.floatField);
+  final _boolFieldHandle = Boolean_toFfi_nullable(value.boolField);
+  final _stringFieldHandle = String_toFfi_nullable(value.stringField);
+  final _enumFieldHandle = smoke_DefaultValues_SomeEnum_toFfi_nullable(value.enumField);
+  final _result = _smokeDefaultvaluesNullablestructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle);
+  Int_releaseFfiHandle_nullable(_intFieldHandle);
+  UInt_releaseFfiHandle_nullable(_uintFieldHandle);
+  Float_releaseFfiHandle_nullable(_floatFieldHandle);
+  Boolean_releaseFfiHandle_nullable(_boolFieldHandle);
+  String_releaseFfiHandle_nullable(_stringFieldHandle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle_nullable(_enumFieldHandle);
   return _result;
 }
 DefaultValues_NullableStructWithDefaults smoke_DefaultValues_NullableStructWithDefaults_fromFfi(Pointer<Void> handle) {
-  final _intField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_intField(handle);
-  final _uintField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_uintField(handle);
-  final _floatField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_floatField(handle);
-  final _boolField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_boolField(handle);
-  final _stringField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField(handle);
-  final _enumField_handle = _smoke_DefaultValues_NullableStructWithDefaults_get_field_enumField(handle);
+  final _intFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldintField(handle);
+  final _uintFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFielduintField(handle);
+  final _floatFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldfloatField(handle);
+  final _boolFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldboolField(handle);
+  final _stringFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldstringField(handle);
+  final _enumFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldenumField(handle);
   try {
     return DefaultValues_NullableStructWithDefaults(
-      Int_fromFfi_nullable(_intField_handle),
-      UInt_fromFfi_nullable(_uintField_handle),
-      Float_fromFfi_nullable(_floatField_handle),
-      Boolean_fromFfi_nullable(_boolField_handle),
-      String_fromFfi_nullable(_stringField_handle),
-      smoke_DefaultValues_SomeEnum_fromFfi_nullable(_enumField_handle)
+      Int_fromFfi_nullable(_intFieldHandle),
+      UInt_fromFfi_nullable(_uintFieldHandle),
+      Float_fromFfi_nullable(_floatFieldHandle),
+      Boolean_fromFfi_nullable(_boolFieldHandle),
+      String_fromFfi_nullable(_stringFieldHandle),
+      smoke_DefaultValues_SomeEnum_fromFfi_nullable(_enumFieldHandle)
     );
   } finally {
-    Int_releaseFfiHandle_nullable(_intField_handle);
-    UInt_releaseFfiHandle_nullable(_uintField_handle);
-    Float_releaseFfiHandle_nullable(_floatField_handle);
-    Boolean_releaseFfiHandle_nullable(_boolField_handle);
-    String_releaseFfiHandle_nullable(_stringField_handle);
-    smoke_DefaultValues_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
+    Int_releaseFfiHandle_nullable(_intFieldHandle);
+    UInt_releaseFfiHandle_nullable(_uintFieldHandle);
+    Float_releaseFfiHandle_nullable(_floatFieldHandle);
+    Boolean_releaseFfiHandle_nullable(_boolFieldHandle);
+    String_releaseFfiHandle_nullable(_stringFieldHandle);
+    smoke_DefaultValues_SomeEnum_releaseFfiHandle_nullable(_enumFieldHandle);
   }
 }
-void smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_NullableStructWithDefaults_release_handle(handle);
+void smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesNullablestructwithdefaultsReleaseHandle(handle);
 // Nullable DefaultValues_NullableStructWithDefaults
-final _smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_NullableStructWithDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable'));
-final _smoke_DefaultValues_NullableStructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_NullableStructWithDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_release_handle_nullable'));
-final _smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_NullableStructWithDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_NullableStructWithDefaults_toFfi_nullable(DefaultValues_NullableStructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_NullableStructWithDefaults_toFfi(value);
-  final result = _smoke_DefaultValues_NullableStructWithDefaults_create_handle_nullable(_handle);
+  final result = _smoke_DefaultValues_NullableStructWithDefaultsCreateHandleNullable(_handle);
   smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 DefaultValues_NullableStructWithDefaults smoke_DefaultValues_NullableStructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable(handle);
+  final _handle = _smoke_DefaultValues_NullableStructWithDefaultsGetValueNullable(handle);
   final result = smoke_DefaultValues_NullableStructWithDefaults_fromFfi(_handle);
   smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DefaultValues_NullableStructWithDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_NullableStructWithDefaults_release_handle_nullable(handle);
+  _smoke_DefaultValues_NullableStructWithDefaultsReleaseHandleNullable(handle);
 // End of DefaultValues_NullableStructWithDefaults "private" section.
 class DefaultValues_StructWithSpecialDefaults {
   double floatNanField;
@@ -396,109 +395,109 @@ class DefaultValues_StructWithSpecialDefaults {
     : floatNanField = double.nan, floatInfinityField = double.infinity, floatNegativeInfinityField = double.negativeInfinity, doubleNanField = double.nan, doubleInfinityField = double.infinity, doubleNegativeInfinityField = double.negativeInfinity;
 }
 // DefaultValues_StructWithSpecialDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithSpecialDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Float, Float, Float, Double, Double, Double),
     Pointer<Void> Function(double, double, double, double, double, double)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_create_handle'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_release_handle'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatNanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatNegativeInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleNanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleNegativeInfinityField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField'));
 Pointer<Void> smoke_DefaultValues_StructWithSpecialDefaults_toFfi(DefaultValues_StructWithSpecialDefaults value) {
-  final _floatNanField_handle = (value.floatNanField);
-  final _floatInfinityField_handle = (value.floatInfinityField);
-  final _floatNegativeInfinityField_handle = (value.floatNegativeInfinityField);
-  final _doubleNanField_handle = (value.doubleNanField);
-  final _doubleInfinityField_handle = (value.doubleInfinityField);
-  final _doubleNegativeInfinityField_handle = (value.doubleNegativeInfinityField);
-  final _result = _smoke_DefaultValues_StructWithSpecialDefaults_create_handle(_floatNanField_handle, _floatInfinityField_handle, _floatNegativeInfinityField_handle, _doubleNanField_handle, _doubleInfinityField_handle, _doubleNegativeInfinityField_handle);
-  (_floatNanField_handle);
-  (_floatInfinityField_handle);
-  (_floatNegativeInfinityField_handle);
-  (_doubleNanField_handle);
-  (_doubleInfinityField_handle);
-  (_doubleNegativeInfinityField_handle);
+  final _floatNanFieldHandle = (value.floatNanField);
+  final _floatInfinityFieldHandle = (value.floatInfinityField);
+  final _floatNegativeInfinityFieldHandle = (value.floatNegativeInfinityField);
+  final _doubleNanFieldHandle = (value.doubleNanField);
+  final _doubleInfinityFieldHandle = (value.doubleInfinityField);
+  final _doubleNegativeInfinityFieldHandle = (value.doubleNegativeInfinityField);
+  final _result = _smokeDefaultvaluesStructwithspecialdefaultsCreateHandle(_floatNanFieldHandle, _floatInfinityFieldHandle, _floatNegativeInfinityFieldHandle, _doubleNanFieldHandle, _doubleInfinityFieldHandle, _doubleNegativeInfinityFieldHandle);
+  (_floatNanFieldHandle);
+  (_floatInfinityFieldHandle);
+  (_floatNegativeInfinityFieldHandle);
+  (_doubleNanFieldHandle);
+  (_doubleInfinityFieldHandle);
+  (_doubleNegativeInfinityFieldHandle);
   return _result;
 }
 DefaultValues_StructWithSpecialDefaults smoke_DefaultValues_StructWithSpecialDefaults_fromFfi(Pointer<Void> handle) {
-  final _floatNanField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNanField(handle);
-  final _floatInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatInfinityField(handle);
-  final _floatNegativeInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_floatNegativeInfinityField(handle);
-  final _doubleNanField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNanField(handle);
-  final _doubleInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleInfinityField(handle);
-  final _doubleNegativeInfinityField_handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField(handle);
+  final _floatNanFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatNanField(handle);
+  final _floatInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatInfinityField(handle);
+  final _floatNegativeInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatNegativeInfinityField(handle);
+  final _doubleNanFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleNanField(handle);
+  final _doubleInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleInfinityField(handle);
+  final _doubleNegativeInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleNegativeInfinityField(handle);
   try {
     return DefaultValues_StructWithSpecialDefaults(
-      (_floatNanField_handle),
-      (_floatInfinityField_handle),
-      (_floatNegativeInfinityField_handle),
-      (_doubleNanField_handle),
-      (_doubleInfinityField_handle),
-      (_doubleNegativeInfinityField_handle)
+      (_floatNanFieldHandle),
+      (_floatInfinityFieldHandle),
+      (_floatNegativeInfinityFieldHandle),
+      (_doubleNanFieldHandle),
+      (_doubleInfinityFieldHandle),
+      (_doubleNegativeInfinityFieldHandle)
     );
   } finally {
-    (_floatNanField_handle);
-    (_floatInfinityField_handle);
-    (_floatNegativeInfinityField_handle);
-    (_doubleNanField_handle);
-    (_doubleInfinityField_handle);
-    (_doubleNegativeInfinityField_handle);
+    (_floatNanFieldHandle);
+    (_floatInfinityFieldHandle);
+    (_floatNegativeInfinityFieldHandle);
+    (_doubleNanFieldHandle);
+    (_doubleInfinityFieldHandle);
+    (_doubleNegativeInfinityFieldHandle);
   }
 }
-void smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithSpecialDefaults_release_handle(handle);
+void smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithspecialdefaultsReleaseHandle(handle);
 // Nullable DefaultValues_StructWithSpecialDefaults
-final _smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithSpecialDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithSpecialDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_release_handle_nullable'));
-final _smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithSpecialDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithSpecialDefaults_toFfi_nullable(DefaultValues_StructWithSpecialDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithSpecialDefaults_toFfi(value);
-  final result = _smoke_DefaultValues_StructWithSpecialDefaults_create_handle_nullable(_handle);
+  final result = _smoke_DefaultValues_StructWithSpecialDefaultsCreateHandleNullable(_handle);
   smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(_handle);
   return result;
 }
 DefaultValues_StructWithSpecialDefaults smoke_DefaultValues_StructWithSpecialDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable(handle);
+  final _handle = _smoke_DefaultValues_StructWithSpecialDefaultsGetValueNullable(handle);
   final result = smoke_DefaultValues_StructWithSpecialDefaults_fromFfi(_handle);
   smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DefaultValues_StructWithSpecialDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_StructWithSpecialDefaults_release_handle_nullable(handle);
+  _smoke_DefaultValues_StructWithSpecialDefaultsReleaseHandleNullable(handle);
 // End of DefaultValues_StructWithSpecialDefaults "private" section.
 class DefaultValues_StructWithEmptyDefaults {
   List<int> intsField;
@@ -511,100 +510,100 @@ class DefaultValues_StructWithEmptyDefaults {
     : intsField = [], floatsField = [], mapField = {}, structField = DefaultValues_StructWithDefaults.withDefaults(), setTypeField = {};
 }
 // DefaultValues_StructWithEmptyDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithEmptyDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithemptydefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_create_handle'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithemptydefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_release_handle'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithemptydefaultsGetFieldintsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithemptydefaultsGetFieldfloatsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithemptydefaultsGetFieldmapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithemptydefaultsGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithemptydefaultsGetFieldsetTypeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField'));
 Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi(DefaultValues_StructWithEmptyDefaults value) {
-  final _intsField_handle = ListOf_Int_toFfi(value.intsField);
-  final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
-  final _mapField_handle = MapOf_UInt_to_String_toFfi(value.mapField);
-  final _structField_handle = smoke_DefaultValues_StructWithDefaults_toFfi(value.structField);
-  final _setTypeField_handle = SetOf_String_toFfi(value.setTypeField);
-  final _result = _smoke_DefaultValues_StructWithEmptyDefaults_create_handle(_intsField_handle, _floatsField_handle, _mapField_handle, _structField_handle, _setTypeField_handle);
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
-  smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
+  final _intsFieldHandle = ListOf_Int_toFfi(value.intsField);
+  final _floatsFieldHandle = ListOf_Float_toFfi(value.floatsField);
+  final _mapFieldHandle = MapOf_UInt_to_String_toFfi(value.mapField);
+  final _structFieldHandle = smoke_DefaultValues_StructWithDefaults_toFfi(value.structField);
+  final _setTypeFieldHandle = SetOf_String_toFfi(value.setTypeField);
+  final _result = _smokeDefaultvaluesStructwithemptydefaultsCreateHandle(_intsFieldHandle, _floatsFieldHandle, _mapFieldHandle, _structFieldHandle, _setTypeFieldHandle);
+  ListOf_Int_releaseFfiHandle(_intsFieldHandle);
+  ListOf_Float_releaseFfiHandle(_floatsFieldHandle);
+  MapOf_UInt_to_String_releaseFfiHandle(_mapFieldHandle);
+  smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structFieldHandle);
+  SetOf_String_releaseFfiHandle(_setTypeFieldHandle);
   return _result;
 }
 DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefaults_fromFfi(Pointer<Void> handle) {
-  final _intsField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_intsField(handle);
-  final _floatsField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_floatsField(handle);
-  final _mapField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_mapField(handle);
-  final _structField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_structField(handle);
-  final _setTypeField_handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField(handle);
+  final _intsFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldintsField(handle);
+  final _floatsFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldfloatsField(handle);
+  final _mapFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldmapField(handle);
+  final _structFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldstructField(handle);
+  final _setTypeFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldsetTypeField(handle);
   try {
     return DefaultValues_StructWithEmptyDefaults(
-      ListOf_Int_fromFfi(_intsField_handle),
-      ListOf_Float_fromFfi(_floatsField_handle),
-      MapOf_UInt_to_String_fromFfi(_mapField_handle),
-      smoke_DefaultValues_StructWithDefaults_fromFfi(_structField_handle),
-      SetOf_String_fromFfi(_setTypeField_handle)
+      ListOf_Int_fromFfi(_intsFieldHandle),
+      ListOf_Float_fromFfi(_floatsFieldHandle),
+      MapOf_UInt_to_String_fromFfi(_mapFieldHandle),
+      smoke_DefaultValues_StructWithDefaults_fromFfi(_structFieldHandle),
+      SetOf_String_fromFfi(_setTypeFieldHandle)
     );
   } finally {
-    ListOf_Int_releaseFfiHandle(_intsField_handle);
-    ListOf_Float_releaseFfiHandle(_floatsField_handle);
-    MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
-    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structField_handle);
-    SetOf_String_releaseFfiHandle(_setTypeField_handle);
+    ListOf_Int_releaseFfiHandle(_intsFieldHandle);
+    ListOf_Float_releaseFfiHandle(_floatsFieldHandle);
+    MapOf_UInt_to_String_releaseFfiHandle(_mapFieldHandle);
+    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_structFieldHandle);
+    SetOf_String_releaseFfiHandle(_setTypeFieldHandle);
   }
 }
-void smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithEmptyDefaults_release_handle(handle);
+void smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithemptydefaultsReleaseHandle(handle);
 // Nullable DefaultValues_StructWithEmptyDefaults
-final _smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithEmptyDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithEmptyDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_release_handle_nullable'));
-final _smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithEmptyDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithEmptyDefaults_toFfi_nullable(DefaultValues_StructWithEmptyDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithEmptyDefaults_toFfi(value);
-  final result = _smoke_DefaultValues_StructWithEmptyDefaults_create_handle_nullable(_handle);
+  final result = _smoke_DefaultValues_StructWithEmptyDefaultsCreateHandleNullable(_handle);
   smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(_handle);
   return result;
 }
 DefaultValues_StructWithEmptyDefaults smoke_DefaultValues_StructWithEmptyDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable(handle);
+  final _handle = _smoke_DefaultValues_StructWithEmptyDefaultsGetValueNullable(handle);
   final result = smoke_DefaultValues_StructWithEmptyDefaults_fromFfi(_handle);
   smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DefaultValues_StructWithEmptyDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_StructWithEmptyDefaults_release_handle_nullable(handle);
+  _smoke_DefaultValues_StructWithEmptyDefaultsReleaseHandleNullable(handle);
 // End of DefaultValues_StructWithEmptyDefaults "private" section.
 class DefaultValues_StructWithTypedefDefaults {
   int longField;
@@ -616,98 +615,98 @@ class DefaultValues_StructWithTypedefDefaults {
     : longField = 42, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue;
 }
 // DefaultValues_StructWithTypedefDefaults "private" section, not exported.
-final _smoke_DefaultValues_StructWithTypedefDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithtypedefdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int64, Uint8, Pointer<Void>, Uint32),
     Pointer<Void> Function(int, int, Pointer<Void>, int)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_create_handle'));
-final _smoke_DefaultValues_StructWithTypedefDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithtypedefdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_release_handle'));
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldlongField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField'));
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField'));
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField'));
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField'));
 Pointer<Void> smoke_DefaultValues_StructWithTypedefDefaults_toFfi(DefaultValues_StructWithTypedefDefaults value) {
-  final _longField_handle = (value.longField);
-  final _boolField_handle = Boolean_toFfi(value.boolField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _enumField_handle = smoke_DefaultValues_SomeEnum_toFfi(value.enumField);
-  final _result = _smoke_DefaultValues_StructWithTypedefDefaults_create_handle(_longField_handle, _boolField_handle, _stringField_handle, _enumField_handle);
-  (_longField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+  final _longFieldHandle = (value.longField);
+  final _boolFieldHandle = Boolean_toFfi(value.boolField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _enumFieldHandle = smoke_DefaultValues_SomeEnum_toFfi(value.enumField);
+  final _result = _smokeDefaultvaluesStructwithtypedefdefaultsCreateHandle(_longFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle);
+  (_longFieldHandle);
+  Boolean_releaseFfiHandle(_boolFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumFieldHandle);
   return _result;
 }
 DefaultValues_StructWithTypedefDefaults smoke_DefaultValues_StructWithTypedefDefaults_fromFfi(Pointer<Void> handle) {
-  final _longField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_longField(handle);
-  final _boolField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_boolField(handle);
-  final _stringField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField(handle);
-  final _enumField_handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_field_enumField(handle);
+  final _longFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldlongField(handle);
+  final _boolFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldboolField(handle);
+  final _stringFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldstringField(handle);
+  final _enumFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldenumField(handle);
   try {
     return DefaultValues_StructWithTypedefDefaults(
-      (_longField_handle),
-      Boolean_fromFfi(_boolField_handle),
-      String_fromFfi(_stringField_handle),
-      smoke_DefaultValues_SomeEnum_fromFfi(_enumField_handle)
+      (_longFieldHandle),
+      Boolean_fromFfi(_boolFieldHandle),
+      String_fromFfi(_stringFieldHandle),
+      smoke_DefaultValues_SomeEnum_fromFfi(_enumFieldHandle)
     );
   } finally {
-    (_longField_handle);
-    Boolean_releaseFfiHandle(_boolField_handle);
-    String_releaseFfiHandle(_stringField_handle);
-    smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumField_handle);
+    (_longFieldHandle);
+    Boolean_releaseFfiHandle(_boolFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    smoke_DefaultValues_SomeEnum_releaseFfiHandle(_enumFieldHandle);
   }
 }
-void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_DefaultValues_StructWithTypedefDefaults_release_handle(handle);
+void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithtypedefdefaultsReleaseHandle(handle);
 // Nullable DefaultValues_StructWithTypedefDefaults
-final _smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithTypedefDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable'));
-final _smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithTypedefDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable'));
-final _smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DefaultValues_StructWithTypedefDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable'));
 Pointer<Void> smoke_DefaultValues_StructWithTypedefDefaults_toFfi_nullable(DefaultValues_StructWithTypedefDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DefaultValues_StructWithTypedefDefaults_toFfi(value);
-  final result = _smoke_DefaultValues_StructWithTypedefDefaults_create_handle_nullable(_handle);
+  final result = _smoke_DefaultValues_StructWithTypedefDefaultsCreateHandleNullable(_handle);
   smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(_handle);
   return result;
 }
 DefaultValues_StructWithTypedefDefaults smoke_DefaultValues_StructWithTypedefDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable(handle);
+  final _handle = _smoke_DefaultValues_StructWithTypedefDefaultsGetValueNullable(handle);
   final result = smoke_DefaultValues_StructWithTypedefDefaults_fromFfi(_handle);
   smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DefaultValues_StructWithTypedefDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_StructWithTypedefDefaults_release_handle_nullable(handle);
+  _smoke_DefaultValues_StructWithTypedefDefaultsReleaseHandleNullable(handle);
 // End of DefaultValues_StructWithTypedefDefaults "private" section.
 // DefaultValues "private" section, not exported.
-final _smoke_DefaultValues_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_copy_handle'));
-final _smoke_DefaultValues_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDefaultvaluesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_release_handle'));
@@ -717,40 +716,40 @@ class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_DefaultValues_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeDefaultvaluesReleaseHandle(handle);
     handle = null;
   }
   static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
-    final _processStructWithDefaults_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults'));
-    final _input_handle = smoke_DefaultValues_StructWithDefaults_toFfi(input);
-    final __result_handle = _processStructWithDefaults_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_input_handle);
+    final _processStructWithDefaultsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults'));
+    final _inputHandle = smoke_DefaultValues_StructWithDefaults_toFfi(input);
+    final __resultHandle = _processStructWithDefaultsFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_DefaultValues_StructWithDefaults_fromFfi(__result_handle);
+      return smoke_DefaultValues_StructWithDefaults_fromFfi(__resultHandle);
     } finally {
-      smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(__result_handle);
+      smoke_DefaultValues_StructWithDefaults_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_DefaultValues_toFfi(DefaultValues value) =>
-  _smoke_DefaultValues_copy_handle((value as __lib.NativeBase).handle);
+  _smokeDefaultvaluesCopyHandle((value as __lib.NativeBase).handle);
 DefaultValues smoke_DefaultValues_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as DefaultValues;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_DefaultValues_copy_handle(handle);
-  final result = DefaultValues$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeDefaultvaluesCopyHandle(handle);
+  final result = DefaultValues$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_DefaultValues_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_DefaultValues_release_handle(handle);
+  _smokeDefaultvaluesReleaseHandle(handle);
 Pointer<Void> smoke_DefaultValues_toFfi_nullable(DefaultValues value) =>
   value != null ? smoke_DefaultValues_toFfi(value) : Pointer<Void>.fromAddress(0);
 DefaultValues smoke_DefaultValues_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_DefaultValues_fromFfi(handle) : null;
 void smoke_DefaultValues_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DefaultValues_release_handle(handle);
+  _smokeDefaultvaluesReleaseHandle(handle);
 // End of DefaultValues "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithAllDefaults {
@@ -12,71 +11,71 @@ class StructWithAllDefaults {
     : intField = 42, stringField = "\\Jonny \"Magic\" Smith\n";
 }
 // StructWithAllDefaults "private" section, not exported.
-final _smoke_StructWithAllDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithalldefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_create_handle'));
-final _smoke_StructWithAllDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithalldefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_release_handle'));
-final _smoke_StructWithAllDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithalldefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_get_field_intField'));
-final _smoke_StructWithAllDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithalldefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_get_field_stringField'));
 Pointer<Void> smoke_StructWithAllDefaults_toFfi(StructWithAllDefaults value) {
-  final _intField_handle = (value.intField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _result = _smoke_StructWithAllDefaults_create_handle(_intField_handle, _stringField_handle);
-  (_intField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _intFieldHandle = (value.intField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _result = _smokeStructwithalldefaultsCreateHandle(_intFieldHandle, _stringFieldHandle);
+  (_intFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 StructWithAllDefaults smoke_StructWithAllDefaults_fromFfi(Pointer<Void> handle) {
-  final _intField_handle = _smoke_StructWithAllDefaults_get_field_intField(handle);
-  final _stringField_handle = _smoke_StructWithAllDefaults_get_field_stringField(handle);
+  final _intFieldHandle = _smokeStructwithalldefaultsGetFieldintField(handle);
+  final _stringFieldHandle = _smokeStructwithalldefaultsGetFieldstringField(handle);
   try {
     return StructWithAllDefaults(
-      (_intField_handle),
-      String_fromFfi(_stringField_handle)
+      (_intFieldHandle),
+      String_fromFfi(_stringFieldHandle)
     );
   } finally {
-    (_intField_handle);
-    String_releaseFfiHandle(_stringField_handle);
+    (_intFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_StructWithAllDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithAllDefaults_release_handle(handle);
+void smoke_StructWithAllDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithalldefaultsReleaseHandle(handle);
 // Nullable StructWithAllDefaults
-final _smoke_StructWithAllDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithAllDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_create_handle_nullable'));
-final _smoke_StructWithAllDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithAllDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_release_handle_nullable'));
-final _smoke_StructWithAllDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithAllDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithAllDefaults_get_value_nullable'));
 Pointer<Void> smoke_StructWithAllDefaults_toFfi_nullable(StructWithAllDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithAllDefaults_toFfi(value);
-  final result = _smoke_StructWithAllDefaults_create_handle_nullable(_handle);
+  final result = _smoke_StructWithAllDefaultsCreateHandleNullable(_handle);
   smoke_StructWithAllDefaults_releaseFfiHandle(_handle);
   return result;
 }
 StructWithAllDefaults smoke_StructWithAllDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithAllDefaults_get_value_nullable(handle);
+  final _handle = _smoke_StructWithAllDefaultsGetValueNullable(handle);
   final result = smoke_StructWithAllDefaults_fromFfi(_handle);
   smoke_StructWithAllDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithAllDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithAllDefaults_release_handle_nullable(handle);
+  _smoke_StructWithAllDefaultsReleaseHandleNullable(handle);
 // End of StructWithAllDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithCollectionDefaults {
@@ -17,107 +16,107 @@ class StructWithCollectionDefaults {
     : emptyListField = [], emptyMapField = {}, emptySetField = {}, listField = ["foo", "bar"], mapField = {"foo": "bar"}, setField = {"foo", "bar"};
 }
 // StructWithCollectionDefaults "private" section, not exported.
-final _smoke_StructWithCollectionDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_create_handle'));
-final _smoke_StructWithCollectionDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_release_handle'));
-final _smoke_StructWithCollectionDefaults_get_field_emptyListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsGetFieldemptyListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_field_emptyListField'));
-final _smoke_StructWithCollectionDefaults_get_field_emptyMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsGetFieldemptyMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_field_emptyMapField'));
-final _smoke_StructWithCollectionDefaults_get_field_emptySetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsGetFieldemptySetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_field_emptySetField'));
-final _smoke_StructWithCollectionDefaults_get_field_listField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsGetFieldlistField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_field_listField'));
-final _smoke_StructWithCollectionDefaults_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsGetFieldmapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_field_mapField'));
-final _smoke_StructWithCollectionDefaults_get_field_setField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithcollectiondefaultsGetFieldsetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_field_setField'));
 Pointer<Void> smoke_StructWithCollectionDefaults_toFfi(StructWithCollectionDefaults value) {
-  final _emptyListField_handle = ListOf_String_toFfi(value.emptyListField);
-  final _emptyMapField_handle = MapOf_String_to_String_toFfi(value.emptyMapField);
-  final _emptySetField_handle = SetOf_String_toFfi(value.emptySetField);
-  final _listField_handle = ListOf_String_toFfi(value.listField);
-  final _mapField_handle = MapOf_String_to_String_toFfi(value.mapField);
-  final _setField_handle = SetOf_String_toFfi(value.setField);
-  final _result = _smoke_StructWithCollectionDefaults_create_handle(_emptyListField_handle, _emptyMapField_handle, _emptySetField_handle, _listField_handle, _mapField_handle, _setField_handle);
-  ListOf_String_releaseFfiHandle(_emptyListField_handle);
-  MapOf_String_to_String_releaseFfiHandle(_emptyMapField_handle);
-  SetOf_String_releaseFfiHandle(_emptySetField_handle);
-  ListOf_String_releaseFfiHandle(_listField_handle);
-  MapOf_String_to_String_releaseFfiHandle(_mapField_handle);
-  SetOf_String_releaseFfiHandle(_setField_handle);
+  final _emptyListFieldHandle = ListOf_String_toFfi(value.emptyListField);
+  final _emptyMapFieldHandle = MapOf_String_to_String_toFfi(value.emptyMapField);
+  final _emptySetFieldHandle = SetOf_String_toFfi(value.emptySetField);
+  final _listFieldHandle = ListOf_String_toFfi(value.listField);
+  final _mapFieldHandle = MapOf_String_to_String_toFfi(value.mapField);
+  final _setFieldHandle = SetOf_String_toFfi(value.setField);
+  final _result = _smokeStructwithcollectiondefaultsCreateHandle(_emptyListFieldHandle, _emptyMapFieldHandle, _emptySetFieldHandle, _listFieldHandle, _mapFieldHandle, _setFieldHandle);
+  ListOf_String_releaseFfiHandle(_emptyListFieldHandle);
+  MapOf_String_to_String_releaseFfiHandle(_emptyMapFieldHandle);
+  SetOf_String_releaseFfiHandle(_emptySetFieldHandle);
+  ListOf_String_releaseFfiHandle(_listFieldHandle);
+  MapOf_String_to_String_releaseFfiHandle(_mapFieldHandle);
+  SetOf_String_releaseFfiHandle(_setFieldHandle);
   return _result;
 }
 StructWithCollectionDefaults smoke_StructWithCollectionDefaults_fromFfi(Pointer<Void> handle) {
-  final _emptyListField_handle = _smoke_StructWithCollectionDefaults_get_field_emptyListField(handle);
-  final _emptyMapField_handle = _smoke_StructWithCollectionDefaults_get_field_emptyMapField(handle);
-  final _emptySetField_handle = _smoke_StructWithCollectionDefaults_get_field_emptySetField(handle);
-  final _listField_handle = _smoke_StructWithCollectionDefaults_get_field_listField(handle);
-  final _mapField_handle = _smoke_StructWithCollectionDefaults_get_field_mapField(handle);
-  final _setField_handle = _smoke_StructWithCollectionDefaults_get_field_setField(handle);
+  final _emptyListFieldHandle = _smokeStructwithcollectiondefaultsGetFieldemptyListField(handle);
+  final _emptyMapFieldHandle = _smokeStructwithcollectiondefaultsGetFieldemptyMapField(handle);
+  final _emptySetFieldHandle = _smokeStructwithcollectiondefaultsGetFieldemptySetField(handle);
+  final _listFieldHandle = _smokeStructwithcollectiondefaultsGetFieldlistField(handle);
+  final _mapFieldHandle = _smokeStructwithcollectiondefaultsGetFieldmapField(handle);
+  final _setFieldHandle = _smokeStructwithcollectiondefaultsGetFieldsetField(handle);
   try {
     return StructWithCollectionDefaults(
-      ListOf_String_fromFfi(_emptyListField_handle),
-      MapOf_String_to_String_fromFfi(_emptyMapField_handle),
-      SetOf_String_fromFfi(_emptySetField_handle),
-      ListOf_String_fromFfi(_listField_handle),
-      MapOf_String_to_String_fromFfi(_mapField_handle),
-      SetOf_String_fromFfi(_setField_handle)
+      ListOf_String_fromFfi(_emptyListFieldHandle),
+      MapOf_String_to_String_fromFfi(_emptyMapFieldHandle),
+      SetOf_String_fromFfi(_emptySetFieldHandle),
+      ListOf_String_fromFfi(_listFieldHandle),
+      MapOf_String_to_String_fromFfi(_mapFieldHandle),
+      SetOf_String_fromFfi(_setFieldHandle)
     );
   } finally {
-    ListOf_String_releaseFfiHandle(_emptyListField_handle);
-    MapOf_String_to_String_releaseFfiHandle(_emptyMapField_handle);
-    SetOf_String_releaseFfiHandle(_emptySetField_handle);
-    ListOf_String_releaseFfiHandle(_listField_handle);
-    MapOf_String_to_String_releaseFfiHandle(_mapField_handle);
-    SetOf_String_releaseFfiHandle(_setField_handle);
+    ListOf_String_releaseFfiHandle(_emptyListFieldHandle);
+    MapOf_String_to_String_releaseFfiHandle(_emptyMapFieldHandle);
+    SetOf_String_releaseFfiHandle(_emptySetFieldHandle);
+    ListOf_String_releaseFfiHandle(_listFieldHandle);
+    MapOf_String_to_String_releaseFfiHandle(_mapFieldHandle);
+    SetOf_String_releaseFfiHandle(_setFieldHandle);
   }
 }
-void smoke_StructWithCollectionDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithCollectionDefaults_release_handle(handle);
+void smoke_StructWithCollectionDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithcollectiondefaultsReleaseHandle(handle);
 // Nullable StructWithCollectionDefaults
-final _smoke_StructWithCollectionDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithCollectionDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_create_handle_nullable'));
-final _smoke_StructWithCollectionDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithCollectionDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_release_handle_nullable'));
-final _smoke_StructWithCollectionDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithCollectionDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithCollectionDefaults_get_value_nullable'));
 Pointer<Void> smoke_StructWithCollectionDefaults_toFfi_nullable(StructWithCollectionDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithCollectionDefaults_toFfi(value);
-  final result = _smoke_StructWithCollectionDefaults_create_handle_nullable(_handle);
+  final result = _smoke_StructWithCollectionDefaultsCreateHandleNullable(_handle);
   smoke_StructWithCollectionDefaults_releaseFfiHandle(_handle);
   return result;
 }
 StructWithCollectionDefaults smoke_StructWithCollectionDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithCollectionDefaults_get_value_nullable(handle);
+  final _handle = _smoke_StructWithCollectionDefaultsGetValueNullable(handle);
   final result = smoke_StructWithCollectionDefaults_fromFfi(_handle);
   smoke_StructWithCollectionDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithCollectionDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithCollectionDefaults_release_handle_nullable(handle);
+  _smoke_StructWithCollectionDefaultsReleaseHandleNullable(handle);
 // End of StructWithCollectionDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/something_enum.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithEnums {
@@ -13,80 +12,80 @@ class StructWithEnums {
   static final SomethingEnum firstConstant = SomethingEnum.reallyFirst;
 }
 // StructWithEnums "private" section, not exported.
-final _smoke_StructWithEnums_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithenumsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32, Uint32, Uint32),
     Pointer<Void> Function(int, int, int)
   >('library_smoke_StructWithEnums_create_handle'));
-final _smoke_StructWithEnums_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithenumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_release_handle'));
-final _smoke_StructWithEnums_get_field_firstField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithenumsGetFieldfirstField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_get_field_firstField'));
-final _smoke_StructWithEnums_get_field_explicitField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithenumsGetFieldexplicitField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_get_field_explicitField'));
-final _smoke_StructWithEnums_get_field_lastField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithenumsGetFieldlastField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_get_field_lastField'));
 Pointer<Void> smoke_StructWithEnums_toFfi(StructWithEnums value) {
-  final _firstField_handle = smoke_SomethingEnum_toFfi(value.firstField);
-  final _explicitField_handle = smoke_SomethingEnum_toFfi(value.explicitField);
-  final _lastField_handle = smoke_SomethingEnum_toFfi(value.lastField);
-  final _result = _smoke_StructWithEnums_create_handle(_firstField_handle, _explicitField_handle, _lastField_handle);
-  smoke_SomethingEnum_releaseFfiHandle(_firstField_handle);
-  smoke_SomethingEnum_releaseFfiHandle(_explicitField_handle);
-  smoke_SomethingEnum_releaseFfiHandle(_lastField_handle);
+  final _firstFieldHandle = smoke_SomethingEnum_toFfi(value.firstField);
+  final _explicitFieldHandle = smoke_SomethingEnum_toFfi(value.explicitField);
+  final _lastFieldHandle = smoke_SomethingEnum_toFfi(value.lastField);
+  final _result = _smokeStructwithenumsCreateHandle(_firstFieldHandle, _explicitFieldHandle, _lastFieldHandle);
+  smoke_SomethingEnum_releaseFfiHandle(_firstFieldHandle);
+  smoke_SomethingEnum_releaseFfiHandle(_explicitFieldHandle);
+  smoke_SomethingEnum_releaseFfiHandle(_lastFieldHandle);
   return _result;
 }
 StructWithEnums smoke_StructWithEnums_fromFfi(Pointer<Void> handle) {
-  final _firstField_handle = _smoke_StructWithEnums_get_field_firstField(handle);
-  final _explicitField_handle = _smoke_StructWithEnums_get_field_explicitField(handle);
-  final _lastField_handle = _smoke_StructWithEnums_get_field_lastField(handle);
+  final _firstFieldHandle = _smokeStructwithenumsGetFieldfirstField(handle);
+  final _explicitFieldHandle = _smokeStructwithenumsGetFieldexplicitField(handle);
+  final _lastFieldHandle = _smokeStructwithenumsGetFieldlastField(handle);
   try {
     return StructWithEnums(
-      smoke_SomethingEnum_fromFfi(_firstField_handle),
-      smoke_SomethingEnum_fromFfi(_explicitField_handle),
-      smoke_SomethingEnum_fromFfi(_lastField_handle)
+      smoke_SomethingEnum_fromFfi(_firstFieldHandle),
+      smoke_SomethingEnum_fromFfi(_explicitFieldHandle),
+      smoke_SomethingEnum_fromFfi(_lastFieldHandle)
     );
   } finally {
-    smoke_SomethingEnum_releaseFfiHandle(_firstField_handle);
-    smoke_SomethingEnum_releaseFfiHandle(_explicitField_handle);
-    smoke_SomethingEnum_releaseFfiHandle(_lastField_handle);
+    smoke_SomethingEnum_releaseFfiHandle(_firstFieldHandle);
+    smoke_SomethingEnum_releaseFfiHandle(_explicitFieldHandle);
+    smoke_SomethingEnum_releaseFfiHandle(_lastFieldHandle);
   }
 }
-void smoke_StructWithEnums_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithEnums_release_handle(handle);
+void smoke_StructWithEnums_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithenumsReleaseHandle(handle);
 // Nullable StructWithEnums
-final _smoke_StructWithEnums_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithEnumsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_create_handle_nullable'));
-final _smoke_StructWithEnums_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithEnumsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_release_handle_nullable'));
-final _smoke_StructWithEnums_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithEnumsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithEnums_get_value_nullable'));
 Pointer<Void> smoke_StructWithEnums_toFfi_nullable(StructWithEnums value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithEnums_toFfi(value);
-  final result = _smoke_StructWithEnums_create_handle_nullable(_handle);
+  final result = _smoke_StructWithEnumsCreateHandleNullable(_handle);
   smoke_StructWithEnums_releaseFfiHandle(_handle);
   return result;
 }
 StructWithEnums smoke_StructWithEnums_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithEnums_get_value_nullable(handle);
+  final _handle = _smoke_StructWithEnumsGetValueNullable(handle);
   final result = smoke_StructWithEnums_fromFfi(_handle);
   smoke_StructWithEnums_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithEnums_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithEnums_release_handle_nullable(handle);
+  _smoke_StructWithEnumsReleaseHandleNullable(handle);
 // End of StructWithEnums "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -2,7 +2,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/types_with_defaults.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithInitializerDefaults {
@@ -16,98 +15,98 @@ class StructWithInitializerDefaults {
     : intsField = [4, -2, 42], floatsField = [3.14, double.negativeInfinity], structField = StructWithAnEnum(AnEnum.disabled), setTypeField = {"foo", "bar"}, mapField = {1: "foo", 42: "bar"};
 }
 // StructWithInitializerDefaults "private" section, not exported.
-final _smoke_StructWithInitializerDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinitializerdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_create_handle'));
-final _smoke_StructWithInitializerDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinitializerdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_release_handle'));
-final _smoke_StructWithInitializerDefaults_get_field_intsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinitializerdefaultsGetFieldintsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_field_intsField'));
-final _smoke_StructWithInitializerDefaults_get_field_floatsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinitializerdefaultsGetFieldfloatsField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_field_floatsField'));
-final _smoke_StructWithInitializerDefaults_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinitializerdefaultsGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_field_structField'));
-final _smoke_StructWithInitializerDefaults_get_field_setTypeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinitializerdefaultsGetFieldsetTypeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_field_setTypeField'));
-final _smoke_StructWithInitializerDefaults_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinitializerdefaultsGetFieldmapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_field_mapField'));
 Pointer<Void> smoke_StructWithInitializerDefaults_toFfi(StructWithInitializerDefaults value) {
-  final _intsField_handle = ListOf_Int_toFfi(value.intsField);
-  final _floatsField_handle = ListOf_Float_toFfi(value.floatsField);
-  final _structField_handle = smoke_TypesWithDefaults_StructWithAnEnum_toFfi(value.structField);
-  final _setTypeField_handle = SetOf_String_toFfi(value.setTypeField);
-  final _mapField_handle = MapOf_UInt_to_String_toFfi(value.mapField);
-  final _result = _smoke_StructWithInitializerDefaults_create_handle(_intsField_handle, _floatsField_handle, _structField_handle, _setTypeField_handle, _mapField_handle);
-  ListOf_Int_releaseFfiHandle(_intsField_handle);
-  ListOf_Float_releaseFfiHandle(_floatsField_handle);
-  smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
-  SetOf_String_releaseFfiHandle(_setTypeField_handle);
-  MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+  final _intsFieldHandle = ListOf_Int_toFfi(value.intsField);
+  final _floatsFieldHandle = ListOf_Float_toFfi(value.floatsField);
+  final _structFieldHandle = smoke_TypesWithDefaults_StructWithAnEnum_toFfi(value.structField);
+  final _setTypeFieldHandle = SetOf_String_toFfi(value.setTypeField);
+  final _mapFieldHandle = MapOf_UInt_to_String_toFfi(value.mapField);
+  final _result = _smokeStructwithinitializerdefaultsCreateHandle(_intsFieldHandle, _floatsFieldHandle, _structFieldHandle, _setTypeFieldHandle, _mapFieldHandle);
+  ListOf_Int_releaseFfiHandle(_intsFieldHandle);
+  ListOf_Float_releaseFfiHandle(_floatsFieldHandle);
+  smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structFieldHandle);
+  SetOf_String_releaseFfiHandle(_setTypeFieldHandle);
+  MapOf_UInt_to_String_releaseFfiHandle(_mapFieldHandle);
   return _result;
 }
 StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi(Pointer<Void> handle) {
-  final _intsField_handle = _smoke_StructWithInitializerDefaults_get_field_intsField(handle);
-  final _floatsField_handle = _smoke_StructWithInitializerDefaults_get_field_floatsField(handle);
-  final _structField_handle = _smoke_StructWithInitializerDefaults_get_field_structField(handle);
-  final _setTypeField_handle = _smoke_StructWithInitializerDefaults_get_field_setTypeField(handle);
-  final _mapField_handle = _smoke_StructWithInitializerDefaults_get_field_mapField(handle);
+  final _intsFieldHandle = _smokeStructwithinitializerdefaultsGetFieldintsField(handle);
+  final _floatsFieldHandle = _smokeStructwithinitializerdefaultsGetFieldfloatsField(handle);
+  final _structFieldHandle = _smokeStructwithinitializerdefaultsGetFieldstructField(handle);
+  final _setTypeFieldHandle = _smokeStructwithinitializerdefaultsGetFieldsetTypeField(handle);
+  final _mapFieldHandle = _smokeStructwithinitializerdefaultsGetFieldmapField(handle);
   try {
     return StructWithInitializerDefaults(
-      ListOf_Int_fromFfi(_intsField_handle),
-      ListOf_Float_fromFfi(_floatsField_handle),
-      smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_structField_handle),
-      SetOf_String_fromFfi(_setTypeField_handle),
-      MapOf_UInt_to_String_fromFfi(_mapField_handle)
+      ListOf_Int_fromFfi(_intsFieldHandle),
+      ListOf_Float_fromFfi(_floatsFieldHandle),
+      smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_structFieldHandle),
+      SetOf_String_fromFfi(_setTypeFieldHandle),
+      MapOf_UInt_to_String_fromFfi(_mapFieldHandle)
     );
   } finally {
-    ListOf_Int_releaseFfiHandle(_intsField_handle);
-    ListOf_Float_releaseFfiHandle(_floatsField_handle);
-    smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structField_handle);
-    SetOf_String_releaseFfiHandle(_setTypeField_handle);
-    MapOf_UInt_to_String_releaseFfiHandle(_mapField_handle);
+    ListOf_Int_releaseFfiHandle(_intsFieldHandle);
+    ListOf_Float_releaseFfiHandle(_floatsFieldHandle);
+    smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_structFieldHandle);
+    SetOf_String_releaseFfiHandle(_setTypeFieldHandle);
+    MapOf_UInt_to_String_releaseFfiHandle(_mapFieldHandle);
   }
 }
-void smoke_StructWithInitializerDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInitializerDefaults_release_handle(handle);
+void smoke_StructWithInitializerDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithinitializerdefaultsReleaseHandle(handle);
 // Nullable StructWithInitializerDefaults
-final _smoke_StructWithInitializerDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInitializerDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_create_handle_nullable'));
-final _smoke_StructWithInitializerDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInitializerDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_release_handle_nullable'));
-final _smoke_StructWithInitializerDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInitializerDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInitializerDefaults_get_value_nullable'));
 Pointer<Void> smoke_StructWithInitializerDefaults_toFfi_nullable(StructWithInitializerDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithInitializerDefaults_toFfi(value);
-  final result = _smoke_StructWithInitializerDefaults_create_handle_nullable(_handle);
+  final result = _smoke_StructWithInitializerDefaultsCreateHandleNullable(_handle);
   smoke_StructWithInitializerDefaults_releaseFfiHandle(_handle);
   return result;
 }
 StructWithInitializerDefaults smoke_StructWithInitializerDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithInitializerDefaults_get_value_nullable(handle);
+  final _handle = _smoke_StructWithInitializerDefaultsGetValueNullable(handle);
   final result = smoke_StructWithInitializerDefaults_fromFfi(_handle);
   smoke_StructWithInitializerDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithInitializerDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithInitializerDefaults_release_handle_nullable(handle);
+  _smoke_StructWithInitializerDefaultsReleaseHandleNullable(handle);
 // End of StructWithInitializerDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithSomeDefaults {
@@ -12,71 +11,71 @@ class StructWithSomeDefaults {
     : intField = 42, stringField = stringField;
 }
 // StructWithSomeDefaults "private" section, not exported.
-final _smoke_StructWithSomeDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithsomedefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_create_handle'));
-final _smoke_StructWithSomeDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithsomedefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_release_handle'));
-final _smoke_StructWithSomeDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithsomedefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_get_field_intField'));
-final _smoke_StructWithSomeDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithsomedefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_get_field_stringField'));
 Pointer<Void> smoke_StructWithSomeDefaults_toFfi(StructWithSomeDefaults value) {
-  final _intField_handle = (value.intField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _result = _smoke_StructWithSomeDefaults_create_handle(_intField_handle, _stringField_handle);
-  (_intField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _intFieldHandle = (value.intField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _result = _smokeStructwithsomedefaultsCreateHandle(_intFieldHandle, _stringFieldHandle);
+  (_intFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 StructWithSomeDefaults smoke_StructWithSomeDefaults_fromFfi(Pointer<Void> handle) {
-  final _intField_handle = _smoke_StructWithSomeDefaults_get_field_intField(handle);
-  final _stringField_handle = _smoke_StructWithSomeDefaults_get_field_stringField(handle);
+  final _intFieldHandle = _smokeStructwithsomedefaultsGetFieldintField(handle);
+  final _stringFieldHandle = _smokeStructwithsomedefaultsGetFieldstringField(handle);
   try {
     return StructWithSomeDefaults(
-      String_fromFfi(_stringField_handle),
-      (_intField_handle)
+      String_fromFfi(_stringFieldHandle),
+      (_intFieldHandle)
     );
   } finally {
-    (_intField_handle);
-    String_releaseFfiHandle(_stringField_handle);
+    (_intFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_StructWithSomeDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithSomeDefaults_release_handle(handle);
+void smoke_StructWithSomeDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithsomedefaultsReleaseHandle(handle);
 // Nullable StructWithSomeDefaults
-final _smoke_StructWithSomeDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithSomeDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_create_handle_nullable'));
-final _smoke_StructWithSomeDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithSomeDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_release_handle_nullable'));
-final _smoke_StructWithSomeDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithSomeDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithSomeDefaults_get_value_nullable'));
 Pointer<Void> smoke_StructWithSomeDefaults_toFfi_nullable(StructWithSomeDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithSomeDefaults_toFfi(value);
-  final result = _smoke_StructWithSomeDefaults_create_handle_nullable(_handle);
+  final result = _smoke_StructWithSomeDefaultsCreateHandleNullable(_handle);
   smoke_StructWithSomeDefaults_releaseFfiHandle(_handle);
   return result;
 }
 StructWithSomeDefaults smoke_StructWithSomeDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithSomeDefaults_get_value_nullable(handle);
+  final _handle = _smoke_StructWithSomeDefaultsGetValueNullable(handle);
   final result = smoke_StructWithSomeDefaults_fromFfi(_handle);
   smoke_StructWithSomeDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithSomeDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithSomeDefaults_release_handle_nullable(handle);
+  _smoke_StructWithSomeDefaultsReleaseHandleNullable(handle);
 // End of StructWithSomeDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -2,7 +2,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/an_enum.dart';
 import 'package:library/src/smoke/default_values.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SomeEnum {
@@ -35,34 +34,34 @@ SomeEnum smoke_TypesWithDefaults_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_TypesWithDefaults_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_TypesWithDefaults_SomeEnum_create_handle_nullable'));
-final _smoke_TypesWithDefaults_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_SomeEnum_release_handle_nullable'));
-final _smoke_TypesWithDefaults_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_SomeEnum_toFfi_nullable(SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_SomeEnum_toFfi(value);
-  final result = _smoke_TypesWithDefaults_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_TypesWithDefaults_SomeEnumCreateHandleNullable(_handle);
   smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 SomeEnum smoke_TypesWithDefaults_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_TypesWithDefaults_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_TypesWithDefaults_SomeEnumGetValueNullable(handle);
   final result = smoke_TypesWithDefaults_SomeEnum_fromFfi(_handle);
   smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypesWithDefaults_SomeEnum_release_handle_nullable(handle);
+  _smoke_TypesWithDefaults_SomeEnumReleaseHandleNullable(handle);
 // End of SomeEnum "private" section.
 class StructWithDefaults {
   int intField;
@@ -77,118 +76,118 @@ class StructWithDefaults {
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue;
 }
 // StructWithDefaults "private" section, not exported.
-final _smoke_TypesWithDefaults_StructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_create_handle'));
-final _smoke_TypesWithDefaults_StructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_release_handle'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_intField'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsGetFielduintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsGetFielddoubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithdefaultsGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithDefaults_toFfi(StructWithDefaults value) {
-  final _intField_handle = (value.intField);
-  final _uintField_handle = (value.uintField);
-  final _floatField_handle = (value.floatField);
-  final _doubleField_handle = (value.doubleField);
-  final _boolField_handle = Boolean_toFfi(value.boolField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _enumField_handle = smoke_TypesWithDefaults_SomeEnum_toFfi(value.enumField);
-  final _result = _smoke_TypesWithDefaults_StructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _doubleField_handle, _boolField_handle, _stringField_handle, _enumField_handle);
-  (_intField_handle);
-  (_uintField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+  final _intFieldHandle = (value.intField);
+  final _uintFieldHandle = (value.uintField);
+  final _floatFieldHandle = (value.floatField);
+  final _doubleFieldHandle = (value.doubleField);
+  final _boolFieldHandle = Boolean_toFfi(value.boolField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _enumFieldHandle = smoke_TypesWithDefaults_SomeEnum_toFfi(value.enumField);
+  final _result = _smokeTypeswithdefaultsStructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle);
+  (_intFieldHandle);
+  (_uintFieldHandle);
+  (_floatFieldHandle);
+  (_doubleFieldHandle);
+  Boolean_releaseFfiHandle(_boolFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumFieldHandle);
   return _result;
 }
 StructWithDefaults smoke_TypesWithDefaults_StructWithDefaults_fromFfi(Pointer<Void> handle) {
-  final _intField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_intField(handle);
-  final _uintField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_uintField(handle);
-  final _floatField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_floatField(handle);
-  final _doubleField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_doubleField(handle);
-  final _boolField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_boolField(handle);
-  final _stringField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField(handle);
-  final _enumField_handle = _smoke_TypesWithDefaults_StructWithDefaults_get_field_enumField(handle);
+  final _intFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldintField(handle);
+  final _uintFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFielduintField(handle);
+  final _floatFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldfloatField(handle);
+  final _doubleFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFielddoubleField(handle);
+  final _boolFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldboolField(handle);
+  final _stringFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldstringField(handle);
+  final _enumFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldenumField(handle);
   try {
     return StructWithDefaults(
-      (_intField_handle),
-      (_uintField_handle),
-      (_floatField_handle),
-      (_doubleField_handle),
-      Boolean_fromFfi(_boolField_handle),
-      String_fromFfi(_stringField_handle),
-      smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle)
+      (_intFieldHandle),
+      (_uintFieldHandle),
+      (_floatFieldHandle),
+      (_doubleFieldHandle),
+      Boolean_fromFfi(_boolFieldHandle),
+      String_fromFfi(_stringFieldHandle),
+      smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumFieldHandle)
     );
   } finally {
-    (_intField_handle);
-    (_uintField_handle);
-    (_floatField_handle);
-    (_doubleField_handle);
-    Boolean_releaseFfiHandle(_boolField_handle);
-    String_releaseFfiHandle(_stringField_handle);
-    smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
+    (_intFieldHandle);
+    (_uintFieldHandle);
+    (_floatFieldHandle);
+    (_doubleFieldHandle);
+    Boolean_releaseFfiHandle(_boolFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumFieldHandle);
   }
 }
-void smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithDefaults_release_handle(handle);
+void smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsStructwithdefaultsReleaseHandle(handle);
 // Nullable StructWithDefaults
-final _smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable'));
-final _smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable'));
-final _smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithDefaults_toFfi_nullable(StructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_StructWithDefaults_toFfi(value);
-  final result = _smoke_TypesWithDefaults_StructWithDefaults_create_handle_nullable(_handle);
+  final result = _smoke_TypesWithDefaults_StructWithDefaultsCreateHandleNullable(_handle);
   smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 StructWithDefaults smoke_TypesWithDefaults_StructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable(handle);
+  final _handle = _smoke_TypesWithDefaults_StructWithDefaultsGetValueNullable(handle);
   final result = smoke_TypesWithDefaults_StructWithDefaults_fromFfi(_handle);
   smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_TypesWithDefaults_StructWithDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypesWithDefaults_StructWithDefaults_release_handle_nullable(handle);
+  _smoke_TypesWithDefaults_StructWithDefaultsReleaseHandleNullable(handle);
 // End of StructWithDefaults "private" section.
 @immutable
 class ImmutableStructWithDefaults {
@@ -205,127 +204,127 @@ class ImmutableStructWithDefaults {
     : intField = 42, uintField = uintField, floatField = 3.14, doubleField = -1.4142, boolField = boolField, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
 }
 // ImmutableStructWithDefaults "private" section, not exported.
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>, Uint32, Uint32),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>, int, int)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFielduintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFielddoubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldexternalEnumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField'));
 Pointer<Void> smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi(ImmutableStructWithDefaults value) {
-  final _intField_handle = (value.intField);
-  final _uintField_handle = (value.uintField);
-  final _floatField_handle = (value.floatField);
-  final _doubleField_handle = (value.doubleField);
-  final _boolField_handle = Boolean_toFfi(value.boolField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _enumField_handle = smoke_TypesWithDefaults_SomeEnum_toFfi(value.enumField);
-  final _externalEnumField_handle = smoke_DefaultValues_ExternalEnum_toFfi(value.externalEnumField);
-  final _result = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle(_intField_handle, _uintField_handle, _floatField_handle, _doubleField_handle, _boolField_handle, _stringField_handle, _enumField_handle, _externalEnumField_handle);
-  (_intField_handle);
-  (_uintField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
-  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+  final _intFieldHandle = (value.intField);
+  final _uintFieldHandle = (value.uintField);
+  final _floatFieldHandle = (value.floatField);
+  final _doubleFieldHandle = (value.doubleField);
+  final _boolFieldHandle = Boolean_toFfi(value.boolField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _enumFieldHandle = smoke_TypesWithDefaults_SomeEnum_toFfi(value.enumField);
+  final _externalEnumFieldHandle = smoke_DefaultValues_ExternalEnum_toFfi(value.externalEnumField);
+  final _result = _smokeTypeswithdefaultsImmutablestructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle, _externalEnumFieldHandle);
+  (_intFieldHandle);
+  (_uintFieldHandle);
+  (_floatFieldHandle);
+  (_doubleFieldHandle);
+  Boolean_releaseFfiHandle(_boolFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumFieldHandle);
+  smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumFieldHandle);
   return _result;
 }
 ImmutableStructWithDefaults smoke_TypesWithDefaults_ImmutableStructWithDefaults_fromFfi(Pointer<Void> handle) {
-  final _intField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_intField(handle);
-  final _uintField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_uintField(handle);
-  final _floatField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_floatField(handle);
-  final _doubleField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_doubleField(handle);
-  final _boolField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_boolField(handle);
-  final _stringField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField(handle);
-  final _enumField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_enumField(handle);
-  final _externalEnumField_handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_externalEnumField(handle);
+  final _intFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldintField(handle);
+  final _uintFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFielduintField(handle);
+  final _floatFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldfloatField(handle);
+  final _doubleFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFielddoubleField(handle);
+  final _boolFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldboolField(handle);
+  final _stringFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldstringField(handle);
+  final _enumFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldenumField(handle);
+  final _externalEnumFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldexternalEnumField(handle);
   try {
     return ImmutableStructWithDefaults(
-      (_intField_handle),
-      (_uintField_handle),
-      (_floatField_handle),
-      (_doubleField_handle),
-      Boolean_fromFfi(_boolField_handle),
-      String_fromFfi(_stringField_handle),
-      smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumField_handle),
-      smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumField_handle)
+      (_intFieldHandle),
+      (_uintFieldHandle),
+      (_floatFieldHandle),
+      (_doubleFieldHandle),
+      Boolean_fromFfi(_boolFieldHandle),
+      String_fromFfi(_stringFieldHandle),
+      smoke_TypesWithDefaults_SomeEnum_fromFfi(_enumFieldHandle),
+      smoke_DefaultValues_ExternalEnum_fromFfi(_externalEnumFieldHandle)
     );
   } finally {
-    (_intField_handle);
-    (_uintField_handle);
-    (_floatField_handle);
-    (_doubleField_handle);
-    Boolean_releaseFfiHandle(_boolField_handle);
-    String_releaseFfiHandle(_stringField_handle);
-    smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumField_handle);
-    smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumField_handle);
+    (_intFieldHandle);
+    (_uintFieldHandle);
+    (_floatFieldHandle);
+    (_doubleFieldHandle);
+    Boolean_releaseFfiHandle(_boolFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    smoke_TypesWithDefaults_SomeEnum_releaseFfiHandle(_enumFieldHandle);
+    smoke_DefaultValues_ExternalEnum_releaseFfiHandle(_externalEnumFieldHandle);
   }
 }
-void smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle(handle);
+void smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseHandle(handle);
 // Nullable ImmutableStructWithDefaults
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle_nullable'));
-final _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_ImmutableStructWithDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi_nullable(ImmutableStructWithDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_ImmutableStructWithDefaults_toFfi(value);
-  final result = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_create_handle_nullable(_handle);
+  final result = _smoke_TypesWithDefaults_ImmutableStructWithDefaultsCreateHandleNullable(_handle);
   smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 ImmutableStructWithDefaults smoke_TypesWithDefaults_ImmutableStructWithDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable(handle);
+  final _handle = _smoke_TypesWithDefaults_ImmutableStructWithDefaultsGetValueNullable(handle);
   final result = smoke_TypesWithDefaults_ImmutableStructWithDefaults_fromFfi(_handle);
   smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_TypesWithDefaults_ImmutableStructWithDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_handle_nullable(handle);
+  _smoke_TypesWithDefaults_ImmutableStructWithDefaultsReleaseHandleNullable(handle);
 // End of ImmutableStructWithDefaults "private" section.
 class StructWithAnEnum {
   AnEnum config;
@@ -334,62 +333,62 @@ class StructWithAnEnum {
     : config = AnEnum.enabled;
 }
 // StructWithAnEnum "private" section, not exported.
-final _smoke_TypesWithDefaults_StructWithAnEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithanenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_TypesWithDefaults_StructWithAnEnum_create_handle'));
-final _smoke_TypesWithDefaults_StructWithAnEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithanenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithAnEnum_release_handle'));
-final _smoke_TypesWithDefaults_StructWithAnEnum_get_field_config = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypeswithdefaultsStructwithanenumGetFieldconfig = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithAnEnum_get_field_config'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi(StructWithAnEnum value) {
-  final _config_handle = smoke_AnEnum_AnEnum_toFfi(value.config);
-  final _result = _smoke_TypesWithDefaults_StructWithAnEnum_create_handle(_config_handle);
-  smoke_AnEnum_AnEnum_releaseFfiHandle(_config_handle);
+  final _configHandle = smoke_AnEnum_AnEnum_toFfi(value.config);
+  final _result = _smokeTypeswithdefaultsStructwithanenumCreateHandle(_configHandle);
+  smoke_AnEnum_AnEnum_releaseFfiHandle(_configHandle);
   return _result;
 }
 StructWithAnEnum smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(Pointer<Void> handle) {
-  final _config_handle = _smoke_TypesWithDefaults_StructWithAnEnum_get_field_config(handle);
+  final _configHandle = _smokeTypeswithdefaultsStructwithanenumGetFieldconfig(handle);
   try {
     return StructWithAnEnum(
-      smoke_AnEnum_AnEnum_fromFfi(_config_handle)
+      smoke_AnEnum_AnEnum_fromFfi(_configHandle)
     );
   } finally {
-    smoke_AnEnum_AnEnum_releaseFfiHandle(_config_handle);
+    smoke_AnEnum_AnEnum_releaseFfiHandle(_configHandle);
   }
 }
-void smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypesWithDefaults_StructWithAnEnum_release_handle(handle);
+void smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsStructwithanenumReleaseHandle(handle);
 // Nullable StructWithAnEnum
-final _smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithAnEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable'));
-final _smoke_TypesWithDefaults_StructWithAnEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithAnEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithAnEnum_release_handle_nullable'));
-final _smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypesWithDefaults_StructWithAnEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable'));
 Pointer<Void> smoke_TypesWithDefaults_StructWithAnEnum_toFfi_nullable(StructWithAnEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypesWithDefaults_StructWithAnEnum_toFfi(value);
-  final result = _smoke_TypesWithDefaults_StructWithAnEnum_create_handle_nullable(_handle);
+  final result = _smoke_TypesWithDefaults_StructWithAnEnumCreateHandleNullable(_handle);
   smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_handle);
   return result;
 }
 StructWithAnEnum smoke_TypesWithDefaults_StructWithAnEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_TypesWithDefaults_StructWithAnEnum_get_value_nullable(handle);
+  final _handle = _smoke_TypesWithDefaults_StructWithAnEnumGetValueNullable(handle);
   final result = smoke_TypesWithDefaults_StructWithAnEnum_fromFfi(_handle);
   smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_TypesWithDefaults_StructWithAnEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypesWithDefaults_StructWithAnEnum_release_handle_nullable(handle);
+  _smoke_TypesWithDefaults_StructWithAnEnumReleaseHandleNullable(handle);
 // End of StructWithAnEnum "private" section.

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum EnumStartsWithOne {
@@ -32,32 +31,32 @@ EnumStartsWithOne smoke_EnumStartsWithOne_fromFfi(int handle) {
   }
 }
 void smoke_EnumStartsWithOne_releaseFfiHandle(int handle) {}
-final _smoke_EnumStartsWithOne_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_EnumStartsWithOneCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_EnumStartsWithOne_create_handle_nullable'));
-final _smoke_EnumStartsWithOne_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_EnumStartsWithOneReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnumStartsWithOne_release_handle_nullable'));
-final _smoke_EnumStartsWithOne_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_EnumStartsWithOneGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_EnumStartsWithOne_get_value_nullable'));
 Pointer<Void> smoke_EnumStartsWithOne_toFfi_nullable(EnumStartsWithOne value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_EnumStartsWithOne_toFfi(value);
-  final result = _smoke_EnumStartsWithOne_create_handle_nullable(_handle);
+  final result = _smoke_EnumStartsWithOneCreateHandleNullable(_handle);
   smoke_EnumStartsWithOne_releaseFfiHandle(_handle);
   return result;
 }
 EnumStartsWithOne smoke_EnumStartsWithOne_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_EnumStartsWithOne_get_value_nullable(handle);
+  final _handle = _smoke_EnumStartsWithOneGetValueNullable(handle);
   final result = smoke_EnumStartsWithOne_fromFfi(_handle);
   smoke_EnumStartsWithOne_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_EnumStartsWithOne_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_EnumStartsWithOne_release_handle_nullable(handle);
+  _smoke_EnumStartsWithOneReleaseHandleNullable(handle);
 // End of EnumStartsWithOne "private" section.

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Enums {
@@ -46,34 +45,34 @@ Enums_SimpleEnum smoke_Enums_SimpleEnum_fromFfi(int handle) {
   }
 }
 void smoke_Enums_SimpleEnum_releaseFfiHandle(int handle) {}
-final _smoke_Enums_SimpleEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_SimpleEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Enums_SimpleEnum_create_handle_nullable'));
-final _smoke_Enums_SimpleEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_SimpleEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_SimpleEnum_release_handle_nullable'));
-final _smoke_Enums_SimpleEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_SimpleEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_SimpleEnum_get_value_nullable'));
 Pointer<Void> smoke_Enums_SimpleEnum_toFfi_nullable(Enums_SimpleEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_SimpleEnum_toFfi(value);
-  final result = _smoke_Enums_SimpleEnum_create_handle_nullable(_handle);
+  final result = _smoke_Enums_SimpleEnumCreateHandleNullable(_handle);
   smoke_Enums_SimpleEnum_releaseFfiHandle(_handle);
   return result;
 }
 Enums_SimpleEnum smoke_Enums_SimpleEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Enums_SimpleEnum_get_value_nullable(handle);
+  final _handle = _smoke_Enums_SimpleEnumGetValueNullable(handle);
   final result = smoke_Enums_SimpleEnum_fromFfi(_handle);
   smoke_Enums_SimpleEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Enums_SimpleEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_SimpleEnum_release_handle_nullable(handle);
+  _smoke_Enums_SimpleEnumReleaseHandleNullable(handle);
 // End of Enums_SimpleEnum "private" section.
 enum Enums_InternalErrorCode {
     errorNone,
@@ -105,34 +104,34 @@ Enums_InternalErrorCode smoke_Enums_InternalErrorCode_fromFfi(int handle) {
   }
 }
 void smoke_Enums_InternalErrorCode_releaseFfiHandle(int handle) {}
-final _smoke_Enums_InternalErrorCode_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_InternalErrorCodeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Enums_InternalErrorCode_create_handle_nullable'));
-final _smoke_Enums_InternalErrorCode_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_InternalErrorCodeReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_InternalErrorCode_release_handle_nullable'));
-final _smoke_Enums_InternalErrorCode_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_InternalErrorCodeGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_InternalErrorCode_get_value_nullable'));
 Pointer<Void> smoke_Enums_InternalErrorCode_toFfi_nullable(Enums_InternalErrorCode value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_InternalErrorCode_toFfi(value);
-  final result = _smoke_Enums_InternalErrorCode_create_handle_nullable(_handle);
+  final result = _smoke_Enums_InternalErrorCodeCreateHandleNullable(_handle);
   smoke_Enums_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
 Enums_InternalErrorCode smoke_Enums_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Enums_InternalErrorCode_get_value_nullable(handle);
+  final _handle = _smoke_Enums_InternalErrorCodeGetValueNullable(handle);
   final result = smoke_Enums_InternalErrorCode_fromFfi(_handle);
   smoke_Enums_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Enums_InternalErrorCode_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_InternalErrorCode_release_handle_nullable(handle);
+  _smoke_Enums_InternalErrorCodeReleaseHandleNullable(handle);
 // End of Enums_InternalErrorCode "private" section.
 class Enums_ErrorStruct {
   Enums_InternalErrorCode type;
@@ -140,80 +139,80 @@ class Enums_ErrorStruct {
   Enums_ErrorStruct(this.type, this.message);
 }
 // Enums_ErrorStruct "private" section, not exported.
-final _smoke_Enums_ErrorStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsErrorstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_create_handle'));
-final _smoke_Enums_ErrorStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsErrorstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_release_handle'));
-final _smoke_Enums_ErrorStruct_get_field_type = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsErrorstructGetFieldtype = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_get_field_type'));
-final _smoke_Enums_ErrorStruct_get_field_message = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsErrorstructGetFieldmessage = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_get_field_message'));
 Pointer<Void> smoke_Enums_ErrorStruct_toFfi(Enums_ErrorStruct value) {
-  final _type_handle = smoke_Enums_InternalErrorCode_toFfi(value.type);
-  final _message_handle = String_toFfi(value.message);
-  final _result = _smoke_Enums_ErrorStruct_create_handle(_type_handle, _message_handle);
-  smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
-  String_releaseFfiHandle(_message_handle);
+  final _typeHandle = smoke_Enums_InternalErrorCode_toFfi(value.type);
+  final _messageHandle = String_toFfi(value.message);
+  final _result = _smokeEnumsErrorstructCreateHandle(_typeHandle, _messageHandle);
+  smoke_Enums_InternalErrorCode_releaseFfiHandle(_typeHandle);
+  String_releaseFfiHandle(_messageHandle);
   return _result;
 }
 Enums_ErrorStruct smoke_Enums_ErrorStruct_fromFfi(Pointer<Void> handle) {
-  final _type_handle = _smoke_Enums_ErrorStruct_get_field_type(handle);
-  final _message_handle = _smoke_Enums_ErrorStruct_get_field_message(handle);
+  final _typeHandle = _smokeEnumsErrorstructGetFieldtype(handle);
+  final _messageHandle = _smokeEnumsErrorstructGetFieldmessage(handle);
   try {
     return Enums_ErrorStruct(
-      smoke_Enums_InternalErrorCode_fromFfi(_type_handle),
-      String_fromFfi(_message_handle)
+      smoke_Enums_InternalErrorCode_fromFfi(_typeHandle),
+      String_fromFfi(_messageHandle)
     );
   } finally {
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
-    String_releaseFfiHandle(_message_handle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(_typeHandle);
+    String_releaseFfiHandle(_messageHandle);
   }
 }
-void smoke_Enums_ErrorStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Enums_ErrorStruct_release_handle(handle);
+void smoke_Enums_ErrorStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeEnumsErrorstructReleaseHandle(handle);
 // Nullable Enums_ErrorStruct
-final _smoke_Enums_ErrorStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ErrorStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_create_handle_nullable'));
-final _smoke_Enums_ErrorStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ErrorStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_release_handle_nullable'));
-final _smoke_Enums_ErrorStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ErrorStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_get_value_nullable'));
 Pointer<Void> smoke_Enums_ErrorStruct_toFfi_nullable(Enums_ErrorStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_ErrorStruct_toFfi(value);
-  final result = _smoke_Enums_ErrorStruct_create_handle_nullable(_handle);
+  final result = _smoke_Enums_ErrorStructCreateHandleNullable(_handle);
   smoke_Enums_ErrorStruct_releaseFfiHandle(_handle);
   return result;
 }
 Enums_ErrorStruct smoke_Enums_ErrorStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Enums_ErrorStruct_get_value_nullable(handle);
+  final _handle = _smoke_Enums_ErrorStructGetValueNullable(handle);
   final result = smoke_Enums_ErrorStruct_fromFfi(_handle);
   smoke_Enums_ErrorStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Enums_ErrorStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_ErrorStruct_release_handle_nullable(handle);
+  _smoke_Enums_ErrorStructReleaseHandleNullable(handle);
 // End of Enums_ErrorStruct "private" section.
 // Enums "private" section, not exported.
-final _smoke_Enums_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_copy_handle'));
-final _smoke_Enums_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_release_handle'));
@@ -223,75 +222,75 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Enums_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeEnumsReleaseHandle(handle);
     handle = null;
   }
   static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) {
-    final _methodWithEnumeration_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum'));
-    final _input_handle = smoke_Enums_SimpleEnum_toFfi(input);
-    final __result_handle = _methodWithEnumeration_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_Enums_SimpleEnum_releaseFfiHandle(_input_handle);
+    final _methodWithEnumerationFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum'));
+    final _inputHandle = smoke_Enums_SimpleEnum_toFfi(input);
+    final __resultHandle = _methodWithEnumerationFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Enums_SimpleEnum_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_Enums_SimpleEnum_fromFfi(__result_handle);
+      return smoke_Enums_SimpleEnum_fromFfi(__resultHandle);
     } finally {
-      smoke_Enums_SimpleEnum_releaseFfiHandle(__result_handle);
+      smoke_Enums_SimpleEnum_releaseFfiHandle(__resultHandle);
     }
   }
   static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) {
-    final _flipEnumValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode'));
-    final _input_handle = smoke_Enums_InternalErrorCode_toFfi(input);
-    final __result_handle = _flipEnumValue_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(_input_handle);
+    final _flipEnumValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode'));
+    final _inputHandle = smoke_Enums_InternalErrorCode_toFfi(input);
+    final __resultHandle = _flipEnumValueFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
+      return smoke_Enums_InternalErrorCode_fromFfi(__resultHandle);
     } finally {
-      smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
+      smoke_Enums_InternalErrorCode_releaseFfiHandle(__resultHandle);
     }
   }
   static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) {
-    final _extractEnumFromStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Pointer<Void>), int Function(int, Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct'));
-    final _input_handle = smoke_Enums_ErrorStruct_toFfi(input);
-    final __result_handle = _extractEnumFromStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_Enums_ErrorStruct_releaseFfiHandle(_input_handle);
+    final _extractEnumFromStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Pointer<Void>), int Function(int, Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct'));
+    final _inputHandle = smoke_Enums_ErrorStruct_toFfi(input);
+    final __resultHandle = _extractEnumFromStructFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Enums_ErrorStruct_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_Enums_InternalErrorCode_fromFfi(__result_handle);
+      return smoke_Enums_InternalErrorCode_fromFfi(__resultHandle);
     } finally {
-      smoke_Enums_InternalErrorCode_releaseFfiHandle(__result_handle);
+      smoke_Enums_InternalErrorCode_releaseFfiHandle(__resultHandle);
     }
   }
   static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) {
-    final _createStructWithEnumInside_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint32, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String'));
-    final _type_handle = smoke_Enums_InternalErrorCode_toFfi(type);
-    final _message_handle = String_toFfi(message);
-    final __result_handle = _createStructWithEnumInside_ffi(__lib.LibraryContext.isolateId, _type_handle, _message_handle);
-    smoke_Enums_InternalErrorCode_releaseFfiHandle(_type_handle);
-    String_releaseFfiHandle(_message_handle);
+    final _createStructWithEnumInsideFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint32, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String'));
+    final _typeHandle = smoke_Enums_InternalErrorCode_toFfi(type);
+    final _messageHandle = String_toFfi(message);
+    final __resultHandle = _createStructWithEnumInsideFfi(__lib.LibraryContext.isolateId, _typeHandle, _messageHandle);
+    smoke_Enums_InternalErrorCode_releaseFfiHandle(_typeHandle);
+    String_releaseFfiHandle(_messageHandle);
     try {
-      return smoke_Enums_ErrorStruct_fromFfi(__result_handle);
+      return smoke_Enums_ErrorStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_Enums_ErrorStruct_releaseFfiHandle(__result_handle);
+      smoke_Enums_ErrorStruct_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Enums_toFfi(Enums value) =>
-  _smoke_Enums_copy_handle((value as __lib.NativeBase).handle);
+  _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Enums;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Enums_copy_handle(handle);
-  final result = Enums$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeEnumsCopyHandle(handle);
+  final result = Enums$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Enums_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Enums_release_handle(handle);
+  _smokeEnumsReleaseHandle(handle);
 Pointer<Void> smoke_Enums_toFfi_nullable(Enums value) =>
   value != null ? smoke_Enums_toFfi(value) : Pointer<Void>.fromAddress(0);
 Enums smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Enums_fromFfi(handle) : null;
 void smoke_Enums_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_release_handle(handle);
+  _smokeEnumsReleaseHandle(handle);
 // End of Enums "private" section.

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -3,7 +3,6 @@ import 'package:collection/collection.dart';
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SomeEnum {
@@ -36,34 +35,34 @@ SomeEnum smoke_Equatable_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_Equatable_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_Equatable_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Equatable_SomeEnum_create_handle_nullable'));
-final _smoke_Equatable_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_SomeEnum_release_handle_nullable'));
-final _smoke_Equatable_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Equatable_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_Equatable_SomeEnum_toFfi_nullable(SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_SomeEnum_toFfi(value);
-  final result = _smoke_Equatable_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_Equatable_SomeEnumCreateHandleNullable(_handle);
   smoke_Equatable_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 SomeEnum smoke_Equatable_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Equatable_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_Equatable_SomeEnumGetValueNullable(handle);
   final result = smoke_Equatable_SomeEnum_fromFfi(_handle);
   smoke_Equatable_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Equatable_SomeEnum_release_handle_nullable(handle);
+  _smoke_Equatable_SomeEnumReleaseHandleNullable(handle);
 // End of SomeEnum "private" section.
 class EquatableStruct {
   bool boolField;
@@ -110,145 +109,145 @@ class EquatableStruct {
   }
 }
 // EquatableStruct "private" section, not exported.
-final _smoke_Equatable_EquatableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8, Int32, Int64, Float, Double, Pointer<Void>, Pointer<Void>, Uint32, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(int, int, int, double, double, Pointer<Void>, Pointer<Void>, int, Pointer<Void>, Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_create_handle'));
-final _smoke_Equatable_EquatableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_release_handle'));
-final _smoke_Equatable_EquatableStruct_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_boolField'));
-final _smoke_Equatable_EquatableStruct_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_intField'));
-final _smoke_Equatable_EquatableStruct_get_field_longField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldlongField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_longField'));
-final _smoke_Equatable_EquatableStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_floatField'));
-final _smoke_Equatable_EquatableStruct_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFielddoubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_doubleField'));
-final _smoke_Equatable_EquatableStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_stringField'));
-final _smoke_Equatable_EquatableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_structField'));
-final _smoke_Equatable_EquatableStruct_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_enumField'));
-final _smoke_Equatable_EquatableStruct_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldarrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_arrayField'));
-final _smoke_Equatable_EquatableStruct_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablestructGetFieldmapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_mapField'));
 Pointer<Void> smoke_Equatable_EquatableStruct_toFfi(EquatableStruct value) {
-  final _boolField_handle = Boolean_toFfi(value.boolField);
-  final _intField_handle = (value.intField);
-  final _longField_handle = (value.longField);
-  final _floatField_handle = (value.floatField);
-  final _doubleField_handle = (value.doubleField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _structField_handle = smoke_Equatable_NestedEquatableStruct_toFfi(value.structField);
-  final _enumField_handle = smoke_Equatable_SomeEnum_toFfi(value.enumField);
-  final _arrayField_handle = foobar_ListOf_String_toFfi(value.arrayField);
-  final _mapField_handle = foobar_MapOf_Int_to_String_toFfi(value.mapField);
-  final _result = _smoke_Equatable_EquatableStruct_create_handle(_boolField_handle, _intField_handle, _longField_handle, _floatField_handle, _doubleField_handle, _stringField_handle, _structField_handle, _enumField_handle, _arrayField_handle, _mapField_handle);
-  Boolean_releaseFfiHandle(_boolField_handle);
-  (_intField_handle);
-  (_longField_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structField_handle);
-  smoke_Equatable_SomeEnum_releaseFfiHandle(_enumField_handle);
-  foobar_ListOf_String_releaseFfiHandle(_arrayField_handle);
-  foobar_MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
+  final _boolFieldHandle = Boolean_toFfi(value.boolField);
+  final _intFieldHandle = (value.intField);
+  final _longFieldHandle = (value.longField);
+  final _floatFieldHandle = (value.floatField);
+  final _doubleFieldHandle = (value.doubleField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _structFieldHandle = smoke_Equatable_NestedEquatableStruct_toFfi(value.structField);
+  final _enumFieldHandle = smoke_Equatable_SomeEnum_toFfi(value.enumField);
+  final _arrayFieldHandle = foobar_ListOf_String_toFfi(value.arrayField);
+  final _mapFieldHandle = foobar_MapOf_Int_to_String_toFfi(value.mapField);
+  final _result = _smokeEquatableEquatablestructCreateHandle(_boolFieldHandle, _intFieldHandle, _longFieldHandle, _floatFieldHandle, _doubleFieldHandle, _stringFieldHandle, _structFieldHandle, _enumFieldHandle, _arrayFieldHandle, _mapFieldHandle);
+  Boolean_releaseFfiHandle(_boolFieldHandle);
+  (_intFieldHandle);
+  (_longFieldHandle);
+  (_floatFieldHandle);
+  (_doubleFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structFieldHandle);
+  smoke_Equatable_SomeEnum_releaseFfiHandle(_enumFieldHandle);
+  foobar_ListOf_String_releaseFfiHandle(_arrayFieldHandle);
+  foobar_MapOf_Int_to_String_releaseFfiHandle(_mapFieldHandle);
   return _result;
 }
 EquatableStruct smoke_Equatable_EquatableStruct_fromFfi(Pointer<Void> handle) {
-  final _boolField_handle = _smoke_Equatable_EquatableStruct_get_field_boolField(handle);
-  final _intField_handle = _smoke_Equatable_EquatableStruct_get_field_intField(handle);
-  final _longField_handle = _smoke_Equatable_EquatableStruct_get_field_longField(handle);
-  final _floatField_handle = _smoke_Equatable_EquatableStruct_get_field_floatField(handle);
-  final _doubleField_handle = _smoke_Equatable_EquatableStruct_get_field_doubleField(handle);
-  final _stringField_handle = _smoke_Equatable_EquatableStruct_get_field_stringField(handle);
-  final _structField_handle = _smoke_Equatable_EquatableStruct_get_field_structField(handle);
-  final _enumField_handle = _smoke_Equatable_EquatableStruct_get_field_enumField(handle);
-  final _arrayField_handle = _smoke_Equatable_EquatableStruct_get_field_arrayField(handle);
-  final _mapField_handle = _smoke_Equatable_EquatableStruct_get_field_mapField(handle);
+  final _boolFieldHandle = _smokeEquatableEquatablestructGetFieldboolField(handle);
+  final _intFieldHandle = _smokeEquatableEquatablestructGetFieldintField(handle);
+  final _longFieldHandle = _smokeEquatableEquatablestructGetFieldlongField(handle);
+  final _floatFieldHandle = _smokeEquatableEquatablestructGetFieldfloatField(handle);
+  final _doubleFieldHandle = _smokeEquatableEquatablestructGetFielddoubleField(handle);
+  final _stringFieldHandle = _smokeEquatableEquatablestructGetFieldstringField(handle);
+  final _structFieldHandle = _smokeEquatableEquatablestructGetFieldstructField(handle);
+  final _enumFieldHandle = _smokeEquatableEquatablestructGetFieldenumField(handle);
+  final _arrayFieldHandle = _smokeEquatableEquatablestructGetFieldarrayField(handle);
+  final _mapFieldHandle = _smokeEquatableEquatablestructGetFieldmapField(handle);
   try {
     return EquatableStruct(
-      Boolean_fromFfi(_boolField_handle),
-      (_intField_handle),
-      (_longField_handle),
-      (_floatField_handle),
-      (_doubleField_handle),
-      String_fromFfi(_stringField_handle),
-      smoke_Equatable_NestedEquatableStruct_fromFfi(_structField_handle),
-      smoke_Equatable_SomeEnum_fromFfi(_enumField_handle),
-      foobar_ListOf_String_fromFfi(_arrayField_handle),
-      foobar_MapOf_Int_to_String_fromFfi(_mapField_handle)
+      Boolean_fromFfi(_boolFieldHandle),
+      (_intFieldHandle),
+      (_longFieldHandle),
+      (_floatFieldHandle),
+      (_doubleFieldHandle),
+      String_fromFfi(_stringFieldHandle),
+      smoke_Equatable_NestedEquatableStruct_fromFfi(_structFieldHandle),
+      smoke_Equatable_SomeEnum_fromFfi(_enumFieldHandle),
+      foobar_ListOf_String_fromFfi(_arrayFieldHandle),
+      foobar_MapOf_Int_to_String_fromFfi(_mapFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle(_boolField_handle);
-    (_intField_handle);
-    (_longField_handle);
-    (_floatField_handle);
-    (_doubleField_handle);
-    String_releaseFfiHandle(_stringField_handle);
-    smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structField_handle);
-    smoke_Equatable_SomeEnum_releaseFfiHandle(_enumField_handle);
-    foobar_ListOf_String_releaseFfiHandle(_arrayField_handle);
-    foobar_MapOf_Int_to_String_releaseFfiHandle(_mapField_handle);
+    Boolean_releaseFfiHandle(_boolFieldHandle);
+    (_intFieldHandle);
+    (_longFieldHandle);
+    (_floatFieldHandle);
+    (_doubleFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_structFieldHandle);
+    smoke_Equatable_SomeEnum_releaseFfiHandle(_enumFieldHandle);
+    foobar_ListOf_String_releaseFfiHandle(_arrayFieldHandle);
+    foobar_MapOf_Int_to_String_releaseFfiHandle(_mapFieldHandle);
   }
 }
-void smoke_Equatable_EquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableStruct_release_handle(handle);
+void smoke_Equatable_EquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeEquatableEquatablestructReleaseHandle(handle);
 // Nullable EquatableStruct
-final _smoke_Equatable_EquatableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_create_handle_nullable'));
-final _smoke_Equatable_EquatableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_release_handle_nullable'));
-final _smoke_Equatable_EquatableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_value_nullable'));
 Pointer<Void> smoke_Equatable_EquatableStruct_toFfi_nullable(EquatableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_EquatableStruct_toFfi(value);
-  final result = _smoke_Equatable_EquatableStruct_create_handle_nullable(_handle);
+  final result = _smoke_Equatable_EquatableStructCreateHandleNullable(_handle);
   smoke_Equatable_EquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
 EquatableStruct smoke_Equatable_EquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Equatable_EquatableStruct_get_value_nullable(handle);
+  final _handle = _smoke_Equatable_EquatableStructGetValueNullable(handle);
   final result = smoke_Equatable_EquatableStruct_fromFfi(_handle);
   smoke_Equatable_EquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Equatable_EquatableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Equatable_EquatableStruct_release_handle_nullable(handle);
+  _smoke_Equatable_EquatableStructReleaseHandleNullable(handle);
 // End of EquatableStruct "private" section.
 class EquatableNullableStruct {
   bool boolField;
@@ -292,136 +291,136 @@ class EquatableNullableStruct {
   }
 }
 // EquatableNullableStruct "private" section, not exported.
-final _smoke_Equatable_EquatableNullableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_create_handle'));
-final _smoke_Equatable_EquatableNullableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_release_handle'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_boolField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_intField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_uintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFielduintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_uintField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_floatField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_stringField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_structField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_enumField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldarrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_arrayField'));
-final _smoke_Equatable_EquatableNullableStruct_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableEquatablenullablestructGetFieldmapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_mapField'));
 Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi(EquatableNullableStruct value) {
-  final _boolField_handle = Boolean_toFfi_nullable(value.boolField);
-  final _intField_handle = Int_toFfi_nullable(value.intField);
-  final _uintField_handle = UShort_toFfi_nullable(value.uintField);
-  final _floatField_handle = Float_toFfi_nullable(value.floatField);
-  final _stringField_handle = String_toFfi_nullable(value.stringField);
-  final _structField_handle = smoke_Equatable_NestedEquatableStruct_toFfi_nullable(value.structField);
-  final _enumField_handle = smoke_Equatable_SomeEnum_toFfi_nullable(value.enumField);
-  final _arrayField_handle = foobar_ListOf_String_toFfi_nullable(value.arrayField);
-  final _mapField_handle = foobar_MapOf_Int_to_String_toFfi_nullable(value.mapField);
-  final _result = _smoke_Equatable_EquatableNullableStruct_create_handle(_boolField_handle, _intField_handle, _uintField_handle, _floatField_handle, _stringField_handle, _structField_handle, _enumField_handle, _arrayField_handle, _mapField_handle);
-  Boolean_releaseFfiHandle_nullable(_boolField_handle);
-  Int_releaseFfiHandle_nullable(_intField_handle);
-  UShort_releaseFfiHandle_nullable(_uintField_handle);
-  Float_releaseFfiHandle_nullable(_floatField_handle);
-  String_releaseFfiHandle_nullable(_stringField_handle);
-  smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structField_handle);
-  smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  foobar_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  foobar_MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
+  final _boolFieldHandle = Boolean_toFfi_nullable(value.boolField);
+  final _intFieldHandle = Int_toFfi_nullable(value.intField);
+  final _uintFieldHandle = UShort_toFfi_nullable(value.uintField);
+  final _floatFieldHandle = Float_toFfi_nullable(value.floatField);
+  final _stringFieldHandle = String_toFfi_nullable(value.stringField);
+  final _structFieldHandle = smoke_Equatable_NestedEquatableStruct_toFfi_nullable(value.structField);
+  final _enumFieldHandle = smoke_Equatable_SomeEnum_toFfi_nullable(value.enumField);
+  final _arrayFieldHandle = foobar_ListOf_String_toFfi_nullable(value.arrayField);
+  final _mapFieldHandle = foobar_MapOf_Int_to_String_toFfi_nullable(value.mapField);
+  final _result = _smokeEquatableEquatablenullablestructCreateHandle(_boolFieldHandle, _intFieldHandle, _uintFieldHandle, _floatFieldHandle, _stringFieldHandle, _structFieldHandle, _enumFieldHandle, _arrayFieldHandle, _mapFieldHandle);
+  Boolean_releaseFfiHandle_nullable(_boolFieldHandle);
+  Int_releaseFfiHandle_nullable(_intFieldHandle);
+  UShort_releaseFfiHandle_nullable(_uintFieldHandle);
+  Float_releaseFfiHandle_nullable(_floatFieldHandle);
+  String_releaseFfiHandle_nullable(_stringFieldHandle);
+  smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structFieldHandle);
+  smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumFieldHandle);
+  foobar_ListOf_String_releaseFfiHandle_nullable(_arrayFieldHandle);
+  foobar_MapOf_Int_to_String_releaseFfiHandle_nullable(_mapFieldHandle);
   return _result;
 }
 EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi(Pointer<Void> handle) {
-  final _boolField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_boolField(handle);
-  final _intField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_intField(handle);
-  final _uintField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_uintField(handle);
-  final _floatField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_floatField(handle);
-  final _stringField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_stringField(handle);
-  final _structField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_structField(handle);
-  final _enumField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_enumField(handle);
-  final _arrayField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_arrayField(handle);
-  final _mapField_handle = _smoke_Equatable_EquatableNullableStruct_get_field_mapField(handle);
+  final _boolFieldHandle = _smokeEquatableEquatablenullablestructGetFieldboolField(handle);
+  final _intFieldHandle = _smokeEquatableEquatablenullablestructGetFieldintField(handle);
+  final _uintFieldHandle = _smokeEquatableEquatablenullablestructGetFielduintField(handle);
+  final _floatFieldHandle = _smokeEquatableEquatablenullablestructGetFieldfloatField(handle);
+  final _stringFieldHandle = _smokeEquatableEquatablenullablestructGetFieldstringField(handle);
+  final _structFieldHandle = _smokeEquatableEquatablenullablestructGetFieldstructField(handle);
+  final _enumFieldHandle = _smokeEquatableEquatablenullablestructGetFieldenumField(handle);
+  final _arrayFieldHandle = _smokeEquatableEquatablenullablestructGetFieldarrayField(handle);
+  final _mapFieldHandle = _smokeEquatableEquatablenullablestructGetFieldmapField(handle);
   try {
     return EquatableNullableStruct(
-      Boolean_fromFfi_nullable(_boolField_handle),
-      Int_fromFfi_nullable(_intField_handle),
-      UShort_fromFfi_nullable(_uintField_handle),
-      Float_fromFfi_nullable(_floatField_handle),
-      String_fromFfi_nullable(_stringField_handle),
-      smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(_structField_handle),
-      smoke_Equatable_SomeEnum_fromFfi_nullable(_enumField_handle),
-      foobar_ListOf_String_fromFfi_nullable(_arrayField_handle),
-      foobar_MapOf_Int_to_String_fromFfi_nullable(_mapField_handle)
+      Boolean_fromFfi_nullable(_boolFieldHandle),
+      Int_fromFfi_nullable(_intFieldHandle),
+      UShort_fromFfi_nullable(_uintFieldHandle),
+      Float_fromFfi_nullable(_floatFieldHandle),
+      String_fromFfi_nullable(_stringFieldHandle),
+      smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(_structFieldHandle),
+      smoke_Equatable_SomeEnum_fromFfi_nullable(_enumFieldHandle),
+      foobar_ListOf_String_fromFfi_nullable(_arrayFieldHandle),
+      foobar_MapOf_Int_to_String_fromFfi_nullable(_mapFieldHandle)
     );
   } finally {
-    Boolean_releaseFfiHandle_nullable(_boolField_handle);
-    Int_releaseFfiHandle_nullable(_intField_handle);
-    UShort_releaseFfiHandle_nullable(_uintField_handle);
-    Float_releaseFfiHandle_nullable(_floatField_handle);
-    String_releaseFfiHandle_nullable(_stringField_handle);
-    smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structField_handle);
-    smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-    foobar_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-    foobar_MapOf_Int_to_String_releaseFfiHandle_nullable(_mapField_handle);
+    Boolean_releaseFfiHandle_nullable(_boolFieldHandle);
+    Int_releaseFfiHandle_nullable(_intFieldHandle);
+    UShort_releaseFfiHandle_nullable(_uintFieldHandle);
+    Float_releaseFfiHandle_nullable(_floatFieldHandle);
+    String_releaseFfiHandle_nullable(_stringFieldHandle);
+    smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(_structFieldHandle);
+    smoke_Equatable_SomeEnum_releaseFfiHandle_nullable(_enumFieldHandle);
+    foobar_ListOf_String_releaseFfiHandle_nullable(_arrayFieldHandle);
+    foobar_MapOf_Int_to_String_releaseFfiHandle_nullable(_mapFieldHandle);
   }
 }
-void smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_EquatableNullableStruct_release_handle(handle);
+void smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeEquatableEquatablenullablestructReleaseHandle(handle);
 // Nullable EquatableNullableStruct
-final _smoke_Equatable_EquatableNullableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableNullableStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_create_handle_nullable'));
-final _smoke_Equatable_EquatableNullableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableNullableStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_release_handle_nullable'));
-final _smoke_Equatable_EquatableNullableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_EquatableNullableStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_value_nullable'));
 Pointer<Void> smoke_Equatable_EquatableNullableStruct_toFfi_nullable(EquatableNullableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_EquatableNullableStruct_toFfi(value);
-  final result = _smoke_Equatable_EquatableNullableStruct_create_handle_nullable(_handle);
+  final result = _smoke_Equatable_EquatableNullableStructCreateHandleNullable(_handle);
   smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(_handle);
   return result;
 }
 EquatableNullableStruct smoke_Equatable_EquatableNullableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Equatable_EquatableNullableStruct_get_value_nullable(handle);
+  final _handle = _smoke_Equatable_EquatableNullableStructGetValueNullable(handle);
   final result = smoke_Equatable_EquatableNullableStruct_fromFfi(_handle);
   smoke_Equatable_EquatableNullableStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Equatable_EquatableNullableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Equatable_EquatableNullableStruct_release_handle_nullable(handle);
+  _smoke_Equatable_EquatableNullableStructReleaseHandleNullable(handle);
 // End of EquatableNullableStruct "private" section.
 class NestedEquatableStruct {
   String fooField;
@@ -441,62 +440,62 @@ class NestedEquatableStruct {
   }
 }
 // NestedEquatableStruct "private" section, not exported.
-final _smoke_Equatable_NestedEquatableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableNestedequatablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_create_handle'));
-final _smoke_Equatable_NestedEquatableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableNestedequatablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_release_handle'));
-final _smoke_Equatable_NestedEquatableStruct_get_field_fooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableNestedequatablestructGetFieldfooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_get_field_fooField'));
 Pointer<Void> smoke_Equatable_NestedEquatableStruct_toFfi(NestedEquatableStruct value) {
-  final _fooField_handle = String_toFfi(value.fooField);
-  final _result = _smoke_Equatable_NestedEquatableStruct_create_handle(_fooField_handle);
-  String_releaseFfiHandle(_fooField_handle);
+  final _fooFieldHandle = String_toFfi(value.fooField);
+  final _result = _smokeEquatableNestedequatablestructCreateHandle(_fooFieldHandle);
+  String_releaseFfiHandle(_fooFieldHandle);
   return _result;
 }
 NestedEquatableStruct smoke_Equatable_NestedEquatableStruct_fromFfi(Pointer<Void> handle) {
-  final _fooField_handle = _smoke_Equatable_NestedEquatableStruct_get_field_fooField(handle);
+  final _fooFieldHandle = _smokeEquatableNestedequatablestructGetFieldfooField(handle);
   try {
     return NestedEquatableStruct(
-      String_fromFfi(_fooField_handle)
+      String_fromFfi(_fooFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_fooField_handle);
+    String_releaseFfiHandle(_fooFieldHandle);
   }
 }
-void smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Equatable_NestedEquatableStruct_release_handle(handle);
+void smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeEquatableNestedequatablestructReleaseHandle(handle);
 // Nullable NestedEquatableStruct
-final _smoke_Equatable_NestedEquatableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_NestedEquatableStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_create_handle_nullable'));
-final _smoke_Equatable_NestedEquatableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_NestedEquatableStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_release_handle_nullable'));
-final _smoke_Equatable_NestedEquatableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Equatable_NestedEquatableStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_get_value_nullable'));
 Pointer<Void> smoke_Equatable_NestedEquatableStruct_toFfi_nullable(NestedEquatableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Equatable_NestedEquatableStruct_toFfi(value);
-  final result = _smoke_Equatable_NestedEquatableStruct_create_handle_nullable(_handle);
+  final result = _smoke_Equatable_NestedEquatableStructCreateHandleNullable(_handle);
   smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
 NestedEquatableStruct smoke_Equatable_NestedEquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Equatable_NestedEquatableStruct_get_value_nullable(handle);
+  final _handle = _smoke_Equatable_NestedEquatableStructGetValueNullable(handle);
   final result = smoke_Equatable_NestedEquatableStruct_fromFfi(_handle);
   smoke_Equatable_NestedEquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Equatable_NestedEquatableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Equatable_NestedEquatableStruct_release_handle_nullable(handle);
+  _smoke_Equatable_NestedEquatableStructReleaseHandleNullable(handle);
 // End of NestedEquatableStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class EquatableInterface {
@@ -14,22 +13,22 @@ abstract class EquatableInterface {
   void release() {}
 }
 // EquatableInterface "private" section, not exported.
-final _smoke_EquatableInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableInterface_copy_handle'));
-final _smoke_EquatableInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EquatableInterface_release_handle'));
-final _smoke_EquatableInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatableinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
   >('library_smoke_EquatableInterface_create_proxy'));
-final __are_equal = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final __areEqual = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
-  >('library_smoke_EquatableInterface_are_equal'));final _smoke_EquatableInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  >('library_smoke_EquatableInterface_are_equal'));final _smokeEquatableinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableInterface_get_type_id'));
@@ -39,20 +38,20 @@ class EquatableInterface$Impl extends __lib.NativeBase implements EquatableInter
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_EquatableInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeEquatableinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;
     if (other is! EquatableInterface$Impl) return false;
-    return __are_equal((this as EquatableInterface$Impl).handle, other.handle) != 0;
+    return __areEqual((this as EquatableInterface$Impl).handle, other.handle) != 0;
   }
 }
 Pointer<Void> smoke_EquatableInterface_toFfi(EquatableInterface value) {
-  if (value is __lib.NativeBase) return _smoke_EquatableInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_EquatableInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeEquatableinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeEquatableinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi
@@ -61,25 +60,25 @@ Pointer<Void> smoke_EquatableInterface_toFfi(EquatableInterface value) {
 }
 EquatableInterface smoke_EquatableInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as EquatableInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_EquatableInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_EquatableInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeEquatableinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeEquatableinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : EquatableInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : EquatableInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_EquatableInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_EquatableInterface_release_handle(handle);
+  _smokeEquatableinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_EquatableInterface_toFfi_nullable(EquatableInterface value) =>
   value != null ? smoke_EquatableInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 EquatableInterface smoke_EquatableInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_EquatableInterface_fromFfi(handle) : null;
 void smoke_EquatableInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_EquatableInterface_release_handle(handle);
+  _smokeEquatableinterfaceReleaseHandle(handle);
 // End of EquatableInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -3,7 +3,6 @@ import 'package:collection/collection.dart';
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class EquatableStructWithInternalFields {
@@ -40,98 +39,98 @@ class EquatableStructWithInternalFields {
   }
 }
 // EquatableStructWithInternalFields "private" section, not exported.
-final _smoke_EquatableStructWithInternalFields_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatablestructwithinternalfieldsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_create_handle'));
-final _smoke_EquatableStructWithInternalFields_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatablestructwithinternalfieldsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_release_handle'));
-final _smoke_EquatableStructWithInternalFields_get_field_publicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatablestructwithinternalfieldsGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_get_field_publicField'));
-final _smoke_EquatableStructWithInternalFields_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatablestructwithinternalfieldsGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_get_field_internalField'));
-final _smoke_EquatableStructWithInternalFields_get_field_internalListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatablestructwithinternalfieldsGetFieldinternalListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_get_field_internalListField'));
-final _smoke_EquatableStructWithInternalFields_get_field_internalMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatablestructwithinternalfieldsGetFieldinternalMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_get_field_internalMapField'));
-final _smoke_EquatableStructWithInternalFields_get_field_internalSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEquatablestructwithinternalfieldsGetFieldinternalSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_get_field_internalSetField'));
 Pointer<Void> smoke_EquatableStructWithInternalFields_toFfi(EquatableStructWithInternalFields value) {
-  final _publicField_handle = String_toFfi(value.publicField);
-  final _internalField_handle = String_toFfi(value.internal_internalField);
-  final _internalListField_handle = foobar_ListOf_String_toFfi(value.internal_internalListField);
-  final _internalMapField_handle = foobar_MapOf_String_to_String_toFfi(value.internal_internalMapField);
-  final _internalSetField_handle = foobar_SetOf_String_toFfi(value.internal_internalSetField);
-  final _result = _smoke_EquatableStructWithInternalFields_create_handle(_publicField_handle, _internalField_handle, _internalListField_handle, _internalMapField_handle, _internalSetField_handle);
-  String_releaseFfiHandle(_publicField_handle);
-  String_releaseFfiHandle(_internalField_handle);
-  foobar_ListOf_String_releaseFfiHandle(_internalListField_handle);
-  foobar_MapOf_String_to_String_releaseFfiHandle(_internalMapField_handle);
-  foobar_SetOf_String_releaseFfiHandle(_internalSetField_handle);
+  final _publicFieldHandle = String_toFfi(value.publicField);
+  final _internalFieldHandle = String_toFfi(value.internal_internalField);
+  final _internalListFieldHandle = foobar_ListOf_String_toFfi(value.internal_internalListField);
+  final _internalMapFieldHandle = foobar_MapOf_String_to_String_toFfi(value.internal_internalMapField);
+  final _internalSetFieldHandle = foobar_SetOf_String_toFfi(value.internal_internalSetField);
+  final _result = _smokeEquatablestructwithinternalfieldsCreateHandle(_publicFieldHandle, _internalFieldHandle, _internalListFieldHandle, _internalMapFieldHandle, _internalSetFieldHandle);
+  String_releaseFfiHandle(_publicFieldHandle);
+  String_releaseFfiHandle(_internalFieldHandle);
+  foobar_ListOf_String_releaseFfiHandle(_internalListFieldHandle);
+  foobar_MapOf_String_to_String_releaseFfiHandle(_internalMapFieldHandle);
+  foobar_SetOf_String_releaseFfiHandle(_internalSetFieldHandle);
   return _result;
 }
 EquatableStructWithInternalFields smoke_EquatableStructWithInternalFields_fromFfi(Pointer<Void> handle) {
-  final _publicField_handle = _smoke_EquatableStructWithInternalFields_get_field_publicField(handle);
-  final _internalField_handle = _smoke_EquatableStructWithInternalFields_get_field_internalField(handle);
-  final _internalListField_handle = _smoke_EquatableStructWithInternalFields_get_field_internalListField(handle);
-  final _internalMapField_handle = _smoke_EquatableStructWithInternalFields_get_field_internalMapField(handle);
-  final _internalSetField_handle = _smoke_EquatableStructWithInternalFields_get_field_internalSetField(handle);
+  final _publicFieldHandle = _smokeEquatablestructwithinternalfieldsGetFieldpublicField(handle);
+  final _internalFieldHandle = _smokeEquatablestructwithinternalfieldsGetFieldinternalField(handle);
+  final _internalListFieldHandle = _smokeEquatablestructwithinternalfieldsGetFieldinternalListField(handle);
+  final _internalMapFieldHandle = _smokeEquatablestructwithinternalfieldsGetFieldinternalMapField(handle);
+  final _internalSetFieldHandle = _smokeEquatablestructwithinternalfieldsGetFieldinternalSetField(handle);
   try {
     return EquatableStructWithInternalFields(
-      String_fromFfi(_publicField_handle),
-      String_fromFfi(_internalField_handle),
-      foobar_ListOf_String_fromFfi(_internalListField_handle),
-      foobar_MapOf_String_to_String_fromFfi(_internalMapField_handle),
-      foobar_SetOf_String_fromFfi(_internalSetField_handle)
+      String_fromFfi(_publicFieldHandle),
+      String_fromFfi(_internalFieldHandle),
+      foobar_ListOf_String_fromFfi(_internalListFieldHandle),
+      foobar_MapOf_String_to_String_fromFfi(_internalMapFieldHandle),
+      foobar_SetOf_String_fromFfi(_internalSetFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_publicField_handle);
-    String_releaseFfiHandle(_internalField_handle);
-    foobar_ListOf_String_releaseFfiHandle(_internalListField_handle);
-    foobar_MapOf_String_to_String_releaseFfiHandle(_internalMapField_handle);
-    foobar_SetOf_String_releaseFfiHandle(_internalSetField_handle);
+    String_releaseFfiHandle(_publicFieldHandle);
+    String_releaseFfiHandle(_internalFieldHandle);
+    foobar_ListOf_String_releaseFfiHandle(_internalListFieldHandle);
+    foobar_MapOf_String_to_String_releaseFfiHandle(_internalMapFieldHandle);
+    foobar_SetOf_String_releaseFfiHandle(_internalSetFieldHandle);
   }
 }
-void smoke_EquatableStructWithInternalFields_releaseFfiHandle(Pointer<Void> handle) => _smoke_EquatableStructWithInternalFields_release_handle(handle);
+void smoke_EquatableStructWithInternalFields_releaseFfiHandle(Pointer<Void> handle) => _smokeEquatablestructwithinternalfieldsReleaseHandle(handle);
 // Nullable EquatableStructWithInternalFields
-final _smoke_EquatableStructWithInternalFields_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_EquatableStructWithInternalFieldsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_create_handle_nullable'));
-final _smoke_EquatableStructWithInternalFields_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_EquatableStructWithInternalFieldsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_release_handle_nullable'));
-final _smoke_EquatableStructWithInternalFields_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_EquatableStructWithInternalFieldsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableStructWithInternalFields_get_value_nullable'));
 Pointer<Void> smoke_EquatableStructWithInternalFields_toFfi_nullable(EquatableStructWithInternalFields value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_EquatableStructWithInternalFields_toFfi(value);
-  final result = _smoke_EquatableStructWithInternalFields_create_handle_nullable(_handle);
+  final result = _smoke_EquatableStructWithInternalFieldsCreateHandleNullable(_handle);
   smoke_EquatableStructWithInternalFields_releaseFfiHandle(_handle);
   return result;
 }
 EquatableStructWithInternalFields smoke_EquatableStructWithInternalFields_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_EquatableStructWithInternalFields_get_value_nullable(handle);
+  final _handle = _smoke_EquatableStructWithInternalFieldsGetValueNullable(handle);
   final result = smoke_EquatableStructWithInternalFields_fromFfi(_handle);
   smoke_EquatableStructWithInternalFields_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_EquatableStructWithInternalFields_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_EquatableStructWithInternalFields_release_handle_nullable(handle);
+  _smoke_EquatableStructWithInternalFieldsReleaseHandleNullable(handle);
 // End of EquatableStructWithInternalFields "private" section.

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
@@ -3,7 +3,6 @@ import 'package:collection/collection.dart';
 import 'package:library/src/smoke/non_equatable_class.dart';
 import 'package:library/src/smoke/non_equatable_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class SimpleEquatableStruct {
@@ -33,89 +32,89 @@ class SimpleEquatableStruct {
   }
 }
 // SimpleEquatableStruct "private" section, not exported.
-final _smoke_SimpleEquatableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleequatablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_create_handle'));
-final _smoke_SimpleEquatableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleequatablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_release_handle'));
-final _smoke_SimpleEquatableStruct_get_field_classField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleequatablestructGetFieldclassField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_get_field_classField'));
-final _smoke_SimpleEquatableStruct_get_field_interfaceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleequatablestructGetFieldinterfaceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_get_field_interfaceField'));
-final _smoke_SimpleEquatableStruct_get_field_nullableClassField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleequatablestructGetFieldnullableClassField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_get_field_nullableClassField'));
-final _smoke_SimpleEquatableStruct_get_field_nullableInterfaceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleequatablestructGetFieldnullableInterfaceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_get_field_nullableInterfaceField'));
 Pointer<Void> smoke_SimpleEquatableStruct_toFfi(SimpleEquatableStruct value) {
-  final _classField_handle = smoke_NonEquatableClass_toFfi(value.classField);
-  final _interfaceField_handle = smoke_NonEquatableInterface_toFfi(value.interfaceField);
-  final _nullableClassField_handle = smoke_NonEquatableClass_toFfi_nullable(value.nullableClassField);
-  final _nullableInterfaceField_handle = smoke_NonEquatableInterface_toFfi_nullable(value.nullableInterfaceField);
-  final _result = _smoke_SimpleEquatableStruct_create_handle(_classField_handle, _interfaceField_handle, _nullableClassField_handle, _nullableInterfaceField_handle);
-  smoke_NonEquatableClass_releaseFfiHandle(_classField_handle);
-  smoke_NonEquatableInterface_releaseFfiHandle(_interfaceField_handle);
-  smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassField_handle);
-  smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceField_handle);
+  final _classFieldHandle = smoke_NonEquatableClass_toFfi(value.classField);
+  final _interfaceFieldHandle = smoke_NonEquatableInterface_toFfi(value.interfaceField);
+  final _nullableClassFieldHandle = smoke_NonEquatableClass_toFfi_nullable(value.nullableClassField);
+  final _nullableInterfaceFieldHandle = smoke_NonEquatableInterface_toFfi_nullable(value.nullableInterfaceField);
+  final _result = _smokeSimpleequatablestructCreateHandle(_classFieldHandle, _interfaceFieldHandle, _nullableClassFieldHandle, _nullableInterfaceFieldHandle);
+  smoke_NonEquatableClass_releaseFfiHandle(_classFieldHandle);
+  smoke_NonEquatableInterface_releaseFfiHandle(_interfaceFieldHandle);
+  smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassFieldHandle);
+  smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceFieldHandle);
   return _result;
 }
 SimpleEquatableStruct smoke_SimpleEquatableStruct_fromFfi(Pointer<Void> handle) {
-  final _classField_handle = _smoke_SimpleEquatableStruct_get_field_classField(handle);
-  final _interfaceField_handle = _smoke_SimpleEquatableStruct_get_field_interfaceField(handle);
-  final _nullableClassField_handle = _smoke_SimpleEquatableStruct_get_field_nullableClassField(handle);
-  final _nullableInterfaceField_handle = _smoke_SimpleEquatableStruct_get_field_nullableInterfaceField(handle);
+  final _classFieldHandle = _smokeSimpleequatablestructGetFieldclassField(handle);
+  final _interfaceFieldHandle = _smokeSimpleequatablestructGetFieldinterfaceField(handle);
+  final _nullableClassFieldHandle = _smokeSimpleequatablestructGetFieldnullableClassField(handle);
+  final _nullableInterfaceFieldHandle = _smokeSimpleequatablestructGetFieldnullableInterfaceField(handle);
   try {
     return SimpleEquatableStruct(
-      smoke_NonEquatableClass_fromFfi(_classField_handle),
-      smoke_NonEquatableInterface_fromFfi(_interfaceField_handle),
-      smoke_NonEquatableClass_fromFfi_nullable(_nullableClassField_handle),
-      smoke_NonEquatableInterface_fromFfi_nullable(_nullableInterfaceField_handle)
+      smoke_NonEquatableClass_fromFfi(_classFieldHandle),
+      smoke_NonEquatableInterface_fromFfi(_interfaceFieldHandle),
+      smoke_NonEquatableClass_fromFfi_nullable(_nullableClassFieldHandle),
+      smoke_NonEquatableInterface_fromFfi_nullable(_nullableInterfaceFieldHandle)
     );
   } finally {
-    smoke_NonEquatableClass_releaseFfiHandle(_classField_handle);
-    smoke_NonEquatableInterface_releaseFfiHandle(_interfaceField_handle);
-    smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassField_handle);
-    smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceField_handle);
+    smoke_NonEquatableClass_releaseFfiHandle(_classFieldHandle);
+    smoke_NonEquatableInterface_releaseFfiHandle(_interfaceFieldHandle);
+    smoke_NonEquatableClass_releaseFfiHandle_nullable(_nullableClassFieldHandle);
+    smoke_NonEquatableInterface_releaseFfiHandle_nullable(_nullableInterfaceFieldHandle);
   }
 }
-void smoke_SimpleEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_SimpleEquatableStruct_release_handle(handle);
+void smoke_SimpleEquatableStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeSimpleequatablestructReleaseHandle(handle);
 // Nullable SimpleEquatableStruct
-final _smoke_SimpleEquatableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SimpleEquatableStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_create_handle_nullable'));
-final _smoke_SimpleEquatableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SimpleEquatableStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_release_handle_nullable'));
-final _smoke_SimpleEquatableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SimpleEquatableStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleEquatableStruct_get_value_nullable'));
 Pointer<Void> smoke_SimpleEquatableStruct_toFfi_nullable(SimpleEquatableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SimpleEquatableStruct_toFfi(value);
-  final result = _smoke_SimpleEquatableStruct_create_handle_nullable(_handle);
+  final result = _smoke_SimpleEquatableStructCreateHandleNullable(_handle);
   smoke_SimpleEquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
 SimpleEquatableStruct smoke_SimpleEquatableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_SimpleEquatableStruct_get_value_nullable(handle);
+  final _handle = _smoke_SimpleEquatableStructGetValueNullable(handle);
   final result = smoke_SimpleEquatableStruct_fromFfi(_handle);
   smoke_SimpleEquatableStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_SimpleEquatableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SimpleEquatableStruct_release_handle_nullable(handle);
+  _smoke_SimpleEquatableStructReleaseHandleNullable(handle);
 // End of SimpleEquatableStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Errors {
@@ -49,34 +48,34 @@ Errors_InternalErrorCode smoke_Errors_InternalErrorCode_fromFfi(int handle) {
   }
 }
 void smoke_Errors_InternalErrorCode_releaseFfiHandle(int handle) {}
-final _smoke_Errors_InternalErrorCode_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_InternalErrorCodeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Errors_InternalErrorCode_create_handle_nullable'));
-final _smoke_Errors_InternalErrorCode_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_InternalErrorCodeReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_InternalErrorCode_release_handle_nullable'));
-final _smoke_Errors_InternalErrorCode_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_InternalErrorCodeGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_InternalErrorCode_get_value_nullable'));
 Pointer<Void> smoke_Errors_InternalErrorCode_toFfi_nullable(Errors_InternalErrorCode value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Errors_InternalErrorCode_toFfi(value);
-  final result = _smoke_Errors_InternalErrorCode_create_handle_nullable(_handle);
+  final result = _smoke_Errors_InternalErrorCodeCreateHandleNullable(_handle);
   smoke_Errors_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
 Errors_InternalErrorCode smoke_Errors_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Errors_InternalErrorCode_get_value_nullable(handle);
+  final _handle = _smoke_Errors_InternalErrorCodeGetValueNullable(handle);
   final result = smoke_Errors_InternalErrorCode_fromFfi(_handle);
   smoke_Errors_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Errors_InternalErrorCode_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Errors_InternalErrorCode_release_handle_nullable(handle);
+  _smoke_Errors_InternalErrorCodeReleaseHandleNullable(handle);
 // End of Errors_InternalErrorCode "private" section.
 enum Errors_ExternalErrors {
     none,
@@ -115,34 +114,34 @@ Errors_ExternalErrors smoke_Errors_ExternalErrors_fromFfi(int handle) {
   }
 }
 void smoke_Errors_ExternalErrors_releaseFfiHandle(int handle) {}
-final _smoke_Errors_ExternalErrors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_ExternalErrorsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Errors_ExternalErrors_create_handle_nullable'));
-final _smoke_Errors_ExternalErrors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_ExternalErrorsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_ExternalErrors_release_handle_nullable'));
-final _smoke_Errors_ExternalErrors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Errors_ExternalErrorsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_ExternalErrors_get_value_nullable'));
 Pointer<Void> smoke_Errors_ExternalErrors_toFfi_nullable(Errors_ExternalErrors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Errors_ExternalErrors_toFfi(value);
-  final result = _smoke_Errors_ExternalErrors_create_handle_nullable(_handle);
+  final result = _smoke_Errors_ExternalErrorsCreateHandleNullable(_handle);
   smoke_Errors_ExternalErrors_releaseFfiHandle(_handle);
   return result;
 }
 Errors_ExternalErrors smoke_Errors_ExternalErrors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Errors_ExternalErrors_get_value_nullable(handle);
+  final _handle = _smoke_Errors_ExternalErrorsGetValueNullable(handle);
   final result = smoke_Errors_ExternalErrors_fromFfi(_handle);
   smoke_Errors_ExternalErrors_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Errors_ExternalErrors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Errors_ExternalErrors_release_handle_nullable(handle);
+  _smoke_Errors_ExternalErrorsReleaseHandleNullable(handle);
 // End of Errors_ExternalErrors "private" section.
 class Errors_InternalException implements Exception {
   final Errors_InternalErrorCode error;
@@ -153,82 +152,82 @@ class Errors_ExternalException implements Exception {
   Errors_ExternalException(this.error);
 }
 // Errors "private" section, not exported.
-final _smoke_Errors_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeErrorsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_copy_handle'));
-final _smoke_Errors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeErrorsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_release_handle'));
-final _methodWithErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_release_handle'));
-final _methodWithErrors_return_get_result = (Pointer) {};
-final _methodWithErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsReturnGetResult = (Pointer) {};
+final _methodWithErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_get_error'));
-final _methodWithErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_has_error'));
-final _methodWithExternalErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_release_handle'));
-final _methodWithExternalErrors_return_get_result = (Pointer) {};
-final _methodWithExternalErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorsReturnGetResult = (Pointer) {};
+final _methodWithExternalErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_get_error'));
-final _methodWithExternalErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_has_error'));
-final _methodWithErrorsAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_release_handle'));
-final _methodWithErrorsAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_result'));
-final _methodWithErrorsAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_error'));
-final _methodWithErrorsAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_has_error'));
-final _methodWithPayloadError_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_release_handle'));
-final _methodWithPayloadError_return_get_result = (Pointer) {};
-final _methodWithPayloadError_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorReturnGetResult = (Pointer) {};
+final _methodWithPayloadErrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_get_error'));
-final _methodWithPayloadError_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_has_error'));
-final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_release_handle'));
-final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_result'));
-final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_error'));
-final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error'));
@@ -238,129 +237,129 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Errors_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeErrorsReleaseHandle(handle);
     handle = null;
   }
   static methodWithErrors() {
-    final _methodWithErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
-    final __call_result_handle = _methodWithErrors_ffi(__lib.LibraryContext.isolateId);
-    if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
-        _methodWithErrors_return_release_handle(__call_result_handle);
+    final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
+    final __callResultHandle = _methodWithErrorsFfi(__lib.LibraryContext.isolateId);
+    if (_methodWithErrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorsReturnGetError(__callResultHandle);
+        _methodWithErrorsReturnReleaseHandle(__callResultHandle);
         try {
-          throw Errors_InternalException(smoke_Errors_InternalErrorCode_fromFfi(__error_handle));
+          throw Errors_InternalException(smoke_Errors_InternalErrorCode_fromFfi(__errorHandle));
         } finally {
-          smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
+          smoke_Errors_InternalErrorCode_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithErrors_return_get_result(__call_result_handle);
-    _methodWithErrors_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithErrorsReturnGetResult(__callResultHandle);
+    _methodWithErrorsReturnReleaseHandle(__callResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static methodWithExternalErrors() {
-    final _methodWithExternalErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors'));
-    final __call_result_handle = _methodWithExternalErrors_ffi(__lib.LibraryContext.isolateId);
-    if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
-        _methodWithExternalErrors_return_release_handle(__call_result_handle);
+    final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors'));
+    final __callResultHandle = _methodWithExternalErrorsFfi(__lib.LibraryContext.isolateId);
+    if (_methodWithExternalErrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithExternalErrorsReturnGetError(__callResultHandle);
+        _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
         try {
-          throw Errors_ExternalException(smoke_Errors_ExternalErrors_fromFfi(__error_handle));
+          throw Errors_ExternalException(smoke_Errors_ExternalErrors_fromFfi(__errorHandle));
         } finally {
-          smoke_Errors_ExternalErrors_releaseFfiHandle(__error_handle);
+          smoke_Errors_ExternalErrors_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithExternalErrors_return_get_result(__call_result_handle);
-    _methodWithExternalErrors_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithExternalErrorsReturnGetResult(__callResultHandle);
+    _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static String methodWithErrorsAndReturnValue() {
-    final _methodWithErrorsAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue'));
-    final __call_result_handle = _methodWithErrorsAndReturnValue_ffi(__lib.LibraryContext.isolateId);
-    if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
-        _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+    final _methodWithErrorsAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue'));
+    final __callResultHandle = _methodWithErrorsAndReturnValueFfi(__lib.LibraryContext.isolateId);
+    if (_methodWithErrorsAndReturnValueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorsAndReturnValueReturnGetError(__callResultHandle);
+        _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
         try {
-          throw Errors_InternalException(smoke_Errors_InternalErrorCode_fromFfi(__error_handle));
+          throw Errors_InternalException(smoke_Errors_InternalErrorCode_fromFfi(__errorHandle));
         } finally {
-          smoke_Errors_InternalErrorCode_releaseFfiHandle(__error_handle);
+          smoke_Errors_InternalErrorCode_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithErrorsAndReturnValue_return_get_result(__call_result_handle);
-    _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithErrorsAndReturnValueReturnGetResult(__callResultHandle);
+    _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   static methodWithPayloadError() {
-    final _methodWithPayloadError_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError'));
-    final __call_result_handle = _methodWithPayloadError_ffi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
-        _methodWithPayloadError_return_release_handle(__call_result_handle);
+    final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError'));
+    final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
+    if (_methodWithPayloadErrorReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
         try {
-          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+          throw WithPayloadException(smoke_Payload_fromFfi(__errorHandle));
         } finally {
-          smoke_Payload_releaseFfiHandle(__error_handle);
+          smoke_Payload_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithPayloadError_return_get_result(__call_result_handle);
-    _methodWithPayloadError_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithPayloadErrorReturnGetResult(__callResultHandle);
+    _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static String methodWithPayloadErrorAndReturnValue() {
-    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue'));
-    final __call_result_handle = _methodWithPayloadErrorAndReturnValue_ffi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);
-        _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+    final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue'));
+    final __callResultHandle = _methodWithPayloadErrorAndReturnValueFfi(__lib.LibraryContext.isolateId);
+    if (_methodWithPayloadErrorAndReturnValueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorAndReturnValueReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
         try {
-          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+          throw WithPayloadException(smoke_Payload_fromFfi(__errorHandle));
         } finally {
-          smoke_Payload_releaseFfiHandle(__error_handle);
+          smoke_Payload_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithPayloadErrorAndReturnValue_return_get_result(__call_result_handle);
-    _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithPayloadErrorAndReturnValueReturnGetResult(__callResultHandle);
+    _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Errors_toFfi(Errors value) =>
-  _smoke_Errors_copy_handle((value as __lib.NativeBase).handle);
+  _smokeErrorsCopyHandle((value as __lib.NativeBase).handle);
 Errors smoke_Errors_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Errors;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Errors_copy_handle(handle);
-  final result = Errors$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeErrorsCopyHandle(handle);
+  final result = Errors$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Errors_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Errors_release_handle(handle);
+  _smokeErrorsReleaseHandle(handle);
 Pointer<Void> smoke_Errors_toFfi_nullable(Errors value) =>
   value != null ? smoke_Errors_toFfi(value) : Pointer<Void>.fromAddress(0);
 Errors smoke_Errors_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Errors_fromFfi(handle) : null;
 void smoke_Errors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Errors_release_handle(handle);
+  _smokeErrorsReleaseHandle(handle);
 // End of Errors "private" section.

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -5,11 +5,10 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ErrorsInterface {
-  ErrorsInterface() {}
+  ErrorsInterface();
   factory ErrorsInterface.fromLambdas({
     @required void Function() lambda_methodWithErrors,
     @required void Function() lambda_methodWithExternalErrors,
@@ -60,34 +59,34 @@ ErrorsInterface_InternalError smoke_ErrorsInterface_InternalError_fromFfi(int ha
   }
 }
 void smoke_ErrorsInterface_InternalError_releaseFfiHandle(int handle) {}
-final _smoke_ErrorsInterface_InternalError_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_InternalErrorCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ErrorsInterface_InternalError_create_handle_nullable'));
-final _smoke_ErrorsInterface_InternalError_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_InternalErrorReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_InternalError_release_handle_nullable'));
-final _smoke_ErrorsInterface_InternalError_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_InternalErrorGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_InternalError_get_value_nullable'));
 Pointer<Void> smoke_ErrorsInterface_InternalError_toFfi_nullable(ErrorsInterface_InternalError value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ErrorsInterface_InternalError_toFfi(value);
-  final result = _smoke_ErrorsInterface_InternalError_create_handle_nullable(_handle);
+  final result = _smoke_ErrorsInterface_InternalErrorCreateHandleNullable(_handle);
   smoke_ErrorsInterface_InternalError_releaseFfiHandle(_handle);
   return result;
 }
 ErrorsInterface_InternalError smoke_ErrorsInterface_InternalError_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ErrorsInterface_InternalError_get_value_nullable(handle);
+  final _handle = _smoke_ErrorsInterface_InternalErrorGetValueNullable(handle);
   final result = smoke_ErrorsInterface_InternalError_fromFfi(_handle);
   smoke_ErrorsInterface_InternalError_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ErrorsInterface_InternalError_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ErrorsInterface_InternalError_release_handle_nullable(handle);
+  _smoke_ErrorsInterface_InternalErrorReleaseHandleNullable(handle);
 // End of ErrorsInterface_InternalError "private" section.
 enum ErrorsInterface_ExternalErrors {
     none,
@@ -126,34 +125,34 @@ ErrorsInterface_ExternalErrors smoke_ErrorsInterface_ExternalErrors_fromFfi(int 
   }
 }
 void smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(int handle) {}
-final _smoke_ErrorsInterface_ExternalErrors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_ExternalErrorsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ErrorsInterface_ExternalErrors_create_handle_nullable'));
-final _smoke_ErrorsInterface_ExternalErrors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_ExternalErrorsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_ExternalErrors_release_handle_nullable'));
-final _smoke_ErrorsInterface_ExternalErrors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ErrorsInterface_ExternalErrorsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_ExternalErrors_get_value_nullable'));
 Pointer<Void> smoke_ErrorsInterface_ExternalErrors_toFfi_nullable(ErrorsInterface_ExternalErrors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ErrorsInterface_ExternalErrors_toFfi(value);
-  final result = _smoke_ErrorsInterface_ExternalErrors_create_handle_nullable(_handle);
+  final result = _smoke_ErrorsInterface_ExternalErrorsCreateHandleNullable(_handle);
   smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(_handle);
   return result;
 }
 ErrorsInterface_ExternalErrors smoke_ErrorsInterface_ExternalErrors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ErrorsInterface_ExternalErrors_get_value_nullable(handle);
+  final _handle = _smoke_ErrorsInterface_ExternalErrorsGetValueNullable(handle);
   final result = smoke_ErrorsInterface_ExternalErrors_fromFfi(_handle);
   smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ErrorsInterface_ExternalErrors_release_handle_nullable(handle);
+  _smoke_ErrorsInterface_ExternalErrorsReleaseHandleNullable(handle);
 // End of ErrorsInterface_ExternalErrors "private" section.
 class ErrorsInterface_InternalException implements Exception {
   final ErrorsInterface_InternalError error;
@@ -164,90 +163,90 @@ class ErrorsInterface_ExternalException implements Exception {
   ErrorsInterface_ExternalException(this.error);
 }
 // ErrorsInterface "private" section, not exported.
-final _smoke_ErrorsInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeErrorsinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_copy_handle'));
-final _smoke_ErrorsInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeErrorsinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_release_handle'));
-final _smoke_ErrorsInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeErrorsinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_ErrorsInterface_create_proxy'));
-final _smoke_ErrorsInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeErrorsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_get_type_id'));
-final _methodWithErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_release_handle'));
-final _methodWithErrors_return_get_result = (Pointer) {};
-final _methodWithErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsReturnGetResult = (Pointer) {};
+final _methodWithErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_get_error'));
-final _methodWithErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_has_error'));
-final _methodWithExternalErrors_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_release_handle'));
-final _methodWithExternalErrors_return_get_result = (Pointer) {};
-final _methodWithExternalErrors_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorsReturnGetResult = (Pointer) {};
+final _methodWithExternalErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_get_error'));
-final _methodWithExternalErrors_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_has_error'));
-final _methodWithErrorsAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_release_handle'));
-final _methodWithErrorsAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_result'));
-final _methodWithErrorsAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_error'));
-final _methodWithErrorsAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_has_error'));
-final _methodWithPayloadError_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_release_handle'));
-final _methodWithPayloadError_return_get_result = (Pointer) {};
-final _methodWithPayloadError_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorReturnGetResult = (Pointer) {};
+final _methodWithPayloadErrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_get_error'));
-final _methodWithPayloadError_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_has_error'));
-final _methodWithPayloadErrorAndReturnValue_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_release_handle'));
-final _methodWithPayloadErrorAndReturnValue_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_result'));
-final _methodWithPayloadErrorAndReturnValue_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_error'));
-final _methodWithPayloadErrorAndReturnValue_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error'));
@@ -278,160 +277,160 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ErrorsInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeErrorsinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   methodWithErrors() {
-    final _methodWithErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors'));
+    final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors'));
     final _handle = this.handle;
-    final __call_result_handle = _methodWithErrors_ffi(_handle, __lib.LibraryContext.isolateId);
-    if (_methodWithErrors_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithErrors_return_get_error(__call_result_handle);
-        _methodWithErrors_return_release_handle(__call_result_handle);
+    final __callResultHandle = _methodWithErrorsFfi(_handle, __lib.LibraryContext.isolateId);
+    if (_methodWithErrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorsReturnGetError(__callResultHandle);
+        _methodWithErrorsReturnReleaseHandle(__callResultHandle);
         try {
-          throw ErrorsInterface_InternalException(smoke_ErrorsInterface_InternalError_fromFfi(__error_handle));
+          throw ErrorsInterface_InternalException(smoke_ErrorsInterface_InternalError_fromFfi(__errorHandle));
         } finally {
-          smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
+          smoke_ErrorsInterface_InternalError_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithErrors_return_get_result(__call_result_handle);
-    _methodWithErrors_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithErrorsReturnGetResult(__callResultHandle);
+    _methodWithErrorsReturnReleaseHandle(__callResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   methodWithExternalErrors() {
-    final _methodWithExternalErrors_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithExternalErrors'));
+    final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithExternalErrors'));
     final _handle = this.handle;
-    final __call_result_handle = _methodWithExternalErrors_ffi(_handle, __lib.LibraryContext.isolateId);
-    if (_methodWithExternalErrors_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithExternalErrors_return_get_error(__call_result_handle);
-        _methodWithExternalErrors_return_release_handle(__call_result_handle);
+    final __callResultHandle = _methodWithExternalErrorsFfi(_handle, __lib.LibraryContext.isolateId);
+    if (_methodWithExternalErrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithExternalErrorsReturnGetError(__callResultHandle);
+        _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
         try {
-          throw ErrorsInterface_ExternalException(smoke_ErrorsInterface_ExternalErrors_fromFfi(__error_handle));
+          throw ErrorsInterface_ExternalException(smoke_ErrorsInterface_ExternalErrors_fromFfi(__errorHandle));
         } finally {
-          smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(__error_handle);
+          smoke_ErrorsInterface_ExternalErrors_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithExternalErrors_return_get_result(__call_result_handle);
-    _methodWithExternalErrors_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithExternalErrorsReturnGetResult(__callResultHandle);
+    _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String methodWithErrorsAndReturnValue() {
-    final _methodWithErrorsAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue'));
+    final _methodWithErrorsAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue'));
     final _handle = this.handle;
-    final __call_result_handle = _methodWithErrorsAndReturnValue_ffi(_handle, __lib.LibraryContext.isolateId);
-    if (_methodWithErrorsAndReturnValue_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithErrorsAndReturnValue_return_get_error(__call_result_handle);
-        _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+    final __callResultHandle = _methodWithErrorsAndReturnValueFfi(_handle, __lib.LibraryContext.isolateId);
+    if (_methodWithErrorsAndReturnValueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorsAndReturnValueReturnGetError(__callResultHandle);
+        _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
         try {
-          throw ErrorsInterface_InternalException(smoke_ErrorsInterface_InternalError_fromFfi(__error_handle));
+          throw ErrorsInterface_InternalException(smoke_ErrorsInterface_InternalError_fromFfi(__errorHandle));
         } finally {
-          smoke_ErrorsInterface_InternalError_releaseFfiHandle(__error_handle);
+          smoke_ErrorsInterface_InternalError_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithErrorsAndReturnValue_return_get_result(__call_result_handle);
-    _methodWithErrorsAndReturnValue_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithErrorsAndReturnValueReturnGetResult(__callResultHandle);
+    _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   static methodWithPayloadError() {
-    final _methodWithPayloadError_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError'));
-    final __call_result_handle = _methodWithPayloadError_ffi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadError_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithPayloadError_return_get_error(__call_result_handle);
-        _methodWithPayloadError_return_release_handle(__call_result_handle);
+    final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError'));
+    final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
+    if (_methodWithPayloadErrorReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
         try {
-          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+          throw WithPayloadException(smoke_Payload_fromFfi(__errorHandle));
         } finally {
-          smoke_Payload_releaseFfiHandle(__error_handle);
+          smoke_Payload_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithPayloadError_return_get_result(__call_result_handle);
-    _methodWithPayloadError_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithPayloadErrorReturnGetResult(__callResultHandle);
+    _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   static String methodWithPayloadErrorAndReturnValue() {
-    final _methodWithPayloadErrorAndReturnValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue'));
-    final __call_result_handle = _methodWithPayloadErrorAndReturnValue_ffi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadErrorAndReturnValue_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _methodWithPayloadErrorAndReturnValue_return_get_error(__call_result_handle);
-        _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+    final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue'));
+    final __callResultHandle = _methodWithPayloadErrorAndReturnValueFfi(__lib.LibraryContext.isolateId);
+    if (_methodWithPayloadErrorAndReturnValueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorAndReturnValueReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
         try {
-          throw WithPayloadException(smoke_Payload_fromFfi(__error_handle));
+          throw WithPayloadException(smoke_Payload_fromFfi(__errorHandle));
         } finally {
-          smoke_Payload_releaseFfiHandle(__error_handle);
+          smoke_Payload_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _methodWithPayloadErrorAndReturnValue_return_get_result(__call_result_handle);
-    _methodWithPayloadErrorAndReturnValue_return_release_handle(__call_result_handle);
+    final __resultHandle = _methodWithPayloadErrorAndReturnValueReturnGetResult(__callResultHandle);
+    _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _ErrorsInterface_methodWithErrors_static(int _token, Pointer<Uint32> _error) {
-  bool _error_flag = false;
+  bool _errorFlag = false;
   try {
     (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrors();
   } on ErrorsInterface_InternalException catch(e) {
-    _error_flag = true;
-    final _error_object = e.error;
-    _error.value = smoke_ErrorsInterface_InternalError_toFfi(_error_object);
+    _errorFlag = true;
+    final _errorObject = e.error;
+    _error.value = smoke_ErrorsInterface_InternalError_toFfi(_errorObject);
   } finally {
   }
-  return _error_flag ? 1 : 0;
+  return _errorFlag ? 1 : 0;
 }
 int _ErrorsInterface_methodWithExternalErrors_static(int _token, Pointer<Uint32> _error) {
-  bool _error_flag = false;
+  bool _errorFlag = false;
   try {
     (__lib.instanceCache[_token] as ErrorsInterface).methodWithExternalErrors();
   } on ErrorsInterface_ExternalException catch(e) {
-    _error_flag = true;
-    final _error_object = e.error;
-    _error.value = smoke_ErrorsInterface_ExternalErrors_toFfi(_error_object);
+    _errorFlag = true;
+    final _errorObject = e.error;
+    _error.value = smoke_ErrorsInterface_ExternalErrors_toFfi(_errorObject);
   } finally {
   }
-  return _error_flag ? 1 : 0;
+  return _errorFlag ? 1 : 0;
 }
 int _ErrorsInterface_methodWithErrorsAndReturnValue_static(int _token, Pointer<Pointer<Void>> _result, Pointer<Uint32> _error) {
-  bool _error_flag = false;
-  String _result_object = null;
+  bool _errorFlag = false;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrorsAndReturnValue();
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrorsAndReturnValue();
+    _result.value = String_toFfi(_resultObject);
   } on ErrorsInterface_InternalException catch(e) {
-    _error_flag = true;
-    final _error_object = e.error;
-    _error.value = smoke_ErrorsInterface_InternalError_toFfi(_error_object);
+    _errorFlag = true;
+    final _errorObject = e.error;
+    _error.value = smoke_ErrorsInterface_InternalError_toFfi(_errorObject);
   } finally {
   }
-  return _error_flag ? 1 : 0;
+  return _errorFlag ? 1 : 0;
 }
 Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
-  if (value is __lib.NativeBase) return _smoke_ErrorsInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_ErrorsInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeErrorsinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeErrorsinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -443,25 +442,25 @@ Pointer<Void> smoke_ErrorsInterface_toFfi(ErrorsInterface value) {
 }
 ErrorsInterface smoke_ErrorsInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ErrorsInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ErrorsInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ErrorsInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeErrorsinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeErrorsinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ErrorsInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ErrorsInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ErrorsInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ErrorsInterface_release_handle(handle);
+  _smokeErrorsinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_ErrorsInterface_toFfi_nullable(ErrorsInterface value) =>
   value != null ? smoke_ErrorsInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 ErrorsInterface smoke_ErrorsInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ErrorsInterface_fromFfi(handle) : null;
 void smoke_ErrorsInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ErrorsInterface_release_handle(handle);
+  _smokeErrorsinterfaceReleaseHandle(handle);
 // End of ErrorsInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -6,7 +6,6 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/package/interface.dart';
 import 'package:library/src/package/types.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Class implements Interface {
@@ -21,31 +20,31 @@ abstract class Class implements Interface {
   set property(Enum value);
 }
 // Class "private" section, not exported.
-final _package_Class_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageClassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Class_copy_handle'));
-final _package_Class_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageClassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Class_release_handle'));
-final _package_Class_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageClassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Class_get_type_id'));
-final _fun_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_release_handle'));
-final _fun_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_get_result'));
-final _fun_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_get_error'));
-final _fun_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_1package_1Types_1Struct_return_has_error'));
@@ -55,90 +54,90 @@ class Class$Impl extends __lib.NativeBase implements Class {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _package_Class_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _packageClassReleaseHandle(handle);
     handle = null;
   }
   Class$Impl.constructor() : super(_constructor()) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   static Pointer<Void> _constructor() {
-    final _constructor_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_package_Class_constructor'));
-    final __result_handle = _constructor_ffi(__lib.LibraryContext.isolateId);
-    return __result_handle;
+    final _constructorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_package_Class_constructor'));
+    final __resultHandle = _constructorFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
   }
   @override
   Struct fun(List<Struct> double) {
-    final _fun_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_package_Class_fun__ListOf_1package_1Types_1Struct'));
-    final _double_handle = foobar_ListOf_package_Types_Struct_toFfi(double);
+    final _funFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_package_Class_fun__ListOf_1package_1Types_1Struct'));
+    final _doubleHandle = foobar_ListOf_package_Types_Struct_toFfi(double);
     final _handle = this.handle;
-    final __call_result_handle = _fun_ffi(_handle, __lib.LibraryContext.isolateId, _double_handle);
-    foobar_ListOf_package_Types_Struct_releaseFfiHandle(_double_handle);
-    if (_fun_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _fun_return_get_error(__call_result_handle);
-        _fun_return_release_handle(__call_result_handle);
+    final __callResultHandle = _funFfi(_handle, __lib.LibraryContext.isolateId, _doubleHandle);
+    foobar_ListOf_package_Types_Struct_releaseFfiHandle(_doubleHandle);
+    if (_funReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _funReturnGetError(__callResultHandle);
+        _funReturnReleaseHandle(__callResultHandle);
         try {
-          throw ExceptionException(package_Types_Enum_fromFfi(__error_handle));
+          throw ExceptionException(package_Types_Enum_fromFfi(__errorHandle));
         } finally {
-          package_Types_Enum_releaseFfiHandle(__error_handle);
+          package_Types_Enum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _fun_return_get_result(__call_result_handle);
-    _fun_return_release_handle(__call_result_handle);
+    final __resultHandle = _funReturnGetResult(__callResultHandle);
+    _funReturnReleaseHandle(__callResultHandle);
     try {
-      return package_Types_Struct_fromFfi(__result_handle);
+      return package_Types_Struct_fromFfi(__resultHandle);
     } finally {
-      package_Types_Struct_releaseFfiHandle(__result_handle);
+      package_Types_Struct_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Enum get property {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_package_Class_property_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_package_Class_property_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return package_Types_Enum_fromFfi(__result_handle);
+      return package_Types_Enum_fromFfi(__resultHandle);
     } finally {
-      package_Types_Enum_releaseFfiHandle(__result_handle);
+      package_Types_Enum_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set property(Enum value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_package_Class_property_set__enum'));
-    final _value_handle = package_Types_Enum_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_package_Class_property_set__enum'));
+    final _valueHandle = package_Types_Enum_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    package_Types_Enum_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    package_Types_Enum_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> package_Class_toFfi(Class value) =>
-  _package_Class_copy_handle((value as __lib.NativeBase).handle);
+  _packageClassCopyHandle((value as __lib.NativeBase).handle);
 Class package_Class_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Class;
   if (instance != null) return instance;
-  final _type_id_handle = _package_Class_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _package_Class_copy_handle(handle);
+  final _typeIdHandle = _packageClassGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _packageClassCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : Class$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : Class$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void package_Class_releaseFfiHandle(Pointer<Void> handle) =>
-  _package_Class_release_handle(handle);
+  _packageClassReleaseHandle(handle);
 Pointer<Void> package_Class_toFfi_nullable(Class value) =>
   value != null ? package_Class_toFfi(value) : Pointer<Void>.fromAddress(0);
 Class package_Class_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? package_Class_fromFfi(handle) : null;
 void package_Class_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _package_Class_release_handle(handle);
+  _packageClassReleaseHandle(handle);
 // End of Class "private" section.

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Interface {
@@ -14,19 +13,19 @@ abstract class Interface {
   void release() {}
 }
 // Interface "private" section, not exported.
-final _package_Interface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageInterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Interface_copy_handle'));
-final _package_Interface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageInterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Interface_release_handle'));
-final _package_Interface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageInterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
   >('library_package_Interface_create_proxy'));
-final _package_Interface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageInterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Interface_get_type_id'));
@@ -36,14 +35,14 @@ class Interface$Impl extends __lib.NativeBase implements Interface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _package_Interface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _packageInterfaceReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> package_Interface_toFfi(Interface value) {
-  if (value is __lib.NativeBase) return _package_Interface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _package_Interface_create_proxy(
+  if (value is __lib.NativeBase) return _packageInterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _packageInterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi
@@ -52,25 +51,25 @@ Pointer<Void> package_Interface_toFfi(Interface value) {
 }
 Interface package_Interface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Interface;
   if (instance != null) return instance;
-  final _type_id_handle = _package_Interface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _package_Interface_copy_handle(handle);
+  final _typeIdHandle = _packageInterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _packageInterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : Interface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : Interface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void package_Interface_releaseFfiHandle(Pointer<Void> handle) =>
-  _package_Interface_release_handle(handle);
+  _packageInterfaceReleaseHandle(handle);
 Pointer<Void> package_Interface_toFfi_nullable(Interface value) =>
   value != null ? package_Interface_toFfi(value) : Pointer<Void>.fromAddress(0);
 Interface package_Interface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? package_Interface_fromFfi(handle) : null;
 void package_Interface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _package_Interface_release_handle(handle);
+  _packageInterfaceReleaseHandle(handle);
 // End of Interface "private" section.

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum Enum {
@@ -25,34 +24,34 @@ Enum package_Types_Enum_fromFfi(int handle) {
   }
 }
 void package_Types_Enum_releaseFfiHandle(int handle) {}
-final _package_Types_Enum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _package_Types_EnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_package_Types_Enum_create_handle_nullable'));
-final _package_Types_Enum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _package_Types_EnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Types_Enum_release_handle_nullable'));
-final _package_Types_Enum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _package_Types_EnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Types_Enum_get_value_nullable'));
 Pointer<Void> package_Types_Enum_toFfi_nullable(Enum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = package_Types_Enum_toFfi(value);
-  final result = _package_Types_Enum_create_handle_nullable(_handle);
+  final result = _package_Types_EnumCreateHandleNullable(_handle);
   package_Types_Enum_releaseFfiHandle(_handle);
   return result;
 }
 Enum package_Types_Enum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _package_Types_Enum_get_value_nullable(handle);
+  final _handle = _package_Types_EnumGetValueNullable(handle);
   final result = package_Types_Enum_fromFfi(_handle);
   package_Types_Enum_releaseFfiHandle(_handle);
   return result;
 }
 void package_Types_Enum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _package_Types_Enum_release_handle_nullable(handle);
+  _package_Types_EnumReleaseHandleNullable(handle);
 // End of Enum "private" section.
 class ExceptionException implements Exception {
   final Enum error;
@@ -65,63 +64,63 @@ class Struct {
     : null = Enum.naN;
 }
 // Struct "private" section, not exported.
-final _package_Types_Struct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageTypesStructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_package_Types_Struct_create_handle'));
-final _package_Types_Struct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageTypesStructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Types_Struct_release_handle'));
-final _package_Types_Struct_get_field_null = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _packageTypesStructGetFieldnull = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Types_Struct_get_field_null'));
 Pointer<Void> package_Types_Struct_toFfi(Struct value) {
-  final _null_handle = package_Types_Enum_toFfi(value.null);
-  final _result = _package_Types_Struct_create_handle(_null_handle);
-  package_Types_Enum_releaseFfiHandle(_null_handle);
+  final _nullHandle = package_Types_Enum_toFfi(value.null);
+  final _result = _packageTypesStructCreateHandle(_nullHandle);
+  package_Types_Enum_releaseFfiHandle(_nullHandle);
   return _result;
 }
 Struct package_Types_Struct_fromFfi(Pointer<Void> handle) {
-  final _null_handle = _package_Types_Struct_get_field_null(handle);
+  final _nullHandle = _packageTypesStructGetFieldnull(handle);
   try {
     return Struct(
-      package_Types_Enum_fromFfi(_null_handle)
+      package_Types_Enum_fromFfi(_nullHandle)
     );
   } finally {
-    package_Types_Enum_releaseFfiHandle(_null_handle);
+    package_Types_Enum_releaseFfiHandle(_nullHandle);
   }
 }
-void package_Types_Struct_releaseFfiHandle(Pointer<Void> handle) => _package_Types_Struct_release_handle(handle);
+void package_Types_Struct_releaseFfiHandle(Pointer<Void> handle) => _packageTypesStructReleaseHandle(handle);
 // Nullable Struct
-final _package_Types_Struct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _package_Types_StructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Types_Struct_create_handle_nullable'));
-final _package_Types_Struct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _package_Types_StructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Types_Struct_release_handle_nullable'));
-final _package_Types_Struct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _package_Types_StructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Types_Struct_get_value_nullable'));
 Pointer<Void> package_Types_Struct_toFfi_nullable(Struct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = package_Types_Struct_toFfi(value);
-  final result = _package_Types_Struct_create_handle_nullable(_handle);
+  final result = _package_Types_StructCreateHandleNullable(_handle);
   package_Types_Struct_releaseFfiHandle(_handle);
   return result;
 }
 Struct package_Types_Struct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _package_Types_Struct_get_value_nullable(handle);
+  final _handle = _package_Types_StructGetValueNullable(handle);
   final result = package_Types_Struct_fromFfi(_handle);
   package_Types_Struct_releaseFfiHandle(_handle);
   return result;
 }
 void package_Types_Struct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _package_Types_Struct_release_handle_nullable(handle);
+  _package_Types_StructReleaseHandleNullable(handle);
 // End of Struct "private" section.
 final Enum Const = Enum.naN;

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
@@ -1,443 +1,441 @@
 import 'dart:math' as math;
 import 'package:foo/bar.dart' as bar;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/http_client_response_compression_state.dart';
 import 'package:library/src/smoke/rectangle_int_.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _foobar_ListOf_Byte_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_Byte_create_handle'));
-final _foobar_ListOf_Byte_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Byte_release_handle'));
-final _foobar_ListOf_Byte_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int8),
     void Function(Pointer<Void>, int)
   >('library_foobar_ListOf_Byte_insert'));
-final _foobar_ListOf_Byte_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_Byte_iterator'));
-final _foobar_ListOf_Byte_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Byte_iterator_release_handle'));
-final _foobar_ListOf_Byte_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_Byte_iterator_is_valid'));
-final _foobar_ListOf_Byte_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Byte_iterator_increment'));
-final _foobar_ListOf_Byte_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofByteIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_Byte_iterator_get'));
 Pointer<Void> foobar_ListOf_Byte_toFfi(List<int> value) {
-  final _result = _foobar_ListOf_Byte_create_handle();
+  final _result = _foobarListofByteCreateHandle();
   for (final element in value) {
-    final _element_handle = (element);
-    _foobar_ListOf_Byte_insert(_result, _element_handle);
-    (_element_handle);
+    final _elementHandle = (element);
+    _foobarListofByteInsert(_result, _elementHandle);
+    (_elementHandle);
   }
   return _result;
 }
 List<int> foobar_ListOf_Byte_fromFfi(Pointer<Void> handle) {
-  final result = List<int>();
-  final _iterator_handle = _foobar_ListOf_Byte_iterator(handle);
-  while (_foobar_ListOf_Byte_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_Byte_iterator_get(_iterator_handle);
+  final result = List<int>.empty(growable: true);
+  final _iteratorHandle = _foobarListofByteIterator(handle);
+  while (_foobarListofByteIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofByteIteratorGet(_iteratorHandle);
     try {
-      result.add((_element_handle));
+      result.add((_elementHandle));
     } finally {
-      (_element_handle);
+      (_elementHandle);
     }
-    _foobar_ListOf_Byte_iterator_increment(_iterator_handle);
+    _foobarListofByteIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_Byte_iterator_release_handle(_iterator_handle);
+  _foobarListofByteIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_Byte_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_Byte_release_handle(handle);
-final _foobar_ListOf_Byte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_Byte_releaseFfiHandle(Pointer<Void> handle) => _foobarListofByteReleaseHandle(handle);
+final _foobar_ListOf_ByteCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Byte_create_handle_nullable'));
-final _foobar_ListOf_Byte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_ByteReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Byte_release_handle_nullable'));
-final _foobar_ListOf_Byte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_ByteGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Byte_get_value_nullable'));
 Pointer<Void> foobar_ListOf_Byte_toFfi_nullable(List<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Byte_toFfi(value);
-  final result = _foobar_ListOf_Byte_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_ByteCreateHandleNullable(_handle);
   foobar_ListOf_Byte_releaseFfiHandle(_handle);
   return result;
 }
 List<int> foobar_ListOf_Byte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_Byte_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_ByteGetValueNullable(handle);
   final result = foobar_ListOf_Byte_fromFfi(_handle);
   foobar_ListOf_Byte_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_Byte_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_Byte_release_handle_nullable(handle);
-final _foobar_ListOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_ByteReleaseHandleNullable(handle);
+final _foobarListofStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_String_create_handle'));
-final _foobar_ListOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_String_release_handle'));
-final _foobar_ListOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_String_insert'));
-final _foobar_ListOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator'));
-final _foobar_ListOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_release_handle'));
-final _foobar_ListOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_is_valid'));
-final _foobar_ListOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_increment'));
-final _foobar_ListOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_get'));
 Pointer<Void> foobar_ListOf_String_toFfi(List<String> value) {
-  final _result = _foobar_ListOf_String_create_handle();
+  final _result = _foobarListofStringCreateHandle();
   for (final element in value) {
-    final _element_handle = String_toFfi(element);
-    _foobar_ListOf_String_insert(_result, _element_handle);
-    String_releaseFfiHandle(_element_handle);
+    final _elementHandle = String_toFfi(element);
+    _foobarListofStringInsert(_result, _elementHandle);
+    String_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
-  final result = List<String>();
-  final _iterator_handle = _foobar_ListOf_String_iterator(handle);
-  while (_foobar_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_String_iterator_get(_iterator_handle);
+  final result = List<String>.empty(growable: true);
+  final _iteratorHandle = _foobarListofStringIterator(handle);
+  while (_foobarListofStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofStringIteratorGet(_iteratorHandle);
     try {
-      result.add(String_fromFfi(_element_handle));
+      result.add(String_fromFfi(_elementHandle));
     } finally {
-      String_releaseFfiHandle(_element_handle);
+      String_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_String_iterator_increment(_iterator_handle);
+    _foobarListofStringIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_String_iterator_release_handle(_iterator_handle);
+  _foobarListofStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_String_release_handle(handle);
-final _foobar_ListOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobarListofStringReleaseHandle(handle);
+final _foobar_ListOf_StringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_create_handle_nullable'));
-final _foobar_ListOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_StringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_String_release_handle_nullable'));
-final _foobar_ListOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_StringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_get_value_nullable'));
 Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_String_toFfi(value);
-  final result = _foobar_ListOf_String_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_StringCreateHandleNullable(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
 List<String> foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_String_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_StringGetValueNullable(handle);
   final result = foobar_ListOf_String_fromFfi(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_String_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_StringReleaseHandleNullable(handle);
+final _foobarListofSmokeRectangleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_Rectangle_create_handle'));
-final _foobar_ListOf_smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeRectangleReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_Rectangle_release_handle'));
-final _foobar_ListOf_smoke_Rectangle_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeRectangleInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_Rectangle_insert'));
-final _foobar_ListOf_smoke_Rectangle_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeRectangleIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_Rectangle_iterator'));
-final _foobar_ListOf_smoke_Rectangle_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeRectangleIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_Rectangle_iterator_release_handle'));
-final _foobar_ListOf_smoke_Rectangle_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeRectangleIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_Rectangle_iterator_is_valid'));
-final _foobar_ListOf_smoke_Rectangle_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeRectangleIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_Rectangle_iterator_increment'));
-final _foobar_ListOf_smoke_Rectangle_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeRectangleIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_Rectangle_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_Rectangle_toFfi(List<math.Rectangle<int>> value) {
-  final _result = _foobar_ListOf_smoke_Rectangle_create_handle();
+  final _result = _foobarListofSmokeRectangleCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_Rectangle_toFfi(element);
-    _foobar_ListOf_smoke_Rectangle_insert(_result, _element_handle);
-    smoke_Rectangle_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_Rectangle_toFfi(element);
+    _foobarListofSmokeRectangleInsert(_result, _elementHandle);
+    smoke_Rectangle_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<math.Rectangle<int>> foobar_ListOf_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
-  final result = List<math.Rectangle<int>>();
-  final _iterator_handle = _foobar_ListOf_smoke_Rectangle_iterator(handle);
-  while (_foobar_ListOf_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_Rectangle_iterator_get(_iterator_handle);
+  final result = List<math.Rectangle<int>>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeRectangleIterator(handle);
+  while (_foobarListofSmokeRectangleIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeRectangleIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_Rectangle_fromFfi(_element_handle));
+      result.add(smoke_Rectangle_fromFfi(_elementHandle));
     } finally {
-      smoke_Rectangle_releaseFfiHandle(_element_handle);
+      smoke_Rectangle_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_Rectangle_iterator_increment(_iterator_handle);
+    _foobarListofSmokeRectangleIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_Rectangle_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeRectangleIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_Rectangle_release_handle(handle);
-final _foobar_ListOf_smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeRectangleReleaseHandle(handle);
+final _foobar_ListOf_smoke_RectangleCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_Rectangle_create_handle_nullable'));
-final _foobar_ListOf_smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_RectangleReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_Rectangle_release_handle_nullable'));
-final _foobar_ListOf_smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_RectangleGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_Rectangle_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_Rectangle_toFfi_nullable(List<math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_Rectangle_toFfi(value);
-  final result = _foobar_ListOf_smoke_Rectangle_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_RectangleCreateHandleNullable(_handle);
   foobar_ListOf_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
 List<math.Rectangle<int>> foobar_ListOf_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_Rectangle_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_RectangleGetValueNullable(handle);
   final result = foobar_ListOf_smoke_Rectangle_fromFfi(_handle);
   foobar_ListOf_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_Rectangle_release_handle_nullable(handle);
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_RectangleReleaseHandleNullable(handle);
+final _foobarMapofSmokeCompressionstateToSmokeRectangleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectangleReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectanglePut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_put'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectangleIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value'));
 Pointer<Void> foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> value) {
-  final _result = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle();
+  final _result = _foobarMapofSmokeCompressionstateToSmokeRectangleCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = smoke_CompressionState_toFfi(entry.key);
-    final _value_handle = smoke_Rectangle_toFfi(entry.value);
-    _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_put(_result, _key_handle, _value_handle);
-    smoke_CompressionState_releaseFfiHandle(_key_handle);
-    smoke_Rectangle_releaseFfiHandle(_value_handle);
+    final _keyHandle = smoke_CompressionState_toFfi(entry.key);
+    final _valueHandle = smoke_Rectangle_toFfi(entry.value);
+    _foobarMapofSmokeCompressionstateToSmokeRectanglePut(_result, _keyHandle, _valueHandle);
+    smoke_CompressionState_releaseFfiHandle(_keyHandle);
+    smoke_Rectangle_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(Pointer<Void> handle) {
   final result = Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>>();
-  final _iterator_handle = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator(handle);
-  while (_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofSmokeCompressionstateToSmokeRectangleIterator(handle);
+  while (_foobarMapofSmokeCompressionstateToSmokeRectangleIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorGetValue(_iteratorHandle);
     try {
-      result[smoke_CompressionState_fromFfi(_key_handle)] =
-        smoke_Rectangle_fromFfi(_value_handle);
+      result[smoke_CompressionState_fromFfi(_keyHandle)] =
+        smoke_Rectangle_fromFfi(_valueHandle);
     } finally {
-      smoke_CompressionState_releaseFfiHandle(_key_handle);
-      smoke_Rectangle_releaseFfiHandle(_value_handle);
+      smoke_CompressionState_releaseFfiHandle(_keyHandle);
+      smoke_Rectangle_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_increment(_iterator_handle);
+    _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_iterator_release_handle(_iterator_handle);
+  _foobarMapofSmokeCompressionstateToSmokeRectangleIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle(handle);
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofSmokeCompressionstateToSmokeRectangleReleaseHandle(handle);
+final _foobar_MapOf_smoke_CompressionState_to_smoke_RectangleCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_CompressionState_to_smoke_RectangleReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable'));
-final _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_CompressionState_to_smoke_RectangleGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable'));
 Pointer<Void> foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi_nullable(Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_toFfi(value);
-  final result = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_smoke_CompressionState_to_smoke_RectangleCreateHandleNullable(_handle);
   foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
 Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_smoke_CompressionState_to_smoke_RectangleGetValueNullable(handle);
   final result = foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_fromFfi(_handle);
   foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_smoke_CompressionState_to_smoke_Rectangle_release_handle_nullable(handle);
-final _foobar_SetOf_smoke_CompressionState_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_smoke_CompressionState_to_smoke_RectangleReleaseHandleNullable(handle);
+final _foobarSetofSmokeCompressionstateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_smoke_CompressionState_create_handle'));
-final _foobar_SetOf_smoke_CompressionState_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeCompressionstateReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_CompressionState_release_handle'));
-final _foobar_SetOf_smoke_CompressionState_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeCompressionstateInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
   >('library_foobar_SetOf_smoke_CompressionState_insert'));
-final _foobar_SetOf_smoke_CompressionState_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeCompressionstateIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_CompressionState_iterator'));
-final _foobar_SetOf_smoke_CompressionState_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeCompressionstateIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_CompressionState_iterator_release_handle'));
-final _foobar_SetOf_smoke_CompressionState_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeCompressionstateIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_smoke_CompressionState_iterator_is_valid'));
-final _foobar_SetOf_smoke_CompressionState_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeCompressionstateIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_CompressionState_iterator_increment'));
-final _foobar_SetOf_smoke_CompressionState_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeCompressionstateIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_CompressionState_iterator_get'));
 Pointer<Void> foobar_SetOf_smoke_CompressionState_toFfi(Set<bar.HttpClientResponseCompressionState> value) {
-  final _result = _foobar_SetOf_smoke_CompressionState_create_handle();
+  final _result = _foobarSetofSmokeCompressionstateCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_CompressionState_toFfi(element);
-    _foobar_SetOf_smoke_CompressionState_insert(_result, _element_handle);
-    smoke_CompressionState_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_CompressionState_toFfi(element);
+    _foobarSetofSmokeCompressionstateInsert(_result, _elementHandle);
+    smoke_CompressionState_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 Set<bar.HttpClientResponseCompressionState> foobar_SetOf_smoke_CompressionState_fromFfi(Pointer<Void> handle) {
   final result = Set<bar.HttpClientResponseCompressionState>();
-  final _iterator_handle = _foobar_SetOf_smoke_CompressionState_iterator(handle);
-  while (_foobar_SetOf_smoke_CompressionState_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_smoke_CompressionState_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofSmokeCompressionstateIterator(handle);
+  while (_foobarSetofSmokeCompressionstateIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofSmokeCompressionstateIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_CompressionState_fromFfi(_element_handle));
+      result.add(smoke_CompressionState_fromFfi(_elementHandle));
     } finally {
-      smoke_CompressionState_releaseFfiHandle(_element_handle);
+      smoke_CompressionState_releaseFfiHandle(_elementHandle);
     }
-    _foobar_SetOf_smoke_CompressionState_iterator_increment(_iterator_handle);
+    _foobarSetofSmokeCompressionstateIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_smoke_CompressionState_iterator_release_handle(_iterator_handle);
+  _foobarSetofSmokeCompressionstateIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_smoke_CompressionState_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_smoke_CompressionState_release_handle(handle);
-final _foobar_SetOf_smoke_CompressionState_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_smoke_CompressionState_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofSmokeCompressionstateReleaseHandle(handle);
+final _foobar_SetOf_smoke_CompressionStateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_CompressionState_create_handle_nullable'));
-final _foobar_SetOf_smoke_CompressionState_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_CompressionStateReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_CompressionState_release_handle_nullable'));
-final _foobar_SetOf_smoke_CompressionState_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_CompressionStateGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_CompressionState_get_value_nullable'));
 Pointer<Void> foobar_SetOf_smoke_CompressionState_toFfi_nullable(Set<bar.HttpClientResponseCompressionState> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_CompressionState_toFfi(value);
-  final result = _foobar_SetOf_smoke_CompressionState_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_smoke_CompressionStateCreateHandleNullable(_handle);
   foobar_SetOf_smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
 Set<bar.HttpClientResponseCompressionState> foobar_SetOf_smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_smoke_CompressionState_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_smoke_CompressionStateGetValueNullable(handle);
   final result = foobar_SetOf_smoke_CompressionState_fromFfi(_handle);
   foobar_SetOf_smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_smoke_CompressionState_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_smoke_CompressionState_release_handle_nullable(handle);
+  _foobar_SetOf_smoke_CompressionStateReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Enums {
@@ -43,34 +42,34 @@ Enums_ExternalEnum smoke_Enums_ExternalEnum_fromFfi(int handle) {
   }
 }
 void smoke_Enums_ExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_Enums_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ExternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Enums_ExternalEnum_create_handle_nullable'));
-final _smoke_Enums_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ExternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_ExternalEnum_release_handle_nullable'));
-final _smoke_Enums_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_ExternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_ExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_Enums_ExternalEnum_toFfi_nullable(Enums_ExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_ExternalEnum_toFfi(value);
-  final result = _smoke_Enums_ExternalEnum_create_handle_nullable(_handle);
+  final result = _smoke_Enums_ExternalEnumCreateHandleNullable(_handle);
   smoke_Enums_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 Enums_ExternalEnum smoke_Enums_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Enums_ExternalEnum_get_value_nullable(handle);
+  final _handle = _smoke_Enums_ExternalEnumGetValueNullable(handle);
   final result = smoke_Enums_ExternalEnum_fromFfi(_handle);
   smoke_Enums_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Enums_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_ExternalEnum_release_handle_nullable(handle);
+  _smoke_Enums_ExternalEnumReleaseHandleNullable(handle);
 // End of Enums_ExternalEnum "private" section.
 enum Enums_VeryExternalEnum {
     foo,
@@ -102,41 +101,41 @@ Enums_VeryExternalEnum smoke_Enums_VeryExternalEnum_fromFfi(int handle) {
   }
 }
 void smoke_Enums_VeryExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_Enums_VeryExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_VeryExternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Enums_VeryExternalEnum_create_handle_nullable'));
-final _smoke_Enums_VeryExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_VeryExternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_VeryExternalEnum_release_handle_nullable'));
-final _smoke_Enums_VeryExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Enums_VeryExternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_VeryExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_Enums_VeryExternalEnum_toFfi_nullable(Enums_VeryExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Enums_VeryExternalEnum_toFfi(value);
-  final result = _smoke_Enums_VeryExternalEnum_create_handle_nullable(_handle);
+  final result = _smoke_Enums_VeryExternalEnumCreateHandleNullable(_handle);
   smoke_Enums_VeryExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 Enums_VeryExternalEnum smoke_Enums_VeryExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Enums_VeryExternalEnum_get_value_nullable(handle);
+  final _handle = _smoke_Enums_VeryExternalEnumGetValueNullable(handle);
   final result = smoke_Enums_VeryExternalEnum_fromFfi(_handle);
   smoke_Enums_VeryExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Enums_VeryExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_VeryExternalEnum_release_handle_nullable(handle);
+  _smoke_Enums_VeryExternalEnumReleaseHandleNullable(handle);
 // End of Enums_VeryExternalEnum "private" section.
 // Enums "private" section, not exported.
-final _smoke_Enums_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_copy_handle'));
-final _smoke_Enums_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_release_handle'));
@@ -146,40 +145,40 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Enums_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeEnumsReleaseHandle(handle);
     handle = null;
   }
   static methodWithExternalEnum(Enums_ExternalEnum input) {
-    final _methodWithExternalEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum'));
-    final _input_handle = smoke_Enums_ExternalEnum_toFfi(input);
-    final __result_handle = _methodWithExternalEnum_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_Enums_ExternalEnum_releaseFfiHandle(_input_handle);
+    final _methodWithExternalEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum'));
+    final _inputHandle = smoke_Enums_ExternalEnum_toFfi(input);
+    final __resultHandle = _methodWithExternalEnumFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Enums_ExternalEnum_releaseFfiHandle(_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Enums_toFfi(Enums value) =>
-  _smoke_Enums_copy_handle((value as __lib.NativeBase).handle);
+  _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
 Enums smoke_Enums_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Enums;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Enums_copy_handle(handle);
-  final result = Enums$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeEnumsCopyHandle(handle);
+  final result = Enums$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Enums_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Enums_release_handle(handle);
+  _smokeEnumsReleaseHandle(handle);
 Pointer<Void> smoke_Enums_toFfi_nullable(Enums value) =>
   value != null ? smoke_Enums_toFfi(value) : Pointer<Void>.fromAddress(0);
 Enums smoke_Enums_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Enums_fromFfi(handle) : null;
 void smoke_Enums_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Enums_release_handle(handle);
+  _smokeEnumsReleaseHandle(handle);
 // End of Enums "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ExternalClass {
@@ -37,105 +36,105 @@ ExternalClass_SomeEnum smoke_ExternalClass_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_ExternalClass_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_ExternalClass_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ExternalClass_SomeEnum_create_handle_nullable'));
-final _smoke_ExternalClass_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeEnum_release_handle_nullable'));
-final _smoke_ExternalClass_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_ExternalClass_SomeEnum_toFfi_nullable(ExternalClass_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalClass_SomeEnum_toFfi(value);
-  final result = _smoke_ExternalClass_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_ExternalClass_SomeEnumCreateHandleNullable(_handle);
   smoke_ExternalClass_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 ExternalClass_SomeEnum smoke_ExternalClass_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExternalClass_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_ExternalClass_SomeEnumGetValueNullable(handle);
   final result = smoke_ExternalClass_SomeEnum_fromFfi(_handle);
   smoke_ExternalClass_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExternalClass_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExternalClass_SomeEnum_release_handle_nullable(handle);
+  _smoke_ExternalClass_SomeEnumReleaseHandleNullable(handle);
 // End of ExternalClass_SomeEnum "private" section.
 class ExternalClass_SomeStruct {
   String someField;
   ExternalClass_SomeStruct(this.someField);
 }
 // ExternalClass_SomeStruct "private" section, not exported.
-final _smoke_ExternalClass_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalclassSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_create_handle'));
-final _smoke_ExternalClass_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalclassSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_release_handle'));
-final _smoke_ExternalClass_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalclassSomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_ExternalClass_SomeStruct_toFfi(ExternalClass_SomeStruct value) {
-  final _someField_handle = String_toFfi(value.someField);
-  final _result = _smoke_ExternalClass_SomeStruct_create_handle(_someField_handle);
-  String_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = String_toFfi(value.someField);
+  final _result = _smokeExternalclassSomestructCreateHandle(_someFieldHandle);
+  String_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 ExternalClass_SomeStruct smoke_ExternalClass_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_ExternalClass_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeExternalclassSomestructGetFieldsomeField(handle);
   try {
     return ExternalClass_SomeStruct(
-      String_fromFfi(_someField_handle)
+      String_fromFfi(_someFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_someField_handle);
+    String_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_ExternalClass_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExternalClass_SomeStruct_release_handle(handle);
+void smoke_ExternalClass_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeExternalclassSomestructReleaseHandle(handle);
 // Nullable ExternalClass_SomeStruct
-final _smoke_ExternalClass_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_create_handle_nullable'));
-final _smoke_ExternalClass_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_release_handle_nullable'));
-final _smoke_ExternalClass_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalClass_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_ExternalClass_SomeStruct_toFfi_nullable(ExternalClass_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalClass_SomeStruct_toFfi(value);
-  final result = _smoke_ExternalClass_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_ExternalClass_SomeStructCreateHandleNullable(_handle);
   smoke_ExternalClass_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 ExternalClass_SomeStruct smoke_ExternalClass_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExternalClass_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_ExternalClass_SomeStructGetValueNullable(handle);
   final result = smoke_ExternalClass_SomeStruct_fromFfi(_handle);
   smoke_ExternalClass_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExternalClass_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExternalClass_SomeStruct_release_handle_nullable(handle);
+  _smoke_ExternalClass_SomeStructReleaseHandleNullable(handle);
 // End of ExternalClass_SomeStruct "private" section.
 // ExternalClass "private" section, not exported.
-final _smoke_ExternalClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_copy_handle'));
-final _smoke_ExternalClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_release_handle'));
@@ -145,53 +144,53 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ExternalClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeExternalclassReleaseHandle(handle);
     handle = null;
   }
   @override
   someMethod(int someParameter) {
-    final _someMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalClass_someMethod__Byte'));
-    final _someParameter_handle = (someParameter);
+    final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalClass_someMethod__Byte'));
+    final _someParameterHandle = (someParameter);
     final _handle = this.handle;
-    final __result_handle = _someMethod_ffi(_handle, __lib.LibraryContext.isolateId, _someParameter_handle);
-    (_someParameter_handle);
+    final __resultHandle = _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
+    (_someParameterHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String get someProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ExternalClass_toFfi(ExternalClass value) =>
-  _smoke_ExternalClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeExternalclassCopyHandle((value as __lib.NativeBase).handle);
 ExternalClass smoke_ExternalClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ExternalClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_ExternalClass_copy_handle(handle);
-  final result = ExternalClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeExternalclassCopyHandle(handle);
+  final result = ExternalClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ExternalClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExternalClass_release_handle(handle);
+  _smokeExternalclassReleaseHandle(handle);
 Pointer<Void> smoke_ExternalClass_toFfi_nullable(ExternalClass value) =>
   value != null ? smoke_ExternalClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 ExternalClass smoke_ExternalClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExternalClass_fromFfi(handle) : null;
 void smoke_ExternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExternalClass_release_handle(handle);
+  _smokeExternalclassReleaseHandle(handle);
 // End of ExternalClass "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ExternalInterface {
-  ExternalInterface() {}
+  ExternalInterface();
   factory ExternalInterface.fromLambdas({
     @required void Function(int) lambda_someMethod,
     @required String Function() lambda_someProperty_get
@@ -46,113 +45,113 @@ ExternalInterface_SomeEnum smoke_ExternalInterface_SomeEnum_fromFfi(int handle) 
   }
 }
 void smoke_ExternalInterface_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_ExternalInterface_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ExternalInterface_SomeEnum_create_handle_nullable'));
-final _smoke_ExternalInterface_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeEnum_release_handle_nullable'));
-final _smoke_ExternalInterface_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_ExternalInterface_SomeEnum_toFfi_nullable(ExternalInterface_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalInterface_SomeEnum_toFfi(value);
-  final result = _smoke_ExternalInterface_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_ExternalInterface_SomeEnumCreateHandleNullable(_handle);
   smoke_ExternalInterface_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 ExternalInterface_SomeEnum smoke_ExternalInterface_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExternalInterface_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_ExternalInterface_SomeEnumGetValueNullable(handle);
   final result = smoke_ExternalInterface_SomeEnum_fromFfi(_handle);
   smoke_ExternalInterface_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExternalInterface_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExternalInterface_SomeEnum_release_handle_nullable(handle);
+  _smoke_ExternalInterface_SomeEnumReleaseHandleNullable(handle);
 // End of ExternalInterface_SomeEnum "private" section.
 class ExternalInterface_SomeStruct {
   String someField;
   ExternalInterface_SomeStruct(this.someField);
 }
 // ExternalInterface_SomeStruct "private" section, not exported.
-final _smoke_ExternalInterface_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalinterfaceSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_create_handle'));
-final _smoke_ExternalInterface_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalinterfaceSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_release_handle'));
-final _smoke_ExternalInterface_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalinterfaceSomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_ExternalInterface_SomeStruct_toFfi(ExternalInterface_SomeStruct value) {
-  final _someField_handle = String_toFfi(value.someField);
-  final _result = _smoke_ExternalInterface_SomeStruct_create_handle(_someField_handle);
-  String_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = String_toFfi(value.someField);
+  final _result = _smokeExternalinterfaceSomestructCreateHandle(_someFieldHandle);
+  String_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 ExternalInterface_SomeStruct smoke_ExternalInterface_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_ExternalInterface_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeExternalinterfaceSomestructGetFieldsomeField(handle);
   try {
     return ExternalInterface_SomeStruct(
-      String_fromFfi(_someField_handle)
+      String_fromFfi(_someFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_someField_handle);
+    String_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_ExternalInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ExternalInterface_SomeStruct_release_handle(handle);
+void smoke_ExternalInterface_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeExternalinterfaceSomestructReleaseHandle(handle);
 // Nullable ExternalInterface_SomeStruct
-final _smoke_ExternalInterface_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_create_handle_nullable'));
-final _smoke_ExternalInterface_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_release_handle_nullable'));
-final _smoke_ExternalInterface_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ExternalInterface_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_ExternalInterface_SomeStruct_toFfi_nullable(ExternalInterface_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ExternalInterface_SomeStruct_toFfi(value);
-  final result = _smoke_ExternalInterface_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_ExternalInterface_SomeStructCreateHandleNullable(_handle);
   smoke_ExternalInterface_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 ExternalInterface_SomeStruct smoke_ExternalInterface_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ExternalInterface_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_ExternalInterface_SomeStructGetValueNullable(handle);
   final result = smoke_ExternalInterface_SomeStruct_fromFfi(_handle);
   smoke_ExternalInterface_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ExternalInterface_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExternalInterface_SomeStruct_release_handle_nullable(handle);
+  _smoke_ExternalInterface_SomeStructReleaseHandleNullable(handle);
 // End of ExternalInterface_SomeStruct "private" section.
 // ExternalInterface "private" section, not exported.
-final _smoke_ExternalInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_copy_handle'));
-final _smoke_ExternalInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_release_handle'));
-final _smoke_ExternalInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer)
   >('library_smoke_ExternalInterface_create_proxy'));
-final _smoke_ExternalInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeExternalinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_get_type_id'));
@@ -177,31 +176,31 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ExternalInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeExternalinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   someMethod(int someParameter) {
-    final _someMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalInterface_someMethod__Byte'));
-    final _someParameter_handle = (someParameter);
+    final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalInterface_someMethod__Byte'));
+    final _someParameterHandle = (someParameter);
     final _handle = this.handle;
-    final __result_handle = _someMethod_ffi(_handle, __lib.LibraryContext.isolateId, _someParameter_handle);
-    (_someParameter_handle);
+    final __resultHandle = _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
+    (_someParameterHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   String get someProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
@@ -218,8 +217,8 @@ int _ExternalInterface_someProperty_get_static(int _token, Pointer<Pointer<Void>
   return 0;
 }
 Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
-  if (value is __lib.NativeBase) return _smoke_ExternalInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_ExternalInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeExternalinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeExternalinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -230,25 +229,25 @@ Pointer<Void> smoke_ExternalInterface_toFfi(ExternalInterface value) {
 }
 ExternalInterface smoke_ExternalInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ExternalInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ExternalInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ExternalInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeExternalinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeExternalinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ExternalInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ExternalInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ExternalInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ExternalInterface_release_handle(handle);
+  _smokeExternalinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_ExternalInterface_toFfi_nullable(ExternalInterface value) =>
   value != null ? smoke_ExternalInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 ExternalInterface smoke_ExternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ExternalInterface_fromFfi(handle) : null;
 void smoke_ExternalInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ExternalInterface_release_handle(handle);
+  _smokeExternalinterfaceReleaseHandle(handle);
 // End of ExternalInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -1,6 +1,5 @@
 import 'package:foo/bar.dart' as bar;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // HttpClientResponseCompressionState "private" section, not exported.
@@ -35,32 +34,32 @@ bar.HttpClientResponseCompressionState smoke_CompressionState_fromFfi(int handle
   }
 }
 void smoke_CompressionState_releaseFfiHandle(int handle) {}
-final _smoke_CompressionState_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CompressionStateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_CompressionState_create_handle_nullable'));
-final _smoke_CompressionState_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CompressionStateReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CompressionState_release_handle_nullable'));
-final _smoke_CompressionState_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CompressionStateGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CompressionState_get_value_nullable'));
 Pointer<Void> smoke_CompressionState_toFfi_nullable(bar.HttpClientResponseCompressionState value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CompressionState_toFfi(value);
-  final result = _smoke_CompressionState_create_handle_nullable(_handle);
+  final result = _smoke_CompressionStateCreateHandleNullable(_handle);
   smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
 bar.HttpClientResponseCompressionState smoke_CompressionState_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_CompressionState_get_value_nullable(handle);
+  final _handle = _smoke_CompressionStateGetValueNullable(handle);
   final result = smoke_CompressionState_fromFfi(_handle);
   smoke_CompressionState_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_CompressionState_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CompressionState_release_handle_nullable(handle);
+  _smoke_CompressionStateReleaseHandleNullable(handle);
 // End of HttpClientResponseCompressionState "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import '../color_converter.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class int_internal {
@@ -14,91 +13,91 @@ class int_internal {
     : red = red, green = green, blue = blue, alpha = 0;
 }
 // int "private" section, not exported.
-final _smoke_DartColor_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDartcolorCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Float, Float, Float, Float),
     Pointer<Void> Function(double, double, double, double)
   >('library_smoke_DartColor_create_handle'));
-final _smoke_DartColor_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDartcolorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DartColor_release_handle'));
-final _smoke_DartColor_get_field_red = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDartcolorGetFieldred = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DartColor_get_field_red'));
-final _smoke_DartColor_get_field_green = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDartcolorGetFieldgreen = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DartColor_get_field_green'));
-final _smoke_DartColor_get_field_blue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDartcolorGetFieldblue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DartColor_get_field_blue'));
-final _smoke_DartColor_get_field_alpha = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeDartcolorGetFieldalpha = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DartColor_get_field_alpha'));
 Pointer<Void> smoke_DartColor_toFfi(int value_ext) {
   final value = ColorConverter.convertToInternal(value_ext);
-  final _red_handle = (value.red);
-  final _green_handle = (value.green);
-  final _blue_handle = (value.blue);
-  final _alpha_handle = (value.alpha);
-  final _result = _smoke_DartColor_create_handle(_red_handle, _green_handle, _blue_handle, _alpha_handle);
-  (_red_handle);
-  (_green_handle);
-  (_blue_handle);
-  (_alpha_handle);
+  final _redHandle = (value.red);
+  final _greenHandle = (value.green);
+  final _blueHandle = (value.blue);
+  final _alphaHandle = (value.alpha);
+  final _result = _smokeDartcolorCreateHandle(_redHandle, _greenHandle, _blueHandle, _alphaHandle);
+  (_redHandle);
+  (_greenHandle);
+  (_blueHandle);
+  (_alphaHandle);
   return _result;
 }
 int smoke_DartColor_fromFfi(Pointer<Void> handle) {
-  final _red_handle = _smoke_DartColor_get_field_red(handle);
-  final _green_handle = _smoke_DartColor_get_field_green(handle);
-  final _blue_handle = _smoke_DartColor_get_field_blue(handle);
-  final _alpha_handle = _smoke_DartColor_get_field_alpha(handle);
+  final _redHandle = _smokeDartcolorGetFieldred(handle);
+  final _greenHandle = _smokeDartcolorGetFieldgreen(handle);
+  final _blueHandle = _smokeDartcolorGetFieldblue(handle);
+  final _alphaHandle = _smokeDartcolorGetFieldalpha(handle);
   try {
-    final result_internal = int_internal(
-      (_red_handle),
-      (_green_handle),
-      (_blue_handle),
-      (_alpha_handle)
+    final resultInternal = int_internal(
+      (_redHandle),
+      (_greenHandle),
+      (_blueHandle),
+      (_alphaHandle)
     );
-    return ColorConverter.convertFromInternal(result_internal);
+    return ColorConverter.convertFromInternal(resultInternal);
   } finally {
-    (_red_handle);
-    (_green_handle);
-    (_blue_handle);
-    (_alpha_handle);
+    (_redHandle);
+    (_greenHandle);
+    (_blueHandle);
+    (_alphaHandle);
   }
 }
-void smoke_DartColor_releaseFfiHandle(Pointer<Void> handle) => _smoke_DartColor_release_handle(handle);
+void smoke_DartColor_releaseFfiHandle(Pointer<Void> handle) => _smokeDartcolorReleaseHandle(handle);
 // Nullable int
-final _smoke_DartColor_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DartColorCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DartColor_create_handle_nullable'));
-final _smoke_DartColor_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DartColorReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DartColor_release_handle_nullable'));
-final _smoke_DartColor_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DartColorGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DartColor_get_value_nullable'));
 Pointer<Void> smoke_DartColor_toFfi_nullable(int value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DartColor_toFfi(value);
-  final result = _smoke_DartColor_create_handle_nullable(_handle);
+  final result = _smoke_DartColorCreateHandleNullable(_handle);
   smoke_DartColor_releaseFfiHandle(_handle);
   return result;
 }
 int smoke_DartColor_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DartColor_get_value_nullable(handle);
+  final _handle = _smoke_DartColorGetValueNullable(handle);
   final result = smoke_DartColor_fromFfi(_handle);
   smoke_DartColor_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DartColor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DartColor_release_handle_nullable(handle);
+  _smoke_DartColorReleaseHandleNullable(handle);
 // End of int "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
@@ -1,93 +1,92 @@
 import 'dart:math' as math;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // Rectangle<int> "private" section, not exported.
-final _smoke_Rectangle_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeRectangleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Int32, Int32, Int32),
     Pointer<Void> Function(int, int, int, int)
   >('library_smoke_Rectangle_create_handle'));
-final _smoke_Rectangle_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeRectangleReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Rectangle_release_handle'));
-final _smoke_Rectangle_get_field_left = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeRectangleGetFieldleft = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_field_left'));
-final _smoke_Rectangle_get_field_top = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeRectangleGetFieldtop = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_field_top'));
-final _smoke_Rectangle_get_field_width = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeRectangleGetFieldwidth = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_field_width'));
-final _smoke_Rectangle_get_field_height = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeRectangleGetFieldheight = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_field_height'));
 Pointer<Void> smoke_Rectangle_toFfi(math.Rectangle<int> value) {
-  final _left_handle = (value.left);
-  final _top_handle = (value.top);
-  final _width_handle = (value.width);
-  final _height_handle = (value.height);
-  final _result = _smoke_Rectangle_create_handle(_left_handle, _top_handle, _width_handle, _height_handle);
-  (_left_handle);
-  (_top_handle);
-  (_width_handle);
-  (_height_handle);
+  final _leftHandle = (value.left);
+  final _topHandle = (value.top);
+  final _widthHandle = (value.width);
+  final _heightHandle = (value.height);
+  final _result = _smokeRectangleCreateHandle(_leftHandle, _topHandle, _widthHandle, _heightHandle);
+  (_leftHandle);
+  (_topHandle);
+  (_widthHandle);
+  (_heightHandle);
   return _result;
 }
 math.Rectangle<int> smoke_Rectangle_fromFfi(Pointer<Void> handle) {
-  final _left_handle = _smoke_Rectangle_get_field_left(handle);
-  final _top_handle = _smoke_Rectangle_get_field_top(handle);
-  final _width_handle = _smoke_Rectangle_get_field_width(handle);
-  final _height_handle = _smoke_Rectangle_get_field_height(handle);
+  final _leftHandle = _smokeRectangleGetFieldleft(handle);
+  final _topHandle = _smokeRectangleGetFieldtop(handle);
+  final _widthHandle = _smokeRectangleGetFieldwidth(handle);
+  final _heightHandle = _smokeRectangleGetFieldheight(handle);
   try {
     return math.Rectangle<int>(
-      (_left_handle),
-      (_top_handle),
-      (_width_handle),
-      (_height_handle)
+      (_leftHandle),
+      (_topHandle),
+      (_widthHandle),
+      (_heightHandle)
     );
   } finally {
-    (_left_handle);
-    (_top_handle);
-    (_width_handle);
-    (_height_handle);
+    (_leftHandle);
+    (_topHandle);
+    (_widthHandle);
+    (_heightHandle);
   }
 }
-void smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _smoke_Rectangle_release_handle(handle);
+void smoke_Rectangle_releaseFfiHandle(Pointer<Void> handle) => _smokeRectangleReleaseHandle(handle);
 // Nullable Rectangle<int>
-final _smoke_Rectangle_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_RectangleCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Rectangle_create_handle_nullable'));
-final _smoke_Rectangle_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_RectangleReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Rectangle_release_handle_nullable'));
-final _smoke_Rectangle_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_RectangleGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Rectangle_get_value_nullable'));
 Pointer<Void> smoke_Rectangle_toFfi_nullable(math.Rectangle<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Rectangle_toFfi(value);
-  final result = _smoke_Rectangle_create_handle_nullable(_handle);
+  final result = _smoke_RectangleCreateHandleNullable(_handle);
   smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
 math.Rectangle<int> smoke_Rectangle_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Rectangle_get_value_nullable(handle);
+  final _handle = _smoke_RectangleGetValueNullable(handle);
   final result = smoke_Rectangle_fromFfi(_handle);
   smoke_Rectangle_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Rectangle_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Rectangle_release_handle_nullable(handle);
+  _smoke_RectangleReleaseHandleNullable(handle);
 // End of Rectangle<int> "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -1,6 +1,5 @@
 import '../season_converter.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum String_internal {
@@ -48,32 +47,32 @@ String smoke_DartSeason_fromFfi(int handle) {
   }
 }
 void smoke_DartSeason_releaseFfiHandle(int handle) {}
-final _smoke_DartSeason_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DartSeasonCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_DartSeason_create_handle_nullable'));
-final _smoke_DartSeason_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DartSeasonReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DartSeason_release_handle_nullable'));
-final _smoke_DartSeason_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_DartSeasonGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DartSeason_get_value_nullable'));
 Pointer<Void> smoke_DartSeason_toFfi_nullable(String value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_DartSeason_toFfi(value);
-  final result = _smoke_DartSeason_create_handle_nullable(_handle);
+  final result = _smoke_DartSeasonCreateHandleNullable(_handle);
   smoke_DartSeason_releaseFfiHandle(_handle);
   return result;
 }
 String smoke_DartSeason_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_DartSeason_get_value_nullable(handle);
+  final _handle = _smoke_DartSeasonGetValueNullable(handle);
   final result = smoke_DartSeason_fromFfi(_handle);
   smoke_DartSeason_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_DartSeason_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_DartSeason_release_handle_nullable(handle);
+  _smoke_DartSeasonReleaseHandleNullable(handle);
 // End of String "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Structs {
@@ -23,162 +22,162 @@ class Structs_ExternalStruct {
   Structs_ExternalStruct(this.stringField, this.externalStringField, this.externalArrayField, this.externalStructField);
 }
 // Structs_ExternalStruct "private" section, not exported.
-final _smoke_Structs_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsExternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_create_handle'));
-final _smoke_Structs_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsExternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_release_handle'));
-final _smoke_Structs_ExternalStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsExternalstructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_field_stringField'));
-final _smoke_Structs_ExternalStruct_get_field_externalStringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsExternalstructGetFieldexternalStringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_field_externalStringField'));
-final _smoke_Structs_ExternalStruct_get_field_externalArrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsExternalstructGetFieldexternalArrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_field_externalArrayField'));
-final _smoke_Structs_ExternalStruct_get_field_externalStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsExternalstructGetFieldexternalStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_field_externalStructField'));
 Pointer<Void> smoke_Structs_ExternalStruct_toFfi(Structs_ExternalStruct value) {
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _externalStringField_handle = String_toFfi(value.externalStringField);
-  final _externalArrayField_handle = foobar_ListOf_Byte_toFfi(value.externalArrayField);
-  final _externalStructField_handle = smoke_Structs_AnotherExternalStruct_toFfi(value.externalStructField);
-  final _result = _smoke_Structs_ExternalStruct_create_handle(_stringField_handle, _externalStringField_handle, _externalArrayField_handle, _externalStructField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  String_releaseFfiHandle(_externalStringField_handle);
-  foobar_ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
-  smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructField_handle);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _externalStringFieldHandle = String_toFfi(value.externalStringField);
+  final _externalArrayFieldHandle = foobar_ListOf_Byte_toFfi(value.externalArrayField);
+  final _externalStructFieldHandle = smoke_Structs_AnotherExternalStruct_toFfi(value.externalStructField);
+  final _result = _smokeStructsExternalstructCreateHandle(_stringFieldHandle, _externalStringFieldHandle, _externalArrayFieldHandle, _externalStructFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  String_releaseFfiHandle(_externalStringFieldHandle);
+  foobar_ListOf_Byte_releaseFfiHandle(_externalArrayFieldHandle);
+  smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructFieldHandle);
   return _result;
 }
 Structs_ExternalStruct smoke_Structs_ExternalStruct_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_Structs_ExternalStruct_get_field_stringField(handle);
-  final _externalStringField_handle = _smoke_Structs_ExternalStruct_get_field_externalStringField(handle);
-  final _externalArrayField_handle = _smoke_Structs_ExternalStruct_get_field_externalArrayField(handle);
-  final _externalStructField_handle = _smoke_Structs_ExternalStruct_get_field_externalStructField(handle);
+  final _stringFieldHandle = _smokeStructsExternalstructGetFieldstringField(handle);
+  final _externalStringFieldHandle = _smokeStructsExternalstructGetFieldexternalStringField(handle);
+  final _externalArrayFieldHandle = _smokeStructsExternalstructGetFieldexternalArrayField(handle);
+  final _externalStructFieldHandle = _smokeStructsExternalstructGetFieldexternalStructField(handle);
   try {
     return Structs_ExternalStruct(
-      String_fromFfi(_stringField_handle),
-      String_fromFfi(_externalStringField_handle),
-      foobar_ListOf_Byte_fromFfi(_externalArrayField_handle),
-      smoke_Structs_AnotherExternalStruct_fromFfi(_externalStructField_handle)
+      String_fromFfi(_stringFieldHandle),
+      String_fromFfi(_externalStringFieldHandle),
+      foobar_ListOf_Byte_fromFfi(_externalArrayFieldHandle),
+      smoke_Structs_AnotherExternalStruct_fromFfi(_externalStructFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
-    String_releaseFfiHandle(_externalStringField_handle);
-    foobar_ListOf_Byte_releaseFfiHandle(_externalArrayField_handle);
-    smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    String_releaseFfiHandle(_externalStringFieldHandle);
+    foobar_ListOf_Byte_releaseFfiHandle(_externalArrayFieldHandle);
+    smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_externalStructFieldHandle);
   }
 }
-void smoke_Structs_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_ExternalStruct_release_handle(handle);
+void smoke_Structs_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsExternalstructReleaseHandle(handle);
 // Nullable Structs_ExternalStruct
-final _smoke_Structs_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ExternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_create_handle_nullable'));
-final _smoke_Structs_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ExternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_release_handle_nullable'));
-final _smoke_Structs_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ExternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_ExternalStruct_toFfi_nullable(Structs_ExternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_ExternalStruct_toFfi(value);
-  final result = _smoke_Structs_ExternalStruct_create_handle_nullable(_handle);
+  final result = _smoke_Structs_ExternalStructCreateHandleNullable(_handle);
   smoke_Structs_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 Structs_ExternalStruct smoke_Structs_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_ExternalStruct_get_value_nullable(handle);
+  final _handle = _smoke_Structs_ExternalStructGetValueNullable(handle);
   final result = smoke_Structs_ExternalStruct_fromFfi(_handle);
   smoke_Structs_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_ExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_ExternalStruct_release_handle_nullable(handle);
+  _smoke_Structs_ExternalStructReleaseHandleNullable(handle);
 // End of Structs_ExternalStruct "private" section.
 class Structs_AnotherExternalStruct {
   int intField;
   Structs_AnotherExternalStruct(this.intField);
 }
 // Structs_AnotherExternalStruct "private" section, not exported.
-final _smoke_Structs_AnotherExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAnotherexternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8),
     Pointer<Void> Function(int)
   >('library_smoke_Structs_AnotherExternalStruct_create_handle'));
-final _smoke_Structs_AnotherExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAnotherexternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_release_handle'));
-final _smoke_Structs_AnotherExternalStruct_get_field_intField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAnotherexternalstructGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_get_field_intField'));
 Pointer<Void> smoke_Structs_AnotherExternalStruct_toFfi(Structs_AnotherExternalStruct value) {
-  final _intField_handle = (value.intField);
-  final _result = _smoke_Structs_AnotherExternalStruct_create_handle(_intField_handle);
-  (_intField_handle);
+  final _intFieldHandle = (value.intField);
+  final _result = _smokeStructsAnotherexternalstructCreateHandle(_intFieldHandle);
+  (_intFieldHandle);
   return _result;
 }
 Structs_AnotherExternalStruct smoke_Structs_AnotherExternalStruct_fromFfi(Pointer<Void> handle) {
-  final _intField_handle = _smoke_Structs_AnotherExternalStruct_get_field_intField(handle);
+  final _intFieldHandle = _smokeStructsAnotherexternalstructGetFieldintField(handle);
   try {
     return Structs_AnotherExternalStruct(
-      (_intField_handle)
+      (_intFieldHandle)
     );
   } finally {
-    (_intField_handle);
+    (_intFieldHandle);
   }
 }
-void smoke_Structs_AnotherExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_AnotherExternalStruct_release_handle(handle);
+void smoke_Structs_AnotherExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsAnotherexternalstructReleaseHandle(handle);
 // Nullable Structs_AnotherExternalStruct
-final _smoke_Structs_AnotherExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AnotherExternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_create_handle_nullable'));
-final _smoke_Structs_AnotherExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AnotherExternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_release_handle_nullable'));
-final _smoke_Structs_AnotherExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AnotherExternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_AnotherExternalStruct_toFfi_nullable(Structs_AnotherExternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_AnotherExternalStruct_toFfi(value);
-  final result = _smoke_Structs_AnotherExternalStruct_create_handle_nullable(_handle);
+  final result = _smoke_Structs_AnotherExternalStructCreateHandleNullable(_handle);
   smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 Structs_AnotherExternalStruct smoke_Structs_AnotherExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_AnotherExternalStruct_get_value_nullable(handle);
+  final _handle = _smoke_Structs_AnotherExternalStructGetValueNullable(handle);
   final result = smoke_Structs_AnotherExternalStruct_fromFfi(_handle);
   smoke_Structs_AnotherExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_AnotherExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_AnotherExternalStruct_release_handle_nullable(handle);
+  _smoke_Structs_AnotherExternalStructReleaseHandleNullable(handle);
 // End of Structs_AnotherExternalStruct "private" section.
 // Structs "private" section, not exported.
-final _smoke_Structs_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_copy_handle'));
-final _smoke_Structs_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_release_handle'));
@@ -188,47 +187,47 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Structs_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeStructsReleaseHandle(handle);
     handle = null;
   }
   static Structs_ExternalStruct getExternalStruct() {
-    final _getExternalStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getExternalStruct'));
-    final __result_handle = _getExternalStruct_ffi(__lib.LibraryContext.isolateId);
+    final _getExternalStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getExternalStruct'));
+    final __resultHandle = _getExternalStructFfi(__lib.LibraryContext.isolateId);
     try {
-      return smoke_Structs_ExternalStruct_fromFfi(__result_handle);
+      return smoke_Structs_ExternalStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_Structs_ExternalStruct_releaseFfiHandle(__result_handle);
+      smoke_Structs_ExternalStruct_releaseFfiHandle(__resultHandle);
     }
   }
   static Structs_AnotherExternalStruct getAnotherExternalStruct() {
-    final _getAnotherExternalStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getAnotherExternalStruct'));
-    final __result_handle = _getAnotherExternalStruct_ffi(__lib.LibraryContext.isolateId);
+    final _getAnotherExternalStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getAnotherExternalStruct'));
+    final __resultHandle = _getAnotherExternalStructFfi(__lib.LibraryContext.isolateId);
     try {
-      return smoke_Structs_AnotherExternalStruct_fromFfi(__result_handle);
+      return smoke_Structs_AnotherExternalStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_Structs_AnotherExternalStruct_releaseFfiHandle(__result_handle);
+      smoke_Structs_AnotherExternalStruct_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Structs_toFfi(Structs value) =>
-  _smoke_Structs_copy_handle((value as __lib.NativeBase).handle);
+  _smokeStructsCopyHandle((value as __lib.NativeBase).handle);
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Structs;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Structs_copy_handle(handle);
-  final result = Structs$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeStructsCopyHandle(handle);
+  final result = Structs$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Structs_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Structs_release_handle(handle);
+  _smokeStructsReleaseHandle(handle);
 Pointer<Void> smoke_Structs_toFfi_nullable(Structs value) =>
   value != null ? smoke_Structs_toFfi(value) : Pointer<Void>.fromAddress(0);
 Structs smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Structs_fromFfi(handle) : null;
 void smoke_Structs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_release_handle(handle);
+  _smokeStructsReleaseHandle(handle);
 // End of Structs "private" section.

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -7,7 +7,6 @@ import 'package:library/src/smoke/int.dart';
 import 'package:library/src/smoke/rectangle_int_.dart';
 import 'package:library/src/smoke/string.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseDartExternalTypes {
@@ -22,11 +21,11 @@ abstract class UseDartExternalTypes {
   static String seasonRoundTrip(String input) => UseDartExternalTypes$Impl.seasonRoundTrip(input);
 }
 // UseDartExternalTypes "private" section, not exported.
-final _smoke_UseDartExternalTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUsedartexternaltypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseDartExternalTypes_copy_handle'));
-final _smoke_UseDartExternalTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUsedartexternaltypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseDartExternalTypes_release_handle'));
@@ -36,73 +35,73 @@ class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExter
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_UseDartExternalTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeUsedartexternaltypesReleaseHandle(handle);
     handle = null;
   }
   static math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) {
-    final _rectangleRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle'));
-    final _input_handle = smoke_Rectangle_toFfi(input);
-    final __result_handle = _rectangleRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_Rectangle_releaseFfiHandle(_input_handle);
+    final _rectangleRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle'));
+    final _inputHandle = smoke_Rectangle_toFfi(input);
+    final __resultHandle = _rectangleRoundTripFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Rectangle_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_Rectangle_fromFfi(__result_handle);
+      return smoke_Rectangle_fromFfi(__resultHandle);
     } finally {
-      smoke_Rectangle_releaseFfiHandle(__result_handle);
+      smoke_Rectangle_releaseFfiHandle(__resultHandle);
     }
   }
   static bar.HttpClientResponseCompressionState compressionStateRoundTrip(bar.HttpClientResponseCompressionState input) {
-    final _compressionStateRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState'));
-    final _input_handle = smoke_CompressionState_toFfi(input);
-    final __result_handle = _compressionStateRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_CompressionState_releaseFfiHandle(_input_handle);
+    final _compressionStateRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState'));
+    final _inputHandle = smoke_CompressionState_toFfi(input);
+    final __resultHandle = _compressionStateRoundTripFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_CompressionState_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_CompressionState_fromFfi(__result_handle);
+      return smoke_CompressionState_fromFfi(__resultHandle);
     } finally {
-      smoke_CompressionState_releaseFfiHandle(__result_handle);
+      smoke_CompressionState_releaseFfiHandle(__resultHandle);
     }
   }
   static int colorRoundTrip(int input) {
-    final _colorRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_colorRoundTrip__DartColor'));
-    final _input_handle = smoke_DartColor_toFfi(input);
-    final __result_handle = _colorRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_DartColor_releaseFfiHandle(_input_handle);
+    final _colorRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_colorRoundTrip__DartColor'));
+    final _inputHandle = smoke_DartColor_toFfi(input);
+    final __resultHandle = _colorRoundTripFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_DartColor_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_DartColor_fromFfi(__result_handle);
+      return smoke_DartColor_fromFfi(__resultHandle);
     } finally {
-      smoke_DartColor_releaseFfiHandle(__result_handle);
+      smoke_DartColor_releaseFfiHandle(__resultHandle);
     }
   }
   static String seasonRoundTrip(String input) {
-    final _seasonRoundTrip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_seasonRoundTrip__DartSeason'));
-    final _input_handle = smoke_DartSeason_toFfi(input);
-    final __result_handle = _seasonRoundTrip_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_DartSeason_releaseFfiHandle(_input_handle);
+    final _seasonRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_seasonRoundTrip__DartSeason'));
+    final _inputHandle = smoke_DartSeason_toFfi(input);
+    final __resultHandle = _seasonRoundTripFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_DartSeason_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_DartSeason_fromFfi(__result_handle);
+      return smoke_DartSeason_fromFfi(__resultHandle);
     } finally {
-      smoke_DartSeason_releaseFfiHandle(__result_handle);
+      smoke_DartSeason_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_UseDartExternalTypes_toFfi(UseDartExternalTypes value) =>
-  _smoke_UseDartExternalTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeUsedartexternaltypesCopyHandle((value as __lib.NativeBase).handle);
 UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as UseDartExternalTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_UseDartExternalTypes_copy_handle(handle);
-  final result = UseDartExternalTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeUsedartexternaltypesCopyHandle(handle);
+  final result = UseDartExternalTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_UseDartExternalTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_UseDartExternalTypes_release_handle(handle);
+  _smokeUsedartexternaltypesReleaseHandle(handle);
 Pointer<Void> smoke_UseDartExternalTypes_toFfi_nullable(UseDartExternalTypes value) =>
   value != null ? smoke_UseDartExternalTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 UseDartExternalTypes smoke_UseDartExternalTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UseDartExternalTypes_fromFfi(handle) : null;
 void smoke_UseDartExternalTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_UseDartExternalTypes_release_handle(handle);
+  _smokeUsedartexternaltypesReleaseHandle(handle);
 // End of UseDartExternalTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/_lazy_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/_lazy_list.dart
@@ -6,7 +6,7 @@ class _LazyIterator<E> extends Iterator<E> {
   final int length;
   int position;
   _LazyIterator(this.list, [int start = -1, int step = 1])
-    : step = step, length = list.length, position = start {}
+    : step = step, length = list.length, position = start;
   bool moveNext() {
     position += step;
     return position >= 0 && position < length;
@@ -20,7 +20,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   final int _length;
   final E Function(int) _elementGetter;
   final void Function() _releaser;
-  LazyList(this.handle, int length, this._elementGetter, this._releaser) : _length = length {}
+  LazyList(this.handle, int length, this._elementGetter, this._releaser) : _length = length;
   void release() => _releaser();
   Iterator<E> get iterator => _LazyIterator(this);
   int get length => _length;
@@ -30,7 +30,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   List<E> operator +(List<E> other) => cast<E>() + other;
   Map<int, E> asMap() => cast<E>().asMap();
   Iterable<E> getRange(int start, int end) => cast<E>().getRange(start, end);
-  List<E> sublist(int start, [int end = null]) => cast<E>().sublist(start, end);
+  List<E> sublist(int start, [int end]) => cast<E>().sublist(start, end);
   Iterable<E> get reversed => cast<E>().reversed;
   // Methods relying on the iterator
   int indexOf(E element, [int start = 0]) => indexWhere((it) => element == it, start);
@@ -41,8 +41,8 @@ class LazyList<E> extends Iterable<E> implements List<E> {
     }
     return -1;
   }
-  int lastIndexOf(E element, [int start = null]) => lastIndexWhere((it) => element == it, start);
-  int lastIndexWhere(bool test(E element), [int start = null]) {
+  int lastIndexOf(E element, [int start]) => lastIndexWhere((it) => element == it, start);
+  int lastIndexWhere(bool test(E element), [int start]) {
     final iterator = _LazyIterator(this, start ?? length, -1);
     while (iterator.moveNext()) {
       if (test(iterator.current)) return iterator.position;
@@ -68,7 +68,7 @@ class LazyList<E> extends Iterable<E> implements List<E> {
   void setRange(int start, int end, Iterable<E> iterable, [int skipCount = 0]) => throw UnsupportedError(_cannotModify);
   void shuffle([Random random]) => throw UnsupportedError(_cannotModify);
   void sort([int compare(E a, E b)]) => throw UnsupportedError(_cannotModify);
-  void set first(E value) => throw UnsupportedError(_cannotModify);
-  void set last(E value) => throw UnsupportedError(_cannotModify);
+  set first(E value) => throw UnsupportedError(_cannotModify);
+  set last(E value) => throw UnsupportedError(_cannotModify);
   set length(int newLength) => throw UnsupportedError(_cannotModify);
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
@@ -1,5 +1,4 @@
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/another_dummy_class.dart';
 import 'package:library/src/smoke/dummy_class.dart';
 import 'package:library/src/smoke/dummy_interface.dart';
@@ -8,3907 +7,3906 @@ import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
 import 'package:library/src/smoke/yet_another_dummy_class.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _foobar_ListOf_Float_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_Float_create_handle'));
-final _foobar_ListOf_Float_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Float_release_handle'));
-final _foobar_ListOf_Float_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Float),
     void Function(Pointer<Void>, double)
   >('library_foobar_ListOf_Float_insert'));
-final _foobar_ListOf_Float_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_Float_iterator'));
-final _foobar_ListOf_Float_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Float_iterator_release_handle'));
-final _foobar_ListOf_Float_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_Float_iterator_is_valid'));
-final _foobar_ListOf_Float_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Float_iterator_increment'));
-final _foobar_ListOf_Float_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFloatIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
 >('library_foobar_ListOf_Float_iterator_get'));
 Pointer<Void> foobar_ListOf_Float_toFfi(List<double> value) {
-  final _result = _foobar_ListOf_Float_create_handle();
+  final _result = _foobarListofFloatCreateHandle();
   for (final element in value) {
-    final _element_handle = (element);
-    _foobar_ListOf_Float_insert(_result, _element_handle);
-    (_element_handle);
+    final _elementHandle = (element);
+    _foobarListofFloatInsert(_result, _elementHandle);
+    (_elementHandle);
   }
   return _result;
 }
 List<double> foobar_ListOf_Float_fromFfi(Pointer<Void> handle) {
-  final result = List<double>();
-  final _iterator_handle = _foobar_ListOf_Float_iterator(handle);
-  while (_foobar_ListOf_Float_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_Float_iterator_get(_iterator_handle);
+  final result = List<double>.empty(growable: true);
+  final _iteratorHandle = _foobarListofFloatIterator(handle);
+  while (_foobarListofFloatIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofFloatIteratorGet(_iteratorHandle);
     try {
-      result.add((_element_handle));
+      result.add((_elementHandle));
     } finally {
-      (_element_handle);
+      (_elementHandle);
     }
-    _foobar_ListOf_Float_iterator_increment(_iterator_handle);
+    _foobarListofFloatIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_Float_iterator_release_handle(_iterator_handle);
+  _foobarListofFloatIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_Float_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_Float_release_handle(handle);
-final _foobar_ListOf_Float_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_Float_releaseFfiHandle(Pointer<Void> handle) => _foobarListofFloatReleaseHandle(handle);
+final _foobar_ListOf_FloatCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Float_create_handle_nullable'));
-final _foobar_ListOf_Float_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_FloatReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Float_release_handle_nullable'));
-final _foobar_ListOf_Float_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_FloatGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Float_get_value_nullable'));
 Pointer<Void> foobar_ListOf_Float_toFfi_nullable(List<double> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Float_toFfi(value);
-  final result = _foobar_ListOf_Float_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_FloatCreateHandleNullable(_handle);
   foobar_ListOf_Float_releaseFfiHandle(_handle);
   return result;
 }
 List<double> foobar_ListOf_Float_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_Float_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_FloatGetValueNullable(handle);
   final result = foobar_ListOf_Float_fromFfi(_handle);
   foobar_ListOf_Float_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_Float_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_Float_release_handle_nullable(handle);
-final _foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_FloatReleaseHandleNullable(handle);
+final _foobarListofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_Int_create_handle'));
-final _foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Int_release_handle'));
-final _foobar_ListOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofIntInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32),
     void Function(Pointer<Void>, int)
   >('library_foobar_ListOf_Int_insert'));
-final _foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_Int_iterator'));
-final _foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Int_iterator_release_handle'));
-final _foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_Int_iterator_is_valid'));
-final _foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Int_iterator_increment'));
-final _foobar_ListOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofIntIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_Int_iterator_get'));
 Pointer<Void> foobar_ListOf_Int_toFfi(List<int> value) {
-  final _result = _foobar_ListOf_Int_create_handle();
+  final _result = _foobarListofIntCreateHandle();
   for (final element in value) {
-    final _element_handle = (element);
-    _foobar_ListOf_Int_insert(_result, _element_handle);
-    (_element_handle);
+    final _elementHandle = (element);
+    _foobarListofIntInsert(_result, _elementHandle);
+    (_elementHandle);
   }
   return _result;
 }
 List<int> foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
-  final result = List<int>();
-  final _iterator_handle = _foobar_ListOf_Int_iterator(handle);
-  while (_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_Int_iterator_get(_iterator_handle);
+  final result = List<int>.empty(growable: true);
+  final _iteratorHandle = _foobarListofIntIterator(handle);
+  while (_foobarListofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofIntIteratorGet(_iteratorHandle);
     try {
-      result.add((_element_handle));
+      result.add((_elementHandle));
     } finally {
-      (_element_handle);
+      (_elementHandle);
     }
-    _foobar_ListOf_Int_iterator_increment(_iterator_handle);
+    _foobarListofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarListofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_Int_release_handle(handle);
-final _foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarListofIntReleaseHandle(handle);
+final _foobar_ListOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Int_create_handle_nullable'));
-final _foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Int_release_handle_nullable'));
-final _foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_ListOf_Int_toFfi_nullable(List<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Int_toFfi(value);
-  final result = _foobar_ListOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_IntCreateHandleNullable(_handle);
   foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 List<int> foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_IntGetValueNullable(handle);
   final result = foobar_ListOf_Int_fromFfi(_handle);
   foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_ListOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_IntReleaseHandleNullable(handle);
+final _foobarListofStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_String_create_handle'));
-final _foobar_ListOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_String_release_handle'));
-final _foobar_ListOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_String_insert'));
-final _foobar_ListOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator'));
-final _foobar_ListOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_release_handle'));
-final _foobar_ListOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_is_valid'));
-final _foobar_ListOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_increment'));
-final _foobar_ListOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_get'));
 Pointer<Void> foobar_ListOf_String_toFfi(List<String> value) {
-  final _result = _foobar_ListOf_String_create_handle();
+  final _result = _foobarListofStringCreateHandle();
   for (final element in value) {
-    final _element_handle = String_toFfi(element);
-    _foobar_ListOf_String_insert(_result, _element_handle);
-    String_releaseFfiHandle(_element_handle);
+    final _elementHandle = String_toFfi(element);
+    _foobarListofStringInsert(_result, _elementHandle);
+    String_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
-  final result = List<String>();
-  final _iterator_handle = _foobar_ListOf_String_iterator(handle);
-  while (_foobar_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_String_iterator_get(_iterator_handle);
+  final result = List<String>.empty(growable: true);
+  final _iteratorHandle = _foobarListofStringIterator(handle);
+  while (_foobarListofStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofStringIteratorGet(_iteratorHandle);
     try {
-      result.add(String_fromFfi(_element_handle));
+      result.add(String_fromFfi(_elementHandle));
     } finally {
-      String_releaseFfiHandle(_element_handle);
+      String_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_String_iterator_increment(_iterator_handle);
+    _foobarListofStringIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_String_iterator_release_handle(_iterator_handle);
+  _foobarListofStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_String_release_handle(handle);
-final _foobar_ListOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobarListofStringReleaseHandle(handle);
+final _foobar_ListOf_StringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_create_handle_nullable'));
-final _foobar_ListOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_StringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_String_release_handle_nullable'));
-final _foobar_ListOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_StringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_get_value_nullable'));
 Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_String_toFfi(value);
-  final result = _foobar_ListOf_String_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_StringCreateHandleNullable(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
 List<String> foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_String_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_StringGetValueNullable(handle);
   final result = foobar_ListOf_String_fromFfi(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_String_release_handle_nullable(handle);
-final _foobar_ListOf_UByte_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_StringReleaseHandleNullable(handle);
+final _foobarListofUbyteCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_UByte_create_handle'));
-final _foobar_ListOf_UByte_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofUbyteReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_UByte_release_handle'));
-final _foobar_ListOf_UByte_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofUbyteInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint8),
     void Function(Pointer<Void>, int)
   >('library_foobar_ListOf_UByte_insert'));
-final _foobar_ListOf_UByte_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofUbyteIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_UByte_iterator'));
-final _foobar_ListOf_UByte_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofUbyteIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_UByte_iterator_release_handle'));
-final _foobar_ListOf_UByte_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofUbyteIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_UByte_iterator_is_valid'));
-final _foobar_ListOf_UByte_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofUbyteIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_UByte_iterator_increment'));
-final _foobar_ListOf_UByte_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofUbyteIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_UByte_iterator_get'));
 Pointer<Void> foobar_ListOf_UByte_toFfi(List<int> value) {
-  final _result = _foobar_ListOf_UByte_create_handle();
+  final _result = _foobarListofUbyteCreateHandle();
   for (final element in value) {
-    final _element_handle = (element);
-    _foobar_ListOf_UByte_insert(_result, _element_handle);
-    (_element_handle);
+    final _elementHandle = (element);
+    _foobarListofUbyteInsert(_result, _elementHandle);
+    (_elementHandle);
   }
   return _result;
 }
 List<int> foobar_ListOf_UByte_fromFfi(Pointer<Void> handle) {
-  final result = List<int>();
-  final _iterator_handle = _foobar_ListOf_UByte_iterator(handle);
-  while (_foobar_ListOf_UByte_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_UByte_iterator_get(_iterator_handle);
+  final result = List<int>.empty(growable: true);
+  final _iteratorHandle = _foobarListofUbyteIterator(handle);
+  while (_foobarListofUbyteIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofUbyteIteratorGet(_iteratorHandle);
     try {
-      result.add((_element_handle));
+      result.add((_elementHandle));
     } finally {
-      (_element_handle);
+      (_elementHandle);
     }
-    _foobar_ListOf_UByte_iterator_increment(_iterator_handle);
+    _foobarListofUbyteIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_UByte_iterator_release_handle(_iterator_handle);
+  _foobarListofUbyteIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_UByte_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_UByte_release_handle(handle);
-final _foobar_ListOf_UByte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_UByte_releaseFfiHandle(Pointer<Void> handle) => _foobarListofUbyteReleaseHandle(handle);
+final _foobar_ListOf_UByteCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_UByte_create_handle_nullable'));
-final _foobar_ListOf_UByte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_UByteReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_UByte_release_handle_nullable'));
-final _foobar_ListOf_UByte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_UByteGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_UByte_get_value_nullable'));
 Pointer<Void> foobar_ListOf_UByte_toFfi_nullable(List<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_UByte_toFfi(value);
-  final result = _foobar_ListOf_UByte_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_UByteCreateHandleNullable(_handle);
   foobar_ListOf_UByte_releaseFfiHandle(_handle);
   return result;
 }
 List<int> foobar_ListOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_UByte_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_UByteGetValueNullable(handle);
   final result = foobar_ListOf_UByte_fromFfi(_handle);
   foobar_ListOf_UByte_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_UByte_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_UByte_release_handle_nullable(handle);
-final _foobar_ListOf_foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_UByteReleaseHandleNullable(handle);
+final _foobarListofFoobarListofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_foobar_ListOf_Int_create_handle'));
-final _foobar_ListOf_foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarListofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_ListOf_Int_release_handle'));
-final _foobar_ListOf_foobar_ListOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarListofIntInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_foobar_ListOf_Int_insert'));
-final _foobar_ListOf_foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarListofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_ListOf_Int_iterator'));
-final _foobar_ListOf_foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarListofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_ListOf_Int_iterator_release_handle'));
-final _foobar_ListOf_foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarListofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_foobar_ListOf_Int_iterator_is_valid'));
-final _foobar_ListOf_foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarListofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_ListOf_Int_iterator_increment'));
-final _foobar_ListOf_foobar_ListOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarListofIntIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_ListOf_Int_iterator_get'));
 Pointer<Void> foobar_ListOf_foobar_ListOf_Int_toFfi(List<List<int>> value) {
-  final _result = _foobar_ListOf_foobar_ListOf_Int_create_handle();
+  final _result = _foobarListofFoobarListofIntCreateHandle();
   for (final element in value) {
-    final _element_handle = foobar_ListOf_Int_toFfi(element);
-    _foobar_ListOf_foobar_ListOf_Int_insert(_result, _element_handle);
-    foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+    final _elementHandle = foobar_ListOf_Int_toFfi(element);
+    _foobarListofFoobarListofIntInsert(_result, _elementHandle);
+    foobar_ListOf_Int_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<List<int>> foobar_ListOf_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
-  final result = List<List<int>>();
-  final _iterator_handle = _foobar_ListOf_foobar_ListOf_Int_iterator(handle);
-  while (_foobar_ListOf_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_foobar_ListOf_Int_iterator_get(_iterator_handle);
+  final result = List<List<int>>.empty(growable: true);
+  final _iteratorHandle = _foobarListofFoobarListofIntIterator(handle);
+  while (_foobarListofFoobarListofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofFoobarListofIntIteratorGet(_iteratorHandle);
     try {
-      result.add(foobar_ListOf_Int_fromFfi(_element_handle));
+      result.add(foobar_ListOf_Int_fromFfi(_elementHandle));
     } finally {
-      foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+      foobar_ListOf_Int_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_foobar_ListOf_Int_iterator_increment(_iterator_handle);
+    _foobarListofFoobarListofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarListofFoobarListofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_foobar_ListOf_Int_release_handle(handle);
-final _foobar_ListOf_foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarListofFoobarListofIntReleaseHandle(handle);
+final _foobar_ListOf_foobar_ListOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_ListOf_Int_create_handle_nullable'));
-final _foobar_ListOf_foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_ListOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_ListOf_Int_release_handle_nullable'));
-final _foobar_ListOf_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_ListOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_ListOf_foobar_ListOf_Int_toFfi_nullable(List<List<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_ListOf_Int_toFfi(value);
-  final result = _foobar_ListOf_foobar_ListOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_foobar_ListOf_IntCreateHandleNullable(_handle);
   foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 List<List<int>> foobar_ListOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_foobar_ListOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_foobar_ListOf_IntGetValueNullable(handle);
   final result = foobar_ListOf_foobar_ListOf_Int_fromFfi(_handle);
   foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_foobar_ListOf_IntReleaseHandleNullable(handle);
+final _foobarListofFoobarMapofIntToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarMapofIntToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarMapofIntToBooleanInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_insert'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarMapofIntToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarMapofIntToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarMapofIntToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarMapofIntToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarMapofIntToBooleanIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get'));
 Pointer<Void> foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(List<Map<int, bool>> value) {
-  final _result = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle();
+  final _result = _foobarListofFoobarMapofIntToBooleanCreateHandle();
   for (final element in value) {
-    final _element_handle = foobar_MapOf_Int_to_Boolean_toFfi(element);
-    _foobar_ListOf_foobar_MapOf_Int_to_Boolean_insert(_result, _element_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+    final _elementHandle = foobar_MapOf_Int_to_Boolean_toFfi(element);
+    _foobarListofFoobarMapofIntToBooleanInsert(_result, _elementHandle);
+    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<Map<int, bool>> foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
-  final result = List<Map<int, bool>>();
-  final _iterator_handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator(handle);
-  while (_foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_get(_iterator_handle);
+  final result = List<Map<int, bool>>.empty(growable: true);
+  final _iteratorHandle = _foobarListofFoobarMapofIntToBooleanIterator(handle);
+  while (_foobarListofFoobarMapofIntToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofFoobarMapofIntToBooleanIteratorGet(_iteratorHandle);
     try {
-      result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_element_handle));
+      result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_elementHandle));
     } finally {
-      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarListofFoobarMapofIntToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarListofFoobarMapofIntToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarListofFoobarMapofIntToBooleanReleaseHandle(handle);
+final _foobar_ListOf_foobar_MapOf_Int_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_MapOf_Int_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
-final _foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_MapOf_Int_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(List<Map<int, bool>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(value);
-  final result = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_foobar_MapOf_Int_to_BooleanCreateHandleNullable(_handle);
   foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 List<Map<int, bool>> foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_foobar_MapOf_Int_to_BooleanGetValueNullable(handle);
   final result = foobar_ListOf_foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
   foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_ListOf_foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_foobar_MapOf_Int_to_BooleanReleaseHandleNullable(handle);
+final _foobarListofFoobarSetofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_foobar_SetOf_Int_create_handle'));
-final _foobar_ListOf_foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarSetofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_SetOf_Int_release_handle'));
-final _foobar_ListOf_foobar_SetOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarSetofIntInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_foobar_SetOf_Int_insert'));
-final _foobar_ListOf_foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarSetofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_SetOf_Int_iterator'));
-final _foobar_ListOf_foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarSetofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_SetOf_Int_iterator_release_handle'));
-final _foobar_ListOf_foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarSetofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_foobar_SetOf_Int_iterator_is_valid'));
-final _foobar_ListOf_foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarSetofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_SetOf_Int_iterator_increment'));
-final _foobar_ListOf_foobar_SetOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofFoobarSetofIntIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_foobar_SetOf_Int_iterator_get'));
 Pointer<Void> foobar_ListOf_foobar_SetOf_Int_toFfi(List<Set<int>> value) {
-  final _result = _foobar_ListOf_foobar_SetOf_Int_create_handle();
+  final _result = _foobarListofFoobarSetofIntCreateHandle();
   for (final element in value) {
-    final _element_handle = foobar_SetOf_Int_toFfi(element);
-    _foobar_ListOf_foobar_SetOf_Int_insert(_result, _element_handle);
-    foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+    final _elementHandle = foobar_SetOf_Int_toFfi(element);
+    _foobarListofFoobarSetofIntInsert(_result, _elementHandle);
+    foobar_SetOf_Int_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
-  final result = List<Set<int>>();
-  final _iterator_handle = _foobar_ListOf_foobar_SetOf_Int_iterator(handle);
-  while (_foobar_ListOf_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_foobar_SetOf_Int_iterator_get(_iterator_handle);
+  final result = List<Set<int>>.empty(growable: true);
+  final _iteratorHandle = _foobarListofFoobarSetofIntIterator(handle);
+  while (_foobarListofFoobarSetofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofFoobarSetofIntIteratorGet(_iteratorHandle);
     try {
-      result.add(foobar_SetOf_Int_fromFfi(_element_handle));
+      result.add(foobar_SetOf_Int_fromFfi(_elementHandle));
     } finally {
-      foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+      foobar_SetOf_Int_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_foobar_SetOf_Int_iterator_increment(_iterator_handle);
+    _foobarListofFoobarSetofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarListofFoobarSetofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_foobar_SetOf_Int_release_handle(handle);
-final _foobar_ListOf_foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarListofFoobarSetofIntReleaseHandle(handle);
+final _foobar_ListOf_foobar_SetOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_SetOf_Int_create_handle_nullable'));
-final _foobar_ListOf_foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_SetOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_SetOf_Int_release_handle_nullable'));
-final _foobar_ListOf_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_foobar_SetOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_ListOf_foobar_SetOf_Int_toFfi_nullable(List<Set<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_foobar_SetOf_Int_toFfi(value);
-  final result = _foobar_ListOf_foobar_SetOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_foobar_SetOf_IntCreateHandleNullable(_handle);
   foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 List<Set<int>> foobar_ListOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_foobar_SetOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_foobar_SetOf_IntGetValueNullable(handle);
   final result = foobar_ListOf_foobar_SetOf_Int_fromFfi(_handle);
   foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_AnotherDummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_foobar_SetOf_IntReleaseHandleNullable(handle);
+final _foobarListofSmokeAnotherdummyclassCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle'));
-final _foobar_ListOf_smoke_AnotherDummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeAnotherdummyclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle'));
-final _foobar_ListOf_smoke_AnotherDummyClass_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeAnotherdummyclassInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_AnotherDummyClass_insert'));
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeAnotherdummyclassIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_AnotherDummyClass_iterator'));
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeAnotherdummyclassIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle'));
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeAnotherdummyclassIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid'));
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeAnotherdummyclassIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_increment'));
-final _foobar_ListOf_smoke_AnotherDummyClass_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeAnotherdummyclassIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_AnotherDummyClass_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi(List<AnotherDummyClass> value) {
-  final _result = _foobar_ListOf_smoke_AnotherDummyClass_create_handle();
+  final _result = _foobarListofSmokeAnotherdummyclassCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_AnotherDummyClass_toFfi(element);
-    _foobar_ListOf_smoke_AnotherDummyClass_insert(_result, _element_handle);
-    smoke_AnotherDummyClass_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_AnotherDummyClass_toFfi(element);
+    _foobarListofSmokeAnotherdummyclassInsert(_result, _elementHandle);
+    smoke_AnotherDummyClass_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<AnotherDummyClass>();
-  final _iterator_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator(handle);
-  while (_foobar_ListOf_smoke_AnotherDummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_AnotherDummyClass_iterator_get(_iterator_handle);
+  final result = List<AnotherDummyClass>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeAnotherdummyclassIterator(handle);
+  while (_foobarListofSmokeAnotherdummyclassIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeAnotherdummyclassIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_AnotherDummyClass_fromFfi(_element_handle));
+      result.add(smoke_AnotherDummyClass_fromFfi(_elementHandle));
     } finally {
-      smoke_AnotherDummyClass_releaseFfiHandle(_element_handle);
+      smoke_AnotherDummyClass_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_AnotherDummyClass_iterator_increment(_iterator_handle);
+    _foobarListofSmokeAnotherdummyclassIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_AnotherDummyClass_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeAnotherdummyclassIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_AnotherDummyClass_release_handle(handle);
-final _foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeAnotherdummyclassReleaseHandle(handle);
+final _foobar_ListOf_smoke_AnotherDummyClassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable'));
-final _foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_AnotherDummyClassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable'));
-final _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_AnotherDummyClassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_AnotherDummyClass_toFfi_nullable(List<AnotherDummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_AnotherDummyClass_toFfi(value);
-  final result = _foobar_ListOf_smoke_AnotherDummyClass_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_AnotherDummyClassCreateHandleNullable(_handle);
   foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(_handle);
   return result;
 }
 List<AnotherDummyClass> foobar_ListOf_smoke_AnotherDummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_AnotherDummyClass_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_AnotherDummyClassGetValueNullable(handle);
   final result = foobar_ListOf_smoke_AnotherDummyClass_fromFfi(_handle);
   foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_AnotherDummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_AnotherDummyClass_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_DummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_AnotherDummyClassReleaseHandleNullable(handle);
+final _foobarListofSmokeDummyclassCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_DummyClass_create_handle'));
-final _foobar_ListOf_smoke_DummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyClass_release_handle'));
-final _foobar_ListOf_smoke_DummyClass_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyclassInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyClass_insert'));
-final _foobar_ListOf_smoke_DummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyclassIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyClass_iterator'));
-final _foobar_ListOf_smoke_DummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyclassIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyClass_iterator_release_handle'));
-final _foobar_ListOf_smoke_DummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyclassIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyClass_iterator_is_valid'));
-final _foobar_ListOf_smoke_DummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyclassIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyClass_iterator_increment'));
-final _foobar_ListOf_smoke_DummyClass_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyclassIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyClass_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_DummyClass_toFfi(List<DummyClass> value) {
-  final _result = _foobar_ListOf_smoke_DummyClass_create_handle();
+  final _result = _foobarListofSmokeDummyclassCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_DummyClass_toFfi(element);
-    _foobar_ListOf_smoke_DummyClass_insert(_result, _element_handle);
-    smoke_DummyClass_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_DummyClass_toFfi(element);
+    _foobarListofSmokeDummyclassInsert(_result, _elementHandle);
+    smoke_DummyClass_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<DummyClass> foobar_ListOf_smoke_DummyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<DummyClass>();
-  final _iterator_handle = _foobar_ListOf_smoke_DummyClass_iterator(handle);
-  while (_foobar_ListOf_smoke_DummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_DummyClass_iterator_get(_iterator_handle);
+  final result = List<DummyClass>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeDummyclassIterator(handle);
+  while (_foobarListofSmokeDummyclassIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeDummyclassIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_DummyClass_fromFfi(_element_handle));
+      result.add(smoke_DummyClass_fromFfi(_elementHandle));
     } finally {
-      smoke_DummyClass_releaseFfiHandle(_element_handle);
+      smoke_DummyClass_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_DummyClass_iterator_increment(_iterator_handle);
+    _foobarListofSmokeDummyclassIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_DummyClass_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeDummyclassIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_DummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_DummyClass_release_handle(handle);
-final _foobar_ListOf_smoke_DummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_DummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeDummyclassReleaseHandle(handle);
+final _foobar_ListOf_smoke_DummyClassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyClass_create_handle_nullable'));
-final _foobar_ListOf_smoke_DummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyClassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyClass_release_handle_nullable'));
-final _foobar_ListOf_smoke_DummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyClassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyClass_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_DummyClass_toFfi_nullable(List<DummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_DummyClass_toFfi(value);
-  final result = _foobar_ListOf_smoke_DummyClass_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_DummyClassCreateHandleNullable(_handle);
   foobar_ListOf_smoke_DummyClass_releaseFfiHandle(_handle);
   return result;
 }
 List<DummyClass> foobar_ListOf_smoke_DummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_DummyClass_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_DummyClassGetValueNullable(handle);
   final result = foobar_ListOf_smoke_DummyClass_fromFfi(_handle);
   foobar_ListOf_smoke_DummyClass_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_DummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_DummyClass_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_DummyInterface_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_DummyClassReleaseHandleNullable(handle);
+final _foobarListofSmokeDummyinterfaceCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_DummyInterface_create_handle'));
-final _foobar_ListOf_smoke_DummyInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyInterface_release_handle'));
-final _foobar_ListOf_smoke_DummyInterface_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyinterfaceInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyInterface_insert'));
-final _foobar_ListOf_smoke_DummyInterface_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyinterfaceIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyInterface_iterator'));
-final _foobar_ListOf_smoke_DummyInterface_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyinterfaceIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyInterface_iterator_release_handle'));
-final _foobar_ListOf_smoke_DummyInterface_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyinterfaceIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyInterface_iterator_is_valid'));
-final _foobar_ListOf_smoke_DummyInterface_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyinterfaceIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyInterface_iterator_increment'));
-final _foobar_ListOf_smoke_DummyInterface_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeDummyinterfaceIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_DummyInterface_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_DummyInterface_toFfi(List<DummyInterface> value) {
-  final _result = _foobar_ListOf_smoke_DummyInterface_create_handle();
+  final _result = _foobarListofSmokeDummyinterfaceCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_DummyInterface_toFfi(element);
-    _foobar_ListOf_smoke_DummyInterface_insert(_result, _element_handle);
-    smoke_DummyInterface_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_DummyInterface_toFfi(element);
+    _foobarListofSmokeDummyinterfaceInsert(_result, _elementHandle);
+    smoke_DummyInterface_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<DummyInterface> foobar_ListOf_smoke_DummyInterface_fromFfi(Pointer<Void> handle) {
-  final result = List<DummyInterface>();
-  final _iterator_handle = _foobar_ListOf_smoke_DummyInterface_iterator(handle);
-  while (_foobar_ListOf_smoke_DummyInterface_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_DummyInterface_iterator_get(_iterator_handle);
+  final result = List<DummyInterface>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeDummyinterfaceIterator(handle);
+  while (_foobarListofSmokeDummyinterfaceIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeDummyinterfaceIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_DummyInterface_fromFfi(_element_handle));
+      result.add(smoke_DummyInterface_fromFfi(_elementHandle));
     } finally {
-      smoke_DummyInterface_releaseFfiHandle(_element_handle);
+      smoke_DummyInterface_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_DummyInterface_iterator_increment(_iterator_handle);
+    _foobarListofSmokeDummyinterfaceIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_DummyInterface_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeDummyinterfaceIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_DummyInterface_release_handle(handle);
-final _foobar_ListOf_smoke_DummyInterface_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeDummyinterfaceReleaseHandle(handle);
+final _foobar_ListOf_smoke_DummyInterfaceCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyInterface_create_handle_nullable'));
-final _foobar_ListOf_smoke_DummyInterface_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyInterfaceReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyInterface_release_handle_nullable'));
-final _foobar_ListOf_smoke_DummyInterface_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_DummyInterfaceGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_DummyInterface_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_DummyInterface_toFfi_nullable(List<DummyInterface> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_DummyInterface_toFfi(value);
-  final result = _foobar_ListOf_smoke_DummyInterface_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_DummyInterfaceCreateHandleNullable(_handle);
   foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(_handle);
   return result;
 }
 List<DummyInterface> foobar_ListOf_smoke_DummyInterface_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_DummyInterface_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_DummyInterfaceGetValueNullable(handle);
   final result = foobar_ListOf_smoke_DummyInterface_fromFfi(_handle);
   foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_DummyInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_DummyInterface_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_DummyInterfaceReleaseHandleNullable(handle);
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(List<GenericTypesWithCompoundTypes_BasicStruct> value) {
-  final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle();
+  final _result = _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(element);
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_insert(_result, _element_handle);
-    smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(element);
+    _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructInsert(_result, _elementHandle);
+    smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<GenericTypesWithCompoundTypes_BasicStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_BasicStruct>();
-  final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(handle);
-  while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get(_iterator_handle);
+  final result = List<GenericTypesWithCompoundTypes_BasicStruct>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIterator(handle);
+  while (_foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_element_handle));
+      result.add(smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_elementHandle));
     } finally {
-      smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_element_handle);
+      smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(_iterator_handle);
+    _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeGenerictypeswithcompoundtypesBasicstructReleaseHandle(handle);
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_BasicStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
-  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStructCreateHandleNullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 List<GenericTypesWithCompoundTypes_BasicStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStructGetValueNullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStructReleaseHandleNullable(handle);
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(List<GenericTypesWithCompoundTypes_ExternalEnum> value) {
-  final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle();
+  final _result = _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(element);
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(_result, _element_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(element);
+    _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumInsert(_result, _elementHandle);
+    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<GenericTypesWithCompoundTypes_ExternalEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_ExternalEnum>();
-  final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle);
-  while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(_iterator_handle);
+  final result = List<GenericTypesWithCompoundTypes_ExternalEnum>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIterator(handle);
+  while (_foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_element_handle));
+      result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_elementHandle));
     } finally {
-      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_iterator_handle);
+    _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeGenerictypeswithcompoundtypesExternalenumReleaseHandle(handle);
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
-  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 List<GenericTypesWithCompoundTypes_ExternalEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable(handle);
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(List<GenericTypesWithCompoundTypes_ExternalStruct> value) {
-  final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle();
+  final _result = _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(element);
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_insert(_result, _element_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(element);
+    _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructInsert(_result, _elementHandle);
+    smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<GenericTypesWithCompoundTypes_ExternalStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_ExternalStruct>();
-  final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(handle);
-  while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get(_iterator_handle);
+  final result = List<GenericTypesWithCompoundTypes_ExternalStruct>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIterator(handle);
+  while (_foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_element_handle));
+      result.add(smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_elementHandle));
     } finally {
-      smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_element_handle);
+      smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(_iterator_handle);
+    _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeGenerictypeswithcompoundtypesExternalstructReleaseHandle(handle);
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(List<GenericTypesWithCompoundTypes_ExternalStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
-  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStructCreateHandleNullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 List<GenericTypesWithCompoundTypes_ExternalStruct> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStructGetValueNullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStructReleaseHandleNullable(handle);
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(List<GenericTypesWithCompoundTypes_SomeEnum> value) {
-  final _result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle();
+  final _result = _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(element);
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(_result, _element_handle);
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(element);
+    _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumInsert(_result, _elementHandle);
+    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<GenericTypesWithCompoundTypes_SomeEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(Pointer<Void> handle) {
-  final result = List<GenericTypesWithCompoundTypes_SomeEnum>();
-  final _iterator_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle);
-  while (_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(_iterator_handle);
+  final result = List<GenericTypesWithCompoundTypes_SomeEnum>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIterator(handle);
+  while (_foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_element_handle));
+      result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_elementHandle));
     } finally {
-      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_iterator_handle);
+    _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(handle);
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeGenerictypeswithcompoundtypesSomeenumReleaseHandle(handle);
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
-final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(List<GenericTypesWithCompoundTypes_SomeEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
-  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 List<GenericTypesWithCompoundTypes_SomeEnum> foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable(handle);
   final result = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);
   foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable(handle);
+final _foobarListofSmokeUnreasonablylazyclassCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_create_handle'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeUnreasonablylazyclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_release_handle'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeUnreasonablylazyclassInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_insert'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeUnreasonablylazyclassIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_iterator'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeUnreasonablylazyclassIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_release_handle'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeUnreasonablylazyclassIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_is_valid'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeUnreasonablylazyclassIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_increment'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeUnreasonablylazyclassIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_UnreasonablyLazyClass_toFfi(List<UnreasonablyLazyClass> value) {
-  final _result = _foobar_ListOf_smoke_UnreasonablyLazyClass_create_handle();
+  final _result = _foobarListofSmokeUnreasonablylazyclassCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_UnreasonablyLazyClass_toFfi(element);
-    _foobar_ListOf_smoke_UnreasonablyLazyClass_insert(_result, _element_handle);
-    smoke_UnreasonablyLazyClass_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_UnreasonablyLazyClass_toFfi(element);
+    _foobarListofSmokeUnreasonablylazyclassInsert(_result, _elementHandle);
+    smoke_UnreasonablyLazyClass_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<UnreasonablyLazyClass> foobar_ListOf_smoke_UnreasonablyLazyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<UnreasonablyLazyClass>();
-  final _iterator_handle = _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator(handle);
-  while (_foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_get(_iterator_handle);
+  final result = List<UnreasonablyLazyClass>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeUnreasonablylazyclassIterator(handle);
+  while (_foobarListofSmokeUnreasonablylazyclassIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeUnreasonablylazyclassIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_UnreasonablyLazyClass_fromFfi(_element_handle));
+      result.add(smoke_UnreasonablyLazyClass_fromFfi(_elementHandle));
     } finally {
-      smoke_UnreasonablyLazyClass_releaseFfiHandle(_element_handle);
+      smoke_UnreasonablyLazyClass_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_increment(_iterator_handle);
+    _foobarListofSmokeUnreasonablylazyclassIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_UnreasonablyLazyClass_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeUnreasonablylazyclassIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_UnreasonablyLazyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_UnreasonablyLazyClass_release_handle(handle);
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_UnreasonablyLazyClass_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeUnreasonablylazyclassReleaseHandle(handle);
+final _foobar_ListOf_smoke_UnreasonablyLazyClassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_create_handle_nullable'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_UnreasonablyLazyClassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_release_handle_nullable'));
-final _foobar_ListOf_smoke_UnreasonablyLazyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_UnreasonablyLazyClassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_UnreasonablyLazyClass_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_UnreasonablyLazyClass_toFfi_nullable(List<UnreasonablyLazyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_UnreasonablyLazyClass_toFfi(value);
-  final result = _foobar_ListOf_smoke_UnreasonablyLazyClass_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_UnreasonablyLazyClassCreateHandleNullable(_handle);
   foobar_ListOf_smoke_UnreasonablyLazyClass_releaseFfiHandle(_handle);
   return result;
 }
 List<UnreasonablyLazyClass> foobar_ListOf_smoke_UnreasonablyLazyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_UnreasonablyLazyClass_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_UnreasonablyLazyClassGetValueNullable(handle);
   final result = foobar_ListOf_smoke_UnreasonablyLazyClass_fromFfi(_handle);
   foobar_ListOf_smoke_UnreasonablyLazyClass_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_UnreasonablyLazyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_UnreasonablyLazyClass_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_VeryBigStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_UnreasonablyLazyClassReleaseHandleNullable(handle);
+final _foobarListofSmokeVerybigstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_VeryBigStruct_create_handle'));
-final _foobar_ListOf_smoke_VeryBigStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeVerybigstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_VeryBigStruct_release_handle'));
-final _foobar_ListOf_smoke_VeryBigStruct_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeVerybigstructInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_VeryBigStruct_insert'));
-final _foobar_ListOf_smoke_VeryBigStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeVerybigstructIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_VeryBigStruct_iterator'));
-final _foobar_ListOf_smoke_VeryBigStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeVerybigstructIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_VeryBigStruct_iterator_release_handle'));
-final _foobar_ListOf_smoke_VeryBigStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeVerybigstructIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_VeryBigStruct_iterator_is_valid'));
-final _foobar_ListOf_smoke_VeryBigStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeVerybigstructIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_VeryBigStruct_iterator_increment'));
-final _foobar_ListOf_smoke_VeryBigStruct_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeVerybigstructIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_VeryBigStruct_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_VeryBigStruct_toFfi(List<VeryBigStruct> value) {
-  final _result = _foobar_ListOf_smoke_VeryBigStruct_create_handle();
+  final _result = _foobarListofSmokeVerybigstructCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_VeryBigStruct_toFfi(element);
-    _foobar_ListOf_smoke_VeryBigStruct_insert(_result, _element_handle);
-    smoke_VeryBigStruct_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_VeryBigStruct_toFfi(element);
+    _foobarListofSmokeVerybigstructInsert(_result, _elementHandle);
+    smoke_VeryBigStruct_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<VeryBigStruct> foobar_ListOf_smoke_VeryBigStruct_fromFfi(Pointer<Void> handle) {
-  final result = List<VeryBigStruct>();
-  final _iterator_handle = _foobar_ListOf_smoke_VeryBigStruct_iterator(handle);
-  while (_foobar_ListOf_smoke_VeryBigStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_VeryBigStruct_iterator_get(_iterator_handle);
+  final result = List<VeryBigStruct>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeVerybigstructIterator(handle);
+  while (_foobarListofSmokeVerybigstructIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeVerybigstructIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_VeryBigStruct_fromFfi(_element_handle));
+      result.add(smoke_VeryBigStruct_fromFfi(_elementHandle));
     } finally {
-      smoke_VeryBigStruct_releaseFfiHandle(_element_handle);
+      smoke_VeryBigStruct_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_VeryBigStruct_iterator_increment(_iterator_handle);
+    _foobarListofSmokeVerybigstructIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_VeryBigStruct_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeVerybigstructIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_VeryBigStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_VeryBigStruct_release_handle(handle);
-final _foobar_ListOf_smoke_VeryBigStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_VeryBigStruct_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeVerybigstructReleaseHandle(handle);
+final _foobar_ListOf_smoke_VeryBigStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_VeryBigStruct_create_handle_nullable'));
-final _foobar_ListOf_smoke_VeryBigStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_VeryBigStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_VeryBigStruct_release_handle_nullable'));
-final _foobar_ListOf_smoke_VeryBigStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_VeryBigStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_VeryBigStruct_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_VeryBigStruct_toFfi_nullable(List<VeryBigStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_VeryBigStruct_toFfi(value);
-  final result = _foobar_ListOf_smoke_VeryBigStruct_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_VeryBigStructCreateHandleNullable(_handle);
   foobar_ListOf_smoke_VeryBigStruct_releaseFfiHandle(_handle);
   return result;
 }
 List<VeryBigStruct> foobar_ListOf_smoke_VeryBigStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_VeryBigStruct_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_VeryBigStructGetValueNullable(handle);
   final result = foobar_ListOf_smoke_VeryBigStruct_fromFfi(_handle);
   foobar_ListOf_smoke_VeryBigStruct_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_VeryBigStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_VeryBigStruct_release_handle_nullable(handle);
-final _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_VeryBigStructReleaseHandleNullable(handle);
+final _foobarListofSmokeYetanotherdummyclassCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_smoke_YetAnotherDummyClass_create_handle'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeYetanotherdummyclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_YetAnotherDummyClass_release_handle'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeYetanotherdummyclassInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_smoke_YetAnotherDummyClass_insert'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeYetanotherdummyclassIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeYetanotherdummyclassIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeYetanotherdummyclassIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeYetanotherdummyclassIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofSmokeYetanotherdummyclassIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get'));
 Pointer<Void> foobar_ListOf_smoke_YetAnotherDummyClass_toFfi(List<YetAnotherDummyClass> value) {
-  final _result = _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle();
+  final _result = _foobarListofSmokeYetanotherdummyclassCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_YetAnotherDummyClass_toFfi(element);
-    _foobar_ListOf_smoke_YetAnotherDummyClass_insert(_result, _element_handle);
-    smoke_YetAnotherDummyClass_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_YetAnotherDummyClass_toFfi(element);
+    _foobarListofSmokeYetanotherdummyclassInsert(_result, _elementHandle);
+    smoke_YetAnotherDummyClass_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<YetAnotherDummyClass> foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi(Pointer<Void> handle) {
-  final result = List<YetAnotherDummyClass>();
-  final _iterator_handle = _foobar_ListOf_smoke_YetAnotherDummyClass_iterator(handle);
-  while (_foobar_ListOf_smoke_YetAnotherDummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_get(_iterator_handle);
+  final result = List<YetAnotherDummyClass>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeYetanotherdummyclassIterator(handle);
+  while (_foobarListofSmokeYetanotherdummyclassIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeYetanotherdummyclassIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_YetAnotherDummyClass_fromFfi(_element_handle));
+      result.add(smoke_YetAnotherDummyClass_fromFfi(_elementHandle));
     } finally {
-      smoke_YetAnotherDummyClass_releaseFfiHandle(_element_handle);
+      smoke_YetAnotherDummyClass_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_increment(_iterator_handle);
+    _foobarListofSmokeYetanotherdummyclassIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_smoke_YetAnotherDummyClass_iterator_release_handle(_iterator_handle);
+  _foobarListofSmokeYetanotherdummyclassIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle(handle);
-final _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeYetanotherdummyclassReleaseHandle(handle);
+final _foobar_ListOf_smoke_YetAnotherDummyClassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_YetAnotherDummyClassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable'));
-final _foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_smoke_YetAnotherDummyClassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable'));
 Pointer<Void> foobar_ListOf_smoke_YetAnotherDummyClass_toFfi_nullable(List<YetAnotherDummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_smoke_YetAnotherDummyClass_toFfi(value);
-  final result = _foobar_ListOf_smoke_YetAnotherDummyClass_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_smoke_YetAnotherDummyClassCreateHandleNullable(_handle);
   foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle(_handle);
   return result;
 }
 List<YetAnotherDummyClass> foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_smoke_YetAnotherDummyClass_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_smoke_YetAnotherDummyClassGetValueNullable(handle);
   final result = foobar_ListOf_smoke_YetAnotherDummyClass_fromFfi(_handle);
   foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_smoke_YetAnotherDummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_smoke_YetAnotherDummyClass_release_handle_nullable(handle);
-final _foobar_MapOf_Float_to_Double_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_smoke_YetAnotherDummyClassReleaseHandleNullable(handle);
+final _foobarMapofFloatToDoubleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Float_to_Double_create_handle'));
-final _foobar_MapOf_Float_to_Double_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoubleReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Float_to_Double_release_handle'));
-final _foobar_MapOf_Float_to_Double_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoublePut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Float, Double),
     void Function(Pointer<Void>, double, double)
   >('library_foobar_MapOf_Float_to_Double_put'));
-final _foobar_MapOf_Float_to_Double_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoubleIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Float_to_Double_iterator'));
-final _foobar_MapOf_Float_to_Double_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoubleIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Float_to_Double_iterator_release_handle'));
-final _foobar_MapOf_Float_to_Double_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoubleIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Float_to_Double_iterator_is_valid'));
-final _foobar_MapOf_Float_to_Double_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoubleIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Float_to_Double_iterator_increment'));
-final _foobar_MapOf_Float_to_Double_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoubleIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
 >('library_foobar_MapOf_Float_to_Double_iterator_get_key'));
-final _foobar_MapOf_Float_to_Double_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFloatToDoubleIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
 >('library_foobar_MapOf_Float_to_Double_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Float_to_Double_toFfi(Map<double, double> value) {
-  final _result = _foobar_MapOf_Float_to_Double_create_handle();
+  final _result = _foobarMapofFloatToDoubleCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = (entry.value);
-    _foobar_MapOf_Float_to_Double_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    (_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = (entry.value);
+    _foobarMapofFloatToDoublePut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    (_valueHandle);
   }
   return _result;
 }
 Map<double, double> foobar_MapOf_Float_to_Double_fromFfi(Pointer<Void> handle) {
   final result = Map<double, double>();
-  final _iterator_handle = _foobar_MapOf_Float_to_Double_iterator(handle);
-  while (_foobar_MapOf_Float_to_Double_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Float_to_Double_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Float_to_Double_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofFloatToDoubleIterator(handle);
+  while (_foobarMapofFloatToDoubleIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofFloatToDoubleIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofFloatToDoubleIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        (_value_handle);
+      result[(_keyHandle)] =
+        (_valueHandle);
     } finally {
-      (_key_handle);
-      (_value_handle);
+      (_keyHandle);
+      (_valueHandle);
     }
-    _foobar_MapOf_Float_to_Double_iterator_increment(_iterator_handle);
+    _foobarMapofFloatToDoubleIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Float_to_Double_iterator_release_handle(_iterator_handle);
+  _foobarMapofFloatToDoubleIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Float_to_Double_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Float_to_Double_release_handle(handle);
-final _foobar_MapOf_Float_to_Double_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Float_to_Double_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofFloatToDoubleReleaseHandle(handle);
+final _foobar_MapOf_Float_to_DoubleCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Float_to_Double_create_handle_nullable'));
-final _foobar_MapOf_Float_to_Double_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Float_to_DoubleReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Float_to_Double_release_handle_nullable'));
-final _foobar_MapOf_Float_to_Double_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Float_to_DoubleGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Float_to_Double_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Float_to_Double_toFfi_nullable(Map<double, double> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Float_to_Double_toFfi(value);
-  final result = _foobar_MapOf_Float_to_Double_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Float_to_DoubleCreateHandleNullable(_handle);
   foobar_MapOf_Float_to_Double_releaseFfiHandle(_handle);
   return result;
 }
 Map<double, double> foobar_MapOf_Float_to_Double_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Float_to_Double_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Float_to_DoubleGetValueNullable(handle);
   final result = foobar_MapOf_Float_to_Double_fromFfi(_handle);
   foobar_MapOf_Float_to_Double_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Float_to_Double_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Float_to_Double_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Float_to_DoubleReleaseHandleNullable(handle);
+final _foobarMapofIntToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_Boolean_create_handle'));
-final _foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Boolean_release_handle'));
-final _foobar_MapOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Uint8),
     void Function(Pointer<Void>, int, int)
   >('library_foobar_MapOf_Int_to_Boolean_put'));
-final _foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Boolean_iterator'));
-final _foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
-final _foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
-final _foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Boolean_iterator_increment'));
-final _foobar_MapOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Boolean_iterator_get_key'));
-final _foobar_MapOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToBooleanIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_Boolean_toFfi(Map<int, bool> value) {
-  final _result = _foobar_MapOf_Int_to_Boolean_create_handle();
+  final _result = _foobarMapofIntToBooleanCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = Boolean_toFfi(entry.value);
-    _foobar_MapOf_Int_to_Boolean_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = Boolean_toFfi(entry.value);
+    _foobarMapofIntToBooleanPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, bool> foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Map<int, bool>();
-  final _iterator_handle = _foobar_MapOf_Int_to_Boolean_iterator(handle);
-  while (_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToBooleanIterator(handle);
+  while (_foobarMapofIntToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToBooleanIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToBooleanIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        Boolean_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        Boolean_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      Boolean_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      Boolean_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarMapofIntToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToBooleanReleaseHandle(handle);
+final _foobar_MapOf_Int_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
-final _foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
-final _foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_Boolean_toFfi(value);
-  final result = _foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_BooleanCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, bool> foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_BooleanGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
   foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_BooleanReleaseHandleNullable(handle);
+final _foobarMapofIntToFoobarListofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_put'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarListofIntIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi(Map<int, List<int>> value) {
-  final _result = _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle();
+  final _result = _foobarMapofIntToFoobarListofIntCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = foobar_ListOf_Int_toFfi(entry.value);
-    _foobar_MapOf_Int_to_foobar_ListOf_Int_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    foobar_ListOf_Int_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = foobar_ListOf_Int_toFfi(entry.value);
+    _foobarMapofIntToFoobarListofIntPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    foobar_ListOf_Int_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, List<int>> foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   final result = Map<int, List<int>>();
-  final _iterator_handle = _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator(handle);
-  while (_foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToFoobarListofIntIterator(handle);
+  while (_foobarMapofIntToFoobarListofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToFoobarListofIntIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToFoobarListofIntIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        foobar_ListOf_Int_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        foobar_ListOf_Int_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      foobar_ListOf_Int_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      foobar_ListOf_Int_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_increment(_iterator_handle);
+    _foobarMapofIntToFoobarListofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToFoobarListofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle(handle);
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToFoobarListofIntReleaseHandle(handle);
+final _foobar_MapOf_Int_to_foobar_ListOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_ListOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable'));
-final _foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_ListOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi_nullable(Map<int, List<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_ListOf_Int_toFfi(value);
-  final result = _foobar_MapOf_Int_to_foobar_ListOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_foobar_ListOf_IntCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, List<int>> foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_foobar_ListOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_foobar_ListOf_IntGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(_handle);
   foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_foobar_ListOf_IntReleaseHandleNullable(handle);
+final _foobarMapofIntToFoobarMapofIntToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_put'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarMapofIntToBooleanIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(Map<int, Map<int, bool>> value) {
-  final _result = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle();
+  final _result = _foobarMapofIntToFoobarMapofIntToBooleanCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = foobar_MapOf_Int_to_Boolean_toFfi(entry.value);
-    _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = foobar_MapOf_Int_to_Boolean_toFfi(entry.value);
+    _foobarMapofIntToFoobarMapofIntToBooleanPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, Map<int, bool>> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Map<int, Map<int, bool>>();
-  final _iterator_handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator(handle);
-  while (_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToFoobarMapofIntToBooleanIterator(handle);
+  while (_foobarMapofIntToFoobarMapofIntToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToFoobarMapofIntToBooleanIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToFoobarMapofIntToBooleanIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        foobar_MapOf_Int_to_Boolean_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        foobar_MapOf_Int_to_Boolean_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarMapofIntToFoobarMapofIntToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToFoobarMapofIntToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToFoobarMapofIntToBooleanReleaseHandle(handle);
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
-final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_MapOf_Int_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Map<int, Map<int, bool>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(value);
-  final result = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_BooleanCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, Map<int, bool>> foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_foobar_MapOf_Int_to_BooleanGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
   foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_foobar_MapOf_Int_to_BooleanReleaseHandleNullable(handle);
+final _foobarMapofIntToFoobarSetofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_put'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToFoobarSetofIntIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(Map<int, Set<int>> value) {
-  final _result = _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle();
+  final _result = _foobarMapofIntToFoobarSetofIntCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = foobar_SetOf_Int_toFfi(entry.value);
-    _foobar_MapOf_Int_to_foobar_SetOf_Int_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    foobar_SetOf_Int_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = foobar_SetOf_Int_toFfi(entry.value);
+    _foobarMapofIntToFoobarSetofIntPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    foobar_SetOf_Int_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, Set<int>> foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   final result = Map<int, Set<int>>();
-  final _iterator_handle = _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator(handle);
-  while (_foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToFoobarSetofIntIterator(handle);
+  while (_foobarMapofIntToFoobarSetofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToFoobarSetofIntIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToFoobarSetofIntIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        foobar_SetOf_Int_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        foobar_SetOf_Int_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      foobar_SetOf_Int_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      foobar_SetOf_Int_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_increment(_iterator_handle);
+    _foobarMapofIntToFoobarSetofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToFoobarSetofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle(handle);
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToFoobarSetofIntReleaseHandle(handle);
+final _foobar_MapOf_Int_to_foobar_SetOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_SetOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable'));
-final _foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_foobar_SetOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi_nullable(Map<int, Set<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(value);
-  final result = _foobar_MapOf_Int_to_foobar_SetOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_foobar_SetOf_IntCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, Set<int>> foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_foobar_SetOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_foobar_SetOf_IntGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_foobar_SetOf_Int_fromFfi(_handle);
   foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_DummyClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_foobar_SetOf_IntReleaseHandleNullable(handle);
+final _foobarMapofIntToSmokeDummyclassCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_smoke_DummyClass_create_handle'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyClass_release_handle'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyClass_put'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyclassIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyClass_toFfi(Map<int, DummyClass> value) {
-  final _result = _foobar_MapOf_Int_to_smoke_DummyClass_create_handle();
+  final _result = _foobarMapofIntToSmokeDummyclassCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = smoke_DummyClass_toFfi(entry.value);
-    _foobar_MapOf_Int_to_smoke_DummyClass_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    smoke_DummyClass_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = smoke_DummyClass_toFfi(entry.value);
+    _foobarMapofIntToSmokeDummyclassPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    smoke_DummyClass_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, DummyClass> foobar_MapOf_Int_to_smoke_DummyClass_fromFfi(Pointer<Void> handle) {
   final result = Map<int, DummyClass>();
-  final _iterator_handle = _foobar_MapOf_Int_to_smoke_DummyClass_iterator(handle);
-  while (_foobar_MapOf_Int_to_smoke_DummyClass_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_smoke_DummyClass_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToSmokeDummyclassIterator(handle);
+  while (_foobarMapofIntToSmokeDummyclassIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToSmokeDummyclassIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToSmokeDummyclassIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        smoke_DummyClass_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        smoke_DummyClass_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      smoke_DummyClass_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      smoke_DummyClass_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_smoke_DummyClass_iterator_increment(_iterator_handle);
+    _foobarMapofIntToSmokeDummyclassIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_smoke_DummyClass_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToSmokeDummyclassIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_DummyClass_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToSmokeDummyclassReleaseHandle(handle);
+final _foobar_MapOf_Int_to_smoke_DummyClassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyClassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyClassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyClass_toFfi_nullable(Map<int, DummyClass> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_DummyClass_toFfi(value);
-  final result = _foobar_MapOf_Int_to_smoke_DummyClass_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_smoke_DummyClassCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, DummyClass> foobar_MapOf_Int_to_smoke_DummyClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_smoke_DummyClass_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_smoke_DummyClassGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_smoke_DummyClass_fromFfi(_handle);
   foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_smoke_DummyClass_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_smoke_DummyClassReleaseHandleNullable(handle);
+final _foobarMapofIntToSmokeDummyinterfaceCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_smoke_DummyInterface_create_handle'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyInterface_release_handle'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfacePut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyInterface_put'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfaceIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfaceIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfaceIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfaceIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfaceIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeDummyinterfaceIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyInterface_toFfi(Map<int, DummyInterface> value) {
-  final _result = _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle();
+  final _result = _foobarMapofIntToSmokeDummyinterfaceCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = smoke_DummyInterface_toFfi(entry.value);
-    _foobar_MapOf_Int_to_smoke_DummyInterface_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    smoke_DummyInterface_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = smoke_DummyInterface_toFfi(entry.value);
+    _foobarMapofIntToSmokeDummyinterfacePut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    smoke_DummyInterface_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, DummyInterface> foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(Pointer<Void> handle) {
   final result = Map<int, DummyInterface>();
-  final _iterator_handle = _foobar_MapOf_Int_to_smoke_DummyInterface_iterator(handle);
-  while (_foobar_MapOf_Int_to_smoke_DummyInterface_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToSmokeDummyinterfaceIterator(handle);
+  while (_foobarMapofIntToSmokeDummyinterfaceIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToSmokeDummyinterfaceIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToSmokeDummyinterfaceIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        smoke_DummyInterface_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        smoke_DummyInterface_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      smoke_DummyInterface_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      smoke_DummyInterface_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_increment(_iterator_handle);
+    _foobarMapofIntToSmokeDummyinterfaceIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_smoke_DummyInterface_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToSmokeDummyinterfaceIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToSmokeDummyinterfaceReleaseHandle(handle);
+final _foobar_MapOf_Int_to_smoke_DummyInterfaceCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyInterfaceReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_DummyInterfaceGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_DummyInterface_toFfi_nullable(Map<int, DummyInterface> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_DummyInterface_toFfi(value);
-  final result = _foobar_MapOf_Int_to_smoke_DummyInterface_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_smoke_DummyInterfaceCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, DummyInterface> foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_smoke_DummyInterface_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_smoke_DummyInterfaceGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(_handle);
   foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_smoke_DummyInterface_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_smoke_DummyInterfaceReleaseHandleNullable(handle);
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Uint32),
     void Function(Pointer<Void>, int, int)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(Map<int, GenericTypesWithCompoundTypes_ExternalEnum> value) {
-  final _result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle();
+  final _result = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(entry.value);
-    _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(entry.value);
+    _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, GenericTypesWithCompoundTypes_ExternalEnum> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(Pointer<Void> handle) {
   final result = Map<int, GenericTypesWithCompoundTypes_ExternalEnum>();
-  final _iterator_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle);
-  while (_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIterator(handle);
+  while (_foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_iterator_handle);
+    _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumReleaseHandle(handle);
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_ExternalEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
-  final result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, GenericTypesWithCompoundTypes_ExternalEnum> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
   foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable(handle);
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Uint32),
     void Function(Pointer<Void>, int, int)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(Map<int, GenericTypesWithCompoundTypes_SomeEnum> value) {
-  final _result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle();
+  final _result = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(entry.value);
-    _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(entry.value);
+    _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, GenericTypesWithCompoundTypes_SomeEnum> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(Pointer<Void> handle) {
   final result = Map<int, GenericTypesWithCompoundTypes_SomeEnum>();
-  final _iterator_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle);
-  while (_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIterator(handle);
+  while (_foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_iterator_handle);
+    _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(handle);
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumReleaseHandle(handle);
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
-final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Map<int, GenericTypesWithCompoundTypes_SomeEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
-  final result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, GenericTypesWithCompoundTypes_SomeEnum> foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);
   foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(handle);
-final _foobar_MapOf_String_to_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable(handle);
+final _foobarMapofStringToStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_String_to_String_create_handle'));
-final _foobar_MapOf_String_to_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_String_release_handle'));
-final _foobar_MapOf_String_to_String_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_foobar_MapOf_String_to_String_put'));
-final _foobar_MapOf_String_to_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_String_iterator'));
-final _foobar_MapOf_String_to_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_String_iterator_release_handle'));
-final _foobar_MapOf_String_to_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_String_to_String_iterator_is_valid'));
-final _foobar_MapOf_String_to_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_String_iterator_increment'));
-final _foobar_MapOf_String_to_String_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_String_iterator_get_key'));
-final _foobar_MapOf_String_to_String_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToStringIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_String_iterator_get_value'));
 Pointer<Void> foobar_MapOf_String_to_String_toFfi(Map<String, String> value) {
-  final _result = _foobar_MapOf_String_to_String_create_handle();
+  final _result = _foobarMapofStringToStringCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = String_toFfi(entry.key);
-    final _value_handle = String_toFfi(entry.value);
-    _foobar_MapOf_String_to_String_put(_result, _key_handle, _value_handle);
-    String_releaseFfiHandle(_key_handle);
-    String_releaseFfiHandle(_value_handle);
+    final _keyHandle = String_toFfi(entry.key);
+    final _valueHandle = String_toFfi(entry.value);
+    _foobarMapofStringToStringPut(_result, _keyHandle, _valueHandle);
+    String_releaseFfiHandle(_keyHandle);
+    String_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<String, String> foobar_MapOf_String_to_String_fromFfi(Pointer<Void> handle) {
   final result = Map<String, String>();
-  final _iterator_handle = _foobar_MapOf_String_to_String_iterator(handle);
-  while (_foobar_MapOf_String_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_String_to_String_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_String_to_String_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofStringToStringIterator(handle);
+  while (_foobarMapofStringToStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofStringToStringIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofStringToStringIteratorGetValue(_iteratorHandle);
     try {
-      result[String_fromFfi(_key_handle)] =
-        String_fromFfi(_value_handle);
+      result[String_fromFfi(_keyHandle)] =
+        String_fromFfi(_valueHandle);
     } finally {
-      String_releaseFfiHandle(_key_handle);
-      String_releaseFfiHandle(_value_handle);
+      String_releaseFfiHandle(_keyHandle);
+      String_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_String_to_String_iterator_increment(_iterator_handle);
+    _foobarMapofStringToStringIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_String_to_String_iterator_release_handle(_iterator_handle);
+  _foobarMapofStringToStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_String_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_String_to_String_release_handle(handle);
-final _foobar_MapOf_String_to_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_String_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofStringToStringReleaseHandle(handle);
+final _foobar_MapOf_String_to_StringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_String_create_handle_nullable'));
-final _foobar_MapOf_String_to_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_StringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_String_release_handle_nullable'));
-final _foobar_MapOf_String_to_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_StringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_String_get_value_nullable'));
 Pointer<Void> foobar_MapOf_String_to_String_toFfi_nullable(Map<String, String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_String_toFfi(value);
-  final result = _foobar_MapOf_String_to_String_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_String_to_StringCreateHandleNullable(_handle);
   foobar_MapOf_String_to_String_releaseFfiHandle(_handle);
   return result;
 }
 Map<String, String> foobar_MapOf_String_to_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_String_to_String_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_String_to_StringGetValueNullable(handle);
   final result = foobar_MapOf_String_to_String_fromFfi(_handle);
   foobar_MapOf_String_to_String_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_String_to_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_String_to_String_release_handle_nullable(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_String_to_StringReleaseHandleNullable(handle);
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(Map<String, GenericTypesWithCompoundTypes_BasicStruct> value) {
-  final _result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle();
+  final _result = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = String_toFfi(entry.key);
-    final _value_handle = smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(entry.value);
-    _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_put(_result, _key_handle, _value_handle);
-    String_releaseFfiHandle(_key_handle);
-    smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_value_handle);
+    final _keyHandle = String_toFfi(entry.key);
+    final _valueHandle = smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(entry.value);
+    _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructPut(_result, _keyHandle, _valueHandle);
+    String_releaseFfiHandle(_keyHandle);
+    smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<String, GenericTypesWithCompoundTypes_BasicStruct> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(Pointer<Void> handle) {
   final result = Map<String, GenericTypesWithCompoundTypes_BasicStruct>();
-  final _iterator_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator(handle);
-  while (_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIterator(handle);
+  while (_foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorGetValue(_iteratorHandle);
     try {
-      result[String_fromFfi(_key_handle)] =
-        smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_value_handle);
+      result[String_fromFfi(_keyHandle)] =
+        smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_valueHandle);
     } finally {
-      String_releaseFfiHandle(_key_handle);
-      smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_value_handle);
+      String_releaseFfiHandle(_keyHandle);
+      smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_increment(_iterator_handle);
+    _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_iterator_release_handle(_iterator_handle);
+  _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofStringToSmokeGenerictypeswithcompoundtypesBasicstructReleaseHandle(handle);
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_BasicStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
-  final result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStructCreateHandleNullable(_handle);
   foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 Map<String, GenericTypesWithCompoundTypes_BasicStruct> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStructGetValueNullable(handle);
   final result = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_handle);
   foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStructReleaseHandleNullable(handle);
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(Map<String, GenericTypesWithCompoundTypes_ExternalStruct> value) {
-  final _result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle();
+  final _result = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = String_toFfi(entry.key);
-    final _value_handle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(entry.value);
-    _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_put(_result, _key_handle, _value_handle);
-    String_releaseFfiHandle(_key_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_value_handle);
+    final _keyHandle = String_toFfi(entry.key);
+    final _valueHandle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(entry.value);
+    _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructPut(_result, _keyHandle, _valueHandle);
+    String_releaseFfiHandle(_keyHandle);
+    smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<String, GenericTypesWithCompoundTypes_ExternalStruct> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(Pointer<Void> handle) {
   final result = Map<String, GenericTypesWithCompoundTypes_ExternalStruct>();
-  final _iterator_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator(handle);
-  while (_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIterator(handle);
+  while (_foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorGetValue(_iteratorHandle);
     try {
-      result[String_fromFfi(_key_handle)] =
-        smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_value_handle);
+      result[String_fromFfi(_keyHandle)] =
+        smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_valueHandle);
     } finally {
-      String_releaseFfiHandle(_key_handle);
-      smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_value_handle);
+      String_releaseFfiHandle(_keyHandle);
+      smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_increment(_iterator_handle);
+    _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_iterator_release_handle(_iterator_handle);
+  _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle);
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructReleaseHandle(handle);
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable'));
-final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
 Pointer<Void> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(Map<String, GenericTypesWithCompoundTypes_ExternalStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
-  final result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStructCreateHandleNullable(_handle);
   foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 Map<String, GenericTypesWithCompoundTypes_ExternalStruct> foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStructGetValueNullable(handle);
   final result = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_handle);
   foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(handle);
-final _foobar_MapOf_UByte_to_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStructReleaseHandleNullable(handle);
+final _foobarMapofUbyteToStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_UByte_to_String_create_handle'));
-final _foobar_MapOf_UByte_to_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_UByte_to_String_release_handle'));
-final _foobar_MapOf_UByte_to_String_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint8, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_UByte_to_String_put'));
-final _foobar_MapOf_UByte_to_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_UByte_to_String_iterator'));
-final _foobar_MapOf_UByte_to_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_UByte_to_String_iterator_release_handle'));
-final _foobar_MapOf_UByte_to_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_UByte_to_String_iterator_is_valid'));
-final _foobar_MapOf_UByte_to_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_UByte_to_String_iterator_increment'));
-final _foobar_MapOf_UByte_to_String_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_UByte_to_String_iterator_get_key'));
-final _foobar_MapOf_UByte_to_String_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofUbyteToStringIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_UByte_to_String_iterator_get_value'));
 Pointer<Void> foobar_MapOf_UByte_to_String_toFfi(Map<int, String> value) {
-  final _result = _foobar_MapOf_UByte_to_String_create_handle();
+  final _result = _foobarMapofUbyteToStringCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = String_toFfi(entry.value);
-    _foobar_MapOf_UByte_to_String_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    String_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = String_toFfi(entry.value);
+    _foobarMapofUbyteToStringPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    String_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, String> foobar_MapOf_UByte_to_String_fromFfi(Pointer<Void> handle) {
   final result = Map<int, String>();
-  final _iterator_handle = _foobar_MapOf_UByte_to_String_iterator(handle);
-  while (_foobar_MapOf_UByte_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_UByte_to_String_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_UByte_to_String_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofUbyteToStringIterator(handle);
+  while (_foobarMapofUbyteToStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofUbyteToStringIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofUbyteToStringIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        String_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        String_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      String_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      String_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_UByte_to_String_iterator_increment(_iterator_handle);
+    _foobarMapofUbyteToStringIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_UByte_to_String_iterator_release_handle(_iterator_handle);
+  _foobarMapofUbyteToStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_UByte_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_UByte_to_String_release_handle(handle);
-final _foobar_MapOf_UByte_to_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_UByte_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofUbyteToStringReleaseHandle(handle);
+final _foobar_MapOf_UByte_to_StringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_UByte_to_String_create_handle_nullable'));
-final _foobar_MapOf_UByte_to_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_UByte_to_StringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_UByte_to_String_release_handle_nullable'));
-final _foobar_MapOf_UByte_to_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_UByte_to_StringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_UByte_to_String_get_value_nullable'));
 Pointer<Void> foobar_MapOf_UByte_to_String_toFfi_nullable(Map<int, String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_UByte_to_String_toFfi(value);
-  final result = _foobar_MapOf_UByte_to_String_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_UByte_to_StringCreateHandleNullable(_handle);
   foobar_MapOf_UByte_to_String_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, String> foobar_MapOf_UByte_to_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_UByte_to_String_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_UByte_to_StringGetValueNullable(handle);
   final result = foobar_MapOf_UByte_to_String_fromFfi(_handle);
   foobar_MapOf_UByte_to_String_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_UByte_to_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_UByte_to_String_release_handle_nullable(handle);
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_UByte_to_StringReleaseHandleNullable(handle);
+final _foobarMapofFoobarListofIntToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Uint8),
     void Function(Pointer<Void>, Pointer<Void>, int)
   >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_put'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarListofIntToBooleanIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi(Map<List<int>, bool> value) {
-  final _result = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle();
+  final _result = _foobarMapofFoobarListofIntToBooleanCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = foobar_ListOf_Int_toFfi(entry.key);
-    final _value_handle = Boolean_toFfi(entry.value);
-    _foobar_MapOf_foobar_ListOf_Int_to_Boolean_put(_result, _key_handle, _value_handle);
-    foobar_ListOf_Int_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final _keyHandle = foobar_ListOf_Int_toFfi(entry.key);
+    final _valueHandle = Boolean_toFfi(entry.value);
+    _foobarMapofFoobarListofIntToBooleanPut(_result, _keyHandle, _valueHandle);
+    foobar_ListOf_Int_releaseFfiHandle(_keyHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<List<int>, bool> foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Map<List<int>, bool>();
-  final _iterator_handle = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator(handle);
-  while (_foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofFoobarListofIntToBooleanIterator(handle);
+  while (_foobarMapofFoobarListofIntToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofFoobarListofIntToBooleanIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofFoobarListofIntToBooleanIteratorGetValue(_iteratorHandle);
     try {
-      result[foobar_ListOf_Int_fromFfi(_key_handle)] =
-        Boolean_fromFfi(_value_handle);
+      result[foobar_ListOf_Int_fromFfi(_keyHandle)] =
+        Boolean_fromFfi(_valueHandle);
     } finally {
-      foobar_ListOf_Int_releaseFfiHandle(_key_handle);
-      Boolean_releaseFfiHandle(_value_handle);
+      foobar_ListOf_Int_releaseFfiHandle(_keyHandle);
+      Boolean_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarMapofFoobarListofIntToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_foobar_ListOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarMapofFoobarListofIntToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofFoobarListofIntToBooleanReleaseHandle(handle);
+final _foobar_MapOf_foobar_ListOf_Int_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_ListOf_Int_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable'));
-final _foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_ListOf_Int_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi_nullable(Map<List<int>, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_ListOf_Int_to_Boolean_toFfi(value);
-  final result = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_foobar_ListOf_Int_to_BooleanCreateHandleNullable(_handle);
   foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Map<List<int>, bool> foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_foobar_ListOf_Int_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_foobar_ListOf_Int_to_BooleanGetValueNullable(handle);
   final result = foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(_handle);
   foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_foobar_ListOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_foobar_ListOf_Int_to_BooleanReleaseHandleNullable(handle);
+final _foobarMapofFoobarMapofIntToBooleanToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Uint8),
     void Function(Pointer<Void>, Pointer<Void>, int)
   >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_put'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi(Map<Map<int, bool>, bool> value) {
-  final _result = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle();
+  final _result = _foobarMapofFoobarMapofIntToBooleanToBooleanCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = foobar_MapOf_Int_to_Boolean_toFfi(entry.key);
-    final _value_handle = Boolean_toFfi(entry.value);
-    _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_put(_result, _key_handle, _value_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final _keyHandle = foobar_MapOf_Int_to_Boolean_toFfi(entry.key);
+    final _valueHandle = Boolean_toFfi(entry.value);
+    _foobarMapofFoobarMapofIntToBooleanToBooleanPut(_result, _keyHandle, _valueHandle);
+    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_keyHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<Map<int, bool>, bool> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Map<Map<int, bool>, bool>();
-  final _iterator_handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator(handle);
-  while (_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofFoobarMapofIntToBooleanToBooleanIterator(handle);
+  while (_foobarMapofFoobarMapofIntToBooleanToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorGetValue(_iteratorHandle);
     try {
-      result[foobar_MapOf_Int_to_Boolean_fromFfi(_key_handle)] =
-        Boolean_fromFfi(_value_handle);
+      result[foobar_MapOf_Int_to_Boolean_fromFfi(_keyHandle)] =
+        Boolean_fromFfi(_valueHandle);
     } finally {
-      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_key_handle);
-      Boolean_releaseFfiHandle(_value_handle);
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_keyHandle);
+      Boolean_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarMapofFoobarMapofIntToBooleanToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle(handle);
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofFoobarMapofIntToBooleanToBooleanReleaseHandle(handle);
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable'));
-final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi_nullable(Map<Map<int, bool>, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_toFfi(value);
-  final result = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_BooleanCreateHandleNullable(_handle);
   foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Map<Map<int, bool>, bool> foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_BooleanGetValueNullable(handle);
   final result = foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi(_handle);
   foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_BooleanReleaseHandleNullable(handle);
+final _foobarMapofFoobarSetofIntToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>, Uint8),
     void Function(Pointer<Void>, Pointer<Void>, int)
   >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_put'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofFoobarSetofIntToBooleanIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(Map<Set<int>, bool> value) {
-  final _result = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle();
+  final _result = _foobarMapofFoobarSetofIntToBooleanCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = foobar_SetOf_Int_toFfi(entry.key);
-    final _value_handle = Boolean_toFfi(entry.value);
-    _foobar_MapOf_foobar_SetOf_Int_to_Boolean_put(_result, _key_handle, _value_handle);
-    foobar_SetOf_Int_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final _keyHandle = foobar_SetOf_Int_toFfi(entry.key);
+    final _valueHandle = Boolean_toFfi(entry.value);
+    _foobarMapofFoobarSetofIntToBooleanPut(_result, _keyHandle, _valueHandle);
+    foobar_SetOf_Int_releaseFfiHandle(_keyHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<Set<int>, bool> foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Map<Set<int>, bool>();
-  final _iterator_handle = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator(handle);
-  while (_foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofFoobarSetofIntToBooleanIterator(handle);
+  while (_foobarMapofFoobarSetofIntToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofFoobarSetofIntToBooleanIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofFoobarSetofIntToBooleanIteratorGetValue(_iteratorHandle);
     try {
-      result[foobar_SetOf_Int_fromFfi(_key_handle)] =
-        Boolean_fromFfi(_value_handle);
+      result[foobar_SetOf_Int_fromFfi(_keyHandle)] =
+        Boolean_fromFfi(_valueHandle);
     } finally {
-      foobar_SetOf_Int_releaseFfiHandle(_key_handle);
-      Boolean_releaseFfiHandle(_value_handle);
+      foobar_SetOf_Int_releaseFfiHandle(_keyHandle);
+      Boolean_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarMapofFoobarSetofIntToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_foobar_SetOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarMapofFoobarSetofIntToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle(handle);
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofFoobarSetofIntToBooleanReleaseHandle(handle);
+final _foobar_MapOf_foobar_SetOf_Int_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_SetOf_Int_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable'));
-final _foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_foobar_SetOf_Int_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi_nullable(Map<Set<int>, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(value);
-  final result = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_foobar_SetOf_Int_to_BooleanCreateHandleNullable(_handle);
   foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Map<Set<int>, bool> foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_foobar_SetOf_Int_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_foobar_SetOf_Int_to_BooleanGetValueNullable(handle);
   final result = foobar_MapOf_foobar_SetOf_Int_to_Boolean_fromFfi(_handle);
   foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_foobar_SetOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_foobar_SetOf_Int_to_BooleanReleaseHandleNullable(handle);
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32, Uint8),
     void Function(Pointer<Void>, int, int)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi(Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> value) {
-  final _result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle();
+  final _result = _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(entry.key);
-    final _value_handle = Boolean_toFfi(entry.value);
-    _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_put(_result, _key_handle, _value_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final _keyHandle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(entry.key);
+    final _valueHandle = Boolean_toFfi(entry.value);
+    _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanPut(_result, _keyHandle, _valueHandle);
+    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_keyHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Map<GenericTypesWithCompoundTypes_ExternalEnum, bool>();
-  final _iterator_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator(handle);
-  while (_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIterator(handle);
+  while (_foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorGetValue(_iteratorHandle);
     try {
-      result[smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_key_handle)] =
-        Boolean_fromFfi(_value_handle);
+      result[smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_keyHandle)] =
+        Boolean_fromFfi(_valueHandle);
     } finally {
-      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_key_handle);
-      Boolean_releaseFfiHandle(_value_handle);
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_keyHandle);
+      Boolean_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanReleaseHandle(handle);
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_toFfi(value);
-  final result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_BooleanCreateHandleNullable(_handle);
   foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_BooleanGetValueNullable(handle);
   final result = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(_handle);
   foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_release_handle_nullable(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_BooleanReleaseHandleNullable(handle);
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32, Uint8),
     void Function(Pointer<Void>, int, int)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> value) {
-  final _result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle();
+  final _result = _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(entry.key);
-    final _value_handle = Boolean_toFfi(entry.value);
-    _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_put(_result, _key_handle, _value_handle);
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_key_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final _keyHandle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(entry.key);
+    final _valueHandle = Boolean_toFfi(entry.value);
+    _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanPut(_result, _keyHandle, _valueHandle);
+    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_keyHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<GenericTypesWithCompoundTypes_SomeEnum, bool> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Map<GenericTypesWithCompoundTypes_SomeEnum, bool>();
-  final _iterator_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator(handle);
-  while (_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIterator(handle);
+  while (_foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorGetValue(_iteratorHandle);
     try {
-      result[smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_key_handle)] =
-        Boolean_fromFfi(_value_handle);
+      result[smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_keyHandle)] =
+        Boolean_fromFfi(_valueHandle);
     } finally {
-      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_key_handle);
-      Boolean_releaseFfiHandle(_value_handle);
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_keyHandle);
+      Boolean_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle(handle);
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofSmokeGenerictypeswithcompoundtypesSomeenumToBooleanReleaseHandle(handle);
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable'));
-final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi_nullable(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(value);
-  final result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_BooleanCreateHandleNullable(_handle);
   foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Map<GenericTypesWithCompoundTypes_SomeEnum, bool> foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_BooleanGetValueNullable(handle);
   final result = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_fromFfi(_handle);
   foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_release_handle_nullable(handle);
-final _foobar_SetOf_Float_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_BooleanReleaseHandleNullable(handle);
+final _foobarSetofFloatCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_Float_create_handle'));
-final _foobar_SetOf_Float_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFloatReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_Float_release_handle'));
-final _foobar_SetOf_Float_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFloatInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Float),
     void Function(Pointer<Void>, double)
   >('library_foobar_SetOf_Float_insert'));
-final _foobar_SetOf_Float_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFloatIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_Float_iterator'));
-final _foobar_SetOf_Float_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFloatIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_Float_iterator_release_handle'));
-final _foobar_SetOf_Float_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFloatIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_Float_iterator_is_valid'));
-final _foobar_SetOf_Float_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFloatIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_Float_iterator_increment'));
-final _foobar_SetOf_Float_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFloatIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
 >('library_foobar_SetOf_Float_iterator_get'));
 Pointer<Void> foobar_SetOf_Float_toFfi(Set<double> value) {
-  final _result = _foobar_SetOf_Float_create_handle();
+  final _result = _foobarSetofFloatCreateHandle();
   for (final element in value) {
-    final _element_handle = (element);
-    _foobar_SetOf_Float_insert(_result, _element_handle);
-    (_element_handle);
+    final _elementHandle = (element);
+    _foobarSetofFloatInsert(_result, _elementHandle);
+    (_elementHandle);
   }
   return _result;
 }
 Set<double> foobar_SetOf_Float_fromFfi(Pointer<Void> handle) {
   final result = Set<double>();
-  final _iterator_handle = _foobar_SetOf_Float_iterator(handle);
-  while (_foobar_SetOf_Float_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_Float_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofFloatIterator(handle);
+  while (_foobarSetofFloatIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofFloatIteratorGet(_iteratorHandle);
     try {
-      result.add((_element_handle));
+      result.add((_elementHandle));
     } finally {
-      (_element_handle);
+      (_elementHandle);
     }
-    _foobar_SetOf_Float_iterator_increment(_iterator_handle);
+    _foobarSetofFloatIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_Float_iterator_release_handle(_iterator_handle);
+  _foobarSetofFloatIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_Float_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_Float_release_handle(handle);
-final _foobar_SetOf_Float_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_Float_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofFloatReleaseHandle(handle);
+final _foobar_SetOf_FloatCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_Float_create_handle_nullable'));
-final _foobar_SetOf_Float_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_FloatReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_Float_release_handle_nullable'));
-final _foobar_SetOf_Float_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_FloatGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_Float_get_value_nullable'));
 Pointer<Void> foobar_SetOf_Float_toFfi_nullable(Set<double> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_Float_toFfi(value);
-  final result = _foobar_SetOf_Float_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_FloatCreateHandleNullable(_handle);
   foobar_SetOf_Float_releaseFfiHandle(_handle);
   return result;
 }
 Set<double> foobar_SetOf_Float_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_Float_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_FloatGetValueNullable(handle);
   final result = foobar_SetOf_Float_fromFfi(_handle);
   foobar_SetOf_Float_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_Float_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_Float_release_handle_nullable(handle);
-final _foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_FloatReleaseHandleNullable(handle);
+final _foobarSetofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_Int_create_handle'));
-final _foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_Int_release_handle'));
-final _foobar_SetOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofIntInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32),
     void Function(Pointer<Void>, int)
   >('library_foobar_SetOf_Int_insert'));
-final _foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_Int_iterator'));
-final _foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_Int_iterator_release_handle'));
-final _foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_Int_iterator_is_valid'));
-final _foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_Int_iterator_increment'));
-final _foobar_SetOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofIntIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_SetOf_Int_iterator_get'));
 Pointer<Void> foobar_SetOf_Int_toFfi(Set<int> value) {
-  final _result = _foobar_SetOf_Int_create_handle();
+  final _result = _foobarSetofIntCreateHandle();
   for (final element in value) {
-    final _element_handle = (element);
-    _foobar_SetOf_Int_insert(_result, _element_handle);
-    (_element_handle);
+    final _elementHandle = (element);
+    _foobarSetofIntInsert(_result, _elementHandle);
+    (_elementHandle);
   }
   return _result;
 }
 Set<int> foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   final result = Set<int>();
-  final _iterator_handle = _foobar_SetOf_Int_iterator(handle);
-  while (_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_Int_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofIntIterator(handle);
+  while (_foobarSetofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofIntIteratorGet(_iteratorHandle);
     try {
-      result.add((_element_handle));
+      result.add((_elementHandle));
     } finally {
-      (_element_handle);
+      (_elementHandle);
     }
-    _foobar_SetOf_Int_iterator_increment(_iterator_handle);
+    _foobarSetofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarSetofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_Int_release_handle(handle);
-final _foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofIntReleaseHandle(handle);
+final _foobar_SetOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_Int_create_handle_nullable'));
-final _foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_Int_release_handle_nullable'));
-final _foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_SetOf_Int_toFfi_nullable(Set<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_Int_toFfi(value);
-  final result = _foobar_SetOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_IntCreateHandleNullable(_handle);
   foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 Set<int> foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_IntGetValueNullable(handle);
   final result = foobar_SetOf_Int_fromFfi(_handle);
   foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_SetOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_IntReleaseHandleNullable(handle);
+final _foobarSetofStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_String_create_handle'));
-final _foobar_SetOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_String_release_handle'));
-final _foobar_SetOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofStringInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_SetOf_String_insert'));
-final _foobar_SetOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_String_iterator'));
-final _foobar_SetOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_String_iterator_release_handle'));
-final _foobar_SetOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_String_iterator_is_valid'));
-final _foobar_SetOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_String_iterator_increment'));
-final _foobar_SetOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofStringIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_String_iterator_get'));
 Pointer<Void> foobar_SetOf_String_toFfi(Set<String> value) {
-  final _result = _foobar_SetOf_String_create_handle();
+  final _result = _foobarSetofStringCreateHandle();
   for (final element in value) {
-    final _element_handle = String_toFfi(element);
-    _foobar_SetOf_String_insert(_result, _element_handle);
-    String_releaseFfiHandle(_element_handle);
+    final _elementHandle = String_toFfi(element);
+    _foobarSetofStringInsert(_result, _elementHandle);
+    String_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 Set<String> foobar_SetOf_String_fromFfi(Pointer<Void> handle) {
   final result = Set<String>();
-  final _iterator_handle = _foobar_SetOf_String_iterator(handle);
-  while (_foobar_SetOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_String_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofStringIterator(handle);
+  while (_foobarSetofStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofStringIteratorGet(_iteratorHandle);
     try {
-      result.add(String_fromFfi(_element_handle));
+      result.add(String_fromFfi(_elementHandle));
     } finally {
-      String_releaseFfiHandle(_element_handle);
+      String_releaseFfiHandle(_elementHandle);
     }
-    _foobar_SetOf_String_iterator_increment(_iterator_handle);
+    _foobarSetofStringIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_String_iterator_release_handle(_iterator_handle);
+  _foobarSetofStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_String_release_handle(handle);
-final _foobar_SetOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofStringReleaseHandle(handle);
+final _foobar_SetOf_StringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_String_create_handle_nullable'));
-final _foobar_SetOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_StringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_String_release_handle_nullable'));
-final _foobar_SetOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_StringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_String_get_value_nullable'));
 Pointer<Void> foobar_SetOf_String_toFfi_nullable(Set<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_String_toFfi(value);
-  final result = _foobar_SetOf_String_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_StringCreateHandleNullable(_handle);
   foobar_SetOf_String_releaseFfiHandle(_handle);
   return result;
 }
 Set<String> foobar_SetOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_String_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_StringGetValueNullable(handle);
   final result = foobar_SetOf_String_fromFfi(_handle);
   foobar_SetOf_String_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_String_release_handle_nullable(handle);
-final _foobar_SetOf_UByte_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_StringReleaseHandleNullable(handle);
+final _foobarSetofUbyteCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_UByte_create_handle'));
-final _foobar_SetOf_UByte_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofUbyteReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_UByte_release_handle'));
-final _foobar_SetOf_UByte_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofUbyteInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint8),
     void Function(Pointer<Void>, int)
   >('library_foobar_SetOf_UByte_insert'));
-final _foobar_SetOf_UByte_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofUbyteIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_UByte_iterator'));
-final _foobar_SetOf_UByte_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofUbyteIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_UByte_iterator_release_handle'));
-final _foobar_SetOf_UByte_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofUbyteIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_UByte_iterator_is_valid'));
-final _foobar_SetOf_UByte_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofUbyteIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_UByte_iterator_increment'));
-final _foobar_SetOf_UByte_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofUbyteIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_SetOf_UByte_iterator_get'));
 Pointer<Void> foobar_SetOf_UByte_toFfi(Set<int> value) {
-  final _result = _foobar_SetOf_UByte_create_handle();
+  final _result = _foobarSetofUbyteCreateHandle();
   for (final element in value) {
-    final _element_handle = (element);
-    _foobar_SetOf_UByte_insert(_result, _element_handle);
-    (_element_handle);
+    final _elementHandle = (element);
+    _foobarSetofUbyteInsert(_result, _elementHandle);
+    (_elementHandle);
   }
   return _result;
 }
 Set<int> foobar_SetOf_UByte_fromFfi(Pointer<Void> handle) {
   final result = Set<int>();
-  final _iterator_handle = _foobar_SetOf_UByte_iterator(handle);
-  while (_foobar_SetOf_UByte_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_UByte_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofUbyteIterator(handle);
+  while (_foobarSetofUbyteIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofUbyteIteratorGet(_iteratorHandle);
     try {
-      result.add((_element_handle));
+      result.add((_elementHandle));
     } finally {
-      (_element_handle);
+      (_elementHandle);
     }
-    _foobar_SetOf_UByte_iterator_increment(_iterator_handle);
+    _foobarSetofUbyteIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_UByte_iterator_release_handle(_iterator_handle);
+  _foobarSetofUbyteIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_UByte_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_UByte_release_handle(handle);
-final _foobar_SetOf_UByte_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_UByte_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofUbyteReleaseHandle(handle);
+final _foobar_SetOf_UByteCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_UByte_create_handle_nullable'));
-final _foobar_SetOf_UByte_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_UByteReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_UByte_release_handle_nullable'));
-final _foobar_SetOf_UByte_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_UByteGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_UByte_get_value_nullable'));
 Pointer<Void> foobar_SetOf_UByte_toFfi_nullable(Set<int> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_UByte_toFfi(value);
-  final result = _foobar_SetOf_UByte_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_UByteCreateHandleNullable(_handle);
   foobar_SetOf_UByte_releaseFfiHandle(_handle);
   return result;
 }
 Set<int> foobar_SetOf_UByte_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_UByte_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_UByteGetValueNullable(handle);
   final result = foobar_SetOf_UByte_fromFfi(_handle);
   foobar_SetOf_UByte_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_UByte_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_UByte_release_handle_nullable(handle);
-final _foobar_SetOf_foobar_ListOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_UByteReleaseHandleNullable(handle);
+final _foobarSetofFoobarListofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_foobar_ListOf_Int_create_handle'));
-final _foobar_SetOf_foobar_ListOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarListofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_ListOf_Int_release_handle'));
-final _foobar_SetOf_foobar_ListOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarListofIntInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_SetOf_foobar_ListOf_Int_insert'));
-final _foobar_SetOf_foobar_ListOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarListofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_ListOf_Int_iterator'));
-final _foobar_SetOf_foobar_ListOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarListofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_ListOf_Int_iterator_release_handle'));
-final _foobar_SetOf_foobar_ListOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarListofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_foobar_ListOf_Int_iterator_is_valid'));
-final _foobar_SetOf_foobar_ListOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarListofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_ListOf_Int_iterator_increment'));
-final _foobar_SetOf_foobar_ListOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarListofIntIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_ListOf_Int_iterator_get'));
 Pointer<Void> foobar_SetOf_foobar_ListOf_Int_toFfi(Set<List<int>> value) {
-  final _result = _foobar_SetOf_foobar_ListOf_Int_create_handle();
+  final _result = _foobarSetofFoobarListofIntCreateHandle();
   for (final element in value) {
-    final _element_handle = foobar_ListOf_Int_toFfi(element);
-    _foobar_SetOf_foobar_ListOf_Int_insert(_result, _element_handle);
-    foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+    final _elementHandle = foobar_ListOf_Int_toFfi(element);
+    _foobarSetofFoobarListofIntInsert(_result, _elementHandle);
+    foobar_ListOf_Int_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 Set<List<int>> foobar_SetOf_foobar_ListOf_Int_fromFfi(Pointer<Void> handle) {
   final result = Set<List<int>>();
-  final _iterator_handle = _foobar_SetOf_foobar_ListOf_Int_iterator(handle);
-  while (_foobar_SetOf_foobar_ListOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_foobar_ListOf_Int_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofFoobarListofIntIterator(handle);
+  while (_foobarSetofFoobarListofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofFoobarListofIntIteratorGet(_iteratorHandle);
     try {
-      result.add(foobar_ListOf_Int_fromFfi(_element_handle));
+      result.add(foobar_ListOf_Int_fromFfi(_elementHandle));
     } finally {
-      foobar_ListOf_Int_releaseFfiHandle(_element_handle);
+      foobar_ListOf_Int_releaseFfiHandle(_elementHandle);
     }
-    _foobar_SetOf_foobar_ListOf_Int_iterator_increment(_iterator_handle);
+    _foobarSetofFoobarListofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_foobar_ListOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarSetofFoobarListofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_foobar_ListOf_Int_release_handle(handle);
-final _foobar_SetOf_foobar_ListOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofFoobarListofIntReleaseHandle(handle);
+final _foobar_SetOf_foobar_ListOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_ListOf_Int_create_handle_nullable'));
-final _foobar_SetOf_foobar_ListOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_ListOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_ListOf_Int_release_handle_nullable'));
-final _foobar_SetOf_foobar_ListOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_ListOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_ListOf_Int_get_value_nullable'));
 Pointer<Void> foobar_SetOf_foobar_ListOf_Int_toFfi_nullable(Set<List<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_ListOf_Int_toFfi(value);
-  final result = _foobar_SetOf_foobar_ListOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_foobar_ListOf_IntCreateHandleNullable(_handle);
   foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 Set<List<int>> foobar_SetOf_foobar_ListOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_foobar_ListOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_foobar_ListOf_IntGetValueNullable(handle);
   final result = foobar_SetOf_foobar_ListOf_Int_fromFfi(_handle);
   foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_foobar_ListOf_Int_release_handle_nullable(handle);
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_foobar_ListOf_IntReleaseHandleNullable(handle);
+final _foobarSetofFoobarMapofIntToBooleanCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarMapofIntToBooleanReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarMapofIntToBooleanInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_insert'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarMapofIntToBooleanIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarMapofIntToBooleanIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarMapofIntToBooleanIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarMapofIntToBooleanIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarMapofIntToBooleanIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get'));
 Pointer<Void> foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi(Set<Map<int, bool>> value) {
-  final _result = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle();
+  final _result = _foobarSetofFoobarMapofIntToBooleanCreateHandle();
   for (final element in value) {
-    final _element_handle = foobar_MapOf_Int_to_Boolean_toFfi(element);
-    _foobar_SetOf_foobar_MapOf_Int_to_Boolean_insert(_result, _element_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+    final _elementHandle = foobar_MapOf_Int_to_Boolean_toFfi(element);
+    _foobarSetofFoobarMapofIntToBooleanInsert(_result, _elementHandle);
+    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 Set<Map<int, bool>> foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(Pointer<Void> handle) {
   final result = Set<Map<int, bool>>();
-  final _iterator_handle = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator(handle);
-  while (_foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofFoobarMapofIntToBooleanIterator(handle);
+  while (_foobarSetofFoobarMapofIntToBooleanIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofFoobarMapofIntToBooleanIteratorGet(_iteratorHandle);
     try {
-      result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_element_handle));
+      result.add(foobar_MapOf_Int_to_Boolean_fromFfi(_elementHandle));
     } finally {
-      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_element_handle);
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_elementHandle);
     }
-    _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_increment(_iterator_handle);
+    _foobarSetofFoobarMapofIntToBooleanIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_foobar_MapOf_Int_to_Boolean_iterator_release_handle(_iterator_handle);
+  _foobarSetofFoobarMapofIntToBooleanIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle(handle);
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofFoobarMapofIntToBooleanReleaseHandle(handle);
+final _foobar_SetOf_foobar_MapOf_Int_to_BooleanCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_MapOf_Int_to_BooleanReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable'));
-final _foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_MapOf_Int_to_BooleanGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable'));
 Pointer<Void> foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi_nullable(Set<Map<int, bool>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_MapOf_Int_to_Boolean_toFfi(value);
-  final result = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_foobar_MapOf_Int_to_BooleanCreateHandleNullable(_handle);
   foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 Set<Map<int, bool>> foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_foobar_MapOf_Int_to_Boolean_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_foobar_MapOf_Int_to_BooleanGetValueNullable(handle);
   final result = foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(_handle);
   foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_foobar_MapOf_Int_to_Boolean_release_handle_nullable(handle);
-final _foobar_SetOf_foobar_SetOf_Int_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_foobar_MapOf_Int_to_BooleanReleaseHandleNullable(handle);
+final _foobarSetofFoobarSetofIntCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_foobar_SetOf_Int_create_handle'));
-final _foobar_SetOf_foobar_SetOf_Int_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarSetofIntReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_SetOf_Int_release_handle'));
-final _foobar_SetOf_foobar_SetOf_Int_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarSetofIntInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_SetOf_foobar_SetOf_Int_insert'));
-final _foobar_SetOf_foobar_SetOf_Int_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarSetofIntIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_SetOf_Int_iterator'));
-final _foobar_SetOf_foobar_SetOf_Int_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarSetofIntIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_SetOf_Int_iterator_release_handle'));
-final _foobar_SetOf_foobar_SetOf_Int_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarSetofIntIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_foobar_SetOf_Int_iterator_is_valid'));
-final _foobar_SetOf_foobar_SetOf_Int_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarSetofIntIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_SetOf_Int_iterator_increment'));
-final _foobar_SetOf_foobar_SetOf_Int_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofFoobarSetofIntIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_foobar_SetOf_Int_iterator_get'));
 Pointer<Void> foobar_SetOf_foobar_SetOf_Int_toFfi(Set<Set<int>> value) {
-  final _result = _foobar_SetOf_foobar_SetOf_Int_create_handle();
+  final _result = _foobarSetofFoobarSetofIntCreateHandle();
   for (final element in value) {
-    final _element_handle = foobar_SetOf_Int_toFfi(element);
-    _foobar_SetOf_foobar_SetOf_Int_insert(_result, _element_handle);
-    foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+    final _elementHandle = foobar_SetOf_Int_toFfi(element);
+    _foobarSetofFoobarSetofIntInsert(_result, _elementHandle);
+    foobar_SetOf_Int_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 Set<Set<int>> foobar_SetOf_foobar_SetOf_Int_fromFfi(Pointer<Void> handle) {
   final result = Set<Set<int>>();
-  final _iterator_handle = _foobar_SetOf_foobar_SetOf_Int_iterator(handle);
-  while (_foobar_SetOf_foobar_SetOf_Int_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_foobar_SetOf_Int_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofFoobarSetofIntIterator(handle);
+  while (_foobarSetofFoobarSetofIntIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofFoobarSetofIntIteratorGet(_iteratorHandle);
     try {
-      result.add(foobar_SetOf_Int_fromFfi(_element_handle));
+      result.add(foobar_SetOf_Int_fromFfi(_elementHandle));
     } finally {
-      foobar_SetOf_Int_releaseFfiHandle(_element_handle);
+      foobar_SetOf_Int_releaseFfiHandle(_elementHandle);
     }
-    _foobar_SetOf_foobar_SetOf_Int_iterator_increment(_iterator_handle);
+    _foobarSetofFoobarSetofIntIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_foobar_SetOf_Int_iterator_release_handle(_iterator_handle);
+  _foobarSetofFoobarSetofIntIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_foobar_SetOf_Int_release_handle(handle);
-final _foobar_SetOf_foobar_SetOf_Int_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofFoobarSetofIntReleaseHandle(handle);
+final _foobar_SetOf_foobar_SetOf_IntCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_SetOf_Int_create_handle_nullable'));
-final _foobar_SetOf_foobar_SetOf_Int_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_SetOf_IntReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_SetOf_Int_release_handle_nullable'));
-final _foobar_SetOf_foobar_SetOf_Int_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_foobar_SetOf_IntGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_foobar_SetOf_Int_get_value_nullable'));
 Pointer<Void> foobar_SetOf_foobar_SetOf_Int_toFfi_nullable(Set<Set<int>> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_foobar_SetOf_Int_toFfi(value);
-  final result = _foobar_SetOf_foobar_SetOf_Int_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_foobar_SetOf_IntCreateHandleNullable(_handle);
   foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 Set<Set<int>> foobar_SetOf_foobar_SetOf_Int_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_foobar_SetOf_Int_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_foobar_SetOf_IntGetValueNullable(handle);
   final result = foobar_SetOf_foobar_SetOf_Int_fromFfi(_handle);
   foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_foobar_SetOf_Int_release_handle_nullable(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_foobar_SetOf_IntReleaseHandleNullable(handle);
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(Set<GenericTypesWithCompoundTypes_ExternalEnum> value) {
-  final _result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle();
+  final _result = _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(element);
-    _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_insert(_result, _element_handle);
-    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(element);
+    _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumInsert(_result, _elementHandle);
+    smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 Set<GenericTypesWithCompoundTypes_ExternalEnum> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(Pointer<Void> handle) {
   final result = Set<GenericTypesWithCompoundTypes_ExternalEnum>();
-  final _iterator_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator(handle);
-  while (_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIterator(handle);
+  while (_foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_element_handle));
+      result.add(smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_elementHandle));
     } finally {
-      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_element_handle);
+      smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_elementHandle);
     }
-    _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_increment(_iterator_handle);
+    _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_iterator_release_handle(_iterator_handle);
+  _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumReleaseHandle(handle);
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_ExternalEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
-  final result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable(_handle);
   foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 Set<GenericTypesWithCompoundTypes_ExternalEnum> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable(handle);
   final result = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
   foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable(handle);
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Uint32),
     void Function(Pointer<Void>, int)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(Set<GenericTypesWithCompoundTypes_SomeEnum> value) {
-  final _result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle();
+  final _result = _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumCreateHandle();
   for (final element in value) {
-    final _element_handle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(element);
-    _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_insert(_result, _element_handle);
-    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+    final _elementHandle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(element);
+    _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumInsert(_result, _elementHandle);
+    smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 Set<GenericTypesWithCompoundTypes_SomeEnum> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(Pointer<Void> handle) {
   final result = Set<GenericTypesWithCompoundTypes_SomeEnum>();
-  final _iterator_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator(handle);
-  while (_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_get(_iterator_handle);
+  final _iteratorHandle = _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIterator(handle);
+  while (_foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorGet(_iteratorHandle);
     try {
-      result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_element_handle));
+      result.add(smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_elementHandle));
     } finally {
-      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_element_handle);
+      smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_elementHandle);
     }
-    _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_increment(_iterator_handle);
+    _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorIncrement(_iteratorHandle);
   }
-  _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_iterator_release_handle(_iterator_handle);
+  _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle(handle);
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(Pointer<Void> handle) => _foobarSetofSmokeGenerictypeswithcompoundtypesSomeenumReleaseHandle(handle);
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
-final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(Set<GenericTypesWithCompoundTypes_SomeEnum> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
-  final result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
+  final result = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable(_handle);
   foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 Set<GenericTypesWithCompoundTypes_SomeEnum> foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
+  final _handle = _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable(handle);
   final result = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);
   foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(handle);
+  _foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithBasicTypes {
@@ -32,89 +31,89 @@ class GenericTypesWithBasicTypes_StructWithGenerics {
   GenericTypesWithBasicTypes_StructWithGenerics(this.numbersList, this.numbersMap, this.numbersSet);
 }
 // GenericTypesWithBasicTypes_StructWithGenerics "private" section, not exported.
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithbasictypesStructwithgenericsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle'));
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithbasictypesStructwithgenericsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle'));
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersList = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList'));
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersMap = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap'));
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersSet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet'));
 Pointer<Void> smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi(GenericTypesWithBasicTypes_StructWithGenerics value) {
-  final _numbersList_handle = foobar_ListOf_UByte_toFfi(value.numbersList);
-  final _numbersMap_handle = foobar_MapOf_UByte_to_String_toFfi(value.numbersMap);
-  final _numbersSet_handle = foobar_SetOf_UByte_toFfi(value.numbersSet);
-  final _result = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle(_numbersList_handle, _numbersMap_handle, _numbersSet_handle);
-  foobar_ListOf_UByte_releaseFfiHandle(_numbersList_handle);
-  foobar_MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
-  foobar_SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
+  final _numbersListHandle = foobar_ListOf_UByte_toFfi(value.numbersList);
+  final _numbersMapHandle = foobar_MapOf_UByte_to_String_toFfi(value.numbersMap);
+  final _numbersSetHandle = foobar_SetOf_UByte_toFfi(value.numbersSet);
+  final _result = _smokeGenerictypeswithbasictypesStructwithgenericsCreateHandle(_numbersListHandle, _numbersMapHandle, _numbersSetHandle);
+  foobar_ListOf_UByte_releaseFfiHandle(_numbersListHandle);
+  foobar_MapOf_UByte_to_String_releaseFfiHandle(_numbersMapHandle);
+  foobar_SetOf_UByte_releaseFfiHandle(_numbersSetHandle);
   return _result;
 }
 GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_StructWithGenerics_fromFfi(Pointer<Void> handle) {
-  final _numbersList_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersList(handle);
-  final _numbersMap_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersMap(handle);
-  final _numbersSet_handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet(handle);
+  final _numbersListHandle = _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersList(handle);
+  final _numbersMapHandle = _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersMap(handle);
+  final _numbersSetHandle = _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersSet(handle);
   try {
     return GenericTypesWithBasicTypes_StructWithGenerics(
-      foobar_ListOf_UByte_fromFfi(_numbersList_handle),
-      foobar_MapOf_UByte_to_String_fromFfi(_numbersMap_handle),
-      foobar_SetOf_UByte_fromFfi(_numbersSet_handle)
+      foobar_ListOf_UByte_fromFfi(_numbersListHandle),
+      foobar_MapOf_UByte_to_String_fromFfi(_numbersMapHandle),
+      foobar_SetOf_UByte_fromFfi(_numbersSetHandle)
     );
   } finally {
-    foobar_ListOf_UByte_releaseFfiHandle(_numbersList_handle);
-    foobar_MapOf_UByte_to_String_releaseFfiHandle(_numbersMap_handle);
-    foobar_SetOf_UByte_releaseFfiHandle(_numbersSet_handle);
+    foobar_ListOf_UByte_releaseFfiHandle(_numbersListHandle);
+    foobar_MapOf_UByte_to_String_releaseFfiHandle(_numbersMapHandle);
+    foobar_SetOf_UByte_releaseFfiHandle(_numbersSetHandle);
   }
 }
-void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle(handle);
+void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(Pointer<Void> handle) => _smokeGenerictypeswithbasictypesStructwithgenericsReleaseHandle(handle);
 // Nullable GenericTypesWithBasicTypes_StructWithGenerics
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithBasicTypes_StructWithGenericsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable'));
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithBasicTypes_StructWithGenericsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable'));
-final _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithBasicTypes_StructWithGenericsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi_nullable(GenericTypesWithBasicTypes_StructWithGenerics value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithBasicTypes_StructWithGenerics_toFfi(value);
-  final result = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_create_handle_nullable(_handle);
+  final result = _smoke_GenericTypesWithBasicTypes_StructWithGenericsCreateHandleNullable(_handle);
   smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(_handle);
   return result;
 }
 GenericTypesWithBasicTypes_StructWithGenerics smoke_GenericTypesWithBasicTypes_StructWithGenerics_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable(handle);
+  final _handle = _smoke_GenericTypesWithBasicTypes_StructWithGenericsGetValueNullable(handle);
   final result = smoke_GenericTypesWithBasicTypes_StructWithGenerics_fromFfi(_handle);
   smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_GenericTypesWithBasicTypes_StructWithGenerics_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithBasicTypes_StructWithGenerics_release_handle_nullable(handle);
+  _smoke_GenericTypesWithBasicTypes_StructWithGenericsReleaseHandleNullable(handle);
 // End of GenericTypesWithBasicTypes_StructWithGenerics "private" section.
 // GenericTypesWithBasicTypes "private" section, not exported.
-final _smoke_GenericTypesWithBasicTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithbasictypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_copy_handle'));
-final _smoke_GenericTypesWithBasicTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithbasictypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_release_handle'));
@@ -124,179 +123,179 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_GenericTypesWithBasicTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeGenerictypeswithbasictypesReleaseHandle(handle);
     handle = null;
   }
   @override
   List<int> methodWithList(List<int> input) {
-    final _methodWithList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int'));
-    final _input_handle = foobar_ListOf_Int_toFfi(input);
+    final _methodWithListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_1Int'));
+    final _inputHandle = foobar_ListOf_Int_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_Int_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithListFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_Int_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_ListOf_Int_fromFfi(__result_handle);
+      return foobar_ListOf_Int_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+      foobar_ListOf_Int_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<int, bool> methodWithMap(Map<int, bool> input) {
-    final _methodWithMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean'));
-    final _input_handle = foobar_MapOf_Int_to_Boolean_toFfi(input);
+    final _methodWithMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_1Int_1to_1Boolean'));
+    final _inputHandle = foobar_MapOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithMapFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_Int_to_Boolean_fromFfi(__result_handle);
+      return foobar_MapOf_Int_to_Boolean_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+      foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Set<int> methodWithSet(Set<int> input) {
-    final _methodWithSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int'));
-    final _input_handle = foobar_SetOf_Int_toFfi(input);
+    final _methodWithSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_1Int'));
+    final _inputHandle = foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_SetOf_Int_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithSetFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_SetOf_Int_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_SetOf_Int_fromFfi(__result_handle);
+      return foobar_SetOf_Int_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_Int_releaseFfiHandle(__result_handle);
+      foobar_SetOf_Int_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   List<String> methodWithListTypeAlias(List<String> input) {
-    final _methodWithListTypeAlias_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String'));
-    final _input_handle = foobar_ListOf_String_toFfi(input);
+    final _methodWithListTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_1String'));
+    final _inputHandle = foobar_ListOf_String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithListTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithListTypeAliasFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_String_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_ListOf_String_fromFfi(__result_handle);
+      return foobar_ListOf_String_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_String_releaseFfiHandle(__result_handle);
+      foobar_ListOf_String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
-    final _methodWithMapTypeAlias_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String'));
-    final _input_handle = foobar_MapOf_String_to_String_toFfi(input);
+    final _methodWithMapTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_1String_1to_1String'));
+    final _inputHandle = foobar_MapOf_String_to_String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithMapTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_String_to_String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithMapTypeAliasFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_String_to_String_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_String_to_String_fromFfi(__result_handle);
+      return foobar_MapOf_String_to_String_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_String_to_String_releaseFfiHandle(__result_handle);
+      foobar_MapOf_String_to_String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Set<String> methodWithSetTypeAlias(Set<String> input) {
-    final _methodWithSetTypeAlias_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String'));
-    final _input_handle = foobar_SetOf_String_toFfi(input);
+    final _methodWithSetTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_1String'));
+    final _inputHandle = foobar_SetOf_String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithSetTypeAlias_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_SetOf_String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithSetTypeAliasFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_SetOf_String_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_SetOf_String_fromFfi(__result_handle);
+      return foobar_SetOf_String_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_String_releaseFfiHandle(__result_handle);
+      foobar_SetOf_String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   List<double> get listProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_ListOf_Float_fromFfi(__result_handle);
+      return foobar_ListOf_Float_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_Float_releaseFfiHandle(__result_handle);
+      foobar_ListOf_Float_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set listProperty(List<double> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float'));
-    final _value_handle = foobar_ListOf_Float_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float'));
+    final _valueHandle = foobar_ListOf_Float_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_ListOf_Float_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_ListOf_Float_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Map<double, double> get mapProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_MapOf_Float_to_Double_fromFfi(__result_handle);
+      return foobar_MapOf_Float_to_Double_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_Float_to_Double_releaseFfiHandle(__result_handle);
+      foobar_MapOf_Float_to_Double_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set mapProperty(Map<double, double> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double'));
-    final _value_handle = foobar_MapOf_Float_to_Double_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double'));
+    final _valueHandle = foobar_MapOf_Float_to_Double_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_MapOf_Float_to_Double_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_MapOf_Float_to_Double_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Set<double> get setProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_SetOf_Float_fromFfi(__result_handle);
+      return foobar_SetOf_Float_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_Float_releaseFfiHandle(__result_handle);
+      foobar_SetOf_Float_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set setProperty(Set<double> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float'));
-    final _value_handle = foobar_SetOf_Float_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float'));
+    final _valueHandle = foobar_SetOf_Float_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_SetOf_Float_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_SetOf_Float_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi(GenericTypesWithBasicTypes value) =>
-  _smoke_GenericTypesWithBasicTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeGenerictypeswithbasictypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as GenericTypesWithBasicTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_GenericTypesWithBasicTypes_copy_handle(handle);
-  final result = GenericTypesWithBasicTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeGenerictypeswithbasictypesCopyHandle(handle);
+  final result = GenericTypesWithBasicTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_GenericTypesWithBasicTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithBasicTypes_release_handle(handle);
+  _smokeGenerictypeswithbasictypesReleaseHandle(handle);
 Pointer<Void> smoke_GenericTypesWithBasicTypes_toFfi_nullable(GenericTypesWithBasicTypes value) =>
   value != null ? smoke_GenericTypesWithBasicTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 GenericTypesWithBasicTypes smoke_GenericTypesWithBasicTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_GenericTypesWithBasicTypes_fromFfi(handle) : null;
 void smoke_GenericTypesWithBasicTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithBasicTypes_release_handle(handle);
+  _smokeGenerictypeswithbasictypesReleaseHandle(handle);
 // End of GenericTypesWithBasicTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -5,7 +5,6 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/dummy_class.dart';
 import 'package:library/src/smoke/dummy_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithCompoundTypes {
@@ -53,34 +52,34 @@ GenericTypesWithCompoundTypes_SomeEnum smoke_GenericTypesWithCompoundTypes_SomeE
   }
 }
 void smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi_nullable(GenericTypesWithCompoundTypes_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(value);
-  final result = _smoke_GenericTypesWithCompoundTypes_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_GenericTypesWithCompoundTypes_SomeEnumCreateHandleNullable(_handle);
   smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 GenericTypesWithCompoundTypes_SomeEnum smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_GenericTypesWithCompoundTypes_SomeEnumGetValueNullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_SomeEnum_fromFfi(_handle);
   smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_SomeEnum_release_handle_nullable(handle);
+  _smoke_GenericTypesWithCompoundTypes_SomeEnumReleaseHandleNullable(handle);
 // End of GenericTypesWithCompoundTypes_SomeEnum "private" section.
 enum GenericTypesWithCompoundTypes_ExternalEnum {
     on,
@@ -112,169 +111,169 @@ GenericTypesWithCompoundTypes_ExternalEnum smoke_GenericTypesWithCompoundTypes_E
   }
 }
 void smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_ExternalEnum_toFfi(value);
-  final result = _smoke_GenericTypesWithCompoundTypes_ExternalEnum_create_handle_nullable(_handle);
+  final result = _smoke_GenericTypesWithCompoundTypes_ExternalEnumCreateHandleNullable(_handle);
   smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 GenericTypesWithCompoundTypes_ExternalEnum smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable(handle);
+  final _handle = _smoke_GenericTypesWithCompoundTypes_ExternalEnumGetValueNullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(_handle);
   smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_ExternalEnum_release_handle_nullable(handle);
+  _smoke_GenericTypesWithCompoundTypes_ExternalEnumReleaseHandleNullable(handle);
 // End of GenericTypesWithCompoundTypes_ExternalEnum "private" section.
 class GenericTypesWithCompoundTypes_BasicStruct {
   double value;
   GenericTypesWithCompoundTypes_BasicStruct(this.value);
 }
 // GenericTypesWithCompoundTypes_BasicStruct "private" section, not exported.
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesBasicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle'));
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesBasicstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle'));
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesBasicstructGetFieldvalue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(GenericTypesWithCompoundTypes_BasicStruct value) {
-  final _value_handle = (value.value);
-  final _result = _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle(_value_handle);
-  (_value_handle);
+  final _valueHandle = (value.value);
+  final _result = _smokeGenerictypeswithcompoundtypesBasicstructCreateHandle(_valueHandle);
+  (_valueHandle);
   return _result;
 }
 GenericTypesWithCompoundTypes_BasicStruct smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(Pointer<Void> handle) {
-  final _value_handle = _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value(handle);
+  final _valueHandle = _smokeGenerictypeswithcompoundtypesBasicstructGetFieldvalue(handle);
   try {
     return GenericTypesWithCompoundTypes_BasicStruct(
-      (_value_handle)
+      (_valueHandle)
     );
   } finally {
-    (_value_handle);
+    (_valueHandle);
   }
 }
-void smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle(handle);
+void smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeGenerictypeswithcompoundtypesBasicstructReleaseHandle(handle);
 // Nullable GenericTypesWithCompoundTypes_BasicStruct
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_BasicStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_BasicStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_BasicStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi_nullable(GenericTypesWithCompoundTypes_BasicStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(value);
-  final result = _smoke_GenericTypesWithCompoundTypes_BasicStruct_create_handle_nullable(_handle);
+  final result = _smoke_GenericTypesWithCompoundTypes_BasicStructCreateHandleNullable(_handle);
   smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 GenericTypesWithCompoundTypes_BasicStruct smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable(handle);
+  final _handle = _smoke_GenericTypesWithCompoundTypes_BasicStructGetValueNullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_BasicStruct_fromFfi(_handle);
   smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_BasicStruct_release_handle_nullable(handle);
+  _smoke_GenericTypesWithCompoundTypes_BasicStructReleaseHandleNullable(handle);
 // End of GenericTypesWithCompoundTypes_BasicStruct "private" section.
 class GenericTypesWithCompoundTypes_ExternalStruct {
   String string;
   GenericTypesWithCompoundTypes_ExternalStruct(this.string);
 }
 // GenericTypesWithCompoundTypes_ExternalStruct "private" section, not exported.
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesExternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle'));
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesExternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle'));
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesExternalstructGetFieldstring = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(GenericTypesWithCompoundTypes_ExternalStruct value) {
-  final _string_handle = String_toFfi(value.string);
-  final _result = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle(_string_handle);
-  String_releaseFfiHandle(_string_handle);
+  final _stringHandle = String_toFfi(value.string);
+  final _result = _smokeGenerictypeswithcompoundtypesExternalstructCreateHandle(_stringHandle);
+  String_releaseFfiHandle(_stringHandle);
   return _result;
 }
 GenericTypesWithCompoundTypes_ExternalStruct smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(Pointer<Void> handle) {
-  final _string_handle = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string(handle);
+  final _stringHandle = _smokeGenerictypeswithcompoundtypesExternalstructGetFieldstring(handle);
   try {
     return GenericTypesWithCompoundTypes_ExternalStruct(
-      String_fromFfi(_string_handle)
+      String_fromFfi(_stringHandle)
     );
   } finally {
-    String_releaseFfiHandle(_string_handle);
+    String_releaseFfiHandle(_stringHandle);
   }
 }
-void smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle(handle);
+void smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeGenerictypeswithcompoundtypesExternalstructReleaseHandle(handle);
 // Nullable GenericTypesWithCompoundTypes_ExternalStruct
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable'));
-final _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_GenericTypesWithCompoundTypes_ExternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi_nullable(GenericTypesWithCompoundTypes_ExternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_GenericTypesWithCompoundTypes_ExternalStruct_toFfi(value);
-  final result = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_create_handle_nullable(_handle);
+  final result = _smoke_GenericTypesWithCompoundTypes_ExternalStructCreateHandleNullable(_handle);
   smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 GenericTypesWithCompoundTypes_ExternalStruct smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable(handle);
+  final _handle = _smoke_GenericTypesWithCompoundTypes_ExternalStructGetValueNullable(handle);
   final result = smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(_handle);
   smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_ExternalStruct_release_handle_nullable(handle);
+  _smoke_GenericTypesWithCompoundTypes_ExternalStructReleaseHandleNullable(handle);
 // End of GenericTypesWithCompoundTypes_ExternalStruct "private" section.
 // GenericTypesWithCompoundTypes "private" section, not exported.
-final _smoke_GenericTypesWithCompoundTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_copy_handle'));
-final _smoke_GenericTypesWithCompoundTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithcompoundtypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_release_handle'));
@@ -284,133 +283,133 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeGenerictypeswithcompoundtypesReleaseHandle(handle);
     handle = null;
   }
   @override
   List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input) {
-    final _methodWithStructList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct'));
-    final _input_handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
+    final _methodWithStructListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct'));
+    final _inputHandle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithStructList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithStructListFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+      return foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+      foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
-    final _methodWithStructMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct'));
-    final _input_handle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
+    final _methodWithStructMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_1String_1to_1smoke_1GenericTypesWithCompoundTypes_1BasicStruct'));
+    final _inputHandle = foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithStructMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithStructMapFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__result_handle);
+      return foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__result_handle);
+      foobar_MapOf_String_to_smoke_GenericTypesWithCompoundTypes_ExternalStruct_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
-    final _input_handle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _methodWithEnumListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
+    final _inputHandle = foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithEnumList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithEnumListFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+      return foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+      foobar_ListOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
-    final _methodWithEnumMapKey_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean'));
-    final _input_handle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
+    final _methodWithEnumMapKeyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum_1to_1Boolean'));
+    final _inputHandle = foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithEnumMapKey_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithEnumMapKeyFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__result_handle);
+      return foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__result_handle);
+      foobar_MapOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_to_Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumMapValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
-    final _input_handle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _methodWithEnumMapValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_1Int_1to_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
+    final _inputHandle = foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithEnumMapValue_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithEnumMapValueFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+      return foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+      foobar_MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
-    final _methodWithEnumSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
-    final _input_handle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
+    final _methodWithEnumSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_1smoke_1GenericTypesWithCompoundTypes_1SomeEnum'));
+    final _inputHandle = foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithEnumSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithEnumSetFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__result_handle);
+      return foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__result_handle);
+      foobar_SetOf_smoke_GenericTypesWithCompoundTypes_ExternalEnum_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
-    final _methodWithInstancesList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass'));
-    final _input_handle = foobar_ListOf_smoke_DummyClass_toFfi(input);
+    final _methodWithInstancesListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_1smoke_1DummyClass'));
+    final _inputHandle = foobar_ListOf_smoke_DummyClass_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithInstancesList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_smoke_DummyClass_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithInstancesListFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_smoke_DummyClass_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_ListOf_smoke_DummyInterface_fromFfi(__result_handle);
+      return foobar_ListOf_smoke_DummyInterface_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+      foobar_ListOf_smoke_DummyInterface_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
-    final _methodWithInstancesMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass'));
-    final _input_handle = foobar_MapOf_Int_to_smoke_DummyClass_toFfi(input);
+    final _methodWithInstancesMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_1Int_1to_1smoke_1DummyClass'));
+    final _inputHandle = foobar_MapOf_Int_to_smoke_DummyClass_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithInstancesMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithInstancesMapFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_Int_to_smoke_DummyClass_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(__result_handle);
+      return foobar_MapOf_Int_to_smoke_DummyInterface_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__result_handle);
+      foobar_MapOf_Int_to_smoke_DummyInterface_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi(GenericTypesWithCompoundTypes value) =>
-  _smoke_GenericTypesWithCompoundTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeGenerictypeswithcompoundtypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as GenericTypesWithCompoundTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_GenericTypesWithCompoundTypes_copy_handle(handle);
-  final result = GenericTypesWithCompoundTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeGenerictypeswithcompoundtypesCopyHandle(handle);
+  final result = GenericTypesWithCompoundTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
+  _smokeGenerictypeswithcompoundtypesReleaseHandle(handle);
 Pointer<Void> smoke_GenericTypesWithCompoundTypes_toFfi_nullable(GenericTypesWithCompoundTypes value) =>
   value != null ? smoke_GenericTypesWithCompoundTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 GenericTypesWithCompoundTypes smoke_GenericTypesWithCompoundTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_GenericTypesWithCompoundTypes_fromFfi(handle) : null;
 void smoke_GenericTypesWithCompoundTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithCompoundTypes_release_handle(handle);
+  _smokeGenerictypeswithcompoundtypesReleaseHandle(handle);
 // End of GenericTypesWithCompoundTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithGenericTypes {
@@ -21,11 +20,11 @@ abstract class GenericTypesWithGenericTypes {
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input);
 }
 // GenericTypesWithGenericTypes "private" section, not exported.
-final _smoke_GenericTypesWithGenericTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithgenerictypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithGenericTypes_copy_handle'));
-final _smoke_GenericTypesWithGenericTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeGenerictypeswithgenerictypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithGenericTypes_release_handle'));
@@ -35,120 +34,120 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_GenericTypesWithGenericTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeGenerictypeswithgenerictypesReleaseHandle(handle);
     handle = null;
   }
   @override
   List<List<int>> methodWithListOfLists(List<List<int>> input) {
-    final _methodWithListOfLists_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1foobar_1ListOf_1Int'));
-    final _input_handle = foobar_ListOf_foobar_ListOf_Int_toFfi(input);
+    final _methodWithListOfListsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_1foobar_1ListOf_1Int'));
+    final _inputHandle = foobar_ListOf_foobar_ListOf_Int_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithListOfLists_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithListOfListsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_ListOf_foobar_ListOf_Int_fromFfi(__result_handle);
+      return foobar_ListOf_foobar_ListOf_Int_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+      foobar_ListOf_foobar_ListOf_Int_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input) {
-    final _methodWithMapOfMaps_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1foobar_1MapOf_1Int_1to_1Boolean'));
-    final _input_handle = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(input);
+    final _methodWithMapOfMapsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_1Int_1to_1foobar_1MapOf_1Int_1to_1Boolean'));
+    final _inputHandle = foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithMapOfMaps_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithMapOfMapsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_Int_to_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__result_handle);
+      return foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__result_handle);
+      foobar_MapOf_foobar_MapOf_Int_to_Boolean_to_Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input) {
-    final _methodWithSetOfSets_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1foobar_1SetOf_1Int'));
-    final _input_handle = foobar_SetOf_foobar_SetOf_Int_toFfi(input);
+    final _methodWithSetOfSetsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_1foobar_1SetOf_1Int'));
+    final _inputHandle = foobar_SetOf_foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithSetOfSets_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithSetOfSetsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_SetOf_foobar_SetOf_Int_fromFfi(__result_handle);
+      return foobar_SetOf_foobar_SetOf_Int_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(__result_handle);
+      foobar_SetOf_foobar_SetOf_Int_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input) {
-    final _methodWithListAndMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1foobar_1MapOf_1Int_1to_1Boolean'));
-    final _input_handle = foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(input);
+    final _methodWithListAndMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_1foobar_1MapOf_1Int_1to_1Boolean'));
+    final _inputHandle = foobar_ListOf_foobar_MapOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithListAndMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithListAndMapFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(__result_handle);
+      return foobar_MapOf_Int_to_foobar_ListOf_Int_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+      foobar_MapOf_Int_to_foobar_ListOf_Int_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Set<List<int>> methodWithListAndSet(List<Set<int>> input) {
-    final _methodWithListAndSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1foobar_1SetOf_1Int'));
-    final _input_handle = foobar_ListOf_foobar_SetOf_Int_toFfi(input);
+    final _methodWithListAndSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_1foobar_1SetOf_1Int'));
+    final _inputHandle = foobar_ListOf_foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithListAndSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithListAndSetFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_foobar_SetOf_Int_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_SetOf_foobar_ListOf_Int_fromFfi(__result_handle);
+      return foobar_SetOf_foobar_ListOf_Int_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(__result_handle);
+      foobar_SetOf_foobar_ListOf_Int_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input) {
-    final _methodWithMapAndSet_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1foobar_1SetOf_1Int'));
-    final _input_handle = foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(input);
+    final _methodWithMapAndSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_1Int_1to_1foobar_1SetOf_1Int'));
+    final _inputHandle = foobar_MapOf_Int_to_foobar_SetOf_Int_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithMapAndSet_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithMapAndSetFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_Int_to_foobar_SetOf_Int_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(__result_handle);
+      return foobar_SetOf_foobar_MapOf_Int_to_Boolean_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+      foobar_SetOf_foobar_MapOf_Int_to_Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input) {
-    final _methodWithMapGenericKeys_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1foobar_1SetOf_1Int_1to_1Boolean'));
-    final _input_handle = foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(input);
+    final _methodWithMapGenericKeysFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_1foobar_1SetOf_1Int_1to_1Boolean'));
+    final _inputHandle = foobar_MapOf_foobar_SetOf_Int_to_Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithMapGenericKeys_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _methodWithMapGenericKeysFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_foobar_SetOf_Int_to_Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(__result_handle);
+      return foobar_MapOf_foobar_ListOf_Int_to_Boolean_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(__result_handle);
+      foobar_MapOf_foobar_ListOf_Int_to_Boolean_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi(GenericTypesWithGenericTypes value) =>
-  _smoke_GenericTypesWithGenericTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeGenerictypeswithgenerictypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as GenericTypesWithGenericTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_GenericTypesWithGenericTypes_copy_handle(handle);
-  final result = GenericTypesWithGenericTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeGenerictypeswithgenerictypesCopyHandle(handle);
+  final result = GenericTypesWithGenericTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_GenericTypesWithGenericTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithGenericTypes_release_handle(handle);
+  _smokeGenerictypeswithgenerictypesReleaseHandle(handle);
 Pointer<Void> smoke_GenericTypesWithGenericTypes_toFfi_nullable(GenericTypesWithGenericTypes value) =>
   value != null ? smoke_GenericTypesWithGenericTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 GenericTypesWithGenericTypes smoke_GenericTypesWithGenericTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_GenericTypesWithGenericTypes_fromFfi(handle) : null;
 void smoke_GenericTypesWithGenericTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_GenericTypesWithGenericTypes_release_handle(handle);
+  _smokeGenerictypeswithgenerictypesReleaseHandle(handle);
 // End of GenericTypesWithGenericTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -5,7 +5,6 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseOptimizedList {
@@ -18,11 +17,11 @@ abstract class UseOptimizedList {
   static List<UnreasonablyLazyClass> get lazyOnes => UseOptimizedList$Impl.lazyOnes;
 }
 // UseOptimizedList "private" section, not exported.
-final _smoke_UseOptimizedList_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUseoptimizedlistCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseOptimizedList_copy_handle'));
-final _smoke_UseOptimizedList_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUseoptimizedlistReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseOptimizedList_release_handle'));
@@ -56,59 +55,59 @@ class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_UseOptimizedList_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeUseoptimizedlistReleaseHandle(handle);
     handle = null;
   }
   static List<VeryBigStruct> fetchTheBigOnes() {
-    final _fetchTheBigOnes_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_UseOptimizedList_fetchTheBigOnes'));
-    final __result_handle = _fetchTheBigOnes_ffi(__lib.LibraryContext.isolateId);
+    final _fetchTheBigOnesFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_UseOptimizedList_fetchTheBigOnes'));
+    final __resultHandle = _fetchTheBigOnesFfi(__lib.LibraryContext.isolateId);
     return __lib.LazyList(
-        __result_handle,
-        _smoke_UseOptimizedList_smoke_VeryBigStructLazyList_get_size(__result_handle),
+        __resultHandle,
+        _smoke_UseOptimizedList_smoke_VeryBigStructLazyList_get_size(__resultHandle),
         (index) {
-          final __element_handle = _smoke_UseOptimizedList_smoke_VeryBigStructLazyList_get(__result_handle, index);
-          final __element_result = smoke_VeryBigStruct_fromFfi(__element_handle);
-          smoke_VeryBigStruct_releaseFfiHandle(__element_handle);
-          return __element_result;
+          final __elementHandle = _smoke_UseOptimizedList_smoke_VeryBigStructLazyList_get(__resultHandle, index);
+          final __elementResult = smoke_VeryBigStruct_fromFfi(__elementHandle);
+          smoke_VeryBigStruct_releaseFfiHandle(__elementHandle);
+          return __elementResult;
         },
-        () => _smoke_UseOptimizedList_smoke_VeryBigStructLazyList_release_handle(__result_handle)
+        () => _smoke_UseOptimizedList_smoke_VeryBigStructLazyList_release_handle(__resultHandle)
       );
   }
   static List<UnreasonablyLazyClass> get lazyOnes {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_UseOptimizedList_lazyOnes_get'));
-    final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_UseOptimizedList_lazyOnes_get'));
+    final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
     return __lib.LazyList(
-        __result_handle,
-        _smoke_UseOptimizedList_smoke_UnreasonablyLazyClassLazyList_get_size(__result_handle),
+        __resultHandle,
+        _smoke_UseOptimizedList_smoke_UnreasonablyLazyClassLazyList_get_size(__resultHandle),
         (index) {
-          final __element_handle = _smoke_UseOptimizedList_smoke_UnreasonablyLazyClassLazyList_get(__result_handle, index);
-          final __element_result = smoke_UnreasonablyLazyClass_fromFfi(__element_handle);
-          smoke_UnreasonablyLazyClass_releaseFfiHandle(__element_handle);
-          return __element_result;
+          final __elementHandle = _smoke_UseOptimizedList_smoke_UnreasonablyLazyClassLazyList_get(__resultHandle, index);
+          final __elementResult = smoke_UnreasonablyLazyClass_fromFfi(__elementHandle);
+          smoke_UnreasonablyLazyClass_releaseFfiHandle(__elementHandle);
+          return __elementResult;
         },
-        () => _smoke_UseOptimizedList_smoke_UnreasonablyLazyClassLazyList_release_handle(__result_handle)
+        () => _smoke_UseOptimizedList_smoke_UnreasonablyLazyClassLazyList_release_handle(__resultHandle)
       );
   }
 }
 Pointer<Void> smoke_UseOptimizedList_toFfi(UseOptimizedList value) =>
-  _smoke_UseOptimizedList_copy_handle((value as __lib.NativeBase).handle);
+  _smokeUseoptimizedlistCopyHandle((value as __lib.NativeBase).handle);
 UseOptimizedList smoke_UseOptimizedList_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as UseOptimizedList;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_UseOptimizedList_copy_handle(handle);
-  final result = UseOptimizedList$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeUseoptimizedlistCopyHandle(handle);
+  final result = UseOptimizedList$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_UseOptimizedList_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_UseOptimizedList_release_handle(handle);
+  _smokeUseoptimizedlistReleaseHandle(handle);
 Pointer<Void> smoke_UseOptimizedList_toFfi_nullable(UseOptimizedList value) =>
   value != null ? smoke_UseOptimizedList_toFfi(value) : Pointer<Void>.fromAddress(0);
 UseOptimizedList smoke_UseOptimizedList_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UseOptimizedList_fromFfi(handle) : null;
 void smoke_UseOptimizedList_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_UseOptimizedList_release_handle(handle);
+  _smokeUseoptimizedlistReleaseHandle(handle);
 // End of UseOptimizedList "private" section.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
@@ -3,7 +3,6 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @immutable
@@ -13,19 +12,19 @@ class UseOptimizedListStruct {
   const UseOptimizedListStruct(this.structs, this.classes);
 }
 // UseOptimizedListStruct "private" section, not exported.
-final _smoke_UseOptimizedListStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUseoptimizedliststructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_create_handle'));
-final _smoke_UseOptimizedListStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUseoptimizedliststructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_release_handle'));
-final _smoke_UseOptimizedListStruct_get_field_structs = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUseoptimizedliststructGetFieldstructs = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_get_field_structs'));
-final _smoke_UseOptimizedListStruct_get_field_classes = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUseoptimizedliststructGetFieldclasses = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_get_field_classes'));
@@ -54,70 +53,70 @@ final _smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_release_
     void Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_release_handle'));
 Pointer<Void> smoke_UseOptimizedListStruct_toFfi(UseOptimizedListStruct value) {
-  final _structs_handle = (value.structs as __lib.LazyList).handle;
-  final _classes_handle = (value.classes as __lib.LazyList).handle;
-  final _result = _smoke_UseOptimizedListStruct_create_handle(_structs_handle, _classes_handle);
+  final _structsHandle = (value.structs as __lib.LazyList).handle;
+  final _classesHandle = (value.classes as __lib.LazyList).handle;
+  final _result = _smokeUseoptimizedliststructCreateHandle(_structsHandle, _classesHandle);
   return _result;
 }
 UseOptimizedListStruct smoke_UseOptimizedListStruct_fromFfi(Pointer<Void> handle) {
-  final _structs_handle = _smoke_UseOptimizedListStruct_get_field_structs(handle);
-  final _classes_handle = _smoke_UseOptimizedListStruct_get_field_classes(handle);
+  final _structsHandle = _smokeUseoptimizedliststructGetFieldstructs(handle);
+  final _classesHandle = _smokeUseoptimizedliststructGetFieldclasses(handle);
   try {
     return UseOptimizedListStruct(
       __lib.LazyList(
-        _structs_handle,
-        _smoke_UseOptimizedListStruct_smoke_VeryBigStructLazyList_get_size(_structs_handle),
+        _structsHandle,
+        _smoke_UseOptimizedListStruct_smoke_VeryBigStructLazyList_get_size(_structsHandle),
         (index) {
-          final __element_handle = _smoke_UseOptimizedListStruct_smoke_VeryBigStructLazyList_get(_structs_handle, index);
-          final __element_result = smoke_VeryBigStruct_fromFfi(__element_handle);
-          smoke_VeryBigStruct_releaseFfiHandle(__element_handle);
-          return __element_result;
+          final __elementHandle = _smoke_UseOptimizedListStruct_smoke_VeryBigStructLazyList_get(_structsHandle, index);
+          final __elementResult = smoke_VeryBigStruct_fromFfi(__elementHandle);
+          smoke_VeryBigStruct_releaseFfiHandle(__elementHandle);
+          return __elementResult;
         },
-        () => _smoke_UseOptimizedListStruct_smoke_VeryBigStructLazyList_release_handle(_structs_handle)
+        () => _smoke_UseOptimizedListStruct_smoke_VeryBigStructLazyList_release_handle(_structsHandle)
       ),
       __lib.LazyList(
-        _classes_handle,
-        _smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_get_size(_classes_handle),
+        _classesHandle,
+        _smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_get_size(_classesHandle),
         (index) {
-          final __element_handle = _smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_get(_classes_handle, index);
-          final __element_result = smoke_UnreasonablyLazyClass_fromFfi(__element_handle);
-          smoke_UnreasonablyLazyClass_releaseFfiHandle(__element_handle);
-          return __element_result;
+          final __elementHandle = _smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_get(_classesHandle, index);
+          final __elementResult = smoke_UnreasonablyLazyClass_fromFfi(__elementHandle);
+          smoke_UnreasonablyLazyClass_releaseFfiHandle(__elementHandle);
+          return __elementResult;
         },
-        () => _smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_release_handle(_classes_handle)
+        () => _smoke_UseOptimizedListStruct_smoke_UnreasonablyLazyClassLazyList_release_handle(_classesHandle)
       )
     );
   } finally {
   }
 }
-void smoke_UseOptimizedListStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_UseOptimizedListStruct_release_handle(handle);
+void smoke_UseOptimizedListStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeUseoptimizedliststructReleaseHandle(handle);
 // Nullable UseOptimizedListStruct
-final _smoke_UseOptimizedListStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_UseOptimizedListStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_create_handle_nullable'));
-final _smoke_UseOptimizedListStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_UseOptimizedListStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_release_handle_nullable'));
-final _smoke_UseOptimizedListStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_UseOptimizedListStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseOptimizedListStruct_get_value_nullable'));
 Pointer<Void> smoke_UseOptimizedListStruct_toFfi_nullable(UseOptimizedListStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_UseOptimizedListStruct_toFfi(value);
-  final result = _smoke_UseOptimizedListStruct_create_handle_nullable(_handle);
+  final result = _smoke_UseOptimizedListStructCreateHandleNullable(_handle);
   smoke_UseOptimizedListStruct_releaseFfiHandle(_handle);
   return result;
 }
 UseOptimizedListStruct smoke_UseOptimizedListStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_UseOptimizedListStruct_get_value_nullable(handle);
+  final _handle = _smoke_UseOptimizedListStructGetValueNullable(handle);
   final result = smoke_UseOptimizedListStruct_fromFfi(_handle);
   smoke_UseOptimizedListStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_UseOptimizedListStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_UseOptimizedListStruct_release_handle_nullable(handle);
+  _smoke_UseOptimizedListStructReleaseHandleNullable(handle);
 // End of UseOptimizedListStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
@@ -9,8 +9,6 @@ import 'package:library/src/smoke/internal_parent.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
-import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 final Map<String, Function> typeRepository = {
   "smoke_ChildClassFromClass": (handle) => ChildClassFromClass$Impl(handle),
   "smoke_ChildClassFromInterface": (handle) => ChildClassFromInterface$Impl(handle),

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildClassFromClass implements ParentClass {
@@ -16,15 +15,15 @@ abstract class ChildClassFromClass implements ParentClass {
   childClassMethod();
 }
 // ChildClassFromClass "private" section, not exported.
-final _smoke_ChildClassFromClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildclassfromclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromClass_copy_handle'));
-final _smoke_ChildClassFromClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildclassfromclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ChildClassFromClass_release_handle'));
-final _smoke_ChildClassFromClass_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildclassfromclassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromClass_get_type_id'));
@@ -34,45 +33,45 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ChildClassFromClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeChildclassfromclassReleaseHandle(handle);
     handle = null;
   }
   @override
   childClassMethod() {
-    final _childClassMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod'));
+    final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod'));
     final _handle = this.handle;
-    final __result_handle = _childClassMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ChildClassFromClass_toFfi(ChildClassFromClass value) =>
-  _smoke_ChildClassFromClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeChildclassfromclassCopyHandle((value as __lib.NativeBase).handle);
 ChildClassFromClass smoke_ChildClassFromClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ChildClassFromClass;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ChildClassFromClass_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ChildClassFromClass_copy_handle(handle);
+  final _typeIdHandle = _smokeChildclassfromclassGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeChildclassfromclassCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ChildClassFromClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ChildClassFromClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ChildClassFromClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ChildClassFromClass_release_handle(handle);
+  _smokeChildclassfromclassReleaseHandle(handle);
 Pointer<Void> smoke_ChildClassFromClass_toFfi_nullable(ChildClassFromClass value) =>
   value != null ? smoke_ChildClassFromClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 ChildClassFromClass smoke_ChildClassFromClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildClassFromClass_fromFfi(handle) : null;
 void smoke_ChildClassFromClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ChildClassFromClass_release_handle(handle);
+  _smokeChildclassfromclassReleaseHandle(handle);
 // End of ChildClassFromClass "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildClassFromInterface implements ParentInterface {
@@ -16,15 +15,15 @@ abstract class ChildClassFromInterface implements ParentInterface {
   childClassMethod();
 }
 // ChildClassFromInterface "private" section, not exported.
-final _smoke_ChildClassFromInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildclassfrominterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromInterface_copy_handle'));
-final _smoke_ChildClassFromInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildclassfrominterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ChildClassFromInterface_release_handle'));
-final _smoke_ChildClassFromInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildclassfrominterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromInterface_get_type_id'));
@@ -34,80 +33,80 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ChildClassFromInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeChildclassfrominterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   childClassMethod() {
-    final _childClassMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));
+    final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));
     final _handle = this.handle;
-    final __result_handle = _childClassMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   rootMethod() {
-    final _rootMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
+    final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
-    final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String get rootProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set rootProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ChildClassFromInterface_toFfi(ChildClassFromInterface value) =>
-  _smoke_ChildClassFromInterface_copy_handle((value as __lib.NativeBase).handle);
+  _smokeChildclassfrominterfaceCopyHandle((value as __lib.NativeBase).handle);
 ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ChildClassFromInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ChildClassFromInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ChildClassFromInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeChildclassfrominterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeChildclassfrominterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ChildClassFromInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ChildClassFromInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ChildClassFromInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ChildClassFromInterface_release_handle(handle);
+  _smokeChildclassfrominterfaceReleaseHandle(handle);
 Pointer<Void> smoke_ChildClassFromInterface_toFfi_nullable(ChildClassFromInterface value) =>
   value != null ? smoke_ChildClassFromInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 ChildClassFromInterface smoke_ChildClassFromInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildClassFromInterface_fromFfi(handle) : null;
 void smoke_ChildClassFromInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ChildClassFromInterface_release_handle(handle);
+  _smokeChildclassfrominterfaceReleaseHandle(handle);
 // End of ChildClassFromInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -4,11 +4,10 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildInterface implements ParentInterface {
-  ChildInterface() {}
+  ChildInterface();
   factory ChildInterface.fromLambdas({
     @required void Function() lambda_rootMethod,
     @required void Function() lambda_childMethod,
@@ -28,19 +27,19 @@ abstract class ChildInterface implements ParentInterface {
   childMethod();
 }
 // ChildInterface "private" section, not exported.
-final _smoke_ChildInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildInterface_copy_handle'));
-final _smoke_ChildInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ChildInterface_release_handle'));
-final _smoke_ChildInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_ChildInterface_create_proxy'));
-final _smoke_ChildInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildInterface_get_type_id'));
@@ -74,52 +73,52 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ChildInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeChildinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   rootMethod() {
-    final _rootMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
+    final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
-    final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   childMethod() {
-    final _childMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod'));
+    final _childMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod'));
     final _handle = this.handle;
-    final __result_handle = _childMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _childMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   String get rootProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   set rootProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -151,8 +150,8 @@ int _ChildInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
-  if (value is __lib.NativeBase) return _smoke_ChildInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_ChildInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeChildinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeChildinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -165,25 +164,25 @@ Pointer<Void> smoke_ChildInterface_toFfi(ChildInterface value) {
 }
 ChildInterface smoke_ChildInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ChildInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ChildInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ChildInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeChildinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeChildinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ChildInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ChildInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ChildInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ChildInterface_release_handle(handle);
+  _smokeChildinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_ChildInterface_toFfi_nullable(ChildInterface value) =>
   value != null ? smoke_ChildInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 ChildInterface smoke_ChildInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildInterface_fromFfi(handle) : null;
 void smoke_ChildInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ChildInterface_release_handle(handle);
+  _smokeChildinterfaceReleaseHandle(handle);
 // End of ChildInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -6,7 +6,6 @@ import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildWithParentClassReferences implements ParentWithClassReferences {
@@ -17,15 +16,15 @@ abstract class ChildWithParentClassReferences implements ParentWithClassReferenc
   void release();
 }
 // ChildWithParentClassReferences "private" section, not exported.
-final _smoke_ChildWithParentClassReferences_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildwithparentclassreferencesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildWithParentClassReferences_copy_handle'));
-final _smoke_ChildWithParentClassReferences_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildwithparentclassreferencesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ChildWithParentClassReferences_release_handle'));
-final _smoke_ChildWithParentClassReferences_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeChildwithparentclassreferencesGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildWithParentClassReferences_get_type_id'));
@@ -35,69 +34,69 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ChildWithParentClassReferences_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeChildwithparentclassreferencesReleaseHandle(handle);
     handle = null;
   }
   @override
   ChildClassFromClass classFunction() {
-    final _classFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classFunction'));
+    final _classFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classFunction'));
     final _handle = this.handle;
-    final __result_handle = _classFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _classFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_ChildClassFromClass_fromFfi(__result_handle);
+      return smoke_ChildClassFromClass_fromFfi(__resultHandle);
     } finally {
-      smoke_ChildClassFromClass_releaseFfiHandle(__result_handle);
+      smoke_ChildClassFromClass_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   ParentClass get classProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_ParentClass_fromFfi(__result_handle);
+      return smoke_ParentClass_fromFfi(__resultHandle);
     } finally {
-      smoke_ParentClass_releaseFfiHandle(__result_handle);
+      smoke_ParentClass_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set classProperty(ParentClass value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentWithClassReferences_classProperty_set__ParentClass'));
-    final _value_handle = smoke_ParentClass_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentWithClassReferences_classProperty_set__ParentClass'));
+    final _valueHandle = smoke_ParentClass_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_ParentClass_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_ParentClass_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ChildWithParentClassReferences_toFfi(ChildWithParentClassReferences value) =>
-  _smoke_ChildWithParentClassReferences_copy_handle((value as __lib.NativeBase).handle);
+  _smokeChildwithparentclassreferencesCopyHandle((value as __lib.NativeBase).handle);
 ChildWithParentClassReferences smoke_ChildWithParentClassReferences_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ChildWithParentClassReferences;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ChildWithParentClassReferences_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ChildWithParentClassReferences_copy_handle(handle);
+  final _typeIdHandle = _smokeChildwithparentclassreferencesGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeChildwithparentclassreferencesCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ChildWithParentClassReferences$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ChildWithParentClassReferences$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ChildWithParentClassReferences_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ChildWithParentClassReferences_release_handle(handle);
+  _smokeChildwithparentclassreferencesReleaseHandle(handle);
 Pointer<Void> smoke_ChildWithParentClassReferences_toFfi_nullable(ChildWithParentClassReferences value) =>
   value != null ? smoke_ChildWithParentClassReferences_toFfi(value) : Pointer<Void>.fromAddress(0);
 ChildWithParentClassReferences smoke_ChildWithParentClassReferences_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ChildWithParentClassReferences_fromFfi(handle) : null;
 void smoke_ChildWithParentClassReferences_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ChildWithParentClassReferences_release_handle(handle);
+  _smokeChildwithparentclassreferencesReleaseHandle(handle);
 // End of ChildWithParentClassReferences "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ParentClass {
@@ -17,15 +16,15 @@ abstract class ParentClass {
   set rootProperty(String value);
 }
 // ParentClass "private" section, not exported.
-final _smoke_ParentClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeParentclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentClass_copy_handle'));
-final _smoke_ParentClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeParentclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ParentClass_release_handle'));
-final _smoke_ParentClass_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeParentclassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentClass_get_type_id'));
@@ -35,69 +34,69 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ParentClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeParentclassReleaseHandle(handle);
     handle = null;
   }
   @override
   rootMethod() {
-    final _rootMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod'));
+    final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod'));
     final _handle = this.handle;
-    final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String get rootProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set rootProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentClass_rootProperty_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentClass_rootProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ParentClass_toFfi(ParentClass value) =>
-  _smoke_ParentClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeParentclassCopyHandle((value as __lib.NativeBase).handle);
 ParentClass smoke_ParentClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ParentClass;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ParentClass_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ParentClass_copy_handle(handle);
+  final _typeIdHandle = _smokeParentclassGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeParentclassCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ParentClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ParentClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ParentClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ParentClass_release_handle(handle);
+  _smokeParentclassReleaseHandle(handle);
 Pointer<Void> smoke_ParentClass_toFfi_nullable(ParentClass value) =>
   value != null ? smoke_ParentClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 ParentClass smoke_ParentClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ParentClass_fromFfi(handle) : null;
 void smoke_ParentClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ParentClass_release_handle(handle);
+  _smokeParentclassReleaseHandle(handle);
 // End of ParentClass "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ParentInterface {
-  ParentInterface() {}
+  ParentInterface();
   factory ParentInterface.fromLambdas({
     @required void Function() lambda_rootMethod,
     @required String Function() lambda_rootProperty_get,
@@ -27,19 +26,19 @@ abstract class ParentInterface {
   set rootProperty(String value);
 }
 // ParentInterface "private" section, not exported.
-final _smoke_ParentInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeParentinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentInterface_copy_handle'));
-final _smoke_ParentInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeParentinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ParentInterface_release_handle'));
-final _smoke_ParentInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeParentinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_ParentInterface_create_proxy'));
-final _smoke_ParentInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeParentinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentInterface_get_type_id'));
@@ -68,41 +67,41 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ParentInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeParentinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   rootMethod() {
-    final _rootMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
+    final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
-    final __result_handle = _rootMethod_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   String get rootProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   set rootProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -127,8 +126,8 @@ int _ParentInterface_rootProperty_set_static(int _token, Pointer<Void> _value) {
   return 0;
 }
 Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
-  if (value is __lib.NativeBase) return _smoke_ParentInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_ParentInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeParentinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeParentinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -140,25 +139,25 @@ Pointer<Void> smoke_ParentInterface_toFfi(ParentInterface value) {
 }
 ParentInterface smoke_ParentInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ParentInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ParentInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ParentInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeParentinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeParentinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ParentInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ParentInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ParentInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ParentInterface_release_handle(handle);
+  _smokeParentinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_ParentInterface_toFfi_nullable(ParentInterface value) =>
   value != null ? smoke_ParentInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 ParentInterface smoke_ParentInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ParentInterface_fromFfi(handle) : null;
 void smoke_ParentInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ParentInterface_release_handle(handle);
+  _smokeParentinterfaceReleaseHandle(handle);
 // End of ParentInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 /// @nodoc
 class NativeBase {

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SimpleClass {
@@ -15,11 +14,11 @@ abstract class SimpleClass {
   SimpleClass useSimpleClass(SimpleClass input);
 }
 // SimpleClass "private" section, not exported.
-final _smoke_SimpleClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleClass_copy_handle'));
-final _smoke_SimpleClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SimpleClass_release_handle'));
@@ -29,53 +28,53 @@ class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SimpleClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSimpleclassReleaseHandle(handle);
     handle = null;
   }
   @override
   String getStringValue() {
-    final _getStringValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleClass_getStringValue'));
+    final _getStringValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleClass_getStringValue'));
     final _handle = this.handle;
-    final __result_handle = _getStringValue_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getStringValueFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   SimpleClass useSimpleClass(SimpleClass input) {
-    final _useSimpleClass_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleClass_useSimpleClass__SimpleClass'));
-    final _input_handle = smoke_SimpleClass_toFfi(input);
+    final _useSimpleClassFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleClass_useSimpleClass__SimpleClass'));
+    final _inputHandle = smoke_SimpleClass_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _useSimpleClass_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_SimpleClass_releaseFfiHandle(_input_handle);
+    final __resultHandle = _useSimpleClassFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_SimpleClass_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_SimpleClass_fromFfi(__result_handle);
+      return smoke_SimpleClass_fromFfi(__resultHandle);
     } finally {
-      smoke_SimpleClass_releaseFfiHandle(__result_handle);
+      smoke_SimpleClass_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_SimpleClass_toFfi(SimpleClass value) =>
-  _smoke_SimpleClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSimpleclassCopyHandle((value as __lib.NativeBase).handle);
 SimpleClass smoke_SimpleClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SimpleClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SimpleClass_copy_handle(handle);
-  final result = SimpleClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSimpleclassCopyHandle(handle);
+  final result = SimpleClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SimpleClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SimpleClass_release_handle(handle);
+  _smokeSimpleclassReleaseHandle(handle);
 Pointer<Void> smoke_SimpleClass_toFfi_nullable(SimpleClass value) =>
   value != null ? smoke_SimpleClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 SimpleClass smoke_SimpleClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SimpleClass_fromFfi(handle) : null;
 void smoke_SimpleClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SimpleClass_release_handle(handle);
+  _smokeSimpleclassReleaseHandle(handle);
 // End of SimpleClass "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SimpleInterface {
-  SimpleInterface() {}
+  SimpleInterface();
   factory SimpleInterface.fromLambdas({
     @required String Function() lambda_getStringValue,
     @required SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface,
@@ -24,19 +23,19 @@ abstract class SimpleInterface {
   SimpleInterface useSimpleInterface(SimpleInterface input);
 }
 // SimpleInterface "private" section, not exported.
-final _smoke_SimpleInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleInterface_copy_handle'));
-final _smoke_SimpleInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SimpleInterface_release_handle'));
-final _smoke_SimpleInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer)
   >('library_smoke_SimpleInterface_create_proxy'));
-final _smoke_SimpleInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSimpleinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleInterface_get_type_id'));
@@ -62,58 +61,58 @@ class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SimpleInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSimpleinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   String getStringValue() {
-    final _getStringValue_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleInterface_getStringValue'));
+    final _getStringValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleInterface_getStringValue'));
     final _handle = this.handle;
-    final __result_handle = _getStringValue_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getStringValueFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   SimpleInterface useSimpleInterface(SimpleInterface input) {
-    final _useSimpleInterface_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleInterface_useSimpleInterface__SimpleInterface'));
-    final _input_handle = smoke_SimpleInterface_toFfi(input);
+    final _useSimpleInterfaceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleInterface_useSimpleInterface__SimpleInterface'));
+    final _inputHandle = smoke_SimpleInterface_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _useSimpleInterface_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_SimpleInterface_releaseFfiHandle(_input_handle);
+    final __resultHandle = _useSimpleInterfaceFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_SimpleInterface_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_SimpleInterface_fromFfi(__result_handle);
+      return smoke_SimpleInterface_fromFfi(__resultHandle);
     } finally {
-      smoke_SimpleInterface_releaseFfiHandle(__result_handle);
+      smoke_SimpleInterface_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _SimpleInterface_getStringValue_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
+    _result.value = String_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 int _SimpleInterface_useSimpleInterface_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  SimpleInterface _result_object = null;
+  SimpleInterface _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(smoke_SimpleInterface_fromFfi(input));
-    _result.value = smoke_SimpleInterface_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(smoke_SimpleInterface_fromFfi(input));
+    _result.value = smoke_SimpleInterface_toFfi(_resultObject);
   } finally {
     smoke_SimpleInterface_releaseFfiHandle(input);
-    if (_result_object != null) _result_object.release();
+    if (_resultObject != null) _resultObject.release();
   }
   return 0;
 }
 Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
-  if (value is __lib.NativeBase) return _smoke_SimpleInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_SimpleInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeSimpleinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeSimpleinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -124,25 +123,25 @@ Pointer<Void> smoke_SimpleInterface_toFfi(SimpleInterface value) {
 }
 SimpleInterface smoke_SimpleInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SimpleInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_SimpleInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_SimpleInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeSimpleinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeSimpleinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : SimpleInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : SimpleInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SimpleInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SimpleInterface_release_handle(handle);
+  _smokeSimpleinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_SimpleInterface_toFfi_nullable(SimpleInterface value) =>
   value != null ? smoke_SimpleInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 SimpleInterface smoke_SimpleInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SimpleInterface_fromFfi(handle) : null;
 void smoke_SimpleInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SimpleInterface_release_handle(handle);
+  _smokeSimpleinterfaceReleaseHandle(handle);
 // End of SimpleInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/simple_class.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithClass {
@@ -8,62 +7,62 @@ class StructWithClass {
   StructWithClass(this.classInstance);
 }
 // StructWithClass "private" section, not exported.
-final _smoke_StructWithClass_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithclassCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithClass_create_handle'));
-final _smoke_StructWithClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithClass_release_handle'));
-final _smoke_StructWithClass_get_field_classInstance = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithclassGetFieldclassInstance = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithClass_get_field_classInstance'));
 Pointer<Void> smoke_StructWithClass_toFfi(StructWithClass value) {
-  final _classInstance_handle = smoke_SimpleClass_toFfi(value.classInstance);
-  final _result = _smoke_StructWithClass_create_handle(_classInstance_handle);
-  smoke_SimpleClass_releaseFfiHandle(_classInstance_handle);
+  final _classInstanceHandle = smoke_SimpleClass_toFfi(value.classInstance);
+  final _result = _smokeStructwithclassCreateHandle(_classInstanceHandle);
+  smoke_SimpleClass_releaseFfiHandle(_classInstanceHandle);
   return _result;
 }
 StructWithClass smoke_StructWithClass_fromFfi(Pointer<Void> handle) {
-  final _classInstance_handle = _smoke_StructWithClass_get_field_classInstance(handle);
+  final _classInstanceHandle = _smokeStructwithclassGetFieldclassInstance(handle);
   try {
     return StructWithClass(
-      smoke_SimpleClass_fromFfi(_classInstance_handle)
+      smoke_SimpleClass_fromFfi(_classInstanceHandle)
     );
   } finally {
-    smoke_SimpleClass_releaseFfiHandle(_classInstance_handle);
+    smoke_SimpleClass_releaseFfiHandle(_classInstanceHandle);
   }
 }
-void smoke_StructWithClass_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithClass_release_handle(handle);
+void smoke_StructWithClass_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithclassReleaseHandle(handle);
 // Nullable StructWithClass
-final _smoke_StructWithClass_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithClassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithClass_create_handle_nullable'));
-final _smoke_StructWithClass_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithClassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithClass_release_handle_nullable'));
-final _smoke_StructWithClass_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithClassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithClass_get_value_nullable'));
 Pointer<Void> smoke_StructWithClass_toFfi_nullable(StructWithClass value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithClass_toFfi(value);
-  final result = _smoke_StructWithClass_create_handle_nullable(_handle);
+  final result = _smoke_StructWithClassCreateHandleNullable(_handle);
   smoke_StructWithClass_releaseFfiHandle(_handle);
   return result;
 }
 StructWithClass smoke_StructWithClass_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithClass_get_value_nullable(handle);
+  final _handle = _smoke_StructWithClassGetValueNullable(handle);
   final result = smoke_StructWithClass_fromFfi(_handle);
   smoke_StructWithClass_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithClass_release_handle_nullable(handle);
+  _smoke_StructWithClassReleaseHandleNullable(handle);
 // End of StructWithClass "private" section.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/simple_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithInterface {
@@ -8,62 +7,62 @@ class StructWithInterface {
   StructWithInterface(this.interfaceInstance);
 }
 // StructWithInterface "private" section, not exported.
-final _smoke_StructWithInterface_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinterfaceCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInterface_create_handle'));
-final _smoke_StructWithInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithInterface_release_handle'));
-final _smoke_StructWithInterface_get_field_interfaceInstance = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithinterfaceGetFieldinterfaceInstance = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInterface_get_field_interfaceInstance'));
 Pointer<Void> smoke_StructWithInterface_toFfi(StructWithInterface value) {
-  final _interfaceInstance_handle = smoke_SimpleInterface_toFfi(value.interfaceInstance);
-  final _result = _smoke_StructWithInterface_create_handle(_interfaceInstance_handle);
-  smoke_SimpleInterface_releaseFfiHandle(_interfaceInstance_handle);
+  final _interfaceInstanceHandle = smoke_SimpleInterface_toFfi(value.interfaceInstance);
+  final _result = _smokeStructwithinterfaceCreateHandle(_interfaceInstanceHandle);
+  smoke_SimpleInterface_releaseFfiHandle(_interfaceInstanceHandle);
   return _result;
 }
 StructWithInterface smoke_StructWithInterface_fromFfi(Pointer<Void> handle) {
-  final _interfaceInstance_handle = _smoke_StructWithInterface_get_field_interfaceInstance(handle);
+  final _interfaceInstanceHandle = _smokeStructwithinterfaceGetFieldinterfaceInstance(handle);
   try {
     return StructWithInterface(
-      smoke_SimpleInterface_fromFfi(_interfaceInstance_handle)
+      smoke_SimpleInterface_fromFfi(_interfaceInstanceHandle)
     );
   } finally {
-    smoke_SimpleInterface_releaseFfiHandle(_interfaceInstance_handle);
+    smoke_SimpleInterface_releaseFfiHandle(_interfaceInstanceHandle);
   }
 }
-void smoke_StructWithInterface_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithInterface_release_handle(handle);
+void smoke_StructWithInterface_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithinterfaceReleaseHandle(handle);
 // Nullable StructWithInterface
-final _smoke_StructWithInterface_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInterfaceCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInterface_create_handle_nullable'));
-final _smoke_StructWithInterface_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInterfaceReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithInterface_release_handle_nullable'));
-final _smoke_StructWithInterface_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithInterfaceGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithInterface_get_value_nullable'));
 Pointer<Void> smoke_StructWithInterface_toFfi_nullable(StructWithInterface value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithInterface_toFfi(value);
-  final result = _smoke_StructWithInterface_create_handle_nullable(_handle);
+  final result = _smoke_StructWithInterfaceCreateHandleNullable(_handle);
   smoke_StructWithInterface_releaseFfiHandle(_handle);
   return result;
 }
 StructWithInterface smoke_StructWithInterface_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithInterface_get_value_nullable(handle);
+  final _handle = _smoke_StructWithInterfaceGetValueNullable(handle);
   final result = smoke_StructWithInterface_fromFfi(_handle);
   smoke_StructWithInterface_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithInterface_release_handle_nullable(handle);
+  _smoke_StructWithInterfaceReleaseHandleNullable(handle);
 // End of StructWithInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ClassWithInternalLambda {
@@ -16,15 +15,15 @@ abstract class ClassWithInternalLambda {
 /// @nodoc
 typedef ClassWithInternalLambda_InternalLambda = bool Function(String);
 // ClassWithInternalLambda_InternalLambda "private" section, not exported.
-final _smoke_ClassWithInternalLambda_InternalLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeClasswithinternallambdaInternallambdaCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_copy_handle'));
-final _smoke_ClassWithInternalLambda_InternalLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeClasswithinternallambdaInternallambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_release_handle'));
-final _smoke_ClassWithInternalLambda_InternalLambda_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeClasswithinternallambdaInternallambdaCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_create_proxy'));
@@ -32,32 +31,32 @@ class ClassWithInternalLambda_InternalLambda$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   ClassWithInternalLambda_InternalLambda$Impl(this.handle);
-  void release() => _smoke_ClassWithInternalLambda_InternalLambda_release_handle(handle);
+  void release() => _smokeClasswithinternallambdaInternallambdaReleaseHandle(handle);
   bool internal_call(String p0) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_InternalLambda_call__String'));
-    final _p0_handle = String_toFfi(p0);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_InternalLambda_call__String'));
+    final _p0Handle = String_toFfi(p0);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
-    String_releaseFfiHandle(_p0_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    String_releaseFfiHandle(_p0Handle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _ClassWithInternalLambda_InternalLambda_call_static(int _token, Pointer<Void> p0, Pointer<Uint8> _result) {
-  bool _result_object;
+  bool _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as ClassWithInternalLambda_InternalLambda)(String_fromFfi(p0));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ClassWithInternalLambda_InternalLambda)(String_fromFfi(p0));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(p0);
   }
   return 0;
 }
 Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi(ClassWithInternalLambda_InternalLambda value) {
-  final result = _smoke_ClassWithInternalLambda_InternalLambda_create_proxy(
+  final result = _smokeClasswithinternallambdaInternallambdaCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -66,7 +65,7 @@ Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi(ClassWithIntern
   return result;
 }
 ClassWithInternalLambda_InternalLambda smoke_ClassWithInternalLambda_InternalLambda_fromFfi(Pointer<Void> handle) {
-  final _impl = ClassWithInternalLambda_InternalLambda$Impl(_smoke_ClassWithInternalLambda_InternalLambda_copy_handle(handle));
+  final _impl = ClassWithInternalLambda_InternalLambda$Impl(_smokeClasswithinternallambdaInternallambdaCopyHandle(handle));
   return (String p0) {
     final _result =_impl.internal_call(p0);
     _impl.release();
@@ -74,43 +73,43 @@ ClassWithInternalLambda_InternalLambda smoke_ClassWithInternalLambda_InternalLam
   };
 }
 void smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ClassWithInternalLambda_InternalLambda_release_handle(handle);
+  _smokeClasswithinternallambdaInternallambdaReleaseHandle(handle);
 // Nullable ClassWithInternalLambda_InternalLambda
-final _smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ClassWithInternalLambda_InternalLambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable'));
-final _smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ClassWithInternalLambda_InternalLambdaReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable'));
-final _smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ClassWithInternalLambda_InternalLambdaGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable'));
 Pointer<Void> smoke_ClassWithInternalLambda_InternalLambda_toFfi_nullable(ClassWithInternalLambda_InternalLambda value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ClassWithInternalLambda_InternalLambda_toFfi(value);
-  final result = _smoke_ClassWithInternalLambda_InternalLambda_create_handle_nullable(_handle);
+  final result = _smoke_ClassWithInternalLambda_InternalLambdaCreateHandleNullable(_handle);
   smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(_handle);
   return result;
 }
 ClassWithInternalLambda_InternalLambda smoke_ClassWithInternalLambda_InternalLambda_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ClassWithInternalLambda_InternalLambda_get_value_nullable(handle);
+  final _handle = _smoke_ClassWithInternalLambda_InternalLambdaGetValueNullable(handle);
   final result = smoke_ClassWithInternalLambda_InternalLambda_fromFfi(_handle);
   smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ClassWithInternalLambda_InternalLambda_release_handle_nullable(handle);
+  _smoke_ClassWithInternalLambda_InternalLambdaReleaseHandleNullable(handle);
 // End of ClassWithInternalLambda_InternalLambda "private" section.
 // ClassWithInternalLambda "private" section, not exported.
-final _smoke_ClassWithInternalLambda_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeClasswithinternallambdaCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_copy_handle'));
-final _smoke_ClassWithInternalLambda_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeClasswithinternallambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_release_handle'));
@@ -120,42 +119,42 @@ class ClassWithInternalLambda$Impl extends __lib.NativeBase implements ClassWith
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ClassWithInternalLambda_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeClasswithinternallambdaReleaseHandle(handle);
     handle = null;
   }
   static bool invokeInternalLambda(ClassWithInternalLambda_InternalLambda lambda, String value) {
-    final _invokeInternalLambda_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Pointer<Void>, Pointer<Void>), int Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_invokeInternalLambda__InternalLambda_String'));
-    final _lambda_handle = smoke_ClassWithInternalLambda_InternalLambda_toFfi(lambda);
-    final _value_handle = String_toFfi(value);
-    final __result_handle = _invokeInternalLambda_ffi(__lib.LibraryContext.isolateId, _lambda_handle, _value_handle);
-    smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(_lambda_handle);
-    String_releaseFfiHandle(_value_handle);
+    final _invokeInternalLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Pointer<Void>, Pointer<Void>), int Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_invokeInternalLambda__InternalLambda_String'));
+    final _lambdaHandle = smoke_ClassWithInternalLambda_InternalLambda_toFfi(lambda);
+    final _valueHandle = String_toFfi(value);
+    final __resultHandle = _invokeInternalLambdaFfi(__lib.LibraryContext.isolateId, _lambdaHandle, _valueHandle);
+    smoke_ClassWithInternalLambda_InternalLambda_releaseFfiHandle(_lambdaHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_ClassWithInternalLambda_toFfi(ClassWithInternalLambda value) =>
-  _smoke_ClassWithInternalLambda_copy_handle((value as __lib.NativeBase).handle);
+  _smokeClasswithinternallambdaCopyHandle((value as __lib.NativeBase).handle);
 ClassWithInternalLambda smoke_ClassWithInternalLambda_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ClassWithInternalLambda;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_ClassWithInternalLambda_copy_handle(handle);
-  final result = ClassWithInternalLambda$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeClasswithinternallambdaCopyHandle(handle);
+  final result = ClassWithInternalLambda$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ClassWithInternalLambda_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ClassWithInternalLambda_release_handle(handle);
+  _smokeClasswithinternallambdaReleaseHandle(handle);
 Pointer<Void> smoke_ClassWithInternalLambda_toFfi_nullable(ClassWithInternalLambda value) =>
   value != null ? smoke_ClassWithInternalLambda_toFfi(value) : Pointer<Void>.fromAddress(0);
 ClassWithInternalLambda smoke_ClassWithInternalLambda_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ClassWithInternalLambda_fromFfi(handle) : null;
 void smoke_ClassWithInternalLambda_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ClassWithInternalLambda_release_handle(handle);
+  _smokeClasswithinternallambdaReleaseHandle(handle);
 // End of ClassWithInternalLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Lambdas {
@@ -17,15 +16,15 @@ abstract class Lambdas {
 }
 typedef Lambdas_Producer = String Function();
 // Lambdas_Producer "private" section, not exported.
-final _smoke_Lambdas_Producer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasProducerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Producer_copy_handle'));
-final _smoke_Lambdas_Producer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasProducerReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Producer_release_handle'));
-final _smoke_Lambdas_Producer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasProducerCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Producer_create_proxy'));
@@ -33,29 +32,29 @@ class Lambdas_Producer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Producer$Impl(this.handle);
-  void release() => _smoke_Lambdas_Producer_release_handle(handle);
+  void release() => _smokeLambdasProducerReleaseHandle(handle);
   String call() {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Lambdas_Producer_call'));
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Lambdas_Producer_call'));
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _Lambdas_Producer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object;
+  String _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as Lambdas_Producer)();
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as Lambdas_Producer)();
+    _result.value = String_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Producer_toFfi(Lambdas_Producer value) {
-  final result = _smoke_Lambdas_Producer_create_proxy(
+  final result = _smokeLambdasProducerCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -64,7 +63,7 @@ Pointer<Void> smoke_Lambdas_Producer_toFfi(Lambdas_Producer value) {
   return result;
 }
 Lambdas_Producer smoke_Lambdas_Producer_fromFfi(Pointer<Void> handle) {
-  final _impl = Lambdas_Producer$Impl(_smoke_Lambdas_Producer_copy_handle(handle));
+  final _impl = Lambdas_Producer$Impl(_smokeLambdasProducerCopyHandle(handle));
   return () {
     final _result =_impl.call();
     _impl.release();
@@ -72,49 +71,49 @@ Lambdas_Producer smoke_Lambdas_Producer_fromFfi(Pointer<Void> handle) {
   };
 }
 void smoke_Lambdas_Producer_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Lambdas_Producer_release_handle(handle);
+  _smokeLambdasProducerReleaseHandle(handle);
 // Nullable Lambdas_Producer
-final _smoke_Lambdas_Producer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ProducerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Producer_create_handle_nullable'));
-final _smoke_Lambdas_Producer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ProducerReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Producer_release_handle_nullable'));
-final _smoke_Lambdas_Producer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ProducerGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Producer_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Producer_toFfi_nullable(Lambdas_Producer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Producer_toFfi(value);
-  final result = _smoke_Lambdas_Producer_create_handle_nullable(_handle);
+  final result = _smoke_Lambdas_ProducerCreateHandleNullable(_handle);
   smoke_Lambdas_Producer_releaseFfiHandle(_handle);
   return result;
 }
 Lambdas_Producer smoke_Lambdas_Producer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Lambdas_Producer_get_value_nullable(handle);
+  final _handle = _smoke_Lambdas_ProducerGetValueNullable(handle);
   final result = smoke_Lambdas_Producer_fromFfi(_handle);
   smoke_Lambdas_Producer_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Lambdas_Producer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Lambdas_Producer_release_handle_nullable(handle);
+  _smoke_Lambdas_ProducerReleaseHandleNullable(handle);
 // End of Lambdas_Producer "private" section.
 /// Should confuse everyone thoroughly
 typedef Lambdas_Confuser = Lambdas_Producer Function(String);
 // Lambdas_Confuser "private" section, not exported.
-final _smoke_Lambdas_Confuser_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasConfuserCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Confuser_copy_handle'));
-final _smoke_Lambdas_Confuser_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasConfuserReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Confuser_release_handle'));
-final _smoke_Lambdas_Confuser_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasConfuserCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Confuser_create_proxy'));
@@ -122,32 +121,32 @@ class Lambdas_Confuser$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Confuser$Impl(this.handle);
-  void release() => _smoke_Lambdas_Confuser_release_handle(handle);
+  void release() => _smokeLambdasConfuserReleaseHandle(handle);
   Lambdas_Producer call(String p0) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Confuser_call__String'));
-    final _p0_handle = String_toFfi(p0);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Confuser_call__String'));
+    final _p0Handle = String_toFfi(p0);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
-    String_releaseFfiHandle(_p0_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    String_releaseFfiHandle(_p0Handle);
     try {
-      return smoke_Lambdas_Producer_fromFfi(__result_handle);
+      return smoke_Lambdas_Producer_fromFfi(__resultHandle);
     } finally {
-      smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
+      smoke_Lambdas_Producer_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _Lambdas_Confuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  Lambdas_Producer _result_object;
+  Lambdas_Producer _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as Lambdas_Confuser)(String_fromFfi(p0));
-    _result.value = smoke_Lambdas_Producer_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as Lambdas_Confuser)(String_fromFfi(p0));
+    _result.value = smoke_Lambdas_Producer_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(p0);
   }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Confuser_toFfi(Lambdas_Confuser value) {
-  final result = _smoke_Lambdas_Confuser_create_proxy(
+  final result = _smokeLambdasConfuserCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -156,7 +155,7 @@ Pointer<Void> smoke_Lambdas_Confuser_toFfi(Lambdas_Confuser value) {
   return result;
 }
 Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi(Pointer<Void> handle) {
-  final _impl = Lambdas_Confuser$Impl(_smoke_Lambdas_Confuser_copy_handle(handle));
+  final _impl = Lambdas_Confuser$Impl(_smokeLambdasConfuserCopyHandle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -164,48 +163,48 @@ Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi(Pointer<Void> handle) {
   };
 }
 void smoke_Lambdas_Confuser_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Lambdas_Confuser_release_handle(handle);
+  _smokeLambdasConfuserReleaseHandle(handle);
 // Nullable Lambdas_Confuser
-final _smoke_Lambdas_Confuser_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ConfuserCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Confuser_create_handle_nullable'));
-final _smoke_Lambdas_Confuser_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ConfuserReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Confuser_release_handle_nullable'));
-final _smoke_Lambdas_Confuser_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ConfuserGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Confuser_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Confuser_toFfi_nullable(Lambdas_Confuser value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Confuser_toFfi(value);
-  final result = _smoke_Lambdas_Confuser_create_handle_nullable(_handle);
+  final result = _smoke_Lambdas_ConfuserCreateHandleNullable(_handle);
   smoke_Lambdas_Confuser_releaseFfiHandle(_handle);
   return result;
 }
 Lambdas_Confuser smoke_Lambdas_Confuser_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Lambdas_Confuser_get_value_nullable(handle);
+  final _handle = _smoke_Lambdas_ConfuserGetValueNullable(handle);
   final result = smoke_Lambdas_Confuser_fromFfi(_handle);
   smoke_Lambdas_Confuser_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Lambdas_Confuser_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Lambdas_Confuser_release_handle_nullable(handle);
+  _smoke_Lambdas_ConfuserReleaseHandleNullable(handle);
 // End of Lambdas_Confuser "private" section.
 typedef Lambdas_Consumer = void Function(String);
 // Lambdas_Consumer "private" section, not exported.
-final _smoke_Lambdas_Consumer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasConsumerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Consumer_copy_handle'));
-final _smoke_Lambdas_Consumer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasConsumerReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Consumer_release_handle'));
-final _smoke_Lambdas_Consumer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasConsumerCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Consumer_create_proxy'));
@@ -213,17 +212,17 @@ class Lambdas_Consumer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Consumer$Impl(this.handle);
-  void release() => _smoke_Lambdas_Consumer_release_handle(handle);
+  void release() => _smokeLambdasConsumerReleaseHandle(handle);
   call(String p0) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String'));
-    final _p0_handle = String_toFfi(p0);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String'));
+    final _p0Handle = String_toFfi(p0);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
-    String_releaseFfiHandle(_p0_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    String_releaseFfiHandle(_p0Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -236,7 +235,7 @@ int _Lambdas_Consumer_call_static(int _token, Pointer<Void> p0) {
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Consumer_toFfi(Lambdas_Consumer value) {
-  final result = _smoke_Lambdas_Consumer_create_proxy(
+  final result = _smokeLambdasConsumerCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -245,7 +244,7 @@ Pointer<Void> smoke_Lambdas_Consumer_toFfi(Lambdas_Consumer value) {
   return result;
 }
 Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi(Pointer<Void> handle) {
-  final _impl = Lambdas_Consumer$Impl(_smoke_Lambdas_Consumer_copy_handle(handle));
+  final _impl = Lambdas_Consumer$Impl(_smokeLambdasConsumerCopyHandle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -253,48 +252,48 @@ Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi(Pointer<Void> handle) {
   };
 }
 void smoke_Lambdas_Consumer_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Lambdas_Consumer_release_handle(handle);
+  _smokeLambdasConsumerReleaseHandle(handle);
 // Nullable Lambdas_Consumer
-final _smoke_Lambdas_Consumer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ConsumerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Consumer_create_handle_nullable'));
-final _smoke_Lambdas_Consumer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ConsumerReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Consumer_release_handle_nullable'));
-final _smoke_Lambdas_Consumer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_ConsumerGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Consumer_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Consumer_toFfi_nullable(Lambdas_Consumer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Consumer_toFfi(value);
-  final result = _smoke_Lambdas_Consumer_create_handle_nullable(_handle);
+  final result = _smoke_Lambdas_ConsumerCreateHandleNullable(_handle);
   smoke_Lambdas_Consumer_releaseFfiHandle(_handle);
   return result;
 }
 Lambdas_Consumer smoke_Lambdas_Consumer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Lambdas_Consumer_get_value_nullable(handle);
+  final _handle = _smoke_Lambdas_ConsumerGetValueNullable(handle);
   final result = smoke_Lambdas_Consumer_fromFfi(_handle);
   smoke_Lambdas_Consumer_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Lambdas_Consumer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Lambdas_Consumer_release_handle_nullable(handle);
+  _smoke_Lambdas_ConsumerReleaseHandleNullable(handle);
 // End of Lambdas_Consumer "private" section.
 typedef Lambdas_Indexer = int Function(String, double);
 // Lambdas_Indexer "private" section, not exported.
-final _smoke_Lambdas_Indexer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasIndexerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Indexer_copy_handle'));
-final _smoke_Lambdas_Indexer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasIndexerReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Indexer_release_handle'));
-final _smoke_Lambdas_Indexer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasIndexerCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Indexer_create_proxy'));
@@ -302,27 +301,27 @@ class Lambdas_Indexer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Indexer$Impl(this.handle);
-  void release() => _smoke_Lambdas_Indexer_release_handle(handle);
+  void release() => _smokeLambdasIndexerReleaseHandle(handle);
   int call(String p0, double p1) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32, Pointer<Void>, Float), int Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_Lambdas_Indexer_call__String_Float'));
-    final _p0_handle = String_toFfi(p0);
-    final _p1_handle = (p1);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32, Pointer<Void>, Float), int Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_Lambdas_Indexer_call__String_Float'));
+    final _p0Handle = String_toFfi(p0);
+    final _p1Handle = (p1);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle, _p1_handle);
-    String_releaseFfiHandle(_p0_handle);
-    (_p1_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
+    String_releaseFfiHandle(_p0Handle);
+    (_p1Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _Lambdas_Indexer_call_static(int _token, Pointer<Void> p0, double p1, Pointer<Int32> _result) {
-  int _result_object;
+  int _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as Lambdas_Indexer)(String_fromFfi(p0), (p1));
-    _result.value = (_result_object);
+    _resultObject = (__lib.instanceCache[_token] as Lambdas_Indexer)(String_fromFfi(p0), (p1));
+    _result.value = (_resultObject);
   } finally {
     String_releaseFfiHandle(p0);
     (p1);
@@ -330,7 +329,7 @@ int _Lambdas_Indexer_call_static(int _token, Pointer<Void> p0, double p1, Pointe
   return 0;
 }
 Pointer<Void> smoke_Lambdas_Indexer_toFfi(Lambdas_Indexer value) {
-  final result = _smoke_Lambdas_Indexer_create_proxy(
+  final result = _smokeLambdasIndexerCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -339,7 +338,7 @@ Pointer<Void> smoke_Lambdas_Indexer_toFfi(Lambdas_Indexer value) {
   return result;
 }
 Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi(Pointer<Void> handle) {
-  final _impl = Lambdas_Indexer$Impl(_smoke_Lambdas_Indexer_copy_handle(handle));
+  final _impl = Lambdas_Indexer$Impl(_smokeLambdasIndexerCopyHandle(handle));
   return (String p0, double p1) {
     final _result =_impl.call(p0, p1);
     _impl.release();
@@ -347,48 +346,48 @@ Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi(Pointer<Void> handle) {
   };
 }
 void smoke_Lambdas_Indexer_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Lambdas_Indexer_release_handle(handle);
+  _smokeLambdasIndexerReleaseHandle(handle);
 // Nullable Lambdas_Indexer
-final _smoke_Lambdas_Indexer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_IndexerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Indexer_create_handle_nullable'));
-final _smoke_Lambdas_Indexer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_IndexerReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_Indexer_release_handle_nullable'));
-final _smoke_Lambdas_Indexer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_IndexerGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Indexer_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_Indexer_toFfi_nullable(Lambdas_Indexer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_Indexer_toFfi(value);
-  final result = _smoke_Lambdas_Indexer_create_handle_nullable(_handle);
+  final result = _smoke_Lambdas_IndexerCreateHandleNullable(_handle);
   smoke_Lambdas_Indexer_releaseFfiHandle(_handle);
   return result;
 }
 Lambdas_Indexer smoke_Lambdas_Indexer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Lambdas_Indexer_get_value_nullable(handle);
+  final _handle = _smoke_Lambdas_IndexerGetValueNullable(handle);
   final result = smoke_Lambdas_Indexer_fromFfi(_handle);
   smoke_Lambdas_Indexer_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Lambdas_Indexer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Lambdas_Indexer_release_handle_nullable(handle);
+  _smoke_Lambdas_IndexerReleaseHandleNullable(handle);
 // End of Lambdas_Indexer "private" section.
 typedef Lambdas_NullableConfuser = Lambdas_Producer Function(String);
 // Lambdas_NullableConfuser "private" section, not exported.
-final _smoke_Lambdas_NullableConfuser_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasNullableconfuserCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_NullableConfuser_copy_handle'));
-final _smoke_Lambdas_NullableConfuser_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasNullableconfuserReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_NullableConfuser_release_handle'));
-final _smoke_Lambdas_NullableConfuser_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasNullableconfuserCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_NullableConfuser_create_proxy'));
@@ -396,32 +395,32 @@ class Lambdas_NullableConfuser$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_NullableConfuser$Impl(this.handle);
-  void release() => _smoke_Lambdas_NullableConfuser_release_handle(handle);
+  void release() => _smokeLambdasNullableconfuserReleaseHandle(handle);
   Lambdas_Producer call(String p0) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_NullableConfuser_call__String'));
-    final _p0_handle = String_toFfi_nullable(p0);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_NullableConfuser_call__String'));
+    final _p0Handle = String_toFfi_nullable(p0);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
-    String_releaseFfiHandle_nullable(_p0_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    String_releaseFfiHandle_nullable(_p0Handle);
     try {
-      return smoke_Lambdas_Producer_fromFfi_nullable(__result_handle);
+      return smoke_Lambdas_Producer_fromFfi_nullable(__resultHandle);
     } finally {
-      smoke_Lambdas_Producer_releaseFfiHandle_nullable(__result_handle);
+      smoke_Lambdas_Producer_releaseFfiHandle_nullable(__resultHandle);
     }
   }
 }
 int _Lambdas_NullableConfuser_call_static(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
-  Lambdas_Producer _result_object;
+  Lambdas_Producer _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as Lambdas_NullableConfuser)(String_fromFfi_nullable(p0));
-    _result.value = smoke_Lambdas_Producer_toFfi_nullable(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as Lambdas_NullableConfuser)(String_fromFfi_nullable(p0));
+    _result.value = smoke_Lambdas_Producer_toFfi_nullable(_resultObject);
   } finally {
     String_releaseFfiHandle_nullable(p0);
   }
   return 0;
 }
 Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser value) {
-  final result = _smoke_Lambdas_NullableConfuser_create_proxy(
+  final result = _smokeLambdasNullableconfuserCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -430,7 +429,7 @@ Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi(Lambdas_NullableConfuser valu
   return result;
 }
 Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi(Pointer<Void> handle) {
-  final _impl = Lambdas_NullableConfuser$Impl(_smoke_Lambdas_NullableConfuser_copy_handle(handle));
+  final _impl = Lambdas_NullableConfuser$Impl(_smokeLambdasNullableconfuserCopyHandle(handle));
   return (String p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -438,43 +437,43 @@ Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi(Pointer<Void> ha
   };
 }
 void smoke_Lambdas_NullableConfuser_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Lambdas_NullableConfuser_release_handle(handle);
+  _smokeLambdasNullableconfuserReleaseHandle(handle);
 // Nullable Lambdas_NullableConfuser
-final _smoke_Lambdas_NullableConfuser_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_NullableConfuserCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_NullableConfuser_create_handle_nullable'));
-final _smoke_Lambdas_NullableConfuser_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_NullableConfuserReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_NullableConfuser_release_handle_nullable'));
-final _smoke_Lambdas_NullableConfuser_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Lambdas_NullableConfuserGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_NullableConfuser_get_value_nullable'));
 Pointer<Void> smoke_Lambdas_NullableConfuser_toFfi_nullable(Lambdas_NullableConfuser value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Lambdas_NullableConfuser_toFfi(value);
-  final result = _smoke_Lambdas_NullableConfuser_create_handle_nullable(_handle);
+  final result = _smoke_Lambdas_NullableConfuserCreateHandleNullable(_handle);
   smoke_Lambdas_NullableConfuser_releaseFfiHandle(_handle);
   return result;
 }
 Lambdas_NullableConfuser smoke_Lambdas_NullableConfuser_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Lambdas_NullableConfuser_get_value_nullable(handle);
+  final _handle = _smoke_Lambdas_NullableConfuserGetValueNullable(handle);
   final result = smoke_Lambdas_NullableConfuser_fromFfi(_handle);
   smoke_Lambdas_NullableConfuser_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Lambdas_NullableConfuser_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Lambdas_NullableConfuser_release_handle_nullable(handle);
+  _smoke_Lambdas_NullableConfuserReleaseHandleNullable(handle);
 // End of Lambdas_NullableConfuser "private" section.
 // Lambdas "private" section, not exported.
-final _smoke_Lambdas_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_copy_handle'));
-final _smoke_Lambdas_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdasReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_release_handle'));
@@ -484,57 +483,57 @@ class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Lambdas_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeLambdasReleaseHandle(handle);
     handle = null;
   }
   @override
   Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser) {
-    final _deconfuse_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_deconfuse__String_Confuser'));
-    final _value_handle = String_toFfi(value);
-    final _confuser_handle = smoke_Lambdas_Confuser_toFfi(confuser);
+    final _deconfuseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_deconfuse__String_Confuser'));
+    final _valueHandle = String_toFfi(value);
+    final _confuserHandle = smoke_Lambdas_Confuser_toFfi(confuser);
     final _handle = this.handle;
-    final __result_handle = _deconfuse_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle, _confuser_handle);
-    String_releaseFfiHandle(_value_handle);
-    smoke_Lambdas_Confuser_releaseFfiHandle(_confuser_handle);
+    final __resultHandle = _deconfuseFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle, _confuserHandle);
+    String_releaseFfiHandle(_valueHandle);
+    smoke_Lambdas_Confuser_releaseFfiHandle(_confuserHandle);
     try {
-      return smoke_Lambdas_Producer_fromFfi(__result_handle);
+      return smoke_Lambdas_Producer_fromFfi(__resultHandle);
     } finally {
-      smoke_Lambdas_Producer_releaseFfiHandle(__result_handle);
+      smoke_Lambdas_Producer_releaseFfiHandle(__resultHandle);
     }
   }
   static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) {
-    final _fuse_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_1String_Indexer'));
-    final _items_handle = foobar_ListOf_String_toFfi(items);
-    final _callback_handle = smoke_Lambdas_Indexer_toFfi(callback);
-    final __result_handle = _fuse_ffi(__lib.LibraryContext.isolateId, _items_handle, _callback_handle);
-    foobar_ListOf_String_releaseFfiHandle(_items_handle);
-    smoke_Lambdas_Indexer_releaseFfiHandle(_callback_handle);
+    final _fuseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_1String_Indexer'));
+    final _itemsHandle = foobar_ListOf_String_toFfi(items);
+    final _callbackHandle = smoke_Lambdas_Indexer_toFfi(callback);
+    final __resultHandle = _fuseFfi(__lib.LibraryContext.isolateId, _itemsHandle, _callbackHandle);
+    foobar_ListOf_String_releaseFfiHandle(_itemsHandle);
+    smoke_Lambdas_Indexer_releaseFfiHandle(_callbackHandle);
     try {
-      return foobar_MapOf_Int_to_String_fromFfi(__result_handle);
+      return foobar_MapOf_Int_to_String_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_Int_to_String_releaseFfiHandle(__result_handle);
+      foobar_MapOf_Int_to_String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Lambdas_toFfi(Lambdas value) =>
-  _smoke_Lambdas_copy_handle((value as __lib.NativeBase).handle);
+  _smokeLambdasCopyHandle((value as __lib.NativeBase).handle);
 Lambdas smoke_Lambdas_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Lambdas;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Lambdas_copy_handle(handle);
-  final result = Lambdas$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeLambdasCopyHandle(handle);
+  final result = Lambdas$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Lambdas_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Lambdas_release_handle(handle);
+  _smokeLambdasReleaseHandle(handle);
 Pointer<Void> smoke_Lambdas_toFfi_nullable(Lambdas value) =>
   value != null ? smoke_Lambdas_toFfi(value) : Pointer<Void>.fromAddress(0);
 Lambdas smoke_Lambdas_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Lambdas_fromFfi(handle) : null;
 void smoke_Lambdas_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Lambdas_release_handle(handle);
+  _smokeLambdasReleaseHandle(handle);
 // End of Lambdas "private" section.

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/lambdas_declaration_order.dart';
 import 'package:library/src/smoke/lambdas_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class LambdasWithStructuredTypes {
@@ -18,15 +17,15 @@ abstract class LambdasWithStructuredTypes {
 }
 typedef LambdasWithStructuredTypes_ClassCallback = void Function(LambdasInterface);
 // LambdasWithStructuredTypes_ClassCallback "private" section, not exported.
-final _smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesClasscallbackCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle'));
-final _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesClasscallbackReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_release_handle'));
-final _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesClasscallbackCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy'));
@@ -34,17 +33,17 @@ class LambdasWithStructuredTypes_ClassCallback$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_ClassCallback$Impl(this.handle);
-  void release() => _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle(handle);
+  void release() => _smokeLambdaswithstructuredtypesClasscallbackReleaseHandle(handle);
   call(LambdasInterface p0) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface'));
-    final _p0_handle = smoke_LambdasInterface_toFfi(p0);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface'));
+    final _p0Handle = smoke_LambdasInterface_toFfi(p0);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
-    smoke_LambdasInterface_releaseFfiHandle(_p0_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    smoke_LambdasInterface_releaseFfiHandle(_p0Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -57,7 +56,7 @@ int _LambdasWithStructuredTypes_ClassCallback_call_static(int _token, Pointer<Vo
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(LambdasWithStructuredTypes_ClassCallback value) {
-  final result = _smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(
+  final result = _smokeLambdaswithstructuredtypesClasscallbackCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -66,7 +65,7 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(LambdasWithSt
   return result;
 }
 LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi(Pointer<Void> handle) {
-  final _impl = LambdasWithStructuredTypes_ClassCallback$Impl(_smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle));
+  final _impl = LambdasWithStructuredTypes_ClassCallback$Impl(_smokeLambdaswithstructuredtypesClasscallbackCopyHandle(handle));
   return (LambdasInterface p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -74,48 +73,48 @@ LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassC
   };
 }
 void smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle(handle);
+  _smokeLambdaswithstructuredtypesClasscallbackReleaseHandle(handle);
 // Nullable LambdasWithStructuredTypes_ClassCallback
-final _smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_ClassCallbackCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable'));
-final _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_ClassCallbackReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_release_handle_nullable'));
-final _smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_ClassCallbackGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable'));
 Pointer<Void> smoke_LambdasWithStructuredTypes_ClassCallback_toFfi_nullable(LambdasWithStructuredTypes_ClassCallback value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(value);
-  final result = _smoke_LambdasWithStructuredTypes_ClassCallback_create_handle_nullable(_handle);
+  final result = _smoke_LambdasWithStructuredTypes_ClassCallbackCreateHandleNullable(_handle);
   smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_handle);
   return result;
 }
 LambdasWithStructuredTypes_ClassCallback smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable(handle);
+  final _handle = _smoke_LambdasWithStructuredTypes_ClassCallbackGetValueNullable(handle);
   final result = smoke_LambdasWithStructuredTypes_ClassCallback_fromFfi(_handle);
   smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_ClassCallback_release_handle_nullable(handle);
+  _smoke_LambdasWithStructuredTypes_ClassCallbackReleaseHandleNullable(handle);
 // End of LambdasWithStructuredTypes_ClassCallback "private" section.
 typedef LambdasWithStructuredTypes_StructCallback = void Function(LambdasDeclarationOrder_SomeStruct);
 // LambdasWithStructuredTypes_StructCallback "private" section, not exported.
-final _smoke_LambdasWithStructuredTypes_StructCallback_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesStructcallbackCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle'));
-final _smoke_LambdasWithStructuredTypes_StructCallback_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesStructcallbackReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_release_handle'));
-final _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesStructcallbackCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_proxy'));
@@ -123,17 +122,17 @@ class LambdasWithStructuredTypes_StructCallback$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_StructCallback$Impl(this.handle);
-  void release() => _smoke_LambdasWithStructuredTypes_StructCallback_release_handle(handle);
+  void release() => _smokeLambdaswithstructuredtypesStructcallbackReleaseHandle(handle);
   call(LambdasDeclarationOrder_SomeStruct p0) {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct'));
-    final _p0_handle = smoke_LambdasDeclarationOrder_SomeStruct_toFfi(p0);
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct'));
+    final _p0Handle = smoke_LambdasDeclarationOrder_SomeStruct_toFfi(p0);
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId, _p0_handle);
-    smoke_LambdasDeclarationOrder_SomeStruct_releaseFfiHandle(_p0_handle);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    smoke_LambdasDeclarationOrder_SomeStruct_releaseFfiHandle(_p0Handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -146,7 +145,7 @@ int _LambdasWithStructuredTypes_StructCallback_call_static(int _token, Pointer<V
   return 0;
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi(LambdasWithStructuredTypes_StructCallback value) {
-  final result = _smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(
+  final result = _smokeLambdaswithstructuredtypesStructcallbackCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -155,7 +154,7 @@ Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi(LambdasWithS
   return result;
 }
 LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_StructCallback_fromFfi(Pointer<Void> handle) {
-  final _impl = LambdasWithStructuredTypes_StructCallback$Impl(_smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle));
+  final _impl = LambdasWithStructuredTypes_StructCallback$Impl(_smokeLambdaswithstructuredtypesStructcallbackCopyHandle(handle));
   return (LambdasDeclarationOrder_SomeStruct p0) {
     final _result =_impl.call(p0);
     _impl.release();
@@ -163,43 +162,43 @@ LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_Struc
   };
 }
 void smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_StructCallback_release_handle(handle);
+  _smokeLambdaswithstructuredtypesStructcallbackReleaseHandle(handle);
 // Nullable LambdasWithStructuredTypes_StructCallback
-final _smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_StructCallbackCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable'));
-final _smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_StructCallbackReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable'));
-final _smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LambdasWithStructuredTypes_StructCallbackGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable'));
 Pointer<Void> smoke_LambdasWithStructuredTypes_StructCallback_toFfi_nullable(LambdasWithStructuredTypes_StructCallback value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(value);
-  final result = _smoke_LambdasWithStructuredTypes_StructCallback_create_handle_nullable(_handle);
+  final result = _smoke_LambdasWithStructuredTypes_StructCallbackCreateHandleNullable(_handle);
   smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_handle);
   return result;
 }
 LambdasWithStructuredTypes_StructCallback smoke_LambdasWithStructuredTypes_StructCallback_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable(handle);
+  final _handle = _smoke_LambdasWithStructuredTypes_StructCallbackGetValueNullable(handle);
   final result = smoke_LambdasWithStructuredTypes_StructCallback_fromFfi(_handle);
   smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_StructCallback_release_handle_nullable(handle);
+  _smoke_LambdasWithStructuredTypes_StructCallbackReleaseHandleNullable(handle);
 // End of LambdasWithStructuredTypes_StructCallback "private" section.
 // LambdasWithStructuredTypes "private" section, not exported.
-final _smoke_LambdasWithStructuredTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_copy_handle'));
-final _smoke_LambdasWithStructuredTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLambdaswithstructuredtypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_release_handle'));
@@ -209,55 +208,55 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_LambdasWithStructuredTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeLambdaswithstructuredtypesReleaseHandle(handle);
     handle = null;
   }
   @override
   doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
-    final _doClassStuff_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback'));
-    final _callback_handle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(callback);
+    final _doClassStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback'));
+    final _callbackHandle = smoke_LambdasWithStructuredTypes_ClassCallback_toFfi(callback);
     final _handle = this.handle;
-    final __result_handle = _doClassStuff_ffi(_handle, __lib.LibraryContext.isolateId, _callback_handle);
-    smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_callback_handle);
+    final __resultHandle = _doClassStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
+    smoke_LambdasWithStructuredTypes_ClassCallback_releaseFfiHandle(_callbackHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
-    final _doStructStuff_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback'));
-    final _callback_handle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(callback);
+    final _doStructStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback'));
+    final _callbackHandle = smoke_LambdasWithStructuredTypes_StructCallback_toFfi(callback);
     final _handle = this.handle;
-    final __result_handle = _doStructStuff_ffi(_handle, __lib.LibraryContext.isolateId, _callback_handle);
-    smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_callback_handle);
+    final __resultHandle = _doStructStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
+    smoke_LambdasWithStructuredTypes_StructCallback_releaseFfiHandle(_callbackHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi(LambdasWithStructuredTypes value) =>
-  _smoke_LambdasWithStructuredTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeLambdaswithstructuredtypesCopyHandle((value as __lib.NativeBase).handle);
 LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as LambdasWithStructuredTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_LambdasWithStructuredTypes_copy_handle(handle);
-  final result = LambdasWithStructuredTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeLambdaswithstructuredtypesCopyHandle(handle);
+  final result = LambdasWithStructuredTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_LambdasWithStructuredTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_release_handle(handle);
+  _smokeLambdaswithstructuredtypesReleaseHandle(handle);
 Pointer<Void> smoke_LambdasWithStructuredTypes_toFfi_nullable(LambdasWithStructuredTypes value) =>
   value != null ? smoke_LambdasWithStructuredTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 LambdasWithStructuredTypes smoke_LambdasWithStructuredTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LambdasWithStructuredTypes_fromFfi(handle) : null;
 void smoke_LambdasWithStructuredTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LambdasWithStructuredTypes_release_handle(handle);
+  _smokeLambdaswithstructuredtypesReleaseHandle(handle);
 // End of LambdasWithStructuredTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -1,20 +1,19 @@
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 typedef StandaloneProducer = String Function();
 // StandaloneProducer "private" section, not exported.
-final _smoke_StandaloneProducer_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStandaloneproducerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StandaloneProducer_copy_handle'));
-final _smoke_StandaloneProducer_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStandaloneproducerReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StandaloneProducer_release_handle'));
-final _smoke_StandaloneProducer_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStandaloneproducerCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_StandaloneProducer_create_proxy'));
@@ -22,29 +21,29 @@ class StandaloneProducer$Impl {
   Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   StandaloneProducer$Impl(this.handle);
-  void release() => _smoke_StandaloneProducer_release_handle(handle);
+  void release() => _smokeStandaloneproducerReleaseHandle(handle);
   String call() {
-    final _call_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StandaloneProducer_call'));
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StandaloneProducer_call'));
     final _handle = this.handle;
-    final __result_handle = _call_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _StandaloneProducer_call_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object;
+  String _resultObject;
   try {
-    _result_object = (__lib.instanceCache[_token] as StandaloneProducer)();
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as StandaloneProducer)();
+    _result.value = String_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 Pointer<Void> smoke_StandaloneProducer_toFfi(StandaloneProducer value) {
-  final result = _smoke_StandaloneProducer_create_proxy(
+  final result = _smokeStandaloneproducerCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -53,7 +52,7 @@ Pointer<Void> smoke_StandaloneProducer_toFfi(StandaloneProducer value) {
   return result;
 }
 StandaloneProducer smoke_StandaloneProducer_fromFfi(Pointer<Void> handle) {
-  final _impl = StandaloneProducer$Impl(_smoke_StandaloneProducer_copy_handle(handle));
+  final _impl = StandaloneProducer$Impl(_smokeStandaloneproducerCopyHandle(handle));
   return () {
     final _result =_impl.call();
     _impl.release();
@@ -61,34 +60,34 @@ StandaloneProducer smoke_StandaloneProducer_fromFfi(Pointer<Void> handle) {
   };
 }
 void smoke_StandaloneProducer_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_StandaloneProducer_release_handle(handle);
+  _smokeStandaloneproducerReleaseHandle(handle);
 // Nullable StandaloneProducer
-final _smoke_StandaloneProducer_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StandaloneProducerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StandaloneProducer_create_handle_nullable'));
-final _smoke_StandaloneProducer_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StandaloneProducerReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StandaloneProducer_release_handle_nullable'));
-final _smoke_StandaloneProducer_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StandaloneProducerGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StandaloneProducer_get_value_nullable'));
 Pointer<Void> smoke_StandaloneProducer_toFfi_nullable(StandaloneProducer value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StandaloneProducer_toFfi(value);
-  final result = _smoke_StandaloneProducer_create_handle_nullable(_handle);
+  final result = _smoke_StandaloneProducerCreateHandleNullable(_handle);
   smoke_StandaloneProducer_releaseFfiHandle(_handle);
   return result;
 }
 StandaloneProducer smoke_StandaloneProducer_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StandaloneProducer_get_value_nullable(handle);
+  final _handle = _smoke_StandaloneProducerGetValueNullable(handle);
   final result = smoke_StandaloneProducer_fromFfi(_handle);
   smoke_StandaloneProducer_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StandaloneProducer_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StandaloneProducer_release_handle_nullable(handle);
+  _smoke_StandaloneProducerReleaseHandleNullable(handle);
 // End of StandaloneProducer "private" section.

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/_token_cache.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 const unknownError = -1;
 int _instanceCounter = 1024;
@@ -23,15 +22,15 @@ void uncacheObject(Object object) {
   tokenCache.remove(object);
 }
 final uncacheObjectFfi = Pointer.fromFunction<Void Function(Uint64)>(uncacheObjectByToken);
-final ffi_get_cached_token = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final ffiGetCachedToken = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Uint64 Function(Pointer<Void>, Int32),
       int Function(Pointer<Void>, int)
     >('library_get_cached_token'));
-final ffi_cache_token = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final ffiCacheToken = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Void Function(Pointer<Void>, Int32, Uint64),
       void Function(Pointer<Void>, int, int)
     >('library_cache_token'));
-final ffi_uncache_token = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final ffiUncacheToken = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
       Void Function(Pointer<Void>, Int32),
       void Function(Pointer<Void>, int)
     >('library_uncache_token'));

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -5,11 +5,10 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class CalculatorListener {
-  CalculatorListener() {}
+  CalculatorListener();
   factory CalculatorListener.fromLambdas({
     @required void Function(double) lambda_onCalculationResult,
     @required void Function(double) lambda_onCalculationResultConst,
@@ -42,79 +41,79 @@ class CalculatorListener_ResultStruct {
   CalculatorListener_ResultStruct(this.result);
 }
 // CalculatorListener_ResultStruct "private" section, not exported.
-final _smoke_CalculatorListener_ResultStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCalculatorlistenerResultstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_smoke_CalculatorListener_ResultStruct_create_handle'));
-final _smoke_CalculatorListener_ResultStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCalculatorlistenerResultstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_release_handle'));
-final _smoke_CalculatorListener_ResultStruct_get_field_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCalculatorlistenerResultstructGetFieldresult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_get_field_result'));
 Pointer<Void> smoke_CalculatorListener_ResultStruct_toFfi(CalculatorListener_ResultStruct value) {
-  final _result_handle = (value.result);
-  final _result = _smoke_CalculatorListener_ResultStruct_create_handle(_result_handle);
-  (_result_handle);
+  final _resultHandle = (value.result);
+  final _result = _smokeCalculatorlistenerResultstructCreateHandle(_resultHandle);
+  (_resultHandle);
   return _result;
 }
 CalculatorListener_ResultStruct smoke_CalculatorListener_ResultStruct_fromFfi(Pointer<Void> handle) {
-  final _result_handle = _smoke_CalculatorListener_ResultStruct_get_field_result(handle);
+  final _resultHandle = _smokeCalculatorlistenerResultstructGetFieldresult(handle);
   try {
     return CalculatorListener_ResultStruct(
-      (_result_handle)
+      (_resultHandle)
     );
   } finally {
-    (_result_handle);
+    (_resultHandle);
   }
 }
-void smoke_CalculatorListener_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_CalculatorListener_ResultStruct_release_handle(handle);
+void smoke_CalculatorListener_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeCalculatorlistenerResultstructReleaseHandle(handle);
 // Nullable CalculatorListener_ResultStruct
-final _smoke_CalculatorListener_ResultStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CalculatorListener_ResultStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_create_handle_nullable'));
-final _smoke_CalculatorListener_ResultStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CalculatorListener_ResultStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_release_handle_nullable'));
-final _smoke_CalculatorListener_ResultStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_CalculatorListener_ResultStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_get_value_nullable'));
 Pointer<Void> smoke_CalculatorListener_ResultStruct_toFfi_nullable(CalculatorListener_ResultStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_CalculatorListener_ResultStruct_toFfi(value);
-  final result = _smoke_CalculatorListener_ResultStruct_create_handle_nullable(_handle);
+  final result = _smoke_CalculatorListener_ResultStructCreateHandleNullable(_handle);
   smoke_CalculatorListener_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
 CalculatorListener_ResultStruct smoke_CalculatorListener_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_CalculatorListener_ResultStruct_get_value_nullable(handle);
+  final _handle = _smoke_CalculatorListener_ResultStructGetValueNullable(handle);
   final result = smoke_CalculatorListener_ResultStruct_fromFfi(_handle);
   smoke_CalculatorListener_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_CalculatorListener_ResultStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CalculatorListener_ResultStruct_release_handle_nullable(handle);
+  _smoke_CalculatorListener_ResultStructReleaseHandleNullable(handle);
 // End of CalculatorListener_ResultStruct "private" section.
 // CalculatorListener "private" section, not exported.
-final _smoke_CalculatorListener_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCalculatorlistenerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_copy_handle'));
-final _smoke_CalculatorListener_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCalculatorlistenerReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_release_handle'));
-final _smoke_CalculatorListener_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCalculatorlistenerCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_CalculatorListener_create_proxy'));
-final _smoke_CalculatorListener_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCalculatorlistenerGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_get_type_id'));
@@ -160,86 +159,86 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_CalculatorListener_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeCalculatorlistenerReleaseHandle(handle);
     handle = null;
   }
   @override
   onCalculationResult(double calculationResult) {
-    final _onCalculationResult_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResult__Double'));
-    final _calculationResult_handle = (calculationResult);
+    final _onCalculationResultFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResult__Double'));
+    final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
-    final __result_handle = _onCalculationResult_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
-    (_calculationResult_handle);
+    final __resultHandle = _onCalculationResultFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    (_calculationResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   onCalculationResultConst(double calculationResult) {
-    final _onCalculationResultConst_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double'));
-    final _calculationResult_handle = (calculationResult);
+    final _onCalculationResultConstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double'));
+    final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
-    final __result_handle = _onCalculationResultConst_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
-    (_calculationResult_handle);
+    final __resultHandle = _onCalculationResultConstFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    (_calculationResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
-    final _onCalculationResultStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct'));
-    final _calculationResult_handle = smoke_CalculatorListener_ResultStruct_toFfi(calculationResult);
+    final _onCalculationResultStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct'));
+    final _calculationResultHandle = smoke_CalculatorListener_ResultStruct_toFfi(calculationResult);
     final _handle = this.handle;
-    final __result_handle = _onCalculationResultStruct_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
-    smoke_CalculatorListener_ResultStruct_releaseFfiHandle(_calculationResult_handle);
+    final __resultHandle = _onCalculationResultStructFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    smoke_CalculatorListener_ResultStruct_releaseFfiHandle(_calculationResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   onCalculationResultArray(List<double> calculationResult) {
-    final _onCalculationResultArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double'));
-    final _calculationResult_handle = foobar_ListOf_Double_toFfi(calculationResult);
+    final _onCalculationResultArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double'));
+    final _calculationResultHandle = foobar_ListOf_Double_toFfi(calculationResult);
     final _handle = this.handle;
-    final __result_handle = _onCalculationResultArray_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
-    foobar_ListOf_Double_releaseFfiHandle(_calculationResult_handle);
+    final __resultHandle = _onCalculationResultArrayFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    foobar_ListOf_Double_releaseFfiHandle(_calculationResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   onCalculationResultMap(Map<String, double> calculationResults) {
-    final _onCalculationResultMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double'));
-    final _calculationResults_handle = foobar_MapOf_String_to_Double_toFfi(calculationResults);
+    final _onCalculationResultMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double'));
+    final _calculationResultsHandle = foobar_MapOf_String_to_Double_toFfi(calculationResults);
     final _handle = this.handle;
-    final __result_handle = _onCalculationResultMap_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResults_handle);
-    foobar_MapOf_String_to_Double_releaseFfiHandle(_calculationResults_handle);
+    final __resultHandle = _onCalculationResultMapFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultsHandle);
+    foobar_MapOf_String_to_Double_releaseFfiHandle(_calculationResultsHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   onCalculationResultInstance(CalculationResult calculationResult) {
-    final _onCalculationResultInstance_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult'));
-    final _calculationResult_handle = smoke_CalculationResult_toFfi(calculationResult);
+    final _onCalculationResultInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult'));
+    final _calculationResultHandle = smoke_CalculationResult_toFfi(calculationResult);
     final _handle = this.handle;
-    final __result_handle = _onCalculationResultInstance_ffi(_handle, __lib.LibraryContext.isolateId, _calculationResult_handle);
-    smoke_CalculationResult_releaseFfiHandle(_calculationResult_handle);
+    final __resultHandle = _onCalculationResultInstanceFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    smoke_CalculationResult_releaseFfiHandle(_calculationResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -292,8 +291,8 @@ int _CalculatorListener_onCalculationResultInstance_static(int _token, Pointer<V
   return 0;
 }
 Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
-  if (value is __lib.NativeBase) return _smoke_CalculatorListener_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_CalculatorListener_create_proxy(
+  if (value is __lib.NativeBase) return _smokeCalculatorlistenerCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeCalculatorlistenerCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -308,25 +307,25 @@ Pointer<Void> smoke_CalculatorListener_toFfi(CalculatorListener value) {
 }
 CalculatorListener smoke_CalculatorListener_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as CalculatorListener;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_CalculatorListener_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_CalculatorListener_copy_handle(handle);
+  final _typeIdHandle = _smokeCalculatorlistenerGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeCalculatorlistenerCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : CalculatorListener$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : CalculatorListener$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_CalculatorListener_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_CalculatorListener_release_handle(handle);
+  _smokeCalculatorlistenerReleaseHandle(handle);
 Pointer<Void> smoke_CalculatorListener_toFfi_nullable(CalculatorListener value) =>
   value != null ? smoke_CalculatorListener_toFfi(value) : Pointer<Void>.fromAddress(0);
 CalculatorListener smoke_CalculatorListener_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CalculatorListener_fromFfi(handle) : null;
 void smoke_CalculatorListener_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CalculatorListener_release_handle(handle);
+  _smokeCalculatorlistenerReleaseHandle(handle);
 // End of CalculatorListener "private" section.

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class InterfaceWithStatic {
-  InterfaceWithStatic() {}
+  InterfaceWithStatic();
   factory InterfaceWithStatic.fromLambdas({
     @required String Function() lambda_regularFunction,
     @required String Function() lambda_regularProperty_get,
@@ -30,19 +29,19 @@ abstract class InterfaceWithStatic {
   static set staticProperty(String value) { InterfaceWithStatic$Impl.staticProperty = value; }
 }
 // InterfaceWithStatic "private" section, not exported.
-final _smoke_InterfaceWithStatic_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInterfacewithstaticCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InterfaceWithStatic_copy_handle'));
-final _smoke_InterfaceWithStatic_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInterfacewithstaticReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InterfaceWithStatic_release_handle'));
-final _smoke_InterfaceWithStatic_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInterfacewithstaticCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_InterfaceWithStatic_create_proxy'));
-final _smoke_InterfaceWithStatic_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInterfacewithstaticGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InterfaceWithStatic_get_type_id'));
@@ -71,79 +70,79 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_InterfaceWithStatic_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeInterfacewithstaticReleaseHandle(handle);
     handle = null;
   }
   @override
   String regularFunction() {
-    final _regularFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_InterfaceWithStatic_regularFunction'));
+    final _regularFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_InterfaceWithStatic_regularFunction'));
     final _handle = this.handle;
-    final __result_handle = _regularFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _regularFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   static String staticFunction() {
-    final _staticFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticFunction'));
-    final __result_handle = _staticFunction_ffi(__lib.LibraryContext.isolateId);
+    final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticFunction'));
+    final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   String get regularProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_InterfaceWithStatic_regularProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_InterfaceWithStatic_regularProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   set regularProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_regularProperty_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_regularProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static String get staticProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticProperty_get'));
-    final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticProperty_get'));
+    final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   static set staticProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_staticProperty_set__String'));
-    final _value_handle = String_toFfi(value);
-    final __result_handle = _set_ffi(__lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_staticProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
+    final __resultHandle = _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _InterfaceWithStatic_regularFunction_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as InterfaceWithStatic).regularFunction();
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as InterfaceWithStatic).regularFunction();
+    _result.value = String_toFfi(_resultObject);
   } finally {
   }
   return 0;
@@ -162,8 +161,8 @@ int _InterfaceWithStatic_regularProperty_set_static(int _token, Pointer<Void> _v
   return 0;
 }
 Pointer<Void> smoke_InterfaceWithStatic_toFfi(InterfaceWithStatic value) {
-  if (value is __lib.NativeBase) return _smoke_InterfaceWithStatic_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_InterfaceWithStatic_create_proxy(
+  if (value is __lib.NativeBase) return _smokeInterfacewithstaticCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeInterfacewithstaticCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -175,25 +174,25 @@ Pointer<Void> smoke_InterfaceWithStatic_toFfi(InterfaceWithStatic value) {
 }
 InterfaceWithStatic smoke_InterfaceWithStatic_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as InterfaceWithStatic;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_InterfaceWithStatic_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_InterfaceWithStatic_copy_handle(handle);
+  final _typeIdHandle = _smokeInterfacewithstaticGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeInterfacewithstaticCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : InterfaceWithStatic$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : InterfaceWithStatic$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_InterfaceWithStatic_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_InterfaceWithStatic_release_handle(handle);
+  _smokeInterfacewithstaticReleaseHandle(handle);
 Pointer<Void> smoke_InterfaceWithStatic_toFfi_nullable(InterfaceWithStatic value) =>
   value != null ? smoke_InterfaceWithStatic_toFfi(value) : Pointer<Void>.fromAddress(0);
 InterfaceWithStatic smoke_InterfaceWithStatic_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InterfaceWithStatic_fromFfi(handle) : null;
 void smoke_InterfaceWithStatic_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_InterfaceWithStatic_release_handle(handle);
+  _smokeInterfacewithstaticReleaseHandle(handle);
 // End of InterfaceWithStatic "private" section.

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -6,11 +6,10 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenerWithProperties {
-  ListenerWithProperties() {}
+  ListenerWithProperties();
   factory ListenerWithProperties.fromLambdas({
     @required String Function() lambda_message_get,
     @required void Function(String) lambda_message_set,
@@ -92,113 +91,113 @@ ListenerWithProperties_ResultEnum smoke_ListenerWithProperties_ResultEnum_fromFf
   }
 }
 void smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(int handle) {}
-final _smoke_ListenerWithProperties_ResultEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ListenerWithProperties_ResultEnum_create_handle_nullable'));
-final _smoke_ListenerWithProperties_ResultEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultEnum_release_handle_nullable'));
-final _smoke_ListenerWithProperties_ResultEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultEnum_get_value_nullable'));
 Pointer<Void> smoke_ListenerWithProperties_ResultEnum_toFfi_nullable(ListenerWithProperties_ResultEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenerWithProperties_ResultEnum_toFfi(value);
-  final result = _smoke_ListenerWithProperties_ResultEnum_create_handle_nullable(_handle);
+  final result = _smoke_ListenerWithProperties_ResultEnumCreateHandleNullable(_handle);
   smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_handle);
   return result;
 }
 ListenerWithProperties_ResultEnum smoke_ListenerWithProperties_ResultEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ListenerWithProperties_ResultEnum_get_value_nullable(handle);
+  final _handle = _smoke_ListenerWithProperties_ResultEnumGetValueNullable(handle);
   final result = smoke_ListenerWithProperties_ResultEnum_fromFfi(_handle);
   smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ListenerWithProperties_ResultEnum_release_handle_nullable(handle);
+  _smoke_ListenerWithProperties_ResultEnumReleaseHandleNullable(handle);
 // End of ListenerWithProperties_ResultEnum "private" section.
 class ListenerWithProperties_ResultStruct {
   double result;
   ListenerWithProperties_ResultStruct(this.result);
 }
 // ListenerWithProperties_ResultStruct "private" section, not exported.
-final _smoke_ListenerWithProperties_ResultStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerwithpropertiesResultstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_smoke_ListenerWithProperties_ResultStruct_create_handle'));
-final _smoke_ListenerWithProperties_ResultStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerwithpropertiesResultstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_release_handle'));
-final _smoke_ListenerWithProperties_ResultStruct_get_field_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerwithpropertiesResultstructGetFieldresult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_get_field_result'));
 Pointer<Void> smoke_ListenerWithProperties_ResultStruct_toFfi(ListenerWithProperties_ResultStruct value) {
-  final _result_handle = (value.result);
-  final _result = _smoke_ListenerWithProperties_ResultStruct_create_handle(_result_handle);
-  (_result_handle);
+  final _resultHandle = (value.result);
+  final _result = _smokeListenerwithpropertiesResultstructCreateHandle(_resultHandle);
+  (_resultHandle);
   return _result;
 }
 ListenerWithProperties_ResultStruct smoke_ListenerWithProperties_ResultStruct_fromFfi(Pointer<Void> handle) {
-  final _result_handle = _smoke_ListenerWithProperties_ResultStruct_get_field_result(handle);
+  final _resultHandle = _smokeListenerwithpropertiesResultstructGetFieldresult(handle);
   try {
     return ListenerWithProperties_ResultStruct(
-      (_result_handle)
+      (_resultHandle)
     );
   } finally {
-    (_result_handle);
+    (_resultHandle);
   }
 }
-void smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ListenerWithProperties_ResultStruct_release_handle(handle);
+void smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeListenerwithpropertiesResultstructReleaseHandle(handle);
 // Nullable ListenerWithProperties_ResultStruct
-final _smoke_ListenerWithProperties_ResultStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_create_handle_nullable'));
-final _smoke_ListenerWithProperties_ResultStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_release_handle_nullable'));
-final _smoke_ListenerWithProperties_ResultStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenerWithProperties_ResultStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_get_value_nullable'));
 Pointer<Void> smoke_ListenerWithProperties_ResultStruct_toFfi_nullable(ListenerWithProperties_ResultStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenerWithProperties_ResultStruct_toFfi(value);
-  final result = _smoke_ListenerWithProperties_ResultStruct_create_handle_nullable(_handle);
+  final result = _smoke_ListenerWithProperties_ResultStructCreateHandleNullable(_handle);
   smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
 ListenerWithProperties_ResultStruct smoke_ListenerWithProperties_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ListenerWithProperties_ResultStruct_get_value_nullable(handle);
+  final _handle = _smoke_ListenerWithProperties_ResultStructGetValueNullable(handle);
   final result = smoke_ListenerWithProperties_ResultStruct_fromFfi(_handle);
   smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ListenerWithProperties_ResultStruct_release_handle_nullable(handle);
+  _smoke_ListenerWithProperties_ResultStructReleaseHandleNullable(handle);
 // End of ListenerWithProperties_ResultStruct "private" section.
 // ListenerWithProperties "private" section, not exported.
-final _smoke_ListenerWithProperties_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerwithpropertiesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_copy_handle'));
-final _smoke_ListenerWithProperties_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerwithpropertiesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_release_handle'));
-final _smoke_ListenerWithProperties_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerwithpropertiesCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_ListenerWithProperties_create_proxy'));
-final _smoke_ListenerWithProperties_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerwithpropertiesGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_get_type_id'));
@@ -270,162 +269,162 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ListenerWithProperties_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeListenerwithpropertiesReleaseHandle(handle);
     handle = null;
   }
   String get message {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_message_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_message_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   set message(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   CalculationResult get packedMessage {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_packedMessage_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_packedMessage_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_CalculationResult_fromFfi(__result_handle);
+      return smoke_CalculationResult_fromFfi(__resultHandle);
     } finally {
-      smoke_CalculationResult_releaseFfiHandle(__result_handle);
+      smoke_CalculationResult_releaseFfiHandle(__resultHandle);
     }
   }
   set packedMessage(CalculationResult value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult'));
-    final _value_handle = smoke_CalculationResult_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult'));
+    final _valueHandle = smoke_CalculationResult_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_CalculationResult_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_CalculationResult_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   ListenerWithProperties_ResultStruct get structuredMessage {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_structuredMessage_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_structuredMessage_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_ListenerWithProperties_ResultStruct_fromFfi(__result_handle);
+      return smoke_ListenerWithProperties_ResultStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(__result_handle);
+      smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(__resultHandle);
     }
   }
   set structuredMessage(ListenerWithProperties_ResultStruct value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct'));
-    final _value_handle = smoke_ListenerWithProperties_ResultStruct_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct'));
+    final _valueHandle = smoke_ListenerWithProperties_ResultStruct_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_ListenerWithProperties_ResultStruct_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   ListenerWithProperties_ResultEnum get enumeratedMessage {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_ListenerWithProperties_ResultEnum_fromFfi(__result_handle);
+      return smoke_ListenerWithProperties_ResultEnum_fromFfi(__resultHandle);
     } finally {
-      smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(__result_handle);
+      smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(__resultHandle);
     }
   }
   set enumeratedMessage(ListenerWithProperties_ResultEnum value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum'));
-    final _value_handle = smoke_ListenerWithProperties_ResultEnum_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum'));
+    final _valueHandle = smoke_ListenerWithProperties_ResultEnum_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_ListenerWithProperties_ResultEnum_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   List<String> get arrayedMessage {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_arrayedMessage_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_arrayedMessage_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_ListOf_String_fromFfi(__result_handle);
+      return foobar_ListOf_String_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_String_releaseFfiHandle(__result_handle);
+      foobar_ListOf_String_releaseFfiHandle(__resultHandle);
     }
   }
   set arrayedMessage(List<String> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String'));
-    final _value_handle = foobar_ListOf_String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String'));
+    final _valueHandle = foobar_ListOf_String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_ListOf_String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_ListOf_String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   Map<String, double> get mappedMessage {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_MapOf_String_to_Double_fromFfi(__result_handle);
+      return foobar_MapOf_String_to_Double_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_String_to_Double_releaseFfiHandle(__result_handle);
+      foobar_MapOf_String_to_Double_releaseFfiHandle(__resultHandle);
     }
   }
   set mappedMessage(Map<String, double> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double'));
-    final _value_handle = foobar_MapOf_String_to_Double_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double'));
+    final _valueHandle = foobar_MapOf_String_to_Double_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_MapOf_String_to_Double_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_MapOf_String_to_Double_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   Uint8List get bufferedMessage {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_bufferedMessage_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_bufferedMessage_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Blob_fromFfi(__result_handle);
+      return Blob_fromFfi(__resultHandle);
     } finally {
-      Blob_releaseFfiHandle(__result_handle);
+      Blob_releaseFfiHandle(__resultHandle);
     }
   }
   set bufferedMessage(Uint8List value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob'));
-    final _value_handle = Blob_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob'));
+    final _valueHandle = Blob_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Blob_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Blob_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -521,8 +520,8 @@ int _ListenerWithProperties_bufferedMessage_set_static(int _token, Pointer<Void>
   return 0;
 }
 Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
-  if (value is __lib.NativeBase) return _smoke_ListenerWithProperties_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_ListenerWithProperties_create_proxy(
+  if (value is __lib.NativeBase) return _smokeListenerwithpropertiesCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeListenerwithpropertiesCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -545,25 +544,25 @@ Pointer<Void> smoke_ListenerWithProperties_toFfi(ListenerWithProperties value) {
 }
 ListenerWithProperties smoke_ListenerWithProperties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ListenerWithProperties;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ListenerWithProperties_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ListenerWithProperties_copy_handle(handle);
+  final _typeIdHandle = _smokeListenerwithpropertiesGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeListenerwithpropertiesCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ListenerWithProperties$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ListenerWithProperties$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ListenerWithProperties_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ListenerWithProperties_release_handle(handle);
+  _smokeListenerwithpropertiesReleaseHandle(handle);
 Pointer<Void> smoke_ListenerWithProperties_toFfi_nullable(ListenerWithProperties value) =>
   value != null ? smoke_ListenerWithProperties_toFfi(value) : Pointer<Void>.fromAddress(0);
 ListenerWithProperties smoke_ListenerWithProperties_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ListenerWithProperties_fromFfi(handle) : null;
 void smoke_ListenerWithProperties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ListenerWithProperties_release_handle(handle);
+  _smokeListenerwithpropertiesReleaseHandle(handle);
 // End of ListenerWithProperties "private" section.

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -5,11 +5,10 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenersWithReturnValues {
-  ListenersWithReturnValues() {}
+  ListenersWithReturnValues();
   factory ListenersWithReturnValues.fromLambdas({
     @required double Function() lambda_fetchDataDouble,
     @required String Function() lambda_fetchDataString,
@@ -70,113 +69,113 @@ ListenersWithReturnValues_ResultEnum smoke_ListenersWithReturnValues_ResultEnum_
   }
 }
 void smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(int handle) {}
-final _smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable'));
-final _smoke_ListenersWithReturnValues_ResultEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultEnum_release_handle_nullable'));
-final _smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable'));
 Pointer<Void> smoke_ListenersWithReturnValues_ResultEnum_toFfi_nullable(ListenersWithReturnValues_ResultEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenersWithReturnValues_ResultEnum_toFfi(value);
-  final result = _smoke_ListenersWithReturnValues_ResultEnum_create_handle_nullable(_handle);
+  final result = _smoke_ListenersWithReturnValues_ResultEnumCreateHandleNullable(_handle);
   smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(_handle);
   return result;
 }
 ListenersWithReturnValues_ResultEnum smoke_ListenersWithReturnValues_ResultEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable(handle);
+  final _handle = _smoke_ListenersWithReturnValues_ResultEnumGetValueNullable(handle);
   final result = smoke_ListenersWithReturnValues_ResultEnum_fromFfi(_handle);
   smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ListenersWithReturnValues_ResultEnum_release_handle_nullable(handle);
+  _smoke_ListenersWithReturnValues_ResultEnumReleaseHandleNullable(handle);
 // End of ListenersWithReturnValues_ResultEnum "private" section.
 class ListenersWithReturnValues_ResultStruct {
   double result;
   ListenersWithReturnValues_ResultStruct(this.result);
 }
 // ListenersWithReturnValues_ResultStruct "private" section, not exported.
-final _smoke_ListenersWithReturnValues_ResultStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerswithreturnvaluesResultstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_create_handle'));
-final _smoke_ListenersWithReturnValues_ResultStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerswithreturnvaluesResultstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_release_handle'));
-final _smoke_ListenersWithReturnValues_ResultStruct_get_field_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerswithreturnvaluesResultstructGetFieldresult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_get_field_result'));
 Pointer<Void> smoke_ListenersWithReturnValues_ResultStruct_toFfi(ListenersWithReturnValues_ResultStruct value) {
-  final _result_handle = (value.result);
-  final _result = _smoke_ListenersWithReturnValues_ResultStruct_create_handle(_result_handle);
-  (_result_handle);
+  final _resultHandle = (value.result);
+  final _result = _smokeListenerswithreturnvaluesResultstructCreateHandle(_resultHandle);
+  (_resultHandle);
   return _result;
 }
 ListenersWithReturnValues_ResultStruct smoke_ListenersWithReturnValues_ResultStruct_fromFfi(Pointer<Void> handle) {
-  final _result_handle = _smoke_ListenersWithReturnValues_ResultStruct_get_field_result(handle);
+  final _resultHandle = _smokeListenerswithreturnvaluesResultstructGetFieldresult(handle);
   try {
     return ListenersWithReturnValues_ResultStruct(
-      (_result_handle)
+      (_resultHandle)
     );
   } finally {
-    (_result_handle);
+    (_resultHandle);
   }
 }
-void smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_ListenersWithReturnValues_ResultStruct_release_handle(handle);
+void smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeListenerswithreturnvaluesResultstructReleaseHandle(handle);
 // Nullable ListenersWithReturnValues_ResultStruct
-final _smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable'));
-final _smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable'));
-final _smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_ListenersWithReturnValues_ResultStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable'));
 Pointer<Void> smoke_ListenersWithReturnValues_ResultStruct_toFfi_nullable(ListenersWithReturnValues_ResultStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_ListenersWithReturnValues_ResultStruct_toFfi(value);
-  final result = _smoke_ListenersWithReturnValues_ResultStruct_create_handle_nullable(_handle);
+  final result = _smoke_ListenersWithReturnValues_ResultStructCreateHandleNullable(_handle);
   smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
 ListenersWithReturnValues_ResultStruct smoke_ListenersWithReturnValues_ResultStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable(handle);
+  final _handle = _smoke_ListenersWithReturnValues_ResultStructGetValueNullable(handle);
   final result = smoke_ListenersWithReturnValues_ResultStruct_fromFfi(_handle);
   smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ListenersWithReturnValues_ResultStruct_release_handle_nullable(handle);
+  _smoke_ListenersWithReturnValues_ResultStructReleaseHandleNullable(handle);
 // End of ListenersWithReturnValues_ResultStruct "private" section.
 // ListenersWithReturnValues "private" section, not exported.
-final _smoke_ListenersWithReturnValues_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerswithreturnvaluesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_copy_handle'));
-final _smoke_ListenersWithReturnValues_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerswithreturnvaluesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_release_handle'));
-final _smoke_ListenersWithReturnValues_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerswithreturnvaluesCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_ListenersWithReturnValues_create_proxy'));
-final _smoke_ListenersWithReturnValues_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeListenerswithreturnvaluesGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_get_type_id'));
@@ -227,155 +226,155 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_ListenersWithReturnValues_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeListenerswithreturnvaluesReleaseHandle(handle);
     handle = null;
   }
   @override
   double fetchDataDouble() {
-    final _fetchDataDouble_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataDouble'));
+    final _fetchDataDoubleFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataDouble'));
     final _handle = this.handle;
-    final __result_handle = _fetchDataDouble_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fetchDataDoubleFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String fetchDataString() {
-    final _fetchDataString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataString'));
+    final _fetchDataStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataString'));
     final _handle = this.handle;
-    final __result_handle = _fetchDataString_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fetchDataStringFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   ListenersWithReturnValues_ResultStruct fetchDataStruct() {
-    final _fetchDataStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataStruct'));
+    final _fetchDataStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataStruct'));
     final _handle = this.handle;
-    final __result_handle = _fetchDataStruct_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fetchDataStructFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_ListenersWithReturnValues_ResultStruct_fromFfi(__result_handle);
+      return smoke_ListenersWithReturnValues_ResultStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(__result_handle);
+      smoke_ListenersWithReturnValues_ResultStruct_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   ListenersWithReturnValues_ResultEnum fetchDataEnum() {
-    final _fetchDataEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataEnum'));
+    final _fetchDataEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataEnum'));
     final _handle = this.handle;
-    final __result_handle = _fetchDataEnum_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fetchDataEnumFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_ListenersWithReturnValues_ResultEnum_fromFfi(__result_handle);
+      return smoke_ListenersWithReturnValues_ResultEnum_fromFfi(__resultHandle);
     } finally {
-      smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(__result_handle);
+      smoke_ListenersWithReturnValues_ResultEnum_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   List<double> fetchDataArray() {
-    final _fetchDataArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataArray'));
+    final _fetchDataArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataArray'));
     final _handle = this.handle;
-    final __result_handle = _fetchDataArray_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fetchDataArrayFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_ListOf_Double_fromFfi(__result_handle);
+      return foobar_ListOf_Double_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_Double_releaseFfiHandle(__result_handle);
+      foobar_ListOf_Double_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Map<String, double> fetchDataMap() {
-    final _fetchDataMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap'));
+    final _fetchDataMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap'));
     final _handle = this.handle;
-    final __result_handle = _fetchDataMap_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fetchDataMapFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_MapOf_String_to_Double_fromFfi(__result_handle);
+      return foobar_MapOf_String_to_Double_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_String_to_Double_releaseFfiHandle(__result_handle);
+      foobar_MapOf_String_to_Double_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   CalculationResult fetchDataInstance() {
-    final _fetchDataInstance_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataInstance'));
+    final _fetchDataInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataInstance'));
     final _handle = this.handle;
-    final __result_handle = _fetchDataInstance_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fetchDataInstanceFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_CalculationResult_fromFfi(__result_handle);
+      return smoke_CalculationResult_fromFfi(__resultHandle);
     } finally {
-      smoke_CalculationResult_releaseFfiHandle(__result_handle);
+      smoke_CalculationResult_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _ListenersWithReturnValues_fetchDataDouble_static(int _token, Pointer<Double> _result) {
-  double _result_object = null;
+  double _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
-    _result.value = (_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
+    _result.value = (_resultObject);
   } finally {
   }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataString_static(int _token, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
+    _result.value = String_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataStruct_static(int _token, Pointer<Pointer<Void>> _result) {
-  ListenersWithReturnValues_ResultStruct _result_object = null;
+  ListenersWithReturnValues_ResultStruct _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
-    _result.value = smoke_ListenersWithReturnValues_ResultStruct_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
+    _result.value = smoke_ListenersWithReturnValues_ResultStruct_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataEnum_static(int _token, Pointer<Uint32> _result) {
-  ListenersWithReturnValues_ResultEnum _result_object = null;
+  ListenersWithReturnValues_ResultEnum _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
-    _result.value = smoke_ListenersWithReturnValues_ResultEnum_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
+    _result.value = smoke_ListenersWithReturnValues_ResultEnum_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataArray_static(int _token, Pointer<Pointer<Void>> _result) {
-  List<double> _result_object = null;
+  List<double> _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
-    _result.value = foobar_ListOf_Double_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
+    _result.value = foobar_ListOf_Double_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataMap_static(int _token, Pointer<Pointer<Void>> _result) {
-  Map<String, double> _result_object = null;
+  Map<String, double> _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
-    _result.value = foobar_MapOf_String_to_Double_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
+    _result.value = foobar_MapOf_String_to_Double_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 int _ListenersWithReturnValues_fetchDataInstance_static(int _token, Pointer<Pointer<Void>> _result) {
-  CalculationResult _result_object = null;
+  CalculationResult _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
-    _result.value = smoke_CalculationResult_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
+    _result.value = smoke_CalculationResult_toFfi(_resultObject);
   } finally {
-    if (_result_object != null) _result_object.release();
+    if (_resultObject != null) _resultObject.release();
   }
   return 0;
 }
 Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues value) {
-  if (value is __lib.NativeBase) return _smoke_ListenersWithReturnValues_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_ListenersWithReturnValues_create_proxy(
+  if (value is __lib.NativeBase) return _smokeListenerswithreturnvaluesCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeListenerswithreturnvaluesCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -391,25 +390,25 @@ Pointer<Void> smoke_ListenersWithReturnValues_toFfi(ListenersWithReturnValues va
 }
 ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as ListenersWithReturnValues;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_ListenersWithReturnValues_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_ListenersWithReturnValues_copy_handle(handle);
+  final _typeIdHandle = _smokeListenerswithreturnvaluesGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeListenerswithreturnvaluesCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : ListenersWithReturnValues$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : ListenersWithReturnValues$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_ListenersWithReturnValues_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_ListenersWithReturnValues_release_handle(handle);
+  _smokeListenerswithreturnvaluesReleaseHandle(handle);
 Pointer<Void> smoke_ListenersWithReturnValues_toFfi_nullable(ListenersWithReturnValues value) =>
   value != null ? smoke_ListenersWithReturnValues_toFfi(value) : Pointer<Void>.fromAddress(0);
 ListenersWithReturnValues smoke_ListenersWithReturnValues_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_ListenersWithReturnValues_fromFfi(handle) : null;
 void smoke_ListenersWithReturnValues_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_ListenersWithReturnValues_release_handle(handle);
+  _smokeListenerswithreturnvaluesReleaseHandle(handle);
 // End of ListenersWithReturnValues "private" section.

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Locales {
@@ -21,71 +20,71 @@ class Locales_LocaleStruct {
   Locales_LocaleStruct(this.localeField);
 }
 // Locales_LocaleStruct "private" section, not exported.
-final _smoke_Locales_LocaleStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLocalesLocalestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_create_handle'));
-final _smoke_Locales_LocaleStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLocalesLocalestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_release_handle'));
-final _smoke_Locales_LocaleStruct_get_field_localeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLocalesLocalestructGetFieldlocaleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_get_field_localeField'));
 Pointer<Void> smoke_Locales_LocaleStruct_toFfi(Locales_LocaleStruct value) {
-  final _localeField_handle = Locale_toFfi(value.localeField);
-  final _result = _smoke_Locales_LocaleStruct_create_handle(_localeField_handle);
-  Locale_releaseFfiHandle(_localeField_handle);
+  final _localeFieldHandle = Locale_toFfi(value.localeField);
+  final _result = _smokeLocalesLocalestructCreateHandle(_localeFieldHandle);
+  Locale_releaseFfiHandle(_localeFieldHandle);
   return _result;
 }
 Locales_LocaleStruct smoke_Locales_LocaleStruct_fromFfi(Pointer<Void> handle) {
-  final _localeField_handle = _smoke_Locales_LocaleStruct_get_field_localeField(handle);
+  final _localeFieldHandle = _smokeLocalesLocalestructGetFieldlocaleField(handle);
   try {
     return Locales_LocaleStruct(
-      Locale_fromFfi(_localeField_handle)
+      Locale_fromFfi(_localeFieldHandle)
     );
   } finally {
-    Locale_releaseFfiHandle(_localeField_handle);
+    Locale_releaseFfiHandle(_localeFieldHandle);
   }
 }
-void smoke_Locales_LocaleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Locales_LocaleStruct_release_handle(handle);
+void smoke_Locales_LocaleStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeLocalesLocalestructReleaseHandle(handle);
 // Nullable Locales_LocaleStruct
-final _smoke_Locales_LocaleStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Locales_LocaleStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_create_handle_nullable'));
-final _smoke_Locales_LocaleStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Locales_LocaleStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_release_handle_nullable'));
-final _smoke_Locales_LocaleStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Locales_LocaleStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_get_value_nullable'));
 Pointer<Void> smoke_Locales_LocaleStruct_toFfi_nullable(Locales_LocaleStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Locales_LocaleStruct_toFfi(value);
-  final result = _smoke_Locales_LocaleStruct_create_handle_nullable(_handle);
+  final result = _smoke_Locales_LocaleStructCreateHandleNullable(_handle);
   smoke_Locales_LocaleStruct_releaseFfiHandle(_handle);
   return result;
 }
 Locales_LocaleStruct smoke_Locales_LocaleStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Locales_LocaleStruct_get_value_nullable(handle);
+  final _handle = _smoke_Locales_LocaleStructGetValueNullable(handle);
   final result = smoke_Locales_LocaleStruct_fromFfi(_handle);
   smoke_Locales_LocaleStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Locales_LocaleStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Locales_LocaleStruct_release_handle_nullable(handle);
+  _smoke_Locales_LocaleStructReleaseHandleNullable(handle);
 // End of Locales_LocaleStruct "private" section.
 // Locales "private" section, not exported.
-final _smoke_Locales_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLocalesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_copy_handle'));
-final _smoke_Locales_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLocalesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Locales_release_handle'));
@@ -95,66 +94,66 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Locales_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeLocalesReleaseHandle(handle);
     handle = null;
   }
   @override
   Locale localeMethod(Locale input) {
-    final _localeMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeMethod__Locale'));
-    final _input_handle = Locale_toFfi(input);
+    final _localeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeMethod__Locale'));
+    final _inputHandle = Locale_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _localeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Locale_releaseFfiHandle(_input_handle);
+    final __resultHandle = _localeMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Locale_releaseFfiHandle(_inputHandle);
     try {
-      return Locale_fromFfi(__result_handle);
+      return Locale_fromFfi(__resultHandle);
     } finally {
-      Locale_releaseFfiHandle(__result_handle);
+      Locale_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   Locale get localeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Locales_localeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Locales_localeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Locale_fromFfi(__result_handle);
+      return Locale_fromFfi(__resultHandle);
     } finally {
-      Locale_releaseFfiHandle(__result_handle);
+      Locale_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set localeProperty(Locale value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeProperty_set__Locale'));
-    final _value_handle = Locale_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeProperty_set__Locale'));
+    final _valueHandle = Locale_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Locale_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Locale_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Locales_toFfi(Locales value) =>
-  _smoke_Locales_copy_handle((value as __lib.NativeBase).handle);
+  _smokeLocalesCopyHandle((value as __lib.NativeBase).handle);
 Locales smoke_Locales_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Locales;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Locales_copy_handle(handle);
-  final result = Locales$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeLocalesCopyHandle(handle);
+  final result = Locales$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Locales_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Locales_release_handle(handle);
+  _smokeLocalesReleaseHandle(handle);
 Pointer<Void> smoke_Locales_toFfi_nullable(Locales value) =>
   value != null ? smoke_Locales_toFfi(value) : Pointer<Void>.fromAddress(0);
 Locales smoke_Locales_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Locales_fromFfi(handle) : null;
 void smoke_Locales_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Locales_release_handle(handle);
+  _smokeLocalesReleaseHandle(handle);
 // End of Locales "private" section.

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class MethodOverloads {
@@ -29,80 +28,80 @@ class MethodOverloads_Point {
   MethodOverloads_Point(this.x, this.y);
 }
 // MethodOverloads_Point "private" section, not exported.
-final _smoke_MethodOverloads_Point_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMethodoverloadsPointCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
   >('library_smoke_MethodOverloads_Point_create_handle'));
-final _smoke_MethodOverloads_Point_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMethodoverloadsPointReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_release_handle'));
-final _smoke_MethodOverloads_Point_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMethodoverloadsPointGetFieldx = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_get_field_x'));
-final _smoke_MethodOverloads_Point_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMethodoverloadsPointGetFieldy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_get_field_y'));
 Pointer<Void> smoke_MethodOverloads_Point_toFfi(MethodOverloads_Point value) {
-  final _x_handle = (value.x);
-  final _y_handle = (value.y);
-  final _result = _smoke_MethodOverloads_Point_create_handle(_x_handle, _y_handle);
-  (_x_handle);
-  (_y_handle);
+  final _xHandle = (value.x);
+  final _yHandle = (value.y);
+  final _result = _smokeMethodoverloadsPointCreateHandle(_xHandle, _yHandle);
+  (_xHandle);
+  (_yHandle);
   return _result;
 }
 MethodOverloads_Point smoke_MethodOverloads_Point_fromFfi(Pointer<Void> handle) {
-  final _x_handle = _smoke_MethodOverloads_Point_get_field_x(handle);
-  final _y_handle = _smoke_MethodOverloads_Point_get_field_y(handle);
+  final _xHandle = _smokeMethodoverloadsPointGetFieldx(handle);
+  final _yHandle = _smokeMethodoverloadsPointGetFieldy(handle);
   try {
     return MethodOverloads_Point(
-      (_x_handle),
-      (_y_handle)
+      (_xHandle),
+      (_yHandle)
     );
   } finally {
-    (_x_handle);
-    (_y_handle);
+    (_xHandle);
+    (_yHandle);
   }
 }
-void smoke_MethodOverloads_Point_releaseFfiHandle(Pointer<Void> handle) => _smoke_MethodOverloads_Point_release_handle(handle);
+void smoke_MethodOverloads_Point_releaseFfiHandle(Pointer<Void> handle) => _smokeMethodoverloadsPointReleaseHandle(handle);
 // Nullable MethodOverloads_Point
-final _smoke_MethodOverloads_Point_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_MethodOverloads_PointCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_create_handle_nullable'));
-final _smoke_MethodOverloads_Point_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_MethodOverloads_PointReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_release_handle_nullable'));
-final _smoke_MethodOverloads_Point_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_MethodOverloads_PointGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_get_value_nullable'));
 Pointer<Void> smoke_MethodOverloads_Point_toFfi_nullable(MethodOverloads_Point value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_MethodOverloads_Point_toFfi(value);
-  final result = _smoke_MethodOverloads_Point_create_handle_nullable(_handle);
+  final result = _smoke_MethodOverloads_PointCreateHandleNullable(_handle);
   smoke_MethodOverloads_Point_releaseFfiHandle(_handle);
   return result;
 }
 MethodOverloads_Point smoke_MethodOverloads_Point_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_MethodOverloads_Point_get_value_nullable(handle);
+  final _handle = _smoke_MethodOverloads_PointGetValueNullable(handle);
   final result = smoke_MethodOverloads_Point_fromFfi(_handle);
   smoke_MethodOverloads_Point_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_MethodOverloads_Point_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_MethodOverloads_Point_release_handle_nullable(handle);
+  _smoke_MethodOverloads_PointReleaseHandleNullable(handle);
 // End of MethodOverloads_Point "private" section.
 // MethodOverloads "private" section, not exported.
-final _smoke_MethodOverloads_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMethodoverloadsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_copy_handle'));
-final _smoke_MethodOverloads_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeMethodoverloadsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_release_handle'));
@@ -112,163 +111,163 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_MethodOverloads_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeMethodoverloadsReleaseHandle(handle);
     handle = null;
   }
   @override
   bool isBoolean(bool input) {
-    final _isBoolean_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Boolean'));
-    final _input_handle = Boolean_toFfi(input);
+    final _isBooleanFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Boolean'));
+    final _inputHandle = Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _isBoolean_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _isBooleanFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isBooleanByte(int input) {
-    final _isBooleanByte_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Int8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Byte'));
-    final _input_handle = (input);
+    final _isBooleanByteFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Int8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Byte'));
+    final _inputHandle = (input);
     final _handle = this.handle;
-    final __result_handle = _isBooleanByte_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final __resultHandle = _isBooleanByteFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isBooleanString(String input) {
-    final _isBooleanString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__String'));
-    final _input_handle = String_toFfi(input);
+    final _isBooleanStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _isBooleanString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _isBooleanStringFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isBooleanPoint(MethodOverloads_Point input) {
-    final _isBooleanPoint_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Point'));
-    final _input_handle = smoke_MethodOverloads_Point_toFfi(input);
+    final _isBooleanPointFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Point'));
+    final _inputHandle = smoke_MethodOverloads_Point_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _isBooleanPoint_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_MethodOverloads_Point_releaseFfiHandle(_input_handle);
+    final __resultHandle = _isBooleanPointFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_MethodOverloads_Point_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4) {
-    final _isBooleanMulti_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8, Int8, Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, int, int, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Boolean_Byte_String_Point'));
-    final _input1_handle = Boolean_toFfi(input1);
-    final _input2_handle = (input2);
-    final _input3_handle = String_toFfi(input3);
-    final _input4_handle = smoke_MethodOverloads_Point_toFfi(input4);
+    final _isBooleanMultiFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8, Int8, Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, int, int, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Boolean_Byte_String_Point'));
+    final _input1Handle = Boolean_toFfi(input1);
+    final _input2Handle = (input2);
+    final _input3Handle = String_toFfi(input3);
+    final _input4Handle = smoke_MethodOverloads_Point_toFfi(input4);
     final _handle = this.handle;
-    final __result_handle = _isBooleanMulti_ffi(_handle, __lib.LibraryContext.isolateId, _input1_handle, _input2_handle, _input3_handle, _input4_handle);
-    Boolean_releaseFfiHandle(_input1_handle);
-    (_input2_handle);
-    String_releaseFfiHandle(_input3_handle);
-    smoke_MethodOverloads_Point_releaseFfiHandle(_input4_handle);
+    final __resultHandle = _isBooleanMultiFfi(_handle, __lib.LibraryContext.isolateId, _input1Handle, _input2Handle, _input3Handle, _input4Handle);
+    Boolean_releaseFfiHandle(_input1Handle);
+    (_input2Handle);
+    String_releaseFfiHandle(_input3Handle);
+    smoke_MethodOverloads_Point_releaseFfiHandle(_input4Handle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isBooleanStringArray(List<String> input) {
-    final _isBooleanStringArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1String'));
-    final _input_handle = foobar_ListOf_String_toFfi(input);
+    final _isBooleanStringArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1String'));
+    final _inputHandle = foobar_ListOf_String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _isBooleanStringArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _isBooleanStringArrayFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isBooleanIntArray(List<int> input) {
-    final _isBooleanIntArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1Byte'));
-    final _input_handle = foobar_ListOf_Byte_toFfi(input);
+    final _isBooleanIntArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_1Byte'));
+    final _inputHandle = foobar_ListOf_Byte_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _isBooleanIntArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_Byte_releaseFfiHandle(_input_handle);
+    final __resultHandle = _isBooleanIntArrayFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_Byte_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isBooleanConst() {
-    final _isBooleanConst_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean'));
+    final _isBooleanConstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean'));
     final _handle = this.handle;
-    final __result_handle = _isBooleanConst_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _isBooleanConstFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isFloatString(String input) {
-    final _isFloatString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__String'));
-    final _input_handle = String_toFfi(input);
+    final _isFloatStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _isFloatString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _isFloatStringFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool isFloatList(List<int> input) {
-    final _isFloatList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_1Byte'));
-    final _input_handle = foobar_ListOf_Byte_toFfi(input);
+    final _isFloatListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_1Byte'));
+    final _inputHandle = foobar_ListOf_Byte_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _isFloatList_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_Byte_releaseFfiHandle(_input_handle);
+    final __resultHandle = _isFloatListFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_Byte_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_MethodOverloads_toFfi(MethodOverloads value) =>
-  _smoke_MethodOverloads_copy_handle((value as __lib.NativeBase).handle);
+  _smokeMethodoverloadsCopyHandle((value as __lib.NativeBase).handle);
 MethodOverloads smoke_MethodOverloads_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as MethodOverloads;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_MethodOverloads_copy_handle(handle);
-  final result = MethodOverloads$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeMethodoverloadsCopyHandle(handle);
+  final result = MethodOverloads$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_MethodOverloads_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_MethodOverloads_release_handle(handle);
+  _smokeMethodoverloadsReleaseHandle(handle);
 Pointer<Void> smoke_MethodOverloads_toFfi_nullable(MethodOverloads value) =>
   value != null ? smoke_MethodOverloads_toFfi(value) : Pointer<Void>.fromAddress(0);
 MethodOverloads smoke_MethodOverloads_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_MethodOverloads_fromFfi(handle) : null;
 void smoke_MethodOverloads_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_MethodOverloads_release_handle(handle);
+  _smokeMethodoverloadsReleaseHandle(handle);
 // End of MethodOverloads "private" section.

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SpecialNames {
@@ -17,11 +16,11 @@ abstract class SpecialNames {
   Uppercase();
 }
 // SpecialNames "private" section, not exported.
-final _smoke_SpecialNames_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSpecialnamesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SpecialNames_copy_handle'));
-final _smoke_SpecialNames_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSpecialnamesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialNames_release_handle'));
@@ -31,73 +30,73 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SpecialNames_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSpecialnamesReleaseHandle(handle);
     handle = null;
   }
   @override
   create() {
-    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create'));
+    final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create'));
     final _handle = this.handle;
-    final __result_handle = _create_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _createFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   reallyRelease() {
-    final _reallyRelease_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release'));
+    final _reallyReleaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release'));
     final _handle = this.handle;
-    final __result_handle = _reallyRelease_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _reallyReleaseFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   createProxy() {
-    final _createProxy_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy'));
+    final _createProxyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy'));
     final _handle = this.handle;
-    final __result_handle = _createProxy_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _createProxyFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Uppercase() {
-    final _Uppercase_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase'));
+    final _UppercaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase'));
     final _handle = this.handle;
-    final __result_handle = _Uppercase_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _UppercaseFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_SpecialNames_toFfi(SpecialNames value) =>
-  _smoke_SpecialNames_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSpecialnamesCopyHandle((value as __lib.NativeBase).handle);
 SpecialNames smoke_SpecialNames_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SpecialNames;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SpecialNames_copy_handle(handle);
-  final result = SpecialNames$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSpecialnamesCopyHandle(handle);
+  final result = SpecialNames$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SpecialNames_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SpecialNames_release_handle(handle);
+  _smokeSpecialnamesReleaseHandle(handle);
 Pointer<Void> smoke_SpecialNames_toFfi_nullable(SpecialNames value) =>
   value != null ? smoke_SpecialNames_toFfi(value) : Pointer<Void>.fromAddress(0);
 SpecialNames smoke_SpecialNames_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SpecialNames_fromFfi(handle) : null;
 void smoke_SpecialNames_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SpecialNames_release_handle(handle);
+  _smokeSpecialnamesReleaseHandle(handle);
 // End of SpecialNames "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
@@ -1,8 +1,6 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-
 enum FreeEnum {
     foo,
     bar
@@ -33,32 +31,32 @@ FreeEnum smoke_FreeEnum_fromFfi(int handle) {
   }
 }
 void smoke_FreeEnum_releaseFfiHandle(int handle) {}
-final _smoke_FreeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_FreeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_FreeEnum_create_handle_nullable'));
-final _smoke_FreeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_FreeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_FreeEnum_release_handle_nullable'));
-final _smoke_FreeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_FreeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_FreeEnum_get_value_nullable'));
 Pointer<Void> smoke_FreeEnum_toFfi_nullable(FreeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_FreeEnum_toFfi(value);
-  final result = _smoke_FreeEnum_create_handle_nullable(_handle);
+  final result = _smoke_FreeEnumCreateHandleNullable(_handle);
   smoke_FreeEnum_releaseFfiHandle(_handle);
   return result;
 }
 FreeEnum smoke_FreeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_FreeEnum_get_value_nullable(handle);
+  final _handle = _smoke_FreeEnumGetValueNullable(handle);
   final result = smoke_FreeEnum_fromFfi(_handle);
   smoke_FreeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_FreeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_FreeEnum_release_handle_nullable(handle);
+  _smoke_FreeEnumReleaseHandleNullable(handle);
 // End of FreeEnum "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_exception.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_exception.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/free_enum.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class FreeException implements Exception {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/free_enum.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class FreePoint {
@@ -10,83 +9,83 @@ class FreePoint {
   FreePoint(this.x, this.y);
   static final FreeEnum aBar = FreeEnum.bar;
   FreePoint flip() {
-    final _flip_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FreePoint_flip'));
+    final _flipFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FreePoint_flip'));
     final _handle = smoke_FreePoint_toFfi(this);
-    final __result_handle = _flip_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _flipFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_FreePoint_releaseFfiHandle(_handle);
     try {
-      return smoke_FreePoint_fromFfi(__result_handle);
+      return smoke_FreePoint_fromFfi(__resultHandle);
     } finally {
-      smoke_FreePoint_releaseFfiHandle(__result_handle);
+      smoke_FreePoint_releaseFfiHandle(__resultHandle);
     }
   }
 }
 // FreePoint "private" section, not exported.
-final _smoke_FreePoint_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeFreepointCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
   >('library_smoke_FreePoint_create_handle'));
-final _smoke_FreePoint_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeFreepointReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_FreePoint_release_handle'));
-final _smoke_FreePoint_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeFreepointGetFieldx = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_FreePoint_get_field_x'));
-final _smoke_FreePoint_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeFreepointGetFieldy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_FreePoint_get_field_y'));
 Pointer<Void> smoke_FreePoint_toFfi(FreePoint value) {
-  final _x_handle = (value.x);
-  final _y_handle = (value.y);
-  final _result = _smoke_FreePoint_create_handle(_x_handle, _y_handle);
-  (_x_handle);
-  (_y_handle);
+  final _xHandle = (value.x);
+  final _yHandle = (value.y);
+  final _result = _smokeFreepointCreateHandle(_xHandle, _yHandle);
+  (_xHandle);
+  (_yHandle);
   return _result;
 }
 FreePoint smoke_FreePoint_fromFfi(Pointer<Void> handle) {
-  final _x_handle = _smoke_FreePoint_get_field_x(handle);
-  final _y_handle = _smoke_FreePoint_get_field_y(handle);
+  final _xHandle = _smokeFreepointGetFieldx(handle);
+  final _yHandle = _smokeFreepointGetFieldy(handle);
   try {
     return FreePoint(
-      (_x_handle),
-      (_y_handle)
+      (_xHandle),
+      (_yHandle)
     );
   } finally {
-    (_x_handle);
-    (_y_handle);
+    (_xHandle);
+    (_yHandle);
   }
 }
-void smoke_FreePoint_releaseFfiHandle(Pointer<Void> handle) => _smoke_FreePoint_release_handle(handle);
+void smoke_FreePoint_releaseFfiHandle(Pointer<Void> handle) => _smokeFreepointReleaseHandle(handle);
 // Nullable FreePoint
-final _smoke_FreePoint_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_FreePointCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FreePoint_create_handle_nullable'));
-final _smoke_FreePoint_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_FreePointReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_FreePoint_release_handle_nullable'));
-final _smoke_FreePoint_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_FreePointGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FreePoint_get_value_nullable'));
 Pointer<Void> smoke_FreePoint_toFfi_nullable(FreePoint value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_FreePoint_toFfi(value);
-  final result = _smoke_FreePoint_create_handle_nullable(_handle);
+  final result = _smoke_FreePointCreateHandleNullable(_handle);
   smoke_FreePoint_releaseFfiHandle(_handle);
   return result;
 }
 FreePoint smoke_FreePoint_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_FreePoint_get_value_nullable(handle);
+  final _handle = _smoke_FreePointGetValueNullable(handle);
   final result = smoke_FreePoint_fromFfi(_handle);
   smoke_FreePoint_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_FreePoint_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_FreePoint_release_handle_nullable(handle);
+  _smoke_FreePointReleaseHandleNullable(handle);
 // End of FreePoint "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/outer_class.dart';
 import 'package:library/src/smoke/outer_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class LevelOne {
@@ -52,115 +51,115 @@ LevelOne_LevelTwo_LevelThree_LevelFourEnum smoke_LevelOne_LevelTwo_LevelThree_Le
   }
 }
 void smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(int handle) {}
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable'));
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable'));
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable'));
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFourEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_toFfi(value);
-  final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_create_handle_nullable(_handle);
+  final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnumCreateHandleNullable(_handle);
   smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(_handle);
   return result;
 }
 LevelOne_LevelTwo_LevelThree_LevelFourEnum smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable(handle);
+  final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnumGetValueNullable(handle);
   final result = smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_fromFfi(_handle);
   smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_release_handle_nullable(handle);
+  _smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnumReleaseHandleNullable(handle);
 // End of LevelOne_LevelTwo_LevelThree_LevelFourEnum "private" section.
 class LevelOne_LevelTwo_LevelThree_LevelFour {
   String stringField;
   LevelOne_LevelTwo_LevelThree_LevelFour(this.stringField);
   static final bool foo = false;
   static LevelOne_LevelTwo_LevelThree_LevelFour fooFactory() {
-    final _fooFactory_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory'));
-    final __result_handle = _fooFactory_ffi(__lib.LibraryContext.isolateId);
+    final _fooFactoryFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fooFactory'));
+    final __resultHandle = _fooFactoryFfi(__lib.LibraryContext.isolateId);
     try {
-      return smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(__result_handle);
+      return smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(__resultHandle);
     } finally {
-      smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(__result_handle);
+      smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(__resultHandle);
     }
   }
 }
 // LevelOne_LevelTwo_LevelThree_LevelFour "private" section, not exported.
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneLeveltwoLevelthreeLevelfourCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle'));
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneLeveltwoLevelthreeLevelfourReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle'));
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneLeveltwoLevelthreeLevelfourGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField'));
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(LevelOne_LevelTwo_LevelThree_LevelFour value) {
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle(_stringField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _result = _smokeLeveloneLeveltwoLevelthreeLevelfourCreateHandle(_stringFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField(handle);
+  final _stringFieldHandle = _smokeLeveloneLeveltwoLevelthreeLevelfourGetFieldstringField(handle);
   try {
     return LevelOne_LevelTwo_LevelThree_LevelFour(
-      String_fromFfi(_stringField_handle)
+      String_fromFfi(_stringFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(Pointer<Void> handle) => _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle(handle);
+void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(Pointer<Void> handle) => _smokeLeveloneLeveltwoLevelthreeLevelfourReleaseHandle(handle);
 // Nullable LevelOne_LevelTwo_LevelThree_LevelFour
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable'));
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable'));
-final _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_LevelOne_LevelTwo_LevelThree_LevelFourGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable'));
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi_nullable(LevelOne_LevelTwo_LevelThree_LevelFour value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_toFfi(value);
-  final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_create_handle_nullable(_handle);
+  final result = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourCreateHandleNullable(_handle);
   smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(_handle);
   return result;
 }
 LevelOne_LevelTwo_LevelThree_LevelFour smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable(handle);
+  final _handle = _smoke_LevelOne_LevelTwo_LevelThree_LevelFourGetValueNullable(handle);
   final result = smoke_LevelOne_LevelTwo_LevelThree_LevelFour_fromFfi(_handle);
   smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_LevelOne_LevelTwo_LevelThree_LevelFour_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_LevelFour_release_handle_nullable(handle);
+  _smoke_LevelOne_LevelTwo_LevelThree_LevelFourReleaseHandleNullable(handle);
 // End of LevelOne_LevelTwo_LevelThree_LevelFour "private" section.
 // LevelOne_LevelTwo_LevelThree "private" section, not exported.
-final _smoke_LevelOne_LevelTwo_LevelThree_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneLeveltwoLevelthreeCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_copy_handle'));
-final _smoke_LevelOne_LevelTwo_LevelThree_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneLeveltwoLevelthreeReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle'));
@@ -170,51 +169,51 @@ class LevelOne_LevelTwo_LevelThree$Impl extends __lib.NativeBase implements Leve
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeLeveloneLeveltwoLevelthreeReleaseHandle(handle);
     handle = null;
   }
   @override
   OuterInterface_InnerClass foo(OuterClass_InnerInterface input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface'));
-    final _input_handle = smoke_OuterClass_InnerInterface_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface'));
+    final _inputHandle = smoke_OuterClass_InnerInterface_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_OuterClass_InnerInterface_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_OuterClass_InnerInterface_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_OuterInterface_InnerClass_fromFfi(__result_handle);
+      return smoke_OuterInterface_InnerClass_fromFfi(__resultHandle);
     } finally {
-      smoke_OuterInterface_InnerClass_releaseFfiHandle(__result_handle);
+      smoke_OuterInterface_InnerClass_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi(LevelOne_LevelTwo_LevelThree value) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_copy_handle((value as __lib.NativeBase).handle);
+  _smokeLeveloneLeveltwoLevelthreeCopyHandle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as LevelOne_LevelTwo_LevelThree;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_LevelOne_LevelTwo_LevelThree_copy_handle(handle);
-  final result = LevelOne_LevelTwo_LevelThree$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeLeveloneLeveltwoLevelthreeCopyHandle(handle);
+  final result = LevelOne_LevelTwo_LevelThree$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+  _smokeLeveloneLeveltwoLevelthreeReleaseHandle(handle);
 Pointer<Void> smoke_LevelOne_LevelTwo_LevelThree_toFfi_nullable(LevelOne_LevelTwo_LevelThree value) =>
   value != null ? smoke_LevelOne_LevelTwo_LevelThree_toFfi(value) : Pointer<Void>.fromAddress(0);
 LevelOne_LevelTwo_LevelThree smoke_LevelOne_LevelTwo_LevelThree_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LevelOne_LevelTwo_LevelThree_fromFfi(handle) : null;
 void smoke_LevelOne_LevelTwo_LevelThree_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_LevelThree_release_handle(handle);
+  _smokeLeveloneLeveltwoLevelthreeReleaseHandle(handle);
 // End of LevelOne_LevelTwo_LevelThree "private" section.
 // LevelOne_LevelTwo "private" section, not exported.
-final _smoke_LevelOne_LevelTwo_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneLeveltwoCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_copy_handle'));
-final _smoke_LevelOne_LevelTwo_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneLeveltwoReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_release_handle'));
@@ -224,38 +223,38 @@ class LevelOne_LevelTwo$Impl extends __lib.NativeBase implements LevelOne_LevelT
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_LevelOne_LevelTwo_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeLeveloneLeveltwoReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_LevelOne_LevelTwo_toFfi(LevelOne_LevelTwo value) =>
-  _smoke_LevelOne_LevelTwo_copy_handle((value as __lib.NativeBase).handle);
+  _smokeLeveloneLeveltwoCopyHandle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as LevelOne_LevelTwo;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_LevelOne_LevelTwo_copy_handle(handle);
-  final result = LevelOne_LevelTwo$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeLeveloneLeveltwoCopyHandle(handle);
+  final result = LevelOne_LevelTwo$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_LevelOne_LevelTwo_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_release_handle(handle);
+  _smokeLeveloneLeveltwoReleaseHandle(handle);
 Pointer<Void> smoke_LevelOne_LevelTwo_toFfi_nullable(LevelOne_LevelTwo value) =>
   value != null ? smoke_LevelOne_LevelTwo_toFfi(value) : Pointer<Void>.fromAddress(0);
 LevelOne_LevelTwo smoke_LevelOne_LevelTwo_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LevelOne_LevelTwo_fromFfi(handle) : null;
 void smoke_LevelOne_LevelTwo_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_LevelTwo_release_handle(handle);
+  _smokeLeveloneLeveltwoReleaseHandle(handle);
 // End of LevelOne_LevelTwo "private" section.
 // LevelOne "private" section, not exported.
-final _smoke_LevelOne_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_copy_handle'));
-final _smoke_LevelOne_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeLeveloneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_release_handle'));
@@ -265,29 +264,29 @@ class LevelOne$Impl extends __lib.NativeBase implements LevelOne {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_LevelOne_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeLeveloneReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_LevelOne_toFfi(LevelOne value) =>
-  _smoke_LevelOne_copy_handle((value as __lib.NativeBase).handle);
+  _smokeLeveloneCopyHandle((value as __lib.NativeBase).handle);
 LevelOne smoke_LevelOne_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as LevelOne;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_LevelOne_copy_handle(handle);
-  final result = LevelOne$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeLeveloneCopyHandle(handle);
+  final result = LevelOne$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_LevelOne_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_LevelOne_release_handle(handle);
+  _smokeLeveloneReleaseHandle(handle);
 Pointer<Void> smoke_LevelOne_toFfi_nullable(LevelOne value) =>
   value != null ? smoke_LevelOne_toFfi(value) : Pointer<Void>.fromAddress(0);
 LevelOne smoke_LevelOne_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_LevelOne_fromFfi(handle) : null;
 void smoke_LevelOne_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_LevelOne_release_handle(handle);
+  _smokeLeveloneReleaseHandle(handle);
 // End of LevelOne "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterClass {
@@ -23,11 +22,11 @@ abstract class OuterClass_InnerClass {
   String foo(String input);
 }
 // OuterClass_InnerClass "private" section, not exported.
-final _smoke_OuterClass_InnerClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassInnerclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerClass_copy_handle'));
-final _smoke_OuterClass_InnerClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassInnerclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerClass_release_handle'));
@@ -37,47 +36,47 @@ class OuterClass_InnerClass$Impl extends __lib.NativeBase implements OuterClass_
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterClass_InnerClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterclassInnerclassReleaseHandle(handle);
     handle = null;
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerClass_foo__String'));
-    final _input_handle = String_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerClass_foo__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_OuterClass_InnerClass_toFfi(OuterClass_InnerClass value) =>
-  _smoke_OuterClass_InnerClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeOuterclassInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterClass_InnerClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_OuterClass_InnerClass_copy_handle(handle);
-  final result = OuterClass_InnerClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeOuterclassInnerclassCopyHandle(handle);
+  final result = OuterClass_InnerClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterClass_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterClass_InnerClass_release_handle(handle);
+  _smokeOuterclassInnerclassReleaseHandle(handle);
 Pointer<Void> smoke_OuterClass_InnerClass_toFfi_nullable(OuterClass_InnerClass value) =>
   value != null ? smoke_OuterClass_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterClass_InnerClass smoke_OuterClass_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClass_InnerClass_fromFfi(handle) : null;
 void smoke_OuterClass_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterClass_InnerClass_release_handle(handle);
+  _smokeOuterclassInnerclassReleaseHandle(handle);
 // End of OuterClass_InnerClass "private" section.
 abstract class OuterClass_InnerInterface {
-  OuterClass_InnerInterface() {}
+  OuterClass_InnerInterface();
   factory OuterClass_InnerInterface.fromLambdas({
     @required String Function(String) lambda_foo,
   }) => OuterClass_InnerInterface$Lambdas(
@@ -91,19 +90,19 @@ abstract class OuterClass_InnerInterface {
   String foo(String input);
 }
 // OuterClass_InnerInterface "private" section, not exported.
-final _smoke_OuterClass_InnerInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassInnerinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerInterface_copy_handle'));
-final _smoke_OuterClass_InnerInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassInnerinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerInterface_release_handle'));
-final _smoke_OuterClass_InnerInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassInnerinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_OuterClass_InnerInterface_create_proxy'));
-final _smoke_OuterClass_InnerInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassInnerinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerInterface_get_type_id'));
@@ -124,37 +123,37 @@ class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterCl
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterClass_InnerInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterclassInnerinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerInterface_foo__String'));
-    final _input_handle = String_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerInterface_foo__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _OuterClass_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(String_fromFfi(input));
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(String_fromFfi(input));
+    _result.value = String_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface value) {
-  if (value is __lib.NativeBase) return _smoke_OuterClass_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_OuterClass_InnerInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeOuterclassInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeOuterclassInnerinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -164,34 +163,34 @@ Pointer<Void> smoke_OuterClass_InnerInterface_toFfi(OuterClass_InnerInterface va
 }
 OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterClass_InnerInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_OuterClass_InnerInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_OuterClass_InnerInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeOuterclassInnerinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeOuterclassInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : OuterClass_InnerInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : OuterClass_InnerInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterClass_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterClass_InnerInterface_release_handle(handle);
+  _smokeOuterclassInnerinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_OuterClass_InnerInterface_toFfi_nullable(OuterClass_InnerInterface value) =>
   value != null ? smoke_OuterClass_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterClass_InnerInterface smoke_OuterClass_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClass_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterClass_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterClass_InnerInterface_release_handle(handle);
+  _smokeOuterclassInnerinterfaceReleaseHandle(handle);
 // End of OuterClass_InnerInterface "private" section.
 // OuterClass "private" section, not exported.
-final _smoke_OuterClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_copy_handle'));
-final _smoke_OuterClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_release_handle'));
@@ -201,42 +200,42 @@ class OuterClass$Impl extends __lib.NativeBase implements OuterClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterclassReleaseHandle(handle);
     handle = null;
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_foo__String'));
-    final _input_handle = String_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_foo__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_OuterClass_toFfi(OuterClass value) =>
-  _smoke_OuterClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeOuterclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClass smoke_OuterClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_OuterClass_copy_handle(handle);
-  final result = OuterClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeOuterclassCopyHandle(handle);
+  final result = OuterClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterClass_release_handle(handle);
+  _smokeOuterclassReleaseHandle(handle);
 Pointer<Void> smoke_OuterClass_toFfi_nullable(OuterClass value) =>
   value != null ? smoke_OuterClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterClass smoke_OuterClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClass_fromFfi(handle) : null;
 void smoke_OuterClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterClass_release_handle(handle);
+  _smokeOuterclassReleaseHandle(handle);
 // End of OuterClass "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterClassWithInheritance implements ParentClass {
@@ -24,11 +23,11 @@ abstract class OuterClassWithInheritance_InnerClass {
   String bar(String input);
 }
 // OuterClassWithInheritance_InnerClass "private" section, not exported.
-final _smoke_OuterClassWithInheritance_InnerClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceInnerclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerClass_copy_handle'));
-final _smoke_OuterClassWithInheritance_InnerClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceInnerclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerClass_release_handle'));
@@ -38,47 +37,47 @@ class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase impleme
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterclasswithinheritanceInnerclassReleaseHandle(handle);
     handle = null;
   }
   @override
   String bar(String input) {
-    final _bar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerClass_bar__String'));
-    final _input_handle = String_toFfi(input);
+    final _barFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerClass_bar__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _bar_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _barFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi(OuterClassWithInheritance_InnerClass value) =>
-  _smoke_OuterClassWithInheritance_InnerClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeOuterclasswithinheritanceInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterClassWithInheritance_InnerClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_OuterClassWithInheritance_InnerClass_copy_handle(handle);
-  final result = OuterClassWithInheritance_InnerClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeOuterclasswithinheritanceInnerclassCopyHandle(handle);
+  final result = OuterClassWithInheritance_InnerClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterClassWithInheritance_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
+  _smokeOuterclasswithinheritanceInnerclassReleaseHandle(handle);
 Pointer<Void> smoke_OuterClassWithInheritance_InnerClass_toFfi_nullable(OuterClassWithInheritance_InnerClass value) =>
   value != null ? smoke_OuterClassWithInheritance_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterClassWithInheritance_InnerClass smoke_OuterClassWithInheritance_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClassWithInheritance_InnerClass_fromFfi(handle) : null;
 void smoke_OuterClassWithInheritance_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterClassWithInheritance_InnerClass_release_handle(handle);
+  _smokeOuterclasswithinheritanceInnerclassReleaseHandle(handle);
 // End of OuterClassWithInheritance_InnerClass "private" section.
 abstract class OuterClassWithInheritance_InnerInterface {
-  OuterClassWithInheritance_InnerInterface() {}
+  OuterClassWithInheritance_InnerInterface();
   factory OuterClassWithInheritance_InnerInterface.fromLambdas({
     @required String Function(String) lambda_baz,
   }) => OuterClassWithInheritance_InnerInterface$Lambdas(
@@ -92,19 +91,19 @@ abstract class OuterClassWithInheritance_InnerInterface {
   String baz(String input);
 }
 // OuterClassWithInheritance_InnerInterface "private" section, not exported.
-final _smoke_OuterClassWithInheritance_InnerInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceInnerinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerInterface_copy_handle'));
-final _smoke_OuterClassWithInheritance_InnerInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceInnerinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerInterface_release_handle'));
-final _smoke_OuterClassWithInheritance_InnerInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceInnerinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_OuterClassWithInheritance_InnerInterface_create_proxy'));
-final _smoke_OuterClassWithInheritance_InnerInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceInnerinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerInterface_get_type_id'));
@@ -125,37 +124,37 @@ class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase imp
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterclasswithinheritanceInnerinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   String baz(String input) {
-    final _baz_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerInterface_baz__String'));
-    final _input_handle = String_toFfi(input);
+    final _bazFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerInterface_baz__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _baz_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _bazFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _OuterClassWithInheritance_InnerInterface_baz_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as OuterClassWithInheritance_InnerInterface).baz(String_fromFfi(input));
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as OuterClassWithInheritance_InnerInterface).baz(String_fromFfi(input));
+    _result.value = String_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi(OuterClassWithInheritance_InnerInterface value) {
-  if (value is __lib.NativeBase) return _smoke_OuterClassWithInheritance_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_OuterClassWithInheritance_InnerInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeOuterclasswithinheritanceInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeOuterclasswithinheritanceInnerinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -165,38 +164,38 @@ Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi(OuterClassWit
 }
 OuterClassWithInheritance_InnerInterface smoke_OuterClassWithInheritance_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterClassWithInheritance_InnerInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_OuterClassWithInheritance_InnerInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_OuterClassWithInheritance_InnerInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeOuterclasswithinheritanceInnerinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeOuterclasswithinheritanceInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : OuterClassWithInheritance_InnerInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : OuterClassWithInheritance_InnerInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterClassWithInheritance_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
+  _smokeOuterclasswithinheritanceInnerinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_OuterClassWithInheritance_InnerInterface_toFfi_nullable(OuterClassWithInheritance_InnerInterface value) =>
   value != null ? smoke_OuterClassWithInheritance_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterClassWithInheritance_InnerInterface smoke_OuterClassWithInheritance_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClassWithInheritance_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterClassWithInheritance_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterClassWithInheritance_InnerInterface_release_handle(handle);
+  _smokeOuterclasswithinheritanceInnerinterfaceReleaseHandle(handle);
 // End of OuterClassWithInheritance_InnerInterface "private" section.
 // OuterClassWithInheritance "private" section, not exported.
-final _smoke_OuterClassWithInheritance_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_copy_handle'));
-final _smoke_OuterClassWithInheritance_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_release_handle'));
-final _smoke_OuterClassWithInheritance_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterclasswithinheritanceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_get_type_id'));
@@ -206,47 +205,47 @@ class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterCl
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterClassWithInheritance_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterclasswithinheritanceReleaseHandle(handle);
     handle = null;
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_foo__String'));
-    final _input_handle = String_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_foo__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_OuterClassWithInheritance_toFfi(OuterClassWithInheritance value) =>
-  _smoke_OuterClassWithInheritance_copy_handle((value as __lib.NativeBase).handle);
+  _smokeOuterclasswithinheritanceCopyHandle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterClassWithInheritance;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_OuterClassWithInheritance_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_OuterClassWithInheritance_copy_handle(handle);
+  final _typeIdHandle = _smokeOuterclasswithinheritanceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeOuterclasswithinheritanceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : OuterClassWithInheritance$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : OuterClassWithInheritance$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterClassWithInheritance_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterClassWithInheritance_release_handle(handle);
+  _smokeOuterclasswithinheritanceReleaseHandle(handle);
 Pointer<Void> smoke_OuterClassWithInheritance_toFfi_nullable(OuterClassWithInheritance value) =>
   value != null ? smoke_OuterClassWithInheritance_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterClassWithInheritance smoke_OuterClassWithInheritance_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterClassWithInheritance_fromFfi(handle) : null;
 void smoke_OuterClassWithInheritance_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterClassWithInheritance_release_handle(handle);
+  _smokeOuterclasswithinheritanceReleaseHandle(handle);
 // End of OuterClassWithInheritance "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterInterface {
-  OuterInterface() {}
+  OuterInterface();
   factory OuterInterface.fromLambdas({
     @required String Function(String) lambda_foo,
   }) => OuterInterface$Lambdas(
@@ -29,11 +28,11 @@ abstract class OuterInterface_InnerClass {
   String foo(String input);
 }
 // OuterInterface_InnerClass "private" section, not exported.
-final _smoke_OuterInterface_InnerClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceInnerclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerClass_copy_handle'));
-final _smoke_OuterInterface_InnerClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceInnerclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerClass_release_handle'));
@@ -43,47 +42,47 @@ class OuterInterface_InnerClass$Impl extends __lib.NativeBase implements OuterIn
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterInterface_InnerClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterinterfaceInnerclassReleaseHandle(handle);
     handle = null;
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerClass_foo__String'));
-    final _input_handle = String_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerClass_foo__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_OuterInterface_InnerClass_toFfi(OuterInterface_InnerClass value) =>
-  _smoke_OuterInterface_InnerClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeOuterinterfaceInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterInterface_InnerClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_OuterInterface_InnerClass_copy_handle(handle);
-  final result = OuterInterface_InnerClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeOuterinterfaceInnerclassCopyHandle(handle);
+  final result = OuterInterface_InnerClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterInterface_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterInterface_InnerClass_release_handle(handle);
+  _smokeOuterinterfaceInnerclassReleaseHandle(handle);
 Pointer<Void> smoke_OuterInterface_InnerClass_toFfi_nullable(OuterInterface_InnerClass value) =>
   value != null ? smoke_OuterInterface_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterInterface_InnerClass smoke_OuterInterface_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterInterface_InnerClass_fromFfi(handle) : null;
 void smoke_OuterInterface_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterInterface_InnerClass_release_handle(handle);
+  _smokeOuterinterfaceInnerclassReleaseHandle(handle);
 // End of OuterInterface_InnerClass "private" section.
 abstract class OuterInterface_InnerInterface {
-  OuterInterface_InnerInterface() {}
+  OuterInterface_InnerInterface();
   factory OuterInterface_InnerInterface.fromLambdas({
     @required String Function(String) lambda_foo,
   }) => OuterInterface_InnerInterface$Lambdas(
@@ -97,19 +96,19 @@ abstract class OuterInterface_InnerInterface {
   String foo(String input);
 }
 // OuterInterface_InnerInterface "private" section, not exported.
-final _smoke_OuterInterface_InnerInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceInnerinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerInterface_copy_handle'));
-final _smoke_OuterInterface_InnerInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceInnerinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerInterface_release_handle'));
-final _smoke_OuterInterface_InnerInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceInnerinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_OuterInterface_InnerInterface_create_proxy'));
-final _smoke_OuterInterface_InnerInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceInnerinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerInterface_get_type_id'));
@@ -130,37 +129,37 @@ class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements Out
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterInterface_InnerInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterinterfaceInnerinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerInterface_foo__String'));
-    final _input_handle = String_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerInterface_foo__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _OuterInterface_InnerInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(String_fromFfi(input));
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(String_fromFfi(input));
+    _result.value = String_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInterface value) {
-  if (value is __lib.NativeBase) return _smoke_OuterInterface_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_OuterInterface_InnerInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeOuterinterfaceInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeOuterinterfaceInnerinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -170,42 +169,42 @@ Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi(OuterInterface_InnerInte
 }
 OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterInterface_InnerInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_OuterInterface_InnerInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_OuterInterface_InnerInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeOuterinterfaceInnerinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeOuterinterfaceInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : OuterInterface_InnerInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : OuterInterface_InnerInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterInterface_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterInterface_InnerInterface_release_handle(handle);
+  _smokeOuterinterfaceInnerinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_OuterInterface_InnerInterface_toFfi_nullable(OuterInterface_InnerInterface value) =>
   value != null ? smoke_OuterInterface_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterInterface_InnerInterface smoke_OuterInterface_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterInterface_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterInterface_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterInterface_InnerInterface_release_handle(handle);
+  _smokeOuterinterfaceInnerinterfaceReleaseHandle(handle);
 // End of OuterInterface_InnerInterface "private" section.
 // OuterInterface "private" section, not exported.
-final _smoke_OuterInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_copy_handle'));
-final _smoke_OuterInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterInterface_release_handle'));
-final _smoke_OuterInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_OuterInterface_create_proxy'));
-final _smoke_OuterInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_get_type_id'));
@@ -226,37 +225,37 @@ class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   String foo(String input) {
-    final _foo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_foo__String'));
-    final _input_handle = String_toFfi(input);
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_foo__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _foo_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _OuterInterface_foo_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as OuterInterface).foo(String_fromFfi(input));
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as OuterInterface).foo(String_fromFfi(input));
+    _result.value = String_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
-  if (value is __lib.NativeBase) return _smoke_OuterInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_OuterInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeOuterinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeOuterinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -266,25 +265,25 @@ Pointer<Void> smoke_OuterInterface_toFfi(OuterInterface value) {
 }
 OuterInterface smoke_OuterInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_OuterInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_OuterInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeOuterinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeOuterinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : OuterInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : OuterInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterInterface_release_handle(handle);
+  _smokeOuterinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_OuterInterface_toFfi_nullable(OuterInterface value) =>
   value != null ? smoke_OuterInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterInterface smoke_OuterInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterInterface_fromFfi(handle) : null;
 void smoke_OuterInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterInterface_release_handle(handle);
+  _smokeOuterinterfaceReleaseHandle(handle);
 // End of OuterInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -6,19 +6,18 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _doNothing_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doNothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_release_handle'));
-final _doNothing_return_get_result = (Pointer) {};
-final _doNothing_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doNothingReturnGetResult = (Pointer) {};
+final _doNothingReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_get_error'));
-final _doNothing_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doNothingReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_has_error'));
@@ -26,25 +25,25 @@ class OuterStruct {
   String field;
   OuterStruct(this.field);
   doNothing() {
-    final _doNothing_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_doNothing'));
+    final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_doNothing'));
     final _handle = smoke_OuterStruct_toFfi(this);
-    final __call_result_handle = _doNothing_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __callResultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_OuterStruct_releaseFfiHandle(_handle);
-    if (_doNothing_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _doNothing_return_get_error(__call_result_handle);
-        _doNothing_return_release_handle(__call_result_handle);
+    if (_doNothingReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _doNothingReturnGetError(__callResultHandle);
+        _doNothingReturnReleaseHandle(__callResultHandle);
         try {
-          throw OuterStruct_InstantiationException(smoke_OuterStruct_InnerEnum_fromFfi(__error_handle));
+          throw OuterStruct_InstantiationException(smoke_OuterStruct_InnerEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_OuterStruct_InnerEnum_releaseFfiHandle(__error_handle);
+          smoke_OuterStruct_InnerEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _doNothing_return_get_result(__call_result_handle);
-    _doNothing_return_release_handle(__call_result_handle);
+    final __resultHandle = _doNothingReturnGetResult(__callResultHandle);
+    _doNothingReturnReleaseHandle(__callResultHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -78,34 +77,34 @@ OuterStruct_InnerEnum smoke_OuterStruct_InnerEnum_fromFfi(int handle) {
   }
 }
 void smoke_OuterStruct_InnerEnum_releaseFfiHandle(int handle) {}
-final _smoke_OuterStruct_InnerEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStruct_InnerEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_OuterStruct_InnerEnum_create_handle_nullable'));
-final _smoke_OuterStruct_InnerEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStruct_InnerEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerEnum_release_handle_nullable'));
-final _smoke_OuterStruct_InnerEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStruct_InnerEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerEnum_get_value_nullable'));
 Pointer<Void> smoke_OuterStruct_InnerEnum_toFfi_nullable(OuterStruct_InnerEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_OuterStruct_InnerEnum_toFfi(value);
-  final result = _smoke_OuterStruct_InnerEnum_create_handle_nullable(_handle);
+  final result = _smoke_OuterStruct_InnerEnumCreateHandleNullable(_handle);
   smoke_OuterStruct_InnerEnum_releaseFfiHandle(_handle);
   return result;
 }
 OuterStruct_InnerEnum smoke_OuterStruct_InnerEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_OuterStruct_InnerEnum_get_value_nullable(handle);
+  final _handle = _smoke_OuterStruct_InnerEnumGetValueNullable(handle);
   final result = smoke_OuterStruct_InnerEnum_fromFfi(_handle);
   smoke_OuterStruct_InnerEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_OuterStruct_InnerEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterStruct_InnerEnum_release_handle_nullable(handle);
+  _smoke_OuterStruct_InnerEnumReleaseHandleNullable(handle);
 // End of OuterStruct_InnerEnum "private" section.
 class OuterStruct_InstantiationException implements Exception {
   final OuterStruct_InnerEnum error;
@@ -115,76 +114,76 @@ class OuterStruct_InnerStruct {
   List<DateTime> otherField;
   OuterStruct_InnerStruct(this.otherField);
   doSomething() {
-    final _doSomething_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerStruct_doSomething'));
+    final _doSomethingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerStruct_doSomething'));
     final _handle = smoke_OuterStruct_InnerStruct_toFfi(this);
-    final __result_handle = _doSomething_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _doSomethingFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_OuterStruct_InnerStruct_releaseFfiHandle(_handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 // OuterStruct_InnerStruct "private" section, not exported.
-final _smoke_OuterStruct_InnerStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_create_handle'));
-final _smoke_OuterStruct_InnerStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_release_handle'));
-final _smoke_OuterStruct_InnerStruct_get_field_otherField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerstructGetFieldotherField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_get_field_otherField'));
 Pointer<Void> smoke_OuterStruct_InnerStruct_toFfi(OuterStruct_InnerStruct value) {
-  final _otherField_handle = foobar_ListOf_Date_toFfi(value.otherField);
-  final _result = _smoke_OuterStruct_InnerStruct_create_handle(_otherField_handle);
-  foobar_ListOf_Date_releaseFfiHandle(_otherField_handle);
+  final _otherFieldHandle = foobar_ListOf_Date_toFfi(value.otherField);
+  final _result = _smokeOuterstructInnerstructCreateHandle(_otherFieldHandle);
+  foobar_ListOf_Date_releaseFfiHandle(_otherFieldHandle);
   return _result;
 }
 OuterStruct_InnerStruct smoke_OuterStruct_InnerStruct_fromFfi(Pointer<Void> handle) {
-  final _otherField_handle = _smoke_OuterStruct_InnerStruct_get_field_otherField(handle);
+  final _otherFieldHandle = _smokeOuterstructInnerstructGetFieldotherField(handle);
   try {
     return OuterStruct_InnerStruct(
-      foobar_ListOf_Date_fromFfi(_otherField_handle)
+      foobar_ListOf_Date_fromFfi(_otherFieldHandle)
     );
   } finally {
-    foobar_ListOf_Date_releaseFfiHandle(_otherField_handle);
+    foobar_ListOf_Date_releaseFfiHandle(_otherFieldHandle);
   }
 }
-void smoke_OuterStruct_InnerStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_OuterStruct_InnerStruct_release_handle(handle);
+void smoke_OuterStruct_InnerStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructInnerstructReleaseHandle(handle);
 // Nullable OuterStruct_InnerStruct
-final _smoke_OuterStruct_InnerStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStruct_InnerStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_create_handle_nullable'));
-final _smoke_OuterStruct_InnerStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStruct_InnerStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_release_handle_nullable'));
-final _smoke_OuterStruct_InnerStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStruct_InnerStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_get_value_nullable'));
 Pointer<Void> smoke_OuterStruct_InnerStruct_toFfi_nullable(OuterStruct_InnerStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_OuterStruct_InnerStruct_toFfi(value);
-  final result = _smoke_OuterStruct_InnerStruct_create_handle_nullable(_handle);
+  final result = _smoke_OuterStruct_InnerStructCreateHandleNullable(_handle);
   smoke_OuterStruct_InnerStruct_releaseFfiHandle(_handle);
   return result;
 }
 OuterStruct_InnerStruct smoke_OuterStruct_InnerStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_OuterStruct_InnerStruct_get_value_nullable(handle);
+  final _handle = _smoke_OuterStruct_InnerStructGetValueNullable(handle);
   final result = smoke_OuterStruct_InnerStruct_fromFfi(_handle);
   smoke_OuterStruct_InnerStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_OuterStruct_InnerStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterStruct_InnerStruct_release_handle_nullable(handle);
+  _smoke_OuterStruct_InnerStructReleaseHandleNullable(handle);
 // End of OuterStruct_InnerStruct "private" section.
 abstract class OuterStruct_InnerClass {
   /// Destroys the underlying native object.
@@ -195,11 +194,11 @@ abstract class OuterStruct_InnerClass {
   Set<Locale> fooBar();
 }
 // OuterStruct_InnerClass "private" section, not exported.
-final _smoke_OuterStruct_InnerClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerClass_copy_handle'));
-final _smoke_OuterStruct_InnerClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerClass_release_handle'));
@@ -209,45 +208,45 @@ class OuterStruct_InnerClass$Impl extends __lib.NativeBase implements OuterStruc
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterStruct_InnerClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterstructInnerclassReleaseHandle(handle);
     handle = null;
   }
   @override
   Set<Locale> fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerClass_fooBar'));
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerClass_fooBar'));
     final _handle = this.handle;
-    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_SetOf_Locale_fromFfi(__result_handle);
+      return foobar_SetOf_Locale_fromFfi(__resultHandle);
     } finally {
-      foobar_SetOf_Locale_releaseFfiHandle(__result_handle);
+      foobar_SetOf_Locale_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_OuterStruct_InnerClass_toFfi(OuterStruct_InnerClass value) =>
-  _smoke_OuterStruct_InnerClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeOuterstructInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterStruct_InnerClass smoke_OuterStruct_InnerClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterStruct_InnerClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_OuterStruct_InnerClass_copy_handle(handle);
-  final result = OuterStruct_InnerClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeOuterstructInnerclassCopyHandle(handle);
+  final result = OuterStruct_InnerClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterStruct_InnerClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterStruct_InnerClass_release_handle(handle);
+  _smokeOuterstructInnerclassReleaseHandle(handle);
 Pointer<Void> smoke_OuterStruct_InnerClass_toFfi_nullable(OuterStruct_InnerClass value) =>
   value != null ? smoke_OuterStruct_InnerClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterStruct_InnerClass smoke_OuterStruct_InnerClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterStruct_InnerClass_fromFfi(handle) : null;
 void smoke_OuterStruct_InnerClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterStruct_InnerClass_release_handle(handle);
+  _smokeOuterstructInnerclassReleaseHandle(handle);
 // End of OuterStruct_InnerClass "private" section.
 abstract class OuterStruct_InnerInterface {
-  OuterStruct_InnerInterface() {}
+  OuterStruct_InnerInterface();
   factory OuterStruct_InnerInterface.fromLambdas({
     @required Map<String, Uint8List> Function() lambda_barBaz,
   }) => OuterStruct_InnerInterface$Lambdas(
@@ -261,19 +260,19 @@ abstract class OuterStruct_InnerInterface {
   Map<String, Uint8List> barBaz();
 }
 // OuterStruct_InnerInterface "private" section, not exported.
-final _smoke_OuterStruct_InnerInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerInterface_copy_handle'));
-final _smoke_OuterStruct_InnerInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerInterface_release_handle'));
-final _smoke_OuterStruct_InnerInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_OuterStruct_InnerInterface_create_proxy'));
-final _smoke_OuterStruct_InnerInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructInnerinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerInterface_get_type_id'));
@@ -294,34 +293,34 @@ class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterS
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_OuterStruct_InnerInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOuterstructInnerinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   Map<String, Uint8List> barBaz() {
-    final _barBaz_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerInterface_barBaz'));
+    final _barBazFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerInterface_barBaz'));
     final _handle = this.handle;
-    final __result_handle = _barBaz_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _barBazFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_MapOf_String_to_Blob_fromFfi(__result_handle);
+      return foobar_MapOf_String_to_Blob_fromFfi(__resultHandle);
     } finally {
-      foobar_MapOf_String_to_Blob_releaseFfiHandle(__result_handle);
+      foobar_MapOf_String_to_Blob_releaseFfiHandle(__resultHandle);
     }
   }
 }
 int _OuterStruct_InnerInterface_barBaz_static(int _token, Pointer<Pointer<Void>> _result) {
-  Map<String, Uint8List> _result_object = null;
+  Map<String, Uint8List> _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as OuterStruct_InnerInterface).barBaz();
-    _result.value = foobar_MapOf_String_to_Blob_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as OuterStruct_InnerInterface).barBaz();
+    _result.value = foobar_MapOf_String_to_Blob_toFfi(_resultObject);
   } finally {
   }
   return 0;
 }
 Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi(OuterStruct_InnerInterface value) {
-  if (value is __lib.NativeBase) return _smoke_OuterStruct_InnerInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_OuterStruct_InnerInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeOuterstructInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeOuterstructInnerinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -331,85 +330,85 @@ Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi(OuterStruct_InnerInterface 
 }
 OuterStruct_InnerInterface smoke_OuterStruct_InnerInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as OuterStruct_InnerInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_OuterStruct_InnerInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_OuterStruct_InnerInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeOuterstructInnerinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeOuterstructInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : OuterStruct_InnerInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : OuterStruct_InnerInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_OuterStruct_InnerInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_OuterStruct_InnerInterface_release_handle(handle);
+  _smokeOuterstructInnerinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_OuterStruct_InnerInterface_toFfi_nullable(OuterStruct_InnerInterface value) =>
   value != null ? smoke_OuterStruct_InnerInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 OuterStruct_InnerInterface smoke_OuterStruct_InnerInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_OuterStruct_InnerInterface_fromFfi(handle) : null;
 void smoke_OuterStruct_InnerInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterStruct_InnerInterface_release_handle(handle);
+  _smokeOuterstructInnerinterfaceReleaseHandle(handle);
 // End of OuterStruct_InnerInterface "private" section.
 // OuterStruct "private" section, not exported.
-final _smoke_OuterStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_create_handle'));
-final _smoke_OuterStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_release_handle'));
-final _smoke_OuterStruct_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOuterstructGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_get_field_field'));
 Pointer<Void> smoke_OuterStruct_toFfi(OuterStruct value) {
-  final _field_handle = String_toFfi(value.field);
-  final _result = _smoke_OuterStruct_create_handle(_field_handle);
-  String_releaseFfiHandle(_field_handle);
+  final _fieldHandle = String_toFfi(value.field);
+  final _result = _smokeOuterstructCreateHandle(_fieldHandle);
+  String_releaseFfiHandle(_fieldHandle);
   return _result;
 }
 OuterStruct smoke_OuterStruct_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_OuterStruct_get_field_field(handle);
+  final _fieldHandle = _smokeOuterstructGetFieldfield(handle);
   try {
     return OuterStruct(
-      String_fromFfi(_field_handle)
+      String_fromFfi(_fieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_field_handle);
+    String_releaseFfiHandle(_fieldHandle);
   }
 }
-void smoke_OuterStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_OuterStruct_release_handle(handle);
+void smoke_OuterStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructReleaseHandle(handle);
 // Nullable OuterStruct
-final _smoke_OuterStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_create_handle_nullable'));
-final _smoke_OuterStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_release_handle_nullable'));
-final _smoke_OuterStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_OuterStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_get_value_nullable'));
 Pointer<Void> smoke_OuterStruct_toFfi_nullable(OuterStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_OuterStruct_toFfi(value);
-  final result = _smoke_OuterStruct_create_handle_nullable(_handle);
+  final result = _smoke_OuterStructCreateHandleNullable(_handle);
   smoke_OuterStruct_releaseFfiHandle(_handle);
   return result;
 }
 OuterStruct smoke_OuterStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_OuterStruct_get_value_nullable(handle);
+  final _handle = _smoke_OuterStructGetValueNullable(handle);
   final result = smoke_OuterStruct_fromFfi(_handle);
   smoke_OuterStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_OuterStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_OuterStruct_release_handle_nullable(handle);
+  _smoke_OuterStructReleaseHandleNullable(handle);
 // End of OuterStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -5,7 +5,6 @@ import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseFreeTypes {
@@ -17,27 +16,27 @@ abstract class UseFreeTypes {
   DateTime doStuff(FreePoint point, FreeEnum mode);
 }
 // UseFreeTypes "private" section, not exported.
-final _smoke_UseFreeTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUsefreetypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_copy_handle'));
-final _smoke_UseFreeTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeUsefreetypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_release_handle'));
-final _doStuff_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_release_handle'));
-final _doStuff_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_result'));
-final _doStuff_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_error'));
-final _doStuff_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
@@ -47,55 +46,55 @@ class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_UseFreeTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeUsefreetypesReleaseHandle(handle);
     handle = null;
   }
   @override
   DateTime doStuff(FreePoint point, FreeEnum mode) {
-    final _doStuff_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));
-    final _point_handle = smoke_FreePoint_toFfi(point);
-    final _mode_handle = smoke_FreeEnum_toFfi(mode);
+    final _doStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));
+    final _pointHandle = smoke_FreePoint_toFfi(point);
+    final _modeHandle = smoke_FreeEnum_toFfi(mode);
     final _handle = this.handle;
-    final __call_result_handle = _doStuff_ffi(_handle, __lib.LibraryContext.isolateId, _point_handle, _mode_handle);
-    smoke_FreePoint_releaseFfiHandle(_point_handle);
-    smoke_FreeEnum_releaseFfiHandle(_mode_handle);
-    if (_doStuff_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _doStuff_return_get_error(__call_result_handle);
-        _doStuff_return_release_handle(__call_result_handle);
+    final __callResultHandle = _doStuffFfi(_handle, __lib.LibraryContext.isolateId, _pointHandle, _modeHandle);
+    smoke_FreePoint_releaseFfiHandle(_pointHandle);
+    smoke_FreeEnum_releaseFfiHandle(_modeHandle);
+    if (_doStuffReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _doStuffReturnGetError(__callResultHandle);
+        _doStuffReturnReleaseHandle(__callResultHandle);
         try {
-          throw FreeException(smoke_FreeEnum_fromFfi(__error_handle));
+          throw FreeException(smoke_FreeEnum_fromFfi(__errorHandle));
         } finally {
-          smoke_FreeEnum_releaseFfiHandle(__error_handle);
+          smoke_FreeEnum_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _doStuff_return_get_result(__call_result_handle);
-    _doStuff_return_release_handle(__call_result_handle);
+    final __resultHandle = _doStuffReturnGetResult(__callResultHandle);
+    _doStuffReturnReleaseHandle(__callResultHandle);
     try {
-      return Date_fromFfi(__result_handle);
+      return Date_fromFfi(__resultHandle);
     } finally {
-      Date_releaseFfiHandle(__result_handle);
+      Date_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_UseFreeTypes_toFfi(UseFreeTypes value) =>
-  _smoke_UseFreeTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeUsefreetypesCopyHandle((value as __lib.NativeBase).handle);
 UseFreeTypes smoke_UseFreeTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as UseFreeTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_UseFreeTypes_copy_handle(handle);
-  final result = UseFreeTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeUsefreetypesCopyHandle(handle);
+  final result = UseFreeTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_UseFreeTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_UseFreeTypes_release_handle(handle);
+  _smokeUsefreetypesReleaseHandle(handle);
 Pointer<Void> smoke_UseFreeTypes_toFfi_nullable(UseFreeTypes value) =>
   value != null ? smoke_UseFreeTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 UseFreeTypes smoke_UseFreeTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_UseFreeTypes_fromFfi(handle) : null;
 void smoke_UseFreeTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_UseFreeTypes_release_handle(handle);
+  _smokeUsefreetypesReleaseHandle(handle);
 // End of UseFreeTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
@@ -1,364 +1,362 @@
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/nullable.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _foobar_ListOf_Nullable_Date_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_Nullable_Date_create_handle'));
-final _foobar_ListOf_Nullable_Date_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Nullable_Date_release_handle'));
-final _foobar_ListOf_Nullable_Date_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_Nullable_Date_insert'));
-final _foobar_ListOf_Nullable_Date_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_Nullable_Date_iterator'));
-final _foobar_ListOf_Nullable_Date_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Nullable_Date_iterator_release_handle'));
-final _foobar_ListOf_Nullable_Date_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_Nullable_Date_iterator_is_valid'));
-final _foobar_ListOf_Nullable_Date_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_Nullable_Date_iterator_increment'));
-final _foobar_ListOf_Nullable_Date_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofNullableDateIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_Nullable_Date_iterator_get'));
 Pointer<Void> foobar_ListOf_Nullable_Date_toFfi(List<DateTime> value) {
-  final _result = _foobar_ListOf_Nullable_Date_create_handle();
+  final _result = _foobarListofNullableDateCreateHandle();
   for (final element in value) {
-    final _element_handle = Date_toFfi_nullable(element);
-    _foobar_ListOf_Nullable_Date_insert(_result, _element_handle);
-    Date_releaseFfiHandle_nullable(_element_handle);
+    final _elementHandle = Date_toFfi_nullable(element);
+    _foobarListofNullableDateInsert(_result, _elementHandle);
+    Date_releaseFfiHandle_nullable(_elementHandle);
   }
   return _result;
 }
 List<DateTime> foobar_ListOf_Nullable_Date_fromFfi(Pointer<Void> handle) {
-  final result = List<DateTime>();
-  final _iterator_handle = _foobar_ListOf_Nullable_Date_iterator(handle);
-  while (_foobar_ListOf_Nullable_Date_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_Nullable_Date_iterator_get(_iterator_handle);
+  final result = List<DateTime>.empty(growable: true);
+  final _iteratorHandle = _foobarListofNullableDateIterator(handle);
+  while (_foobarListofNullableDateIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofNullableDateIteratorGet(_iteratorHandle);
     try {
-      result.add(Date_fromFfi_nullable(_element_handle));
+      result.add(Date_fromFfi_nullable(_elementHandle));
     } finally {
-      Date_releaseFfiHandle_nullable(_element_handle);
+      Date_releaseFfiHandle_nullable(_elementHandle);
     }
-    _foobar_ListOf_Nullable_Date_iterator_increment(_iterator_handle);
+    _foobarListofNullableDateIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_Nullable_Date_iterator_release_handle(_iterator_handle);
+  _foobarListofNullableDateIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_Nullable_Date_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_Nullable_Date_release_handle(handle);
-final _foobar_ListOf_Nullable_Date_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_Nullable_Date_releaseFfiHandle(Pointer<Void> handle) => _foobarListofNullableDateReleaseHandle(handle);
+final _foobar_ListOf_Nullable_DateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Nullable_Date_create_handle_nullable'));
-final _foobar_ListOf_Nullable_Date_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_Nullable_DateReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_Nullable_Date_release_handle_nullable'));
-final _foobar_ListOf_Nullable_Date_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_Nullable_DateGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Nullable_Date_get_value_nullable'));
 Pointer<Void> foobar_ListOf_Nullable_Date_toFfi_nullable(List<DateTime> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_Nullable_Date_toFfi(value);
-  final result = _foobar_ListOf_Nullable_Date_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_Nullable_DateCreateHandleNullable(_handle);
   foobar_ListOf_Nullable_Date_releaseFfiHandle(_handle);
   return result;
 }
 List<DateTime> foobar_ListOf_Nullable_Date_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_Nullable_Date_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_Nullable_DateGetValueNullable(handle);
   final result = foobar_ListOf_Nullable_Date_fromFfi(_handle);
   foobar_ListOf_Nullable_Date_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_Nullable_Date_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_Nullable_Date_release_handle_nullable(handle);
-final _foobar_ListOf_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_Nullable_DateReleaseHandleNullable(handle);
+final _foobarListofStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_ListOf_String_create_handle'));
-final _foobar_ListOf_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_String_release_handle'));
-final _foobar_ListOf_String_insert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Pointer<Void>),
     void Function(Pointer<Void>, Pointer<Void>)
   >('library_foobar_ListOf_String_insert'));
-final _foobar_ListOf_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator'));
-final _foobar_ListOf_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_release_handle'));
-final _foobar_ListOf_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_is_valid'));
-final _foobar_ListOf_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_increment'));
-final _foobar_ListOf_String_iterator_get = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarListofStringIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_ListOf_String_iterator_get'));
 Pointer<Void> foobar_ListOf_String_toFfi(List<String> value) {
-  final _result = _foobar_ListOf_String_create_handle();
+  final _result = _foobarListofStringCreateHandle();
   for (final element in value) {
-    final _element_handle = String_toFfi(element);
-    _foobar_ListOf_String_insert(_result, _element_handle);
-    String_releaseFfiHandle(_element_handle);
+    final _elementHandle = String_toFfi(element);
+    _foobarListofStringInsert(_result, _elementHandle);
+    String_releaseFfiHandle(_elementHandle);
   }
   return _result;
 }
 List<String> foobar_ListOf_String_fromFfi(Pointer<Void> handle) {
-  final result = List<String>();
-  final _iterator_handle = _foobar_ListOf_String_iterator(handle);
-  while (_foobar_ListOf_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _element_handle = _foobar_ListOf_String_iterator_get(_iterator_handle);
+  final result = List<String>.empty(growable: true);
+  final _iteratorHandle = _foobarListofStringIterator(handle);
+  while (_foobarListofStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofStringIteratorGet(_iteratorHandle);
     try {
-      result.add(String_fromFfi(_element_handle));
+      result.add(String_fromFfi(_elementHandle));
     } finally {
-      String_releaseFfiHandle(_element_handle);
+      String_releaseFfiHandle(_elementHandle);
     }
-    _foobar_ListOf_String_iterator_increment(_iterator_handle);
+    _foobarListofStringIteratorIncrement(_iteratorHandle);
   }
-  _foobar_ListOf_String_iterator_release_handle(_iterator_handle);
+  _foobarListofStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_ListOf_String_release_handle(handle);
-final _foobar_ListOf_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_ListOf_String_releaseFfiHandle(Pointer<Void> handle) => _foobarListofStringReleaseHandle(handle);
+final _foobar_ListOf_StringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_create_handle_nullable'));
-final _foobar_ListOf_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_StringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_ListOf_String_release_handle_nullable'));
-final _foobar_ListOf_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_ListOf_StringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_String_get_value_nullable'));
 Pointer<Void> foobar_ListOf_String_toFfi_nullable(List<String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_ListOf_String_toFfi(value);
-  final result = _foobar_ListOf_String_create_handle_nullable(_handle);
+  final result = _foobar_ListOf_StringCreateHandleNullable(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
 List<String> foobar_ListOf_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_ListOf_String_get_value_nullable(handle);
+  final _handle = _foobar_ListOf_StringGetValueNullable(handle);
   final result = foobar_ListOf_String_fromFfi(_handle);
   foobar_ListOf_String_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_ListOf_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_ListOf_String_release_handle_nullable(handle);
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_ListOf_StringReleaseHandleNullable(handle);
+final _foobarMapofIntToNullableSmokeNullableSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofIntToNullableSmokeNullableSomestructIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(Map<int, Nullable_SomeStruct> value) {
-  final _result = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle();
+  final _result = _foobarMapofIntToNullableSmokeNullableSomestructCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = smoke_Nullable_SomeStruct_toFfi_nullable(entry.value);
-    _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = smoke_Nullable_SomeStruct_toFfi_nullable(entry.value);
+    _foobarMapofIntToNullableSmokeNullableSomestructPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_valueHandle);
   }
   return _result;
 }
 Map<int, Nullable_SomeStruct> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
   final result = Map<int, Nullable_SomeStruct>();
-  final _iterator_handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator(handle);
-  while (_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofIntToNullableSmokeNullableSomestructIterator(handle);
+  while (_foobarMapofIntToNullableSmokeNullableSomestructIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofIntToNullableSmokeNullableSomestructIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofIntToNullableSmokeNullableSomestructIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        smoke_Nullable_SomeStruct_fromFfi_nullable(_value_handle);
+      result[(_keyHandle)] =
+        smoke_Nullable_SomeStruct_fromFfi_nullable(_valueHandle);
     } finally {
-      (_key_handle);
-      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
+      (_keyHandle);
+      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_valueHandle);
     }
-    _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_increment(_iterator_handle);
+    _foobarMapofIntToNullableSmokeNullableSomestructIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_iterator_release_handle(_iterator_handle);
+  _foobarMapofIntToNullableSmokeNullableSomestructIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle(handle);
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofIntToNullableSmokeNullableSomestructReleaseHandle(handle);
+final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable'));
-final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi_nullable(Map<int, Nullable_SomeStruct> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_toFfi(value);
-  final result = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStructCreateHandleNullable(_handle);
   foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, Nullable_SomeStruct> foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStructGetValueNullable(handle);
   final result = foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_fromFfi(_handle);
   foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStruct_release_handle_nullable(handle);
-final _foobar_MapOf_Long_to_String_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+  _foobar_MapOf_Int_to_Nullable_smoke_Nullable_SomeStructReleaseHandleNullable(handle);
+final _foobarMapofLongToStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
   >('library_foobar_MapOf_Long_to_String_create_handle'));
-final _foobar_MapOf_Long_to_String_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Long_to_String_release_handle'));
-final _foobar_MapOf_Long_to_String_put = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int64, Pointer<Void>),
     void Function(Pointer<Void>, int, Pointer<Void>)
   >('library_foobar_MapOf_Long_to_String_put'));
-final _foobar_MapOf_Long_to_String_iterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Long_to_String_iterator'));
-final _foobar_MapOf_Long_to_String_iterator_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Long_to_String_iterator_release_handle'));
-final _foobar_MapOf_Long_to_String_iterator_is_valid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>, Pointer<Void>),
     int Function(Pointer<Void>, Pointer<Void>)
 >('library_foobar_MapOf_Long_to_String_iterator_is_valid'));
-final _foobar_MapOf_Long_to_String_iterator_increment = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
 >('library_foobar_MapOf_Long_to_String_iterator_increment'));
-final _foobar_MapOf_Long_to_String_iterator_get_key = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_MapOf_Long_to_String_iterator_get_key'));
-final _foobar_MapOf_Long_to_String_iterator_get_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobarMapofLongToStringIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Long_to_String_iterator_get_value'));
 Pointer<Void> foobar_MapOf_Long_to_String_toFfi(Map<int, String> value) {
-  final _result = _foobar_MapOf_Long_to_String_create_handle();
+  final _result = _foobarMapofLongToStringCreateHandle();
   for (final entry in value.entries) {
-    final _key_handle = (entry.key);
-    final _value_handle = String_toFfi(entry.value);
-    _foobar_MapOf_Long_to_String_put(_result, _key_handle, _value_handle);
-    (_key_handle);
-    String_releaseFfiHandle(_value_handle);
+    final _keyHandle = (entry.key);
+    final _valueHandle = String_toFfi(entry.value);
+    _foobarMapofLongToStringPut(_result, _keyHandle, _valueHandle);
+    (_keyHandle);
+    String_releaseFfiHandle(_valueHandle);
   }
   return _result;
 }
 Map<int, String> foobar_MapOf_Long_to_String_fromFfi(Pointer<Void> handle) {
   final result = Map<int, String>();
-  final _iterator_handle = _foobar_MapOf_Long_to_String_iterator(handle);
-  while (_foobar_MapOf_Long_to_String_iterator_is_valid(handle, _iterator_handle) != 0) {
-    final _key_handle = _foobar_MapOf_Long_to_String_iterator_get_key(_iterator_handle);
-    final _value_handle = _foobar_MapOf_Long_to_String_iterator_get_value(_iterator_handle);
+  final _iteratorHandle = _foobarMapofLongToStringIterator(handle);
+  while (_foobarMapofLongToStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofLongToStringIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofLongToStringIteratorGetValue(_iteratorHandle);
     try {
-      result[(_key_handle)] =
-        String_fromFfi(_value_handle);
+      result[(_keyHandle)] =
+        String_fromFfi(_valueHandle);
     } finally {
-      (_key_handle);
-      String_releaseFfiHandle(_value_handle);
+      (_keyHandle);
+      String_releaseFfiHandle(_valueHandle);
     }
-    _foobar_MapOf_Long_to_String_iterator_increment(_iterator_handle);
+    _foobarMapofLongToStringIteratorIncrement(_iteratorHandle);
   }
-  _foobar_MapOf_Long_to_String_iterator_release_handle(_iterator_handle);
+  _foobarMapofLongToStringIteratorReleaseHandle(_iteratorHandle);
   return result;
 }
-void foobar_MapOf_Long_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobar_MapOf_Long_to_String_release_handle(handle);
-final _foobar_MapOf_Long_to_String_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+void foobar_MapOf_Long_to_String_releaseFfiHandle(Pointer<Void> handle) => _foobarMapofLongToStringReleaseHandle(handle);
+final _foobar_MapOf_Long_to_StringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Long_to_String_create_handle_nullable'));
-final _foobar_MapOf_Long_to_String_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Long_to_StringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_foobar_MapOf_Long_to_String_release_handle_nullable'));
-final _foobar_MapOf_Long_to_String_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _foobar_MapOf_Long_to_StringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Long_to_String_get_value_nullable'));
 Pointer<Void> foobar_MapOf_Long_to_String_toFfi_nullable(Map<int, String> value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobar_MapOf_Long_to_String_toFfi(value);
-  final result = _foobar_MapOf_Long_to_String_create_handle_nullable(_handle);
+  final result = _foobar_MapOf_Long_to_StringCreateHandleNullable(_handle);
   foobar_MapOf_Long_to_String_releaseFfiHandle(_handle);
   return result;
 }
 Map<int, String> foobar_MapOf_Long_to_String_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _foobar_MapOf_Long_to_String_get_value_nullable(handle);
+  final _handle = _foobar_MapOf_Long_to_StringGetValueNullable(handle);
   final result = foobar_MapOf_Long_to_String_fromFfi(_handle);
   foobar_MapOf_Long_to_String_releaseFfiHandle(_handle);
   return result;
 }
 void foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _foobar_MapOf_Long_to_String_release_handle_nullable(handle);
+  _foobar_MapOf_Long_to_StringReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/some_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Nullable {
@@ -74,98 +73,98 @@ Nullable_SomeEnum smoke_Nullable_SomeEnum_fromFfi(int handle) {
   }
 }
 void smoke_Nullable_SomeEnum_releaseFfiHandle(int handle) {}
-final _smoke_Nullable_SomeEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Nullable_SomeEnum_create_handle_nullable'));
-final _smoke_Nullable_SomeEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeEnum_release_handle_nullable'));
-final _smoke_Nullable_SomeEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeEnum_get_value_nullable'));
 Pointer<Void> smoke_Nullable_SomeEnum_toFfi_nullable(Nullable_SomeEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_SomeEnum_toFfi(value);
-  final result = _smoke_Nullable_SomeEnum_create_handle_nullable(_handle);
+  final result = _smoke_Nullable_SomeEnumCreateHandleNullable(_handle);
   smoke_Nullable_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 Nullable_SomeEnum smoke_Nullable_SomeEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Nullable_SomeEnum_get_value_nullable(handle);
+  final _handle = _smoke_Nullable_SomeEnumGetValueNullable(handle);
   final result = smoke_Nullable_SomeEnum_fromFfi(_handle);
   smoke_Nullable_SomeEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Nullable_SomeEnum_release_handle_nullable(handle);
+  _smoke_Nullable_SomeEnumReleaseHandleNullable(handle);
 // End of Nullable_SomeEnum "private" section.
 class Nullable_SomeStruct {
   String stringField;
   Nullable_SomeStruct(this.stringField);
 }
 // Nullable_SomeStruct "private" section, not exported.
-final _smoke_Nullable_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_create_handle'));
-final _smoke_Nullable_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_release_handle'));
-final _smoke_Nullable_SomeStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableSomestructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_get_field_stringField'));
 Pointer<Void> smoke_Nullable_SomeStruct_toFfi(Nullable_SomeStruct value) {
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _result = _smoke_Nullable_SomeStruct_create_handle(_stringField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _result = _smokeNullableSomestructCreateHandle(_stringFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 Nullable_SomeStruct smoke_Nullable_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_Nullable_SomeStruct_get_field_stringField(handle);
+  final _stringFieldHandle = _smokeNullableSomestructGetFieldstringField(handle);
   try {
     return Nullable_SomeStruct(
-      String_fromFfi(_stringField_handle)
+      String_fromFfi(_stringFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_SomeStruct_release_handle(handle);
+void smoke_Nullable_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeNullableSomestructReleaseHandle(handle);
 // Nullable Nullable_SomeStruct
-final _smoke_Nullable_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_create_handle_nullable'));
-final _smoke_Nullable_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_release_handle_nullable'));
-final _smoke_Nullable_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_Nullable_SomeStruct_toFfi_nullable(Nullable_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_SomeStruct_toFfi(value);
-  final result = _smoke_Nullable_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_Nullable_SomeStructCreateHandleNullable(_handle);
   smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 Nullable_SomeStruct smoke_Nullable_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Nullable_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_Nullable_SomeStructGetValueNullable(handle);
   final result = smoke_Nullable_SomeStruct_fromFfi(_handle);
   smoke_Nullable_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Nullable_SomeStruct_release_handle_nullable(handle);
+  _smoke_Nullable_SomeStructReleaseHandleNullable(handle);
 // End of Nullable_SomeStruct "private" section.
 class Nullable_NullableStruct {
   String stringField;
@@ -180,136 +179,136 @@ class Nullable_NullableStruct {
   Nullable_NullableStruct(this.stringField, this.boolField, this.doubleField, this.structField, this.enumField, this.arrayField, this.inlineArrayField, this.mapField, this.instanceField);
 }
 // Nullable_NullableStruct "private" section, not exported.
-final _smoke_Nullable_NullableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_create_handle'));
-final _smoke_Nullable_NullableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_release_handle'));
-final _smoke_Nullable_NullableStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_stringField'));
-final _smoke_Nullable_NullableStruct_get_field_boolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_boolField'));
-final _smoke_Nullable_NullableStruct_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFielddoubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_doubleField'));
-final _smoke_Nullable_NullableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_structField'));
-final _smoke_Nullable_NullableStruct_get_field_enumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldenumField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_enumField'));
-final _smoke_Nullable_NullableStruct_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldarrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_arrayField'));
-final _smoke_Nullable_NullableStruct_get_field_inlineArrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldinlineArrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_inlineArrayField'));
-final _smoke_Nullable_NullableStruct_get_field_mapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldmapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_mapField'));
-final _smoke_Nullable_NullableStruct_get_field_instanceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullablestructGetFieldinstanceField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_instanceField'));
 Pointer<Void> smoke_Nullable_NullableStruct_toFfi(Nullable_NullableStruct value) {
-  final _stringField_handle = String_toFfi_nullable(value.stringField);
-  final _boolField_handle = Boolean_toFfi_nullable(value.boolField);
-  final _doubleField_handle = Double_toFfi_nullable(value.doubleField);
-  final _structField_handle = smoke_Nullable_SomeStruct_toFfi_nullable(value.structField);
-  final _enumField_handle = smoke_Nullable_SomeEnum_toFfi_nullable(value.enumField);
-  final _arrayField_handle = foobar_ListOf_String_toFfi_nullable(value.arrayField);
-  final _inlineArrayField_handle = foobar_ListOf_String_toFfi_nullable(value.inlineArrayField);
-  final _mapField_handle = foobar_MapOf_Long_to_String_toFfi_nullable(value.mapField);
-  final _instanceField_handle = smoke_SomeInterface_toFfi_nullable(value.instanceField);
-  final _result = _smoke_Nullable_NullableStruct_create_handle(_stringField_handle, _boolField_handle, _doubleField_handle, _structField_handle, _enumField_handle, _arrayField_handle, _inlineArrayField_handle, _mapField_handle, _instanceField_handle);
-  String_releaseFfiHandle_nullable(_stringField_handle);
-  Boolean_releaseFfiHandle_nullable(_boolField_handle);
-  Double_releaseFfiHandle_nullable(_doubleField_handle);
-  smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structField_handle);
-  smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-  foobar_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-  foobar_ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
-  foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
-  smoke_SomeInterface_releaseFfiHandle_nullable(_instanceField_handle);
+  final _stringFieldHandle = String_toFfi_nullable(value.stringField);
+  final _boolFieldHandle = Boolean_toFfi_nullable(value.boolField);
+  final _doubleFieldHandle = Double_toFfi_nullable(value.doubleField);
+  final _structFieldHandle = smoke_Nullable_SomeStruct_toFfi_nullable(value.structField);
+  final _enumFieldHandle = smoke_Nullable_SomeEnum_toFfi_nullable(value.enumField);
+  final _arrayFieldHandle = foobar_ListOf_String_toFfi_nullable(value.arrayField);
+  final _inlineArrayFieldHandle = foobar_ListOf_String_toFfi_nullable(value.inlineArrayField);
+  final _mapFieldHandle = foobar_MapOf_Long_to_String_toFfi_nullable(value.mapField);
+  final _instanceFieldHandle = smoke_SomeInterface_toFfi_nullable(value.instanceField);
+  final _result = _smokeNullableNullablestructCreateHandle(_stringFieldHandle, _boolFieldHandle, _doubleFieldHandle, _structFieldHandle, _enumFieldHandle, _arrayFieldHandle, _inlineArrayFieldHandle, _mapFieldHandle, _instanceFieldHandle);
+  String_releaseFfiHandle_nullable(_stringFieldHandle);
+  Boolean_releaseFfiHandle_nullable(_boolFieldHandle);
+  Double_releaseFfiHandle_nullable(_doubleFieldHandle);
+  smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structFieldHandle);
+  smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumFieldHandle);
+  foobar_ListOf_String_releaseFfiHandle_nullable(_arrayFieldHandle);
+  foobar_ListOf_String_releaseFfiHandle_nullable(_inlineArrayFieldHandle);
+  foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_mapFieldHandle);
+  smoke_SomeInterface_releaseFfiHandle_nullable(_instanceFieldHandle);
   return _result;
 }
 Nullable_NullableStruct smoke_Nullable_NullableStruct_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_Nullable_NullableStruct_get_field_stringField(handle);
-  final _boolField_handle = _smoke_Nullable_NullableStruct_get_field_boolField(handle);
-  final _doubleField_handle = _smoke_Nullable_NullableStruct_get_field_doubleField(handle);
-  final _structField_handle = _smoke_Nullable_NullableStruct_get_field_structField(handle);
-  final _enumField_handle = _smoke_Nullable_NullableStruct_get_field_enumField(handle);
-  final _arrayField_handle = _smoke_Nullable_NullableStruct_get_field_arrayField(handle);
-  final _inlineArrayField_handle = _smoke_Nullable_NullableStruct_get_field_inlineArrayField(handle);
-  final _mapField_handle = _smoke_Nullable_NullableStruct_get_field_mapField(handle);
-  final _instanceField_handle = _smoke_Nullable_NullableStruct_get_field_instanceField(handle);
+  final _stringFieldHandle = _smokeNullableNullablestructGetFieldstringField(handle);
+  final _boolFieldHandle = _smokeNullableNullablestructGetFieldboolField(handle);
+  final _doubleFieldHandle = _smokeNullableNullablestructGetFielddoubleField(handle);
+  final _structFieldHandle = _smokeNullableNullablestructGetFieldstructField(handle);
+  final _enumFieldHandle = _smokeNullableNullablestructGetFieldenumField(handle);
+  final _arrayFieldHandle = _smokeNullableNullablestructGetFieldarrayField(handle);
+  final _inlineArrayFieldHandle = _smokeNullableNullablestructGetFieldinlineArrayField(handle);
+  final _mapFieldHandle = _smokeNullableNullablestructGetFieldmapField(handle);
+  final _instanceFieldHandle = _smokeNullableNullablestructGetFieldinstanceField(handle);
   try {
     return Nullable_NullableStruct(
-      String_fromFfi_nullable(_stringField_handle),
-      Boolean_fromFfi_nullable(_boolField_handle),
-      Double_fromFfi_nullable(_doubleField_handle),
-      smoke_Nullable_SomeStruct_fromFfi_nullable(_structField_handle),
-      smoke_Nullable_SomeEnum_fromFfi_nullable(_enumField_handle),
-      foobar_ListOf_String_fromFfi_nullable(_arrayField_handle),
-      foobar_ListOf_String_fromFfi_nullable(_inlineArrayField_handle),
-      foobar_MapOf_Long_to_String_fromFfi_nullable(_mapField_handle),
-      smoke_SomeInterface_fromFfi_nullable(_instanceField_handle)
+      String_fromFfi_nullable(_stringFieldHandle),
+      Boolean_fromFfi_nullable(_boolFieldHandle),
+      Double_fromFfi_nullable(_doubleFieldHandle),
+      smoke_Nullable_SomeStruct_fromFfi_nullable(_structFieldHandle),
+      smoke_Nullable_SomeEnum_fromFfi_nullable(_enumFieldHandle),
+      foobar_ListOf_String_fromFfi_nullable(_arrayFieldHandle),
+      foobar_ListOf_String_fromFfi_nullable(_inlineArrayFieldHandle),
+      foobar_MapOf_Long_to_String_fromFfi_nullable(_mapFieldHandle),
+      smoke_SomeInterface_fromFfi_nullable(_instanceFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle_nullable(_stringField_handle);
-    Boolean_releaseFfiHandle_nullable(_boolField_handle);
-    Double_releaseFfiHandle_nullable(_doubleField_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structField_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumField_handle);
-    foobar_ListOf_String_releaseFfiHandle_nullable(_arrayField_handle);
-    foobar_ListOf_String_releaseFfiHandle_nullable(_inlineArrayField_handle);
-    foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_mapField_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(_instanceField_handle);
+    String_releaseFfiHandle_nullable(_stringFieldHandle);
+    Boolean_releaseFfiHandle_nullable(_boolFieldHandle);
+    Double_releaseFfiHandle_nullable(_doubleFieldHandle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_structFieldHandle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_enumFieldHandle);
+    foobar_ListOf_String_releaseFfiHandle_nullable(_arrayFieldHandle);
+    foobar_ListOf_String_releaseFfiHandle_nullable(_inlineArrayFieldHandle);
+    foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_mapFieldHandle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(_instanceFieldHandle);
   }
 }
-void smoke_Nullable_NullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_NullableStruct_release_handle(handle);
+void smoke_Nullable_NullableStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeNullableNullablestructReleaseHandle(handle);
 // Nullable Nullable_NullableStruct
-final _smoke_Nullable_NullableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_create_handle_nullable'));
-final _smoke_Nullable_NullableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_release_handle_nullable'));
-final _smoke_Nullable_NullableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_value_nullable'));
 Pointer<Void> smoke_Nullable_NullableStruct_toFfi_nullable(Nullable_NullableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_NullableStruct_toFfi(value);
-  final result = _smoke_Nullable_NullableStruct_create_handle_nullable(_handle);
+  final result = _smoke_Nullable_NullableStructCreateHandleNullable(_handle);
   smoke_Nullable_NullableStruct_releaseFfiHandle(_handle);
   return result;
 }
 Nullable_NullableStruct smoke_Nullable_NullableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Nullable_NullableStruct_get_value_nullable(handle);
+  final _handle = _smoke_Nullable_NullableStructGetValueNullable(handle);
   final result = smoke_Nullable_NullableStruct_fromFfi(_handle);
   smoke_Nullable_NullableStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Nullable_NullableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Nullable_NullableStruct_release_handle_nullable(handle);
+  _smoke_Nullable_NullableStructReleaseHandleNullable(handle);
 // End of Nullable_NullableStruct "private" section.
 class Nullable_NullableIntsStruct {
   int int8Field;
@@ -323,134 +322,134 @@ class Nullable_NullableIntsStruct {
   Nullable_NullableIntsStruct(this.int8Field, this.int16Field, this.int32Field, this.int64Field, this.uint8Field, this.uint16Field, this.uint32Field, this.uint64Field);
 }
 // Nullable_NullableIntsStruct "private" section, not exported.
-final _smoke_Nullable_NullableIntsStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_create_handle'));
-final _smoke_Nullable_NullableIntsStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_release_handle'));
-final _smoke_Nullable_NullableIntsStruct_get_field_int8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFieldint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_int8Field'));
-final _smoke_Nullable_NullableIntsStruct_get_field_int16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFieldint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_int16Field'));
-final _smoke_Nullable_NullableIntsStruct_get_field_int32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFieldint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_int32Field'));
-final _smoke_Nullable_NullableIntsStruct_get_field_int64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFieldint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_int64Field'));
-final _smoke_Nullable_NullableIntsStruct_get_field_uint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFielduint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_uint8Field'));
-final _smoke_Nullable_NullableIntsStruct_get_field_uint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFielduint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_uint16Field'));
-final _smoke_Nullable_NullableIntsStruct_get_field_uint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFielduint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_uint32Field'));
-final _smoke_Nullable_NullableIntsStruct_get_field_uint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableNullableintsstructGetFielduint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_uint64Field'));
 Pointer<Void> smoke_Nullable_NullableIntsStruct_toFfi(Nullable_NullableIntsStruct value) {
-  final _int8Field_handle = Byte_toFfi_nullable(value.int8Field);
-  final _int16Field_handle = Short_toFfi_nullable(value.int16Field);
-  final _int32Field_handle = Int_toFfi_nullable(value.int32Field);
-  final _int64Field_handle = Long_toFfi_nullable(value.int64Field);
-  final _uint8Field_handle = UByte_toFfi_nullable(value.uint8Field);
-  final _uint16Field_handle = UShort_toFfi_nullable(value.uint16Field);
-  final _uint32Field_handle = UInt_toFfi_nullable(value.uint32Field);
-  final _uint64Field_handle = ULong_toFfi_nullable(value.uint64Field);
-  final _result = _smoke_Nullable_NullableIntsStruct_create_handle(_int8Field_handle, _int16Field_handle, _int32Field_handle, _int64Field_handle, _uint8Field_handle, _uint16Field_handle, _uint32Field_handle, _uint64Field_handle);
-  Byte_releaseFfiHandle_nullable(_int8Field_handle);
-  Short_releaseFfiHandle_nullable(_int16Field_handle);
-  Int_releaseFfiHandle_nullable(_int32Field_handle);
-  Long_releaseFfiHandle_nullable(_int64Field_handle);
-  UByte_releaseFfiHandle_nullable(_uint8Field_handle);
-  UShort_releaseFfiHandle_nullable(_uint16Field_handle);
-  UInt_releaseFfiHandle_nullable(_uint32Field_handle);
-  ULong_releaseFfiHandle_nullable(_uint64Field_handle);
+  final _int8FieldHandle = Byte_toFfi_nullable(value.int8Field);
+  final _int16FieldHandle = Short_toFfi_nullable(value.int16Field);
+  final _int32FieldHandle = Int_toFfi_nullable(value.int32Field);
+  final _int64FieldHandle = Long_toFfi_nullable(value.int64Field);
+  final _uint8FieldHandle = UByte_toFfi_nullable(value.uint8Field);
+  final _uint16FieldHandle = UShort_toFfi_nullable(value.uint16Field);
+  final _uint32FieldHandle = UInt_toFfi_nullable(value.uint32Field);
+  final _uint64FieldHandle = ULong_toFfi_nullable(value.uint64Field);
+  final _result = _smokeNullableNullableintsstructCreateHandle(_int8FieldHandle, _int16FieldHandle, _int32FieldHandle, _int64FieldHandle, _uint8FieldHandle, _uint16FieldHandle, _uint32FieldHandle, _uint64FieldHandle);
+  Byte_releaseFfiHandle_nullable(_int8FieldHandle);
+  Short_releaseFfiHandle_nullable(_int16FieldHandle);
+  Int_releaseFfiHandle_nullable(_int32FieldHandle);
+  Long_releaseFfiHandle_nullable(_int64FieldHandle);
+  UByte_releaseFfiHandle_nullable(_uint8FieldHandle);
+  UShort_releaseFfiHandle_nullable(_uint16FieldHandle);
+  UInt_releaseFfiHandle_nullable(_uint32FieldHandle);
+  ULong_releaseFfiHandle_nullable(_uint64FieldHandle);
   return _result;
 }
 Nullable_NullableIntsStruct smoke_Nullable_NullableIntsStruct_fromFfi(Pointer<Void> handle) {
-  final _int8Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_int8Field(handle);
-  final _int16Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_int16Field(handle);
-  final _int32Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_int32Field(handle);
-  final _int64Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_int64Field(handle);
-  final _uint8Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_uint8Field(handle);
-  final _uint16Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_uint16Field(handle);
-  final _uint32Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_uint32Field(handle);
-  final _uint64Field_handle = _smoke_Nullable_NullableIntsStruct_get_field_uint64Field(handle);
+  final _int8FieldHandle = _smokeNullableNullableintsstructGetFieldint8Field(handle);
+  final _int16FieldHandle = _smokeNullableNullableintsstructGetFieldint16Field(handle);
+  final _int32FieldHandle = _smokeNullableNullableintsstructGetFieldint32Field(handle);
+  final _int64FieldHandle = _smokeNullableNullableintsstructGetFieldint64Field(handle);
+  final _uint8FieldHandle = _smokeNullableNullableintsstructGetFielduint8Field(handle);
+  final _uint16FieldHandle = _smokeNullableNullableintsstructGetFielduint16Field(handle);
+  final _uint32FieldHandle = _smokeNullableNullableintsstructGetFielduint32Field(handle);
+  final _uint64FieldHandle = _smokeNullableNullableintsstructGetFielduint64Field(handle);
   try {
     return Nullable_NullableIntsStruct(
-      Byte_fromFfi_nullable(_int8Field_handle),
-      Short_fromFfi_nullable(_int16Field_handle),
-      Int_fromFfi_nullable(_int32Field_handle),
-      Long_fromFfi_nullable(_int64Field_handle),
-      UByte_fromFfi_nullable(_uint8Field_handle),
-      UShort_fromFfi_nullable(_uint16Field_handle),
-      UInt_fromFfi_nullable(_uint32Field_handle),
-      ULong_fromFfi_nullable(_uint64Field_handle)
+      Byte_fromFfi_nullable(_int8FieldHandle),
+      Short_fromFfi_nullable(_int16FieldHandle),
+      Int_fromFfi_nullable(_int32FieldHandle),
+      Long_fromFfi_nullable(_int64FieldHandle),
+      UByte_fromFfi_nullable(_uint8FieldHandle),
+      UShort_fromFfi_nullable(_uint16FieldHandle),
+      UInt_fromFfi_nullable(_uint32FieldHandle),
+      ULong_fromFfi_nullable(_uint64FieldHandle)
     );
   } finally {
-    Byte_releaseFfiHandle_nullable(_int8Field_handle);
-    Short_releaseFfiHandle_nullable(_int16Field_handle);
-    Int_releaseFfiHandle_nullable(_int32Field_handle);
-    Long_releaseFfiHandle_nullable(_int64Field_handle);
-    UByte_releaseFfiHandle_nullable(_uint8Field_handle);
-    UShort_releaseFfiHandle_nullable(_uint16Field_handle);
-    UInt_releaseFfiHandle_nullable(_uint32Field_handle);
-    ULong_releaseFfiHandle_nullable(_uint64Field_handle);
+    Byte_releaseFfiHandle_nullable(_int8FieldHandle);
+    Short_releaseFfiHandle_nullable(_int16FieldHandle);
+    Int_releaseFfiHandle_nullable(_int32FieldHandle);
+    Long_releaseFfiHandle_nullable(_int64FieldHandle);
+    UByte_releaseFfiHandle_nullable(_uint8FieldHandle);
+    UShort_releaseFfiHandle_nullable(_uint16FieldHandle);
+    UInt_releaseFfiHandle_nullable(_uint32FieldHandle);
+    ULong_releaseFfiHandle_nullable(_uint64FieldHandle);
   }
 }
-void smoke_Nullable_NullableIntsStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Nullable_NullableIntsStruct_release_handle(handle);
+void smoke_Nullable_NullableIntsStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeNullableNullableintsstructReleaseHandle(handle);
 // Nullable Nullable_NullableIntsStruct
-final _smoke_Nullable_NullableIntsStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableIntsStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_create_handle_nullable'));
-final _smoke_Nullable_NullableIntsStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableIntsStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_release_handle_nullable'));
-final _smoke_Nullable_NullableIntsStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Nullable_NullableIntsStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_value_nullable'));
 Pointer<Void> smoke_Nullable_NullableIntsStruct_toFfi_nullable(Nullable_NullableIntsStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Nullable_NullableIntsStruct_toFfi(value);
-  final result = _smoke_Nullable_NullableIntsStruct_create_handle_nullable(_handle);
+  final result = _smoke_Nullable_NullableIntsStructCreateHandleNullable(_handle);
   smoke_Nullable_NullableIntsStruct_releaseFfiHandle(_handle);
   return result;
 }
 Nullable_NullableIntsStruct smoke_Nullable_NullableIntsStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Nullable_NullableIntsStruct_get_value_nullable(handle);
+  final _handle = _smoke_Nullable_NullableIntsStructGetValueNullable(handle);
   final result = smoke_Nullable_NullableIntsStruct_fromFfi(_handle);
   smoke_Nullable_NullableIntsStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Nullable_NullableIntsStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Nullable_NullableIntsStruct_release_handle_nullable(handle);
+  _smoke_Nullable_NullableIntsStructReleaseHandleNullable(handle);
 // End of Nullable_NullableIntsStruct "private" section.
 // Nullable "private" section, not exported.
-final _smoke_Nullable_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_copy_handle'));
-final _smoke_Nullable_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeNullableReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_release_handle'));
@@ -460,399 +459,399 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Nullable_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeNullableReleaseHandle(handle);
     handle = null;
   }
   @override
   String methodWithString(String input) {
-    final _methodWithString_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String'));
-    final _input_handle = String_toFfi_nullable(input);
+    final _methodWithStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String'));
+    final _inputHandle = String_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithString_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithStringFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return String_fromFfi_nullable(__result_handle);
+      return String_fromFfi_nullable(__resultHandle);
     } finally {
-      String_releaseFfiHandle_nullable(__result_handle);
+      String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   bool methodWithBoolean(bool input) {
-    final _methodWithBoolean_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean'));
-    final _input_handle = Boolean_toFfi_nullable(input);
+    final _methodWithBooleanFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean'));
+    final _inputHandle = Boolean_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithBoolean_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Boolean_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithBooleanFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Boolean_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return Boolean_fromFfi_nullable(__result_handle);
+      return Boolean_fromFfi_nullable(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle_nullable(__result_handle);
+      Boolean_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   double methodWithDouble(double input) {
-    final _methodWithDouble_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double'));
-    final _input_handle = Double_toFfi_nullable(input);
+    final _methodWithDoubleFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double'));
+    final _inputHandle = Double_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithDouble_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Double_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithDoubleFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Double_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return Double_fromFfi_nullable(__result_handle);
+      return Double_fromFfi_nullable(__resultHandle);
     } finally {
-      Double_releaseFfiHandle_nullable(__result_handle);
+      Double_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   int methodWithInt(int input) {
-    final _methodWithInt_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long'));
-    final _input_handle = Long_toFfi_nullable(input);
+    final _methodWithIntFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long'));
+    final _inputHandle = Long_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithInt_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Long_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithIntFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Long_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return Long_fromFfi_nullable(__result_handle);
+      return Long_fromFfi_nullable(__resultHandle);
     } finally {
-      Long_releaseFfiHandle_nullable(__result_handle);
+      Long_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   Nullable_SomeStruct methodWithSomeStruct(Nullable_SomeStruct input) {
-    final _methodWithSomeStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct'));
-    final _input_handle = smoke_Nullable_SomeStruct_toFfi_nullable(input);
+    final _methodWithSomeStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct'));
+    final _inputHandle = smoke_Nullable_SomeStruct_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithSomeStruct_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithSomeStructFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
+      return smoke_Nullable_SomeStruct_fromFfi_nullable(__resultHandle);
     } finally {
-      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
+      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   Nullable_SomeEnum methodWithSomeEnum(Nullable_SomeEnum input) {
-    final _methodWithSomeEnum_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum'));
-    final _input_handle = smoke_Nullable_SomeEnum_toFfi_nullable(input);
+    final _methodWithSomeEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum'));
+    final _inputHandle = smoke_Nullable_SomeEnum_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithSomeEnum_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithSomeEnumFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
+      return smoke_Nullable_SomeEnum_fromFfi_nullable(__resultHandle);
     } finally {
-      smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
+      smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   List<String> methodWithSomeArray(List<String> input) {
-    final _methodWithSomeArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_1String'));
-    final _input_handle = foobar_ListOf_String_toFfi_nullable(input);
+    final _methodWithSomeArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_1String'));
+    final _inputHandle = foobar_ListOf_String_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithSomeArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_String_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithSomeArrayFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_String_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return foobar_ListOf_String_fromFfi_nullable(__result_handle);
+      return foobar_ListOf_String_fromFfi_nullable(__resultHandle);
     } finally {
-      foobar_ListOf_String_releaseFfiHandle_nullable(__result_handle);
+      foobar_ListOf_String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   List<String> methodWithInlineArray(List<String> input) {
-    final _methodWithInlineArray_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_1String'));
-    final _input_handle = foobar_ListOf_String_toFfi_nullable(input);
+    final _methodWithInlineArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_1String'));
+    final _inputHandle = foobar_ListOf_String_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithInlineArray_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_String_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithInlineArrayFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_String_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return foobar_ListOf_String_fromFfi_nullable(__result_handle);
+      return foobar_ListOf_String_fromFfi_nullable(__resultHandle);
     } finally {
-      foobar_ListOf_String_releaseFfiHandle_nullable(__result_handle);
+      foobar_ListOf_String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   Map<int, String> methodWithSomeMap(Map<int, String> input) {
-    final _methodWithSomeMap_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String'));
-    final _input_handle = foobar_MapOf_Long_to_String_toFfi_nullable(input);
+    final _methodWithSomeMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_1Long_1to_1String'));
+    final _inputHandle = foobar_MapOf_Long_to_String_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithSomeMap_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithSomeMapFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return foobar_MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+      return foobar_MapOf_Long_to_String_fromFfi_nullable(__resultHandle);
     } finally {
-      foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+      foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   SomeInterface methodWithInstance(SomeInterface input) {
-    final _methodWithInstance_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface'));
-    final _input_handle = smoke_SomeInterface_toFfi_nullable(input);
+    final _methodWithInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface'));
+    final _inputHandle = smoke_SomeInterface_toFfi_nullable(input);
     final _handle = this.handle;
-    final __result_handle = _methodWithInstance_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(_input_handle);
+    final __resultHandle = _methodWithInstanceFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(_inputHandle);
     try {
-      return smoke_SomeInterface_fromFfi_nullable(__result_handle);
+      return smoke_SomeInterface_fromFfi_nullable(__resultHandle);
     } finally {
-      smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
+      smoke_SomeInterface_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   String get stringProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_stringProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_stringProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi_nullable(__result_handle);
+      return String_fromFfi_nullable(__resultHandle);
     } finally {
-      String_releaseFfiHandle_nullable(__result_handle);
+      String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set stringProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String'));
-    final _value_handle = String_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String'));
+    final _valueHandle = String_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool get isBoolProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_isBoolProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_isBoolProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi_nullable(__result_handle);
+      return Boolean_fromFfi_nullable(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle_nullable(__result_handle);
+      Boolean_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set isBoolProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   double get doubleProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_doubleProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_doubleProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Double_fromFfi_nullable(__result_handle);
+      return Double_fromFfi_nullable(__resultHandle);
     } finally {
-      Double_releaseFfiHandle_nullable(__result_handle);
+      Double_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set doubleProperty(double value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double'));
-    final _value_handle = Double_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double'));
+    final _valueHandle = Double_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Double_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Double_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   int get intProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_intProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_intProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Long_fromFfi_nullable(__result_handle);
+      return Long_fromFfi_nullable(__resultHandle);
     } finally {
-      Long_releaseFfiHandle_nullable(__result_handle);
+      Long_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set intProperty(int value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long'));
-    final _value_handle = Long_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long'));
+    final _valueHandle = Long_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Long_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Long_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Nullable_SomeStruct get structProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_structProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_structProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_Nullable_SomeStruct_fromFfi_nullable(__result_handle);
+      return smoke_Nullable_SomeStruct_fromFfi_nullable(__resultHandle);
     } finally {
-      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__result_handle);
+      smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set structProperty(Nullable_SomeStruct value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct'));
-    final _value_handle = smoke_Nullable_SomeStruct_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct'));
+    final _valueHandle = smoke_Nullable_SomeStruct_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_Nullable_SomeStruct_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Nullable_SomeEnum get enumProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_enumProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_enumProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_Nullable_SomeEnum_fromFfi_nullable(__result_handle);
+      return smoke_Nullable_SomeEnum_fromFfi_nullable(__resultHandle);
     } finally {
-      smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__result_handle);
+      smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set enumProperty(Nullable_SomeEnum value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum'));
-    final _value_handle = smoke_Nullable_SomeEnum_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum'));
+    final _valueHandle = smoke_Nullable_SomeEnum_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_Nullable_SomeEnum_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   List<String> get arrayProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_ListOf_String_fromFfi_nullable(__result_handle);
+      return foobar_ListOf_String_fromFfi_nullable(__resultHandle);
     } finally {
-      foobar_ListOf_String_releaseFfiHandle_nullable(__result_handle);
+      foobar_ListOf_String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set arrayProperty(List<String> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String'));
-    final _value_handle = foobar_ListOf_String_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String'));
+    final _valueHandle = foobar_ListOf_String_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_ListOf_String_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_ListOf_String_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   List<String> get inlineArrayProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_inlineArrayProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_inlineArrayProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_ListOf_String_fromFfi_nullable(__result_handle);
+      return foobar_ListOf_String_fromFfi_nullable(__resultHandle);
     } finally {
-      foobar_ListOf_String_releaseFfiHandle_nullable(__result_handle);
+      foobar_ListOf_String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set inlineArrayProperty(List<String> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String'));
-    final _value_handle = foobar_ListOf_String_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String'));
+    final _valueHandle = foobar_ListOf_String_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_ListOf_String_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_ListOf_String_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Map<int, String> get mapProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_MapOf_Long_to_String_fromFfi_nullable(__result_handle);
+      return foobar_MapOf_Long_to_String_fromFfi_nullable(__resultHandle);
     } finally {
-      foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(__result_handle);
+      foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set mapProperty(Map<int, String> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String'));
-    final _value_handle = foobar_MapOf_Long_to_String_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String'));
+    final _valueHandle = foobar_MapOf_Long_to_String_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_MapOf_Long_to_String_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   SomeInterface get instanceProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_instanceProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_instanceProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_SomeInterface_fromFfi_nullable(__result_handle);
+      return smoke_SomeInterface_fromFfi_nullable(__resultHandle);
     } finally {
-      smoke_SomeInterface_releaseFfiHandle_nullable(__result_handle);
+      smoke_SomeInterface_releaseFfiHandle_nullable(__resultHandle);
     }
   }
   @override
   set instanceProperty(SomeInterface value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface'));
-    final _value_handle = smoke_SomeInterface_toFfi_nullable(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface'));
+    final _valueHandle = smoke_SomeInterface_toFfi_nullable(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_SomeInterface_releaseFfiHandle_nullable(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_SomeInterface_releaseFfiHandle_nullable(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Nullable_toFfi(Nullable value) =>
-  _smoke_Nullable_copy_handle((value as __lib.NativeBase).handle);
+  _smokeNullableCopyHandle((value as __lib.NativeBase).handle);
 Nullable smoke_Nullable_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Nullable;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Nullable_copy_handle(handle);
-  final result = Nullable$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeNullableCopyHandle(handle);
+  final result = Nullable$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Nullable_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Nullable_release_handle(handle);
+  _smokeNullableReleaseHandle(handle);
 Pointer<Void> smoke_Nullable_toFfi_nullable(Nullable value) =>
   value != null ? smoke_Nullable_toFfi(value) : Pointer<Void>.fromAddress(0);
 Nullable smoke_Nullable_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Nullable_fromFfi(handle) : null;
 void smoke_Nullable_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Nullable_release_handle(handle);
+  _smokeNullableReleaseHandle(handle);
 // End of Nullable "private" section.

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class NestedPackages {
@@ -18,71 +17,71 @@ class NestedPackages_SomeStruct {
   NestedPackages_SomeStruct(this.someField);
 }
 // NestedPackages_SomeStruct "private" section, not exported.
-final _smoke_off_NestedPackages_SomeStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOffNestedpackagesSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_create_handle'));
-final _smoke_off_NestedPackages_SomeStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOffNestedpackagesSomestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_release_handle'));
-final _smoke_off_NestedPackages_SomeStruct_get_field_someField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOffNestedpackagesSomestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_get_field_someField'));
 Pointer<Void> smoke_off_NestedPackages_SomeStruct_toFfi(NestedPackages_SomeStruct value) {
-  final _someField_handle = String_toFfi(value.someField);
-  final _result = _smoke_off_NestedPackages_SomeStruct_create_handle(_someField_handle);
-  String_releaseFfiHandle(_someField_handle);
+  final _someFieldHandle = String_toFfi(value.someField);
+  final _result = _smokeOffNestedpackagesSomestructCreateHandle(_someFieldHandle);
+  String_releaseFfiHandle(_someFieldHandle);
   return _result;
 }
 NestedPackages_SomeStruct smoke_off_NestedPackages_SomeStruct_fromFfi(Pointer<Void> handle) {
-  final _someField_handle = _smoke_off_NestedPackages_SomeStruct_get_field_someField(handle);
+  final _someFieldHandle = _smokeOffNestedpackagesSomestructGetFieldsomeField(handle);
   try {
     return NestedPackages_SomeStruct(
-      String_fromFfi(_someField_handle)
+      String_fromFfi(_someFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_someField_handle);
+    String_releaseFfiHandle(_someFieldHandle);
   }
 }
-void smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_off_NestedPackages_SomeStruct_release_handle(handle);
+void smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeOffNestedpackagesSomestructReleaseHandle(handle);
 // Nullable NestedPackages_SomeStruct
-final _smoke_off_NestedPackages_SomeStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_off_NestedPackages_SomeStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_create_handle_nullable'));
-final _smoke_off_NestedPackages_SomeStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_off_NestedPackages_SomeStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_release_handle_nullable'));
-final _smoke_off_NestedPackages_SomeStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_off_NestedPackages_SomeStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_get_value_nullable'));
 Pointer<Void> smoke_off_NestedPackages_SomeStruct_toFfi_nullable(NestedPackages_SomeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_off_NestedPackages_SomeStruct_toFfi(value);
-  final result = _smoke_off_NestedPackages_SomeStruct_create_handle_nullable(_handle);
+  final result = _smoke_off_NestedPackages_SomeStructCreateHandleNullable(_handle);
   smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 NestedPackages_SomeStruct smoke_off_NestedPackages_SomeStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_off_NestedPackages_SomeStruct_get_value_nullable(handle);
+  final _handle = _smoke_off_NestedPackages_SomeStructGetValueNullable(handle);
   final result = smoke_off_NestedPackages_SomeStruct_fromFfi(_handle);
   smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_off_NestedPackages_SomeStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_off_NestedPackages_SomeStruct_release_handle_nullable(handle);
+  _smoke_off_NestedPackages_SomeStructReleaseHandleNullable(handle);
 // End of NestedPackages_SomeStruct "private" section.
 // NestedPackages "private" section, not exported.
-final _smoke_off_NestedPackages_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOffNestedpackagesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_copy_handle'));
-final _smoke_off_NestedPackages_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeOffNestedpackagesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_release_handle'));
@@ -92,40 +91,40 @@ class NestedPackages$Impl extends __lib.NativeBase implements NestedPackages {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_off_NestedPackages_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeOffNestedpackagesReleaseHandle(handle);
     handle = null;
   }
   static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) {
-    final _basicMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct'));
-    final _input_handle = smoke_off_NestedPackages_SomeStruct_toFfi(input);
-    final __result_handle = _basicMethod_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_input_handle);
+    final _basicMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct'));
+    final _inputHandle = smoke_off_NestedPackages_SomeStruct_toFfi(input);
+    final __resultHandle = _basicMethodFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_off_NestedPackages_SomeStruct_fromFfi(__result_handle);
+      return smoke_off_NestedPackages_SomeStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(__result_handle);
+      smoke_off_NestedPackages_SomeStruct_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_off_NestedPackages_toFfi(NestedPackages value) =>
-  _smoke_off_NestedPackages_copy_handle((value as __lib.NativeBase).handle);
+  _smokeOffNestedpackagesCopyHandle((value as __lib.NativeBase).handle);
 NestedPackages smoke_off_NestedPackages_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as NestedPackages;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_off_NestedPackages_copy_handle(handle);
-  final result = NestedPackages$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeOffNestedpackagesCopyHandle(handle);
+  final result = NestedPackages$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_off_NestedPackages_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_off_NestedPackages_release_handle(handle);
+  _smokeOffNestedpackagesReleaseHandle(handle);
 Pointer<Void> smoke_off_NestedPackages_toFfi_nullable(NestedPackages value) =>
   value != null ? smoke_off_NestedPackages_toFfi(value) : Pointer<Void>.fromAddress(0);
 NestedPackages smoke_off_NestedPackages_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_off_NestedPackages_fromFfi(handle) : null;
 void smoke_off_NestedPackages_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_off_NestedPackages_release_handle(handle);
+  _smokeOffNestedpackagesReleaseHandle(handle);
 // End of NestedPackages "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/wee_types.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeInterface {
@@ -18,11 +17,11 @@ abstract class weeInterface {
   set WEE_PROPERTY(int value);
 }
 // weeInterface "private" section, not exported.
-final _smoke_PlatformNamesInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnamesinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNamesInterface_copy_handle'));
-final _smoke_PlatformNamesInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnamesinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNamesInterface_release_handle'));
@@ -32,76 +31,76 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_PlatformNamesInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokePlatformnamesinterfaceReleaseHandle(handle);
     handle = null;
   }
   weeInterface$Impl.make(String makeParameter) : super(_make(makeParameter)) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   @override
   weeStruct WeeMethod(String WeeParameter) {
-    final _WeeMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicMethod__String'));
-    final _WeeParameter_handle = String_toFfi(WeeParameter);
+    final _WeeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicMethod__String'));
+    final _WeeParameterHandle = String_toFfi(WeeParameter);
     final _handle = this.handle;
-    final __result_handle = _WeeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _WeeParameter_handle);
-    String_releaseFfiHandle(_WeeParameter_handle);
+    final __resultHandle = _WeeMethodFfi(_handle, __lib.LibraryContext.isolateId, _WeeParameterHandle);
+    String_releaseFfiHandle(_WeeParameterHandle);
     try {
-      return smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
+      return smoke_PlatformNames_BasicStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
+      smoke_PlatformNames_BasicStruct_releaseFfiHandle(__resultHandle);
     }
   }
   static Pointer<Void> _make(String makeParameter) {
-    final _make_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_create__String'));
-    final _makeParameter_handle = String_toFfi(makeParameter);
-    final __result_handle = _make_ffi(__lib.LibraryContext.isolateId, _makeParameter_handle);
-    String_releaseFfiHandle(_makeParameter_handle);
-    return __result_handle;
+    final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_create__String'));
+    final _makeParameterHandle = String_toFfi(makeParameter);
+    final __resultHandle = _makeFfi(__lib.LibraryContext.isolateId, _makeParameterHandle);
+    String_releaseFfiHandle(_makeParameterHandle);
+    return __resultHandle;
   }
   @override
   int get WEE_PROPERTY {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_PlatformNamesInterface_basicProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_PlatformNamesInterface_basicProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   set WEE_PROPERTY(int value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_PlatformNamesInterface_basicProperty_set__UInt'));
-    final _value_handle = (value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_PlatformNamesInterface_basicProperty_set__UInt'));
+    final _valueHandle = (value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    (_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    (_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_PlatformNamesInterface_toFfi(weeInterface value) =>
-  _smoke_PlatformNamesInterface_copy_handle((value as __lib.NativeBase).handle);
+  _smokePlatformnamesinterfaceCopyHandle((value as __lib.NativeBase).handle);
 weeInterface smoke_PlatformNamesInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as weeInterface;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_PlatformNamesInterface_copy_handle(handle);
-  final result = weeInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokePlatformnamesinterfaceCopyHandle(handle);
+  final result = weeInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_PlatformNamesInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PlatformNamesInterface_release_handle(handle);
+  _smokePlatformnamesinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_PlatformNamesInterface_toFfi_nullable(weeInterface value) =>
   value != null ? smoke_PlatformNamesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 weeInterface smoke_PlatformNamesInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PlatformNamesInterface_fromFfi(handle) : null;
 void smoke_PlatformNamesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformNamesInterface_release_handle(handle);
+  _smokePlatformnamesinterfaceReleaseHandle(handle);
 // End of weeInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeListener {
-  weeListener() {}
+  weeListener();
   factory weeListener.fromLambdas({
     @required void Function(String) lambda_WeeMethod,
   }) => weeListener$Lambdas(
@@ -21,19 +20,19 @@ abstract class weeListener {
   WeeMethod(String WeeParameter);
 }
 // weeListener "private" section, not exported.
-final _smoke_PlatformNamesListener_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnameslistenerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNamesListener_copy_handle'));
-final _smoke_PlatformNamesListener_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnameslistenerReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNamesListener_release_handle'));
-final _smoke_PlatformNamesListener_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnameslistenerCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_PlatformNamesListener_create_proxy'));
-final _smoke_PlatformNamesListener_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnameslistenerGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNamesListener_get_type_id'));
@@ -54,21 +53,21 @@ class weeListener$Impl extends __lib.NativeBase implements weeListener {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_PlatformNamesListener_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokePlatformnameslistenerReleaseHandle(handle);
     handle = null;
   }
   @override
   WeeMethod(String WeeParameter) {
-    final _WeeMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String'));
-    final _WeeParameter_handle = String_toFfi(WeeParameter);
+    final _WeeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String'));
+    final _WeeParameterHandle = String_toFfi(WeeParameter);
     final _handle = this.handle;
-    final __result_handle = _WeeMethod_ffi(_handle, __lib.LibraryContext.isolateId, _WeeParameter_handle);
-    String_releaseFfiHandle(_WeeParameter_handle);
+    final __resultHandle = _WeeMethodFfi(_handle, __lib.LibraryContext.isolateId, _WeeParameterHandle);
+    String_releaseFfiHandle(_WeeParameterHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -81,8 +80,8 @@ int _weeListener_WeeMethod_static(int _token, Pointer<Void> WeeParameter) {
   return 0;
 }
 Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
-  if (value is __lib.NativeBase) return _smoke_PlatformNamesListener_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_PlatformNamesListener_create_proxy(
+  if (value is __lib.NativeBase) return _smokePlatformnameslistenerCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokePlatformnameslistenerCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -92,25 +91,25 @@ Pointer<Void> smoke_PlatformNamesListener_toFfi(weeListener value) {
 }
 weeListener smoke_PlatformNamesListener_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as weeListener;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_PlatformNamesListener_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_PlatformNamesListener_copy_handle(handle);
+  final _typeIdHandle = _smokePlatformnameslistenerGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokePlatformnameslistenerCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : weeListener$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : weeListener$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_PlatformNamesListener_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PlatformNamesListener_release_handle(handle);
+  _smokePlatformnameslistenerReleaseHandle(handle);
 Pointer<Void> smoke_PlatformNamesListener_toFfi_nullable(weeListener value) =>
   value != null ? smoke_PlatformNamesListener_toFfi(value) : Pointer<Void>.fromAddress(0);
 weeListener smoke_PlatformNamesListener_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PlatformNamesListener_fromFfi(handle) : null;
 void smoke_PlatformNamesListener_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformNamesListener_release_handle(handle);
+  _smokePlatformnameslistenerReleaseHandle(handle);
 // End of weeListener "private" section.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum werrEnum {
@@ -26,34 +25,34 @@ werrEnum smoke_PlatformNames_BasicEnum_fromFfi(int handle) {
   }
 }
 void smoke_PlatformNames_BasicEnum_releaseFfiHandle(int handle) {}
-final _smoke_PlatformNames_BasicEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_PlatformNames_BasicEnum_create_handle_nullable'));
-final _smoke_PlatformNames_BasicEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicEnum_release_handle_nullable'));
-final _smoke_PlatformNames_BasicEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicEnum_get_value_nullable'));
 Pointer<Void> smoke_PlatformNames_BasicEnum_toFfi_nullable(werrEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformNames_BasicEnum_toFfi(value);
-  final result = _smoke_PlatformNames_BasicEnum_create_handle_nullable(_handle);
+  final result = _smoke_PlatformNames_BasicEnumCreateHandleNullable(_handle);
   smoke_PlatformNames_BasicEnum_releaseFfiHandle(_handle);
   return result;
 }
 werrEnum smoke_PlatformNames_BasicEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PlatformNames_BasicEnum_get_value_nullable(handle);
+  final _handle = _smoke_PlatformNames_BasicEnumGetValueNullable(handle);
   final result = smoke_PlatformNames_BasicEnum_fromFfi(_handle);
   smoke_PlatformNames_BasicEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PlatformNames_BasicEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformNames_BasicEnum_release_handle_nullable(handle);
+  _smoke_PlatformNames_BasicEnumReleaseHandleNullable(handle);
 // End of werrEnum "private" section.
 class weeStruct {
   String WEE_FIELD;
@@ -61,74 +60,74 @@ class weeStruct {
   weeStruct._copy(weeStruct _other) : this._(_other.WEE_FIELD);
   weeStruct.WeeCreate(String WeeParameter) : this._copy(_WeeCreate(WeeParameter));
   static weeStruct _WeeCreate(String WeeParameter) {
-    final _WeeCreate_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNames_BasicStruct_make__String'));
-    final _WeeParameter_handle = String_toFfi(WeeParameter);
-    final __result_handle = _WeeCreate_ffi(__lib.LibraryContext.isolateId, _WeeParameter_handle);
-    String_releaseFfiHandle(_WeeParameter_handle);
+    final _WeeCreateFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNames_BasicStruct_make__String'));
+    final _WeeParameterHandle = String_toFfi(WeeParameter);
+    final __resultHandle = _WeeCreateFfi(__lib.LibraryContext.isolateId, _WeeParameterHandle);
+    String_releaseFfiHandle(_WeeParameterHandle);
     try {
-      return smoke_PlatformNames_BasicStruct_fromFfi(__result_handle);
+      return smoke_PlatformNames_BasicStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_PlatformNames_BasicStruct_releaseFfiHandle(__result_handle);
+      smoke_PlatformNames_BasicStruct_releaseFfiHandle(__resultHandle);
     }
   }
 }
 // weeStruct "private" section, not exported.
-final _smoke_PlatformNames_BasicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnamesBasicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_create_handle'));
-final _smoke_PlatformNames_BasicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnamesBasicstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_release_handle'));
-final _smoke_PlatformNames_BasicStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePlatformnamesBasicstructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_get_field_stringField'));
 Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi(weeStruct value) {
-  final _WEE_FIELD_handle = String_toFfi(value.WEE_FIELD);
-  final _result = _smoke_PlatformNames_BasicStruct_create_handle(_WEE_FIELD_handle);
-  String_releaseFfiHandle(_WEE_FIELD_handle);
+  final _WEE_FIELDHandle = String_toFfi(value.WEE_FIELD);
+  final _result = _smokePlatformnamesBasicstructCreateHandle(_WEE_FIELDHandle);
+  String_releaseFfiHandle(_WEE_FIELDHandle);
   return _result;
 }
 weeStruct smoke_PlatformNames_BasicStruct_fromFfi(Pointer<Void> handle) {
-  final _WEE_FIELD_handle = _smoke_PlatformNames_BasicStruct_get_field_stringField(handle);
+  final _WEE_FIELDHandle = _smokePlatformnamesBasicstructGetFieldstringField(handle);
   try {
     return weeStruct._(
-      String_fromFfi(_WEE_FIELD_handle)
+      String_fromFfi(_WEE_FIELDHandle)
     );
   } finally {
-    String_releaseFfiHandle(_WEE_FIELD_handle);
+    String_releaseFfiHandle(_WEE_FIELDHandle);
   }
 }
-void smoke_PlatformNames_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PlatformNames_BasicStruct_release_handle(handle);
+void smoke_PlatformNames_BasicStruct_releaseFfiHandle(Pointer<Void> handle) => _smokePlatformnamesBasicstructReleaseHandle(handle);
 // Nullable weeStruct
-final _smoke_PlatformNames_BasicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_create_handle_nullable'));
-final _smoke_PlatformNames_BasicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_release_handle_nullable'));
-final _smoke_PlatformNames_BasicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PlatformNames_BasicStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_get_value_nullable'));
 Pointer<Void> smoke_PlatformNames_BasicStruct_toFfi_nullable(weeStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PlatformNames_BasicStruct_toFfi(value);
-  final result = _smoke_PlatformNames_BasicStruct_create_handle_nullable(_handle);
+  final result = _smoke_PlatformNames_BasicStructCreateHandleNullable(_handle);
   smoke_PlatformNames_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 weeStruct smoke_PlatformNames_BasicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PlatformNames_BasicStruct_get_value_nullable(handle);
+  final _handle = _smoke_PlatformNames_BasicStructGetValueNullable(handle);
   final result = smoke_PlatformNames_BasicStruct_fromFfi(_handle);
   smoke_PlatformNames_BasicStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PlatformNames_BasicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PlatformNames_BasicStruct_release_handle_nullable(handle);
+  _smoke_PlatformNames_BasicStructReleaseHandleNullable(handle);
 // End of weeStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class CachedProperties {
@@ -17,11 +16,11 @@ abstract class CachedProperties {
   static Uint8List get staticCachedProperty => CachedProperties$Impl.staticCachedProperty;
 }
 // CachedProperties "private" section, not exported.
-final _smoke_CachedProperties_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCachedpropertiesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CachedProperties_copy_handle'));
-final _smoke_CachedProperties_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeCachedpropertiesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CachedProperties_release_handle'));
@@ -31,60 +30,60 @@ class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_CachedProperties_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeCachedpropertiesReleaseHandle(handle);
     handle = null;
   }
-  List<String> _cache_cachedProperty;
-  bool _is_cached_cachedProperty = false;
+  /*late*/ List<String> _cachedPropertyCache;
+  bool _cachedPropertyIsCached = false;
   @override
   List<String> get cachedProperty {
-    if (!_is_cached_cachedProperty) {
-      final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CachedProperties_cachedProperty_get'));
-      final __result_handle = _get_ffi(this.handle, __lib.LibraryContext.isolateId);
+    if (!_cachedPropertyIsCached) {
+      final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CachedProperties_cachedProperty_get'));
+      final __resultHandle = _getFfi(this.handle, __lib.LibraryContext.isolateId);
       try {
-        _cache_cachedProperty = foobar_ListOf_String_fromFfi(__result_handle);
+        _cachedPropertyCache = foobar_ListOf_String_fromFfi(__resultHandle);
       } finally {
-        foobar_ListOf_String_releaseFfiHandle(__result_handle);
+        foobar_ListOf_String_releaseFfiHandle(__resultHandle);
       }
-      _is_cached_cachedProperty = true;
+      _cachedPropertyIsCached = true;
     }
-    return _cache_cachedProperty;
+    return _cachedPropertyCache;
   }
-  static Uint8List _cache_staticCachedProperty;
-  static bool _is_cached_staticCachedProperty = false;
+  static /*late*/ Uint8List _staticCachedPropertyCache;
+  static bool _staticCachedPropertyIsCached = false;
   static Uint8List get staticCachedProperty {
-    if (!_is_cached_staticCachedProperty) {
-      final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_CachedProperties_staticCachedProperty_get'));
-      final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
+    if (!_staticCachedPropertyIsCached) {
+      final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_CachedProperties_staticCachedProperty_get'));
+      final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
       try {
-        _cache_staticCachedProperty = Blob_fromFfi(__result_handle);
+        _staticCachedPropertyCache = Blob_fromFfi(__resultHandle);
       } finally {
-        Blob_releaseFfiHandle(__result_handle);
+        Blob_releaseFfiHandle(__resultHandle);
       }
-      _is_cached_staticCachedProperty = true;
+      _staticCachedPropertyIsCached = true;
     }
-    return _cache_staticCachedProperty;
+    return _staticCachedPropertyCache;
   }
 }
 Pointer<Void> smoke_CachedProperties_toFfi(CachedProperties value) =>
-  _smoke_CachedProperties_copy_handle((value as __lib.NativeBase).handle);
+  _smokeCachedpropertiesCopyHandle((value as __lib.NativeBase).handle);
 CachedProperties smoke_CachedProperties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as CachedProperties;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_CachedProperties_copy_handle(handle);
-  final result = CachedProperties$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeCachedpropertiesCopyHandle(handle);
+  final result = CachedProperties$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_CachedProperties_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_CachedProperties_release_handle(handle);
+  _smokeCachedpropertiesReleaseHandle(handle);
 Pointer<Void> smoke_CachedProperties_toFfi_nullable(CachedProperties value) =>
   value != null ? smoke_CachedProperties_toFfi(value) : Pointer<Void>.fromAddress(0);
 CachedProperties smoke_CachedProperties_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_CachedProperties_fromFfi(handle) : null;
 void smoke_CachedProperties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_CachedProperties_release_handle(handle);
+  _smokeCachedpropertiesReleaseHandle(handle);
 // End of CachedProperties "private" section.

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -5,7 +5,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/properties_interface.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Properties {
@@ -63,105 +62,105 @@ Properties_InternalErrorCode smoke_Properties_InternalErrorCode_fromFfi(int hand
   }
 }
 void smoke_Properties_InternalErrorCode_releaseFfiHandle(int handle) {}
-final _smoke_Properties_InternalErrorCode_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_InternalErrorCodeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Properties_InternalErrorCode_create_handle_nullable'));
-final _smoke_Properties_InternalErrorCode_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_InternalErrorCodeReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Properties_InternalErrorCode_release_handle_nullable'));
-final _smoke_Properties_InternalErrorCode_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_InternalErrorCodeGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Properties_InternalErrorCode_get_value_nullable'));
 Pointer<Void> smoke_Properties_InternalErrorCode_toFfi_nullable(Properties_InternalErrorCode value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Properties_InternalErrorCode_toFfi(value);
-  final result = _smoke_Properties_InternalErrorCode_create_handle_nullable(_handle);
+  final result = _smoke_Properties_InternalErrorCodeCreateHandleNullable(_handle);
   smoke_Properties_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
 Properties_InternalErrorCode smoke_Properties_InternalErrorCode_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Properties_InternalErrorCode_get_value_nullable(handle);
+  final _handle = _smoke_Properties_InternalErrorCodeGetValueNullable(handle);
   final result = smoke_Properties_InternalErrorCode_fromFfi(_handle);
   smoke_Properties_InternalErrorCode_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Properties_InternalErrorCode_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Properties_InternalErrorCode_release_handle_nullable(handle);
+  _smoke_Properties_InternalErrorCodeReleaseHandleNullable(handle);
 // End of Properties_InternalErrorCode "private" section.
 class Properties_ExampleStruct {
   double value;
   Properties_ExampleStruct(this.value);
 }
 // Properties_ExampleStruct "private" section, not exported.
-final _smoke_Properties_ExampleStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesExamplestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_smoke_Properties_ExampleStruct_create_handle'));
-final _smoke_Properties_ExampleStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesExamplestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_release_handle'));
-final _smoke_Properties_ExampleStruct_get_field_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesExamplestructGetFieldvalue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_get_field_value'));
 Pointer<Void> smoke_Properties_ExampleStruct_toFfi(Properties_ExampleStruct value) {
-  final _value_handle = (value.value);
-  final _result = _smoke_Properties_ExampleStruct_create_handle(_value_handle);
-  (_value_handle);
+  final _valueHandle = (value.value);
+  final _result = _smokePropertiesExamplestructCreateHandle(_valueHandle);
+  (_valueHandle);
   return _result;
 }
 Properties_ExampleStruct smoke_Properties_ExampleStruct_fromFfi(Pointer<Void> handle) {
-  final _value_handle = _smoke_Properties_ExampleStruct_get_field_value(handle);
+  final _valueHandle = _smokePropertiesExamplestructGetFieldvalue(handle);
   try {
     return Properties_ExampleStruct(
-      (_value_handle)
+      (_valueHandle)
     );
   } finally {
-    (_value_handle);
+    (_valueHandle);
   }
 }
-void smoke_Properties_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Properties_ExampleStruct_release_handle(handle);
+void smoke_Properties_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smokePropertiesExamplestructReleaseHandle(handle);
 // Nullable Properties_ExampleStruct
-final _smoke_Properties_ExampleStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_ExampleStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_create_handle_nullable'));
-final _smoke_Properties_ExampleStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_ExampleStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_release_handle_nullable'));
-final _smoke_Properties_ExampleStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Properties_ExampleStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_get_value_nullable'));
 Pointer<Void> smoke_Properties_ExampleStruct_toFfi_nullable(Properties_ExampleStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Properties_ExampleStruct_toFfi(value);
-  final result = _smoke_Properties_ExampleStruct_create_handle_nullable(_handle);
+  final result = _smoke_Properties_ExampleStructCreateHandleNullable(_handle);
   smoke_Properties_ExampleStruct_releaseFfiHandle(_handle);
   return result;
 }
 Properties_ExampleStruct smoke_Properties_ExampleStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Properties_ExampleStruct_get_value_nullable(handle);
+  final _handle = _smoke_Properties_ExampleStructGetValueNullable(handle);
   final result = smoke_Properties_ExampleStruct_fromFfi(_handle);
   smoke_Properties_ExampleStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Properties_ExampleStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Properties_ExampleStruct_release_handle_nullable(handle);
+  _smoke_Properties_ExampleStructReleaseHandleNullable(handle);
 // End of Properties_ExampleStruct "private" section.
 // Properties "private" section, not exported.
-final _smoke_Properties_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Properties_copy_handle'));
-final _smoke_Properties_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Properties_release_handle'));
@@ -171,237 +170,237 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Properties_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokePropertiesReleaseHandle(handle);
     handle = null;
   }
   @override
   int get builtInTypeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   set builtInTypeProperty(int value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt'));
-    final _value_handle = (value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt'));
+    final _valueHandle = (value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    (_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    (_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   double get readonlyProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Properties_readonlyProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Properties_readonlyProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Properties_ExampleStruct get structProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_structProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_structProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+      return smoke_Properties_ExampleStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+      smoke_Properties_ExampleStruct_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set structProperty(Properties_ExampleStruct value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct'));
-    final _value_handle = smoke_Properties_ExampleStruct_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct'));
+    final _valueHandle = smoke_Properties_ExampleStruct_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_Properties_ExampleStruct_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_Properties_ExampleStruct_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   List<String> get arrayProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_arrayProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_arrayProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_ListOf_String_fromFfi(__result_handle);
+      return foobar_ListOf_String_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_String_releaseFfiHandle(__result_handle);
+      foobar_ListOf_String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set arrayProperty(List<String> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_1String'));
-    final _value_handle = foobar_ListOf_String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_1String'));
+    final _valueHandle = foobar_ListOf_String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_ListOf_String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_ListOf_String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Properties_InternalErrorCode get complexTypeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_Properties_InternalErrorCode_fromFfi(__result_handle);
+      return smoke_Properties_InternalErrorCode_fromFfi(__resultHandle);
     } finally {
-      smoke_Properties_InternalErrorCode_releaseFfiHandle(__result_handle);
+      smoke_Properties_InternalErrorCode_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set complexTypeProperty(Properties_InternalErrorCode value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode'));
-    final _value_handle = smoke_Properties_InternalErrorCode_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode'));
+    final _valueHandle = smoke_Properties_InternalErrorCode_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_Properties_InternalErrorCode_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_Properties_InternalErrorCode_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   Uint8List get byteBufferProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_byteBufferProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_byteBufferProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Blob_fromFfi(__result_handle);
+      return Blob_fromFfi(__resultHandle);
     } finally {
-      Blob_releaseFfiHandle(__result_handle);
+      Blob_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set byteBufferProperty(Uint8List value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob'));
-    final _value_handle = Blob_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob'));
+    final _valueHandle = Blob_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Blob_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Blob_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   PropertiesInterface get instanceProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_instanceProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_instanceProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_PropertiesInterface_fromFfi(__result_handle);
+      return smoke_PropertiesInterface_fromFfi(__resultHandle);
     } finally {
-      smoke_PropertiesInterface_releaseFfiHandle(__result_handle);
+      smoke_PropertiesInterface_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set instanceProperty(PropertiesInterface value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface'));
-    final _value_handle = smoke_PropertiesInterface_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface'));
+    final _valueHandle = smoke_PropertiesInterface_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_PropertiesInterface_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_PropertiesInterface_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool get isBooleanProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set isBooleanProperty(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static String get staticProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticProperty_get'));
-    final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticProperty_get'));
+    final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   static set staticProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String'));
-    final _value_handle = String_toFfi(value);
-    final __result_handle = _set_ffi(__lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
+    final __resultHandle = _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static Properties_ExampleStruct get staticReadonlyProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticReadonlyProperty_get'));
-    final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticReadonlyProperty_get'));
+    final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
     try {
-      return smoke_Properties_ExampleStruct_fromFfi(__result_handle);
+      return smoke_Properties_ExampleStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_Properties_ExampleStruct_releaseFfiHandle(__result_handle);
+      smoke_Properties_ExampleStruct_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Properties_toFfi(Properties value) =>
-  _smoke_Properties_copy_handle((value as __lib.NativeBase).handle);
+  _smokePropertiesCopyHandle((value as __lib.NativeBase).handle);
 Properties smoke_Properties_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Properties;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Properties_copy_handle(handle);
-  final result = Properties$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokePropertiesCopyHandle(handle);
+  final result = Properties$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Properties_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Properties_release_handle(handle);
+  _smokePropertiesReleaseHandle(handle);
 Pointer<Void> smoke_Properties_toFfi_nullable(Properties value) =>
   value != null ? smoke_Properties_toFfi(value) : Pointer<Void>.fromAddress(0);
 Properties smoke_Properties_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Properties_fromFfi(handle) : null;
 void smoke_Properties_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Properties_release_handle(handle);
+  _smokePropertiesReleaseHandle(handle);
 // End of Properties "private" section.

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PropertiesInterface {
-  PropertiesInterface() {}
+  PropertiesInterface();
   factory PropertiesInterface.fromLambdas({
     @required PropertiesInterface_ExampleStruct Function() lambda_structProperty_get,
     @required void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set
@@ -28,79 +27,79 @@ class PropertiesInterface_ExampleStruct {
   PropertiesInterface_ExampleStruct(this.value);
 }
 // PropertiesInterface_ExampleStruct "private" section, not exported.
-final _smoke_PropertiesInterface_ExampleStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesinterfaceExamplestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_smoke_PropertiesInterface_ExampleStruct_create_handle'));
-final _smoke_PropertiesInterface_ExampleStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesinterfaceExamplestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_release_handle'));
-final _smoke_PropertiesInterface_ExampleStruct_get_field_value = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesinterfaceExamplestructGetFieldvalue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_get_field_value'));
 Pointer<Void> smoke_PropertiesInterface_ExampleStruct_toFfi(PropertiesInterface_ExampleStruct value) {
-  final _value_handle = (value.value);
-  final _result = _smoke_PropertiesInterface_ExampleStruct_create_handle(_value_handle);
-  (_value_handle);
+  final _valueHandle = (value.value);
+  final _result = _smokePropertiesinterfaceExamplestructCreateHandle(_valueHandle);
+  (_valueHandle);
   return _result;
 }
 PropertiesInterface_ExampleStruct smoke_PropertiesInterface_ExampleStruct_fromFfi(Pointer<Void> handle) {
-  final _value_handle = _smoke_PropertiesInterface_ExampleStruct_get_field_value(handle);
+  final _valueHandle = _smokePropertiesinterfaceExamplestructGetFieldvalue(handle);
   try {
     return PropertiesInterface_ExampleStruct(
-      (_value_handle)
+      (_valueHandle)
     );
   } finally {
-    (_value_handle);
+    (_valueHandle);
   }
 }
-void smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PropertiesInterface_ExampleStruct_release_handle(handle);
+void smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(Pointer<Void> handle) => _smokePropertiesinterfaceExamplestructReleaseHandle(handle);
 // Nullable PropertiesInterface_ExampleStruct
-final _smoke_PropertiesInterface_ExampleStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PropertiesInterface_ExampleStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_create_handle_nullable'));
-final _smoke_PropertiesInterface_ExampleStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PropertiesInterface_ExampleStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_release_handle_nullable'));
-final _smoke_PropertiesInterface_ExampleStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PropertiesInterface_ExampleStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_get_value_nullable'));
 Pointer<Void> smoke_PropertiesInterface_ExampleStruct_toFfi_nullable(PropertiesInterface_ExampleStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
-  final result = _smoke_PropertiesInterface_ExampleStruct_create_handle_nullable(_handle);
+  final result = _smoke_PropertiesInterface_ExampleStructCreateHandleNullable(_handle);
   smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_handle);
   return result;
 }
 PropertiesInterface_ExampleStruct smoke_PropertiesInterface_ExampleStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PropertiesInterface_ExampleStruct_get_value_nullable(handle);
+  final _handle = _smoke_PropertiesInterface_ExampleStructGetValueNullable(handle);
   final result = smoke_PropertiesInterface_ExampleStruct_fromFfi(_handle);
   smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PropertiesInterface_ExampleStruct_release_handle_nullable(handle);
+  _smoke_PropertiesInterface_ExampleStructReleaseHandleNullable(handle);
 // End of PropertiesInterface_ExampleStruct "private" section.
 // PropertiesInterface "private" section, not exported.
-final _smoke_PropertiesInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_copy_handle'));
-final _smoke_PropertiesInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_release_handle'));
-final _smoke_PropertiesInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer)
   >('library_smoke_PropertiesInterface_create_proxy'));
-final _smoke_PropertiesInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePropertiesinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_get_type_id'));
@@ -124,30 +123,30 @@ class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInt
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_PropertiesInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokePropertiesinterfaceReleaseHandle(handle);
     handle = null;
   }
   PropertiesInterface_ExampleStruct get structProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PropertiesInterface_structProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PropertiesInterface_structProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_PropertiesInterface_ExampleStruct_fromFfi(__result_handle);
+      return smoke_PropertiesInterface_ExampleStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(__result_handle);
+      smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(__resultHandle);
     }
   }
   set structProperty(PropertiesInterface_ExampleStruct value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct'));
-    final _value_handle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct'));
+    final _valueHandle = smoke_PropertiesInterface_ExampleStruct_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_PropertiesInterface_ExampleStruct_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -165,8 +164,8 @@ int _PropertiesInterface_structProperty_set_static(int _token, Pointer<Void> _va
   return 0;
 }
 Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
-  if (value is __lib.NativeBase) return _smoke_PropertiesInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_PropertiesInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokePropertiesinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokePropertiesinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -177,25 +176,25 @@ Pointer<Void> smoke_PropertiesInterface_toFfi(PropertiesInterface value) {
 }
 PropertiesInterface smoke_PropertiesInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as PropertiesInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_PropertiesInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_PropertiesInterface_copy_handle(handle);
+  final _typeIdHandle = _smokePropertiesinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokePropertiesinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : PropertiesInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : PropertiesInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_PropertiesInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PropertiesInterface_release_handle(handle);
+  _smokePropertiesinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_PropertiesInterface_toFfi_nullable(PropertiesInterface value) =>
   value != null ? smoke_PropertiesInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 PropertiesInterface smoke_PropertiesInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PropertiesInterface_fromFfi(handle) : null;
 void smoke_PropertiesInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PropertiesInterface_release_handle(handle);
+  _smokePropertiesinterfaceReleaseHandle(handle);
 // End of PropertiesInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/generic_types__conversion.dart
@@ -1,3 +1,2 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:library/src/_library_context.dart' as __lib;

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class EnableIfEnabled {
@@ -20,11 +19,11 @@ abstract class EnableIfEnabled {
   static enableIfMixedList() => EnableIfEnabled$Impl.enableIfMixedList();
 }
 // EnableIfEnabled "private" section, not exported.
-final _smoke_EnableIfEnabled_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnableifenabledCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnableIfEnabled_copy_handle'));
-final _smoke_EnableIfEnabled_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnableifenabledReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnableIfEnabled_release_handle'));
@@ -34,92 +33,92 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_EnableIfEnabled_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeEnableifenabledReleaseHandle(handle);
     handle = null;
   }
   static enableIfUnquoted() {
-    final _enableIfUnquoted_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquoted'));
-    final __result_handle = _enableIfUnquoted_ffi(__lib.LibraryContext.isolateId);
+    final _enableIfUnquotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquoted'));
+    final __resultHandle = _enableIfUnquotedFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static enableIfUnquotedList() {
-    final _enableIfUnquotedList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquotedList'));
-    final __result_handle = _enableIfUnquotedList_ffi(__lib.LibraryContext.isolateId);
+    final _enableIfUnquotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquotedList'));
+    final __resultHandle = _enableIfUnquotedListFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static enableIfQuoted() {
-    final _enableIfQuoted_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuoted'));
-    final __result_handle = _enableIfQuoted_ffi(__lib.LibraryContext.isolateId);
+    final _enableIfQuotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuoted'));
+    final __resultHandle = _enableIfQuotedFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static enableIfQuotedList() {
-    final _enableIfQuotedList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuotedList'));
-    final __result_handle = _enableIfQuotedList_ffi(__lib.LibraryContext.isolateId);
+    final _enableIfQuotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuotedList'));
+    final __resultHandle = _enableIfQuotedListFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static enableIfTagged() {
-    final _enableIfTagged_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTagged'));
-    final __result_handle = _enableIfTagged_ffi(__lib.LibraryContext.isolateId);
+    final _enableIfTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTagged'));
+    final __resultHandle = _enableIfTaggedFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static enableIfTaggedList() {
-    final _enableIfTaggedList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTaggedList'));
-    final __result_handle = _enableIfTaggedList_ffi(__lib.LibraryContext.isolateId);
+    final _enableIfTaggedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTaggedList'));
+    final __resultHandle = _enableIfTaggedListFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static enableIfMixedList() {
-    final _enableIfMixedList_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfMixedList'));
-    final __result_handle = _enableIfMixedList_ffi(__lib.LibraryContext.isolateId);
+    final _enableIfMixedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfMixedList'));
+    final __resultHandle = _enableIfMixedListFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_EnableIfEnabled_toFfi(EnableIfEnabled value) =>
-  _smoke_EnableIfEnabled_copy_handle((value as __lib.NativeBase).handle);
+  _smokeEnableifenabledCopyHandle((value as __lib.NativeBase).handle);
 EnableIfEnabled smoke_EnableIfEnabled_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as EnableIfEnabled;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_EnableIfEnabled_copy_handle(handle);
-  final result = EnableIfEnabled$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeEnableifenabledCopyHandle(handle);
+  final result = EnableIfEnabled$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_EnableIfEnabled_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_EnableIfEnabled_release_handle(handle);
+  _smokeEnableifenabledReleaseHandle(handle);
 Pointer<Void> smoke_EnableIfEnabled_toFfi_nullable(EnableIfEnabled value) =>
   value != null ? smoke_EnableIfEnabled_toFfi(value) : Pointer<Void>.fromAddress(0);
 EnableIfEnabled smoke_EnableIfEnabled_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_EnableIfEnabled_fromFfi(handle) : null;
 void smoke_EnableIfEnabled_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_EnableIfEnabled_release_handle(handle);
+  _smokeEnableifenabledReleaseHandle(handle);
 // End of EnableIfEnabled "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class EnableIfSkipped {
@@ -12,11 +11,11 @@ abstract class EnableIfSkipped {
   void release();
 }
 // EnableIfSkipped "private" section, not exported.
-final _smoke_EnableIfSkipped_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnableifskippedCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnableIfSkipped_copy_handle'));
-final _smoke_EnableIfSkipped_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeEnableifskippedReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnableIfSkipped_release_handle'));
@@ -26,29 +25,29 @@ class EnableIfSkipped$Impl extends __lib.NativeBase implements EnableIfSkipped {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_EnableIfSkipped_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeEnableifskippedReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_EnableIfSkipped_toFfi(EnableIfSkipped value) =>
-  _smoke_EnableIfSkipped_copy_handle((value as __lib.NativeBase).handle);
+  _smokeEnableifskippedCopyHandle((value as __lib.NativeBase).handle);
 EnableIfSkipped smoke_EnableIfSkipped_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as EnableIfSkipped;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_EnableIfSkipped_copy_handle(handle);
-  final result = EnableIfSkipped$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeEnableifskippedCopyHandle(handle);
+  final result = EnableIfSkipped$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_EnableIfSkipped_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_EnableIfSkipped_release_handle(handle);
+  _smokeEnableifskippedReleaseHandle(handle);
 Pointer<Void> smoke_EnableIfSkipped_toFfi_nullable(EnableIfSkipped value) =>
   value != null ? smoke_EnableIfSkipped_toFfi(value) : Pointer<Void>.fromAddress(0);
 EnableIfSkipped smoke_EnableIfSkipped_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_EnableIfSkipped_fromFfi(handle) : null;
 void smoke_EnableIfSkipped_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_EnableIfSkipped_release_handle(handle);
+  _smokeEnableifskippedReleaseHandle(handle);
 // End of EnableIfSkipped "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -4,11 +4,10 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/skip_proxy.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class InheritFromSkipped implements SkipProxy {
-  InheritFromSkipped() {}
+  InheritFromSkipped();
   factory InheritFromSkipped.fromLambdas({
     @required String Function(String) lambda_notInJava,
     @required bool Function(bool) lambda_notInSwift,
@@ -31,19 +30,19 @@ abstract class InheritFromSkipped implements SkipProxy {
   void release() {}
 }
 // InheritFromSkipped "private" section, not exported.
-final _smoke_InheritFromSkipped_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInheritfromskippedCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InheritFromSkipped_copy_handle'));
-final _smoke_InheritFromSkipped_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInheritfromskippedReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InheritFromSkipped_release_handle'));
-final _smoke_InheritFromSkipped_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInheritfromskippedCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_InheritFromSkipped_create_proxy'));
-final _smoke_InheritFromSkipped_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInheritfromskippedGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InheritFromSkipped_get_type_id'));
@@ -85,96 +84,96 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_InheritFromSkipped_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeInheritfromskippedReleaseHandle(handle);
     handle = null;
   }
   @override
   String notInJava(String input) {
-    final _notInJava_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_notInJava__String'));
-    final _input_handle = String_toFfi(input);
+    final _notInJavaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_notInJava__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _notInJava_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _notInJavaFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool notInSwift(bool input) {
-    final _notInSwift_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_notInSwift__Boolean'));
-    final _input_handle = Boolean_toFfi(input);
+    final _notInSwiftFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_notInSwift__Boolean'));
+    final _inputHandle = Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _notInSwift_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _notInSwiftFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   String get skippedInJava {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInJava_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInJava_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   set skippedInJava(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   bool get isSkippedInSwift {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   set isSkippedInSwift(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _InheritFromSkipped_notInJava_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as InheritFromSkipped).notInJava(String_fromFfi(input));
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as InheritFromSkipped).notInJava(String_fromFfi(input));
+    _result.value = String_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 int _InheritFromSkipped_notInSwift_static(int _token, int input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as InheritFromSkipped).notInSwift(Boolean_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as InheritFromSkipped).notInSwift(Boolean_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     Boolean_releaseFfiHandle(input);
   }
@@ -207,8 +206,8 @@ int _InheritFromSkipped_isSkippedInSwift_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_InheritFromSkipped_toFfi(InheritFromSkipped value) {
-  if (value is __lib.NativeBase) return _smoke_InheritFromSkipped_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_InheritFromSkipped_create_proxy(
+  if (value is __lib.NativeBase) return _smokeInheritfromskippedCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeInheritfromskippedCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -223,25 +222,25 @@ Pointer<Void> smoke_InheritFromSkipped_toFfi(InheritFromSkipped value) {
 }
 InheritFromSkipped smoke_InheritFromSkipped_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as InheritFromSkipped;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_InheritFromSkipped_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_InheritFromSkipped_copy_handle(handle);
+  final _typeIdHandle = _smokeInheritfromskippedGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeInheritfromskippedCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : InheritFromSkipped$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : InheritFromSkipped$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_InheritFromSkipped_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_InheritFromSkipped_release_handle(handle);
+  _smokeInheritfromskippedReleaseHandle(handle);
 Pointer<Void> smoke_InheritFromSkipped_toFfi_nullable(InheritFromSkipped value) =>
   value != null ? smoke_InheritFromSkipped_toFfi(value) : Pointer<Void>.fromAddress(0);
 InheritFromSkipped smoke_InheritFromSkipped_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InheritFromSkipped_fromFfi(handle) : null;
 void smoke_InheritFromSkipped_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_InheritFromSkipped_release_handle(handle);
+  _smokeInheritfromskippedReleaseHandle(handle);
 // End of InheritFromSkipped "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SkipEnumeratorAutoTag {
@@ -32,32 +31,32 @@ SkipEnumeratorAutoTag smoke_SkipEnumeratorAutoTag_fromFfi(int handle) {
   }
 }
 void smoke_SkipEnumeratorAutoTag_releaseFfiHandle(int handle) {}
-final _smoke_SkipEnumeratorAutoTag_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipEnumeratorAutoTagCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_SkipEnumeratorAutoTag_create_handle_nullable'));
-final _smoke_SkipEnumeratorAutoTag_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipEnumeratorAutoTagReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorAutoTag_release_handle_nullable'));
-final _smoke_SkipEnumeratorAutoTag_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipEnumeratorAutoTagGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorAutoTag_get_value_nullable'));
 Pointer<Void> smoke_SkipEnumeratorAutoTag_toFfi_nullable(SkipEnumeratorAutoTag value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipEnumeratorAutoTag_toFfi(value);
-  final result = _smoke_SkipEnumeratorAutoTag_create_handle_nullable(_handle);
+  final result = _smoke_SkipEnumeratorAutoTagCreateHandleNullable(_handle);
   smoke_SkipEnumeratorAutoTag_releaseFfiHandle(_handle);
   return result;
 }
 SkipEnumeratorAutoTag smoke_SkipEnumeratorAutoTag_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_SkipEnumeratorAutoTag_get_value_nullable(handle);
+  final _handle = _smoke_SkipEnumeratorAutoTagGetValueNullable(handle);
   final result = smoke_SkipEnumeratorAutoTag_fromFfi(_handle);
   smoke_SkipEnumeratorAutoTag_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_SkipEnumeratorAutoTag_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipEnumeratorAutoTag_release_handle_nullable(handle);
+  _smoke_SkipEnumeratorAutoTagReleaseHandleNullable(handle);
 // End of SkipEnumeratorAutoTag "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SkipEnumeratorExplicitTag {
@@ -39,32 +38,32 @@ SkipEnumeratorExplicitTag smoke_SkipEnumeratorExplicitTag_fromFfi(int handle) {
   }
 }
 void smoke_SkipEnumeratorExplicitTag_releaseFfiHandle(int handle) {}
-final _smoke_SkipEnumeratorExplicitTag_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipEnumeratorExplicitTagCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_SkipEnumeratorExplicitTag_create_handle_nullable'));
-final _smoke_SkipEnumeratorExplicitTag_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipEnumeratorExplicitTagReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorExplicitTag_release_handle_nullable'));
-final _smoke_SkipEnumeratorExplicitTag_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipEnumeratorExplicitTagGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorExplicitTag_get_value_nullable'));
 Pointer<Void> smoke_SkipEnumeratorExplicitTag_toFfi_nullable(SkipEnumeratorExplicitTag value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipEnumeratorExplicitTag_toFfi(value);
-  final result = _smoke_SkipEnumeratorExplicitTag_create_handle_nullable(_handle);
+  final result = _smoke_SkipEnumeratorExplicitTagCreateHandleNullable(_handle);
   smoke_SkipEnumeratorExplicitTag_releaseFfiHandle(_handle);
   return result;
 }
 SkipEnumeratorExplicitTag smoke_SkipEnumeratorExplicitTag_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_SkipEnumeratorExplicitTag_get_value_nullable(handle);
+  final _handle = _smoke_SkipEnumeratorExplicitTagGetValueNullable(handle);
   final result = smoke_SkipEnumeratorExplicitTag_fromFfi(_handle);
   smoke_SkipEnumeratorExplicitTag_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_SkipEnumeratorExplicitTag_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipEnumeratorExplicitTag_release_handle_nullable(handle);
+  _smoke_SkipEnumeratorExplicitTagReleaseHandleNullable(handle);
 // End of SkipEnumeratorExplicitTag "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipFunctions {
@@ -15,11 +14,11 @@ abstract class SkipFunctions {
   static bool notInSwift(bool input) => SkipFunctions$Impl.notInSwift(input);
 }
 // SkipFunctions "private" section, not exported.
-final _smoke_SkipFunctions_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkipfunctionsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipFunctions_copy_handle'));
-final _smoke_SkipFunctions_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkipfunctionsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipFunctions_release_handle'));
@@ -29,51 +28,51 @@ class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SkipFunctions_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSkipfunctionsReleaseHandle(handle);
     handle = null;
   }
   static String notInJava(String input) {
-    final _notInJava_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SkipFunctions_notInJava__String'));
-    final _input_handle = String_toFfi(input);
-    final __result_handle = _notInJava_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final _notInJavaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SkipFunctions_notInJava__String'));
+    final _inputHandle = String_toFfi(input);
+    final __resultHandle = _notInJavaFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   static bool notInSwift(bool input) {
-    final _notInSwift_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_SkipFunctions_notInSwift__Boolean'));
-    final _input_handle = Boolean_toFfi(input);
-    final __result_handle = _notInSwift_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    Boolean_releaseFfiHandle(_input_handle);
+    final _notInSwiftFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_SkipFunctions_notInSwift__Boolean'));
+    final _inputHandle = Boolean_toFfi(input);
+    final __resultHandle = _notInSwiftFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_SkipFunctions_toFfi(SkipFunctions value) =>
-  _smoke_SkipFunctions_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSkipfunctionsCopyHandle((value as __lib.NativeBase).handle);
 SkipFunctions smoke_SkipFunctions_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SkipFunctions;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SkipFunctions_copy_handle(handle);
-  final result = SkipFunctions$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSkipfunctionsCopyHandle(handle);
+  final result = SkipFunctions$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SkipFunctions_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SkipFunctions_release_handle(handle);
+  _smokeSkipfunctionsReleaseHandle(handle);
 Pointer<Void> smoke_SkipFunctions_toFfi_nullable(SkipFunctions value) =>
   value != null ? smoke_SkipFunctions_toFfi(value) : Pointer<Void>.fromAddress(0);
 SkipFunctions smoke_SkipFunctions_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipFunctions_fromFfi(handle) : null;
 void smoke_SkipFunctions_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipFunctions_release_handle(handle);
+  _smokeSkipfunctionsReleaseHandle(handle);
 // End of SkipFunctions "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -3,11 +3,10 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipProxy {
-  SkipProxy() {}
+  SkipProxy();
   factory SkipProxy.fromLambdas({
     @required String Function(String) lambda_notInJava,
     @required bool Function(bool) lambda_notInSwift,
@@ -36,19 +35,19 @@ abstract class SkipProxy {
   set isSkippedInSwift(bool value);
 }
 // SkipProxy "private" section, not exported.
-final _smoke_SkipProxy_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkipproxyCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipProxy_copy_handle'));
-final _smoke_SkipProxy_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkipproxyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipProxy_release_handle'));
-final _smoke_SkipProxy_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkipproxyCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_SkipProxy_create_proxy'));
-final _smoke_SkipProxy_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkipproxyGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipProxy_get_type_id'));
@@ -90,96 +89,96 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SkipProxy_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSkipproxyReleaseHandle(handle);
     handle = null;
   }
   @override
   String notInJava(String input) {
-    final _notInJava_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_notInJava__String'));
-    final _input_handle = String_toFfi(input);
+    final _notInJavaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_notInJava__String'));
+    final _inputHandle = String_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _notInJava_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    String_releaseFfiHandle(_input_handle);
+    final __resultHandle = _notInJavaFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    String_releaseFfiHandle(_inputHandle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   bool notInSwift(bool input) {
-    final _notInSwift_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_notInSwift__Boolean'));
-    final _input_handle = Boolean_toFfi(input);
+    final _notInSwiftFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_notInSwift__Boolean'));
+    final _inputHandle = Boolean_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _notInSwift_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    Boolean_releaseFfiHandle(_input_handle);
+    final __resultHandle = _notInSwiftFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    Boolean_releaseFfiHandle(_inputHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   String get skippedInJava {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInJava_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInJava_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   set skippedInJava(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   bool get isSkippedInSwift {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   set isSkippedInSwift(bool value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
-    final _value_handle = Boolean_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
+    final _valueHandle = Boolean_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    Boolean_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    Boolean_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 int _SkipProxy_notInJava_static(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _result_object = null;
+  String _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as SkipProxy).notInJava(String_fromFfi(input));
-    _result.value = String_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as SkipProxy).notInJava(String_fromFfi(input));
+    _result.value = String_toFfi(_resultObject);
   } finally {
     String_releaseFfiHandle(input);
   }
   return 0;
 }
 int _SkipProxy_notInSwift_static(int _token, int input, Pointer<Uint8> _result) {
-  bool _result_object = null;
+  bool _resultObject = null;
   try {
-    _result_object = (__lib.instanceCache[_token] as SkipProxy).notInSwift(Boolean_fromFfi(input));
-    _result.value = Boolean_toFfi(_result_object);
+    _resultObject = (__lib.instanceCache[_token] as SkipProxy).notInSwift(Boolean_fromFfi(input));
+    _result.value = Boolean_toFfi(_resultObject);
   } finally {
     Boolean_releaseFfiHandle(input);
   }
@@ -212,8 +211,8 @@ int _SkipProxy_isSkippedInSwift_set_static(int _token, int _value) {
   return 0;
 }
 Pointer<Void> smoke_SkipProxy_toFfi(SkipProxy value) {
-  if (value is __lib.NativeBase) return _smoke_SkipProxy_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_SkipProxy_create_proxy(
+  if (value is __lib.NativeBase) return _smokeSkipproxyCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeSkipproxyCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -228,25 +227,25 @@ Pointer<Void> smoke_SkipProxy_toFfi(SkipProxy value) {
 }
 SkipProxy smoke_SkipProxy_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SkipProxy;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_SkipProxy_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_SkipProxy_copy_handle(handle);
+  final _typeIdHandle = _smokeSkipproxyGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeSkipproxyCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : SkipProxy$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : SkipProxy$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SkipProxy_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SkipProxy_release_handle(handle);
+  _smokeSkipproxyReleaseHandle(handle);
 Pointer<Void> smoke_SkipProxy_toFfi_nullable(SkipProxy value) =>
   value != null ? smoke_SkipProxy_toFfi(value) : Pointer<Void>.fromAddress(0);
 SkipProxy smoke_SkipProxy_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipProxy_fromFfi(handle) : null;
 void smoke_SkipProxy_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipProxy_release_handle(handle);
+  _smokeSkipproxyReleaseHandle(handle);
 // End of SkipProxy "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipTagsOnly {
@@ -12,11 +11,11 @@ abstract class SkipTagsOnly {
   void release();
 }
 // SkipTagsOnly "private" section, not exported.
-final _smoke_SkipTagsOnly_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptagsonlyCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTagsOnly_copy_handle'));
-final _smoke_SkipTagsOnly_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptagsonlyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTagsOnly_release_handle'));
@@ -26,29 +25,29 @@ class SkipTagsOnly$Impl extends __lib.NativeBase implements SkipTagsOnly {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SkipTagsOnly_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSkiptagsonlyReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_SkipTagsOnly_toFfi(SkipTagsOnly value) =>
-  _smoke_SkipTagsOnly_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSkiptagsonlyCopyHandle((value as __lib.NativeBase).handle);
 SkipTagsOnly smoke_SkipTagsOnly_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SkipTagsOnly;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SkipTagsOnly_copy_handle(handle);
-  final result = SkipTagsOnly$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSkiptagsonlyCopyHandle(handle);
+  final result = SkipTagsOnly$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SkipTagsOnly_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SkipTagsOnly_release_handle(handle);
+  _smokeSkiptagsonlyReleaseHandle(handle);
 Pointer<Void> smoke_SkipTagsOnly_toFfi_nullable(SkipTagsOnly value) =>
   value != null ? smoke_SkipTagsOnly_toFfi(value) : Pointer<Void>.fromAddress(0);
 SkipTagsOnly smoke_SkipTagsOnly_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipTagsOnly_fromFfi(handle) : null;
 void smoke_SkipTagsOnly_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipTagsOnly_release_handle(handle);
+  _smokeSkiptagsonlyReleaseHandle(handle);
 // End of SkipTagsOnly "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipTypes {
@@ -17,135 +16,135 @@ class SkipTypes_NotInJava {
   SkipTypes_NotInJava(this.fooField);
 }
 // SkipTypes_NotInJava "private" section, not exported.
-final _smoke_SkipTypes_NotInJava_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesNotinjavaCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_create_handle'));
-final _smoke_SkipTypes_NotInJava_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesNotinjavaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_release_handle'));
-final _smoke_SkipTypes_NotInJava_get_field_fooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesNotinjavaGetFieldfooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_get_field_fooField'));
 Pointer<Void> smoke_SkipTypes_NotInJava_toFfi(SkipTypes_NotInJava value) {
-  final _fooField_handle = String_toFfi(value.fooField);
-  final _result = _smoke_SkipTypes_NotInJava_create_handle(_fooField_handle);
-  String_releaseFfiHandle(_fooField_handle);
+  final _fooFieldHandle = String_toFfi(value.fooField);
+  final _result = _smokeSkiptypesNotinjavaCreateHandle(_fooFieldHandle);
+  String_releaseFfiHandle(_fooFieldHandle);
   return _result;
 }
 SkipTypes_NotInJava smoke_SkipTypes_NotInJava_fromFfi(Pointer<Void> handle) {
-  final _fooField_handle = _smoke_SkipTypes_NotInJava_get_field_fooField(handle);
+  final _fooFieldHandle = _smokeSkiptypesNotinjavaGetFieldfooField(handle);
   try {
     return SkipTypes_NotInJava(
-      String_fromFfi(_fooField_handle)
+      String_fromFfi(_fooFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_fooField_handle);
+    String_releaseFfiHandle(_fooFieldHandle);
   }
 }
-void smoke_SkipTypes_NotInJava_releaseFfiHandle(Pointer<Void> handle) => _smoke_SkipTypes_NotInJava_release_handle(handle);
+void smoke_SkipTypes_NotInJava_releaseFfiHandle(Pointer<Void> handle) => _smokeSkiptypesNotinjavaReleaseHandle(handle);
 // Nullable SkipTypes_NotInJava
-final _smoke_SkipTypes_NotInJava_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInJavaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_create_handle_nullable'));
-final _smoke_SkipTypes_NotInJava_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInJavaReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_release_handle_nullable'));
-final _smoke_SkipTypes_NotInJava_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInJavaGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_get_value_nullable'));
 Pointer<Void> smoke_SkipTypes_NotInJava_toFfi_nullable(SkipTypes_NotInJava value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipTypes_NotInJava_toFfi(value);
-  final result = _smoke_SkipTypes_NotInJava_create_handle_nullable(_handle);
+  final result = _smoke_SkipTypes_NotInJavaCreateHandleNullable(_handle);
   smoke_SkipTypes_NotInJava_releaseFfiHandle(_handle);
   return result;
 }
 SkipTypes_NotInJava smoke_SkipTypes_NotInJava_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_SkipTypes_NotInJava_get_value_nullable(handle);
+  final _handle = _smoke_SkipTypes_NotInJavaGetValueNullable(handle);
   final result = smoke_SkipTypes_NotInJava_fromFfi(_handle);
   smoke_SkipTypes_NotInJava_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_SkipTypes_NotInJava_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipTypes_NotInJava_release_handle_nullable(handle);
+  _smoke_SkipTypes_NotInJavaReleaseHandleNullable(handle);
 // End of SkipTypes_NotInJava "private" section.
 class SkipTypes_NotInSwift {
   String fooField;
   SkipTypes_NotInSwift(this.fooField);
 }
 // SkipTypes_NotInSwift "private" section, not exported.
-final _smoke_SkipTypes_NotInSwift_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesNotinswiftCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_create_handle'));
-final _smoke_SkipTypes_NotInSwift_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesNotinswiftReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_release_handle'));
-final _smoke_SkipTypes_NotInSwift_get_field_fooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesNotinswiftGetFieldfooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_get_field_fooField'));
 Pointer<Void> smoke_SkipTypes_NotInSwift_toFfi(SkipTypes_NotInSwift value) {
-  final _fooField_handle = String_toFfi(value.fooField);
-  final _result = _smoke_SkipTypes_NotInSwift_create_handle(_fooField_handle);
-  String_releaseFfiHandle(_fooField_handle);
+  final _fooFieldHandle = String_toFfi(value.fooField);
+  final _result = _smokeSkiptypesNotinswiftCreateHandle(_fooFieldHandle);
+  String_releaseFfiHandle(_fooFieldHandle);
   return _result;
 }
 SkipTypes_NotInSwift smoke_SkipTypes_NotInSwift_fromFfi(Pointer<Void> handle) {
-  final _fooField_handle = _smoke_SkipTypes_NotInSwift_get_field_fooField(handle);
+  final _fooFieldHandle = _smokeSkiptypesNotinswiftGetFieldfooField(handle);
   try {
     return SkipTypes_NotInSwift(
-      String_fromFfi(_fooField_handle)
+      String_fromFfi(_fooFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_fooField_handle);
+    String_releaseFfiHandle(_fooFieldHandle);
   }
 }
-void smoke_SkipTypes_NotInSwift_releaseFfiHandle(Pointer<Void> handle) => _smoke_SkipTypes_NotInSwift_release_handle(handle);
+void smoke_SkipTypes_NotInSwift_releaseFfiHandle(Pointer<Void> handle) => _smokeSkiptypesNotinswiftReleaseHandle(handle);
 // Nullable SkipTypes_NotInSwift
-final _smoke_SkipTypes_NotInSwift_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInSwiftCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_create_handle_nullable'));
-final _smoke_SkipTypes_NotInSwift_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInSwiftReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_release_handle_nullable'));
-final _smoke_SkipTypes_NotInSwift_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_SkipTypes_NotInSwiftGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_get_value_nullable'));
 Pointer<Void> smoke_SkipTypes_NotInSwift_toFfi_nullable(SkipTypes_NotInSwift value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_SkipTypes_NotInSwift_toFfi(value);
-  final result = _smoke_SkipTypes_NotInSwift_create_handle_nullable(_handle);
+  final result = _smoke_SkipTypes_NotInSwiftCreateHandleNullable(_handle);
   smoke_SkipTypes_NotInSwift_releaseFfiHandle(_handle);
   return result;
 }
 SkipTypes_NotInSwift smoke_SkipTypes_NotInSwift_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_SkipTypes_NotInSwift_get_value_nullable(handle);
+  final _handle = _smoke_SkipTypes_NotInSwiftGetValueNullable(handle);
   final result = smoke_SkipTypes_NotInSwift_fromFfi(_handle);
   smoke_SkipTypes_NotInSwift_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_SkipTypes_NotInSwift_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipTypes_NotInSwift_release_handle_nullable(handle);
+  _smoke_SkipTypes_NotInSwiftReleaseHandleNullable(handle);
 // End of SkipTypes_NotInSwift "private" section.
 // SkipTypes "private" section, not exported.
-final _smoke_SkipTypes_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_copy_handle'));
-final _smoke_SkipTypes_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSkiptypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_release_handle'));
@@ -155,29 +154,29 @@ class SkipTypes$Impl extends __lib.NativeBase implements SkipTypes {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SkipTypes_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSkiptypesReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_SkipTypes_toFfi(SkipTypes value) =>
-  _smoke_SkipTypes_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSkiptypesCopyHandle((value as __lib.NativeBase).handle);
 SkipTypes smoke_SkipTypes_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SkipTypes;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SkipTypes_copy_handle(handle);
-  final result = SkipTypes$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSkiptypesCopyHandle(handle);
+  final result = SkipTypes$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SkipTypes_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SkipTypes_release_handle(handle);
+  _smokeSkiptypesReleaseHandle(handle);
 Pointer<Void> smoke_SkipTypes_toFfi_nullable(SkipTypes value) =>
   value != null ? smoke_SkipTypes_toFfi(value) : Pointer<Void>.fromAddress(0);
 SkipTypes smoke_SkipTypes_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SkipTypes_fromFfi(handle) : null;
 void smoke_SkipTypes_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SkipTypes_release_handle(handle);
+  _smokeSkiptypesReleaseHandle(handle);
 // End of SkipTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 final bool placeHolder = true;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -5,7 +5,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Structs {
@@ -49,34 +48,34 @@ Structs_FooBar smoke_Structs_FooBar_fromFfi(int handle) {
   }
 }
 void smoke_Structs_FooBar_releaseFfiHandle(int handle) {}
-final _smoke_Structs_FooBar_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_FooBarCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_Structs_FooBar_create_handle_nullable'));
-final _smoke_Structs_FooBar_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_FooBarReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_FooBar_release_handle_nullable'));
-final _smoke_Structs_FooBar_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_FooBarGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_FooBar_get_value_nullable'));
 Pointer<Void> smoke_Structs_FooBar_toFfi_nullable(Structs_FooBar value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_FooBar_toFfi(value);
-  final result = _smoke_Structs_FooBar_create_handle_nullable(_handle);
+  final result = _smoke_Structs_FooBarCreateHandleNullable(_handle);
   smoke_Structs_FooBar_releaseFfiHandle(_handle);
   return result;
 }
 Structs_FooBar smoke_Structs_FooBar_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_FooBar_get_value_nullable(handle);
+  final _handle = _smoke_Structs_FooBarGetValueNullable(handle);
   final result = smoke_Structs_FooBar_fromFfi(_handle);
   smoke_Structs_FooBar_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_FooBar_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_FooBar_release_handle_nullable(handle);
+  _smoke_Structs_FooBarReleaseHandleNullable(handle);
 // End of Structs_FooBar "private" section.
 class Structs_Point {
   double x;
@@ -84,73 +83,73 @@ class Structs_Point {
   Structs_Point(this.x, this.y);
 }
 // Structs_Point "private" section, not exported.
-final _smoke_Structs_Point_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsPointCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
   >('library_smoke_Structs_Point_create_handle'));
-final _smoke_Structs_Point_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsPointReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_Point_release_handle'));
-final _smoke_Structs_Point_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsPointGetFieldx = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Structs_Point_get_field_x'));
-final _smoke_Structs_Point_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsPointGetFieldy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Structs_Point_get_field_y'));
 Pointer<Void> smoke_Structs_Point_toFfi(Structs_Point value) {
-  final _x_handle = (value.x);
-  final _y_handle = (value.y);
-  final _result = _smoke_Structs_Point_create_handle(_x_handle, _y_handle);
-  (_x_handle);
-  (_y_handle);
+  final _xHandle = (value.x);
+  final _yHandle = (value.y);
+  final _result = _smokeStructsPointCreateHandle(_xHandle, _yHandle);
+  (_xHandle);
+  (_yHandle);
   return _result;
 }
 Structs_Point smoke_Structs_Point_fromFfi(Pointer<Void> handle) {
-  final _x_handle = _smoke_Structs_Point_get_field_x(handle);
-  final _y_handle = _smoke_Structs_Point_get_field_y(handle);
+  final _xHandle = _smokeStructsPointGetFieldx(handle);
+  final _yHandle = _smokeStructsPointGetFieldy(handle);
   try {
     return Structs_Point(
-      (_x_handle),
-      (_y_handle)
+      (_xHandle),
+      (_yHandle)
     );
   } finally {
-    (_x_handle);
-    (_y_handle);
+    (_xHandle);
+    (_yHandle);
   }
 }
-void smoke_Structs_Point_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_Point_release_handle(handle);
+void smoke_Structs_Point_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsPointReleaseHandle(handle);
 // Nullable Structs_Point
-final _smoke_Structs_Point_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_PointCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Point_create_handle_nullable'));
-final _smoke_Structs_Point_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_PointReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_Point_release_handle_nullable'));
-final _smoke_Structs_Point_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_PointGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Point_get_value_nullable'));
 Pointer<Void> smoke_Structs_Point_toFfi_nullable(Structs_Point value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_Point_toFfi(value);
-  final result = _smoke_Structs_Point_create_handle_nullable(_handle);
+  final result = _smoke_Structs_PointCreateHandleNullable(_handle);
   smoke_Structs_Point_releaseFfiHandle(_handle);
   return result;
 }
 Structs_Point smoke_Structs_Point_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_Point_get_value_nullable(handle);
+  final _handle = _smoke_Structs_PointGetValueNullable(handle);
   final result = smoke_Structs_Point_fromFfi(_handle);
   smoke_Structs_Point_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_Point_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_Point_release_handle_nullable(handle);
+  _smoke_Structs_PointReleaseHandleNullable(handle);
 // End of Structs_Point "private" section.
 class Structs_Line {
   Structs_Point a;
@@ -158,73 +157,73 @@ class Structs_Line {
   Structs_Line(this.a, this.b);
 }
 // Structs_Line "private" section, not exported.
-final _smoke_Structs_Line_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsLineCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
   >('library_smoke_Structs_Line_create_handle'));
-final _smoke_Structs_Line_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsLineReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_Line_release_handle'));
-final _smoke_Structs_Line_get_field_a = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsLineGetFielda = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Line_get_field_a'));
-final _smoke_Structs_Line_get_field_b = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsLineGetFieldb = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Line_get_field_b'));
 Pointer<Void> smoke_Structs_Line_toFfi(Structs_Line value) {
-  final _a_handle = smoke_Structs_Point_toFfi(value.a);
-  final _b_handle = smoke_Structs_Point_toFfi(value.b);
-  final _result = _smoke_Structs_Line_create_handle(_a_handle, _b_handle);
-  smoke_Structs_Point_releaseFfiHandle(_a_handle);
-  smoke_Structs_Point_releaseFfiHandle(_b_handle);
+  final _aHandle = smoke_Structs_Point_toFfi(value.a);
+  final _bHandle = smoke_Structs_Point_toFfi(value.b);
+  final _result = _smokeStructsLineCreateHandle(_aHandle, _bHandle);
+  smoke_Structs_Point_releaseFfiHandle(_aHandle);
+  smoke_Structs_Point_releaseFfiHandle(_bHandle);
   return _result;
 }
 Structs_Line smoke_Structs_Line_fromFfi(Pointer<Void> handle) {
-  final _a_handle = _smoke_Structs_Line_get_field_a(handle);
-  final _b_handle = _smoke_Structs_Line_get_field_b(handle);
+  final _aHandle = _smokeStructsLineGetFielda(handle);
+  final _bHandle = _smokeStructsLineGetFieldb(handle);
   try {
     return Structs_Line(
-      smoke_Structs_Point_fromFfi(_a_handle),
-      smoke_Structs_Point_fromFfi(_b_handle)
+      smoke_Structs_Point_fromFfi(_aHandle),
+      smoke_Structs_Point_fromFfi(_bHandle)
     );
   } finally {
-    smoke_Structs_Point_releaseFfiHandle(_a_handle);
-    smoke_Structs_Point_releaseFfiHandle(_b_handle);
+    smoke_Structs_Point_releaseFfiHandle(_aHandle);
+    smoke_Structs_Point_releaseFfiHandle(_bHandle);
   }
 }
-void smoke_Structs_Line_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_Line_release_handle(handle);
+void smoke_Structs_Line_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsLineReleaseHandle(handle);
 // Nullable Structs_Line
-final _smoke_Structs_Line_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_LineCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Line_create_handle_nullable'));
-final _smoke_Structs_Line_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_LineReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_Line_release_handle_nullable'));
-final _smoke_Structs_Line_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_LineGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_Line_get_value_nullable'));
 Pointer<Void> smoke_Structs_Line_toFfi_nullable(Structs_Line value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_Line_toFfi(value);
-  final result = _smoke_Structs_Line_create_handle_nullable(_handle);
+  final result = _smoke_Structs_LineCreateHandleNullable(_handle);
   smoke_Structs_Line_releaseFfiHandle(_handle);
   return result;
 }
 Structs_Line smoke_Structs_Line_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_Line_get_value_nullable(handle);
+  final _handle = _smoke_Structs_LineGetValueNullable(handle);
   final result = smoke_Structs_Line_fromFfi(_handle);
   smoke_Structs_Line_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_Line_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_Line_release_handle_nullable(handle);
+  _smoke_Structs_LineReleaseHandleNullable(handle);
 // End of Structs_Line "private" section.
 @immutable
 class Structs_AllTypesStruct {
@@ -245,373 +244,373 @@ class Structs_AllTypesStruct {
   const Structs_AllTypesStruct(this.int8Field, this.uint8Field, this.int16Field, this.uint16Field, this.int32Field, this.uint32Field, this.int64Field, this.uint64Field, this.floatField, this.doubleField, this.stringField, this.booleanField, this.bytesField, this.pointField);
 }
 // Structs_AllTypesStruct "private" section, not exported.
-final _smoke_Structs_AllTypesStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8, Uint8, Int16, Uint16, Int32, Uint32, Int64, Uint64, Float, Double, Pointer<Void>, Uint8, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(int, int, int, int, int, int, int, int, double, double, Pointer<Void>, int, Pointer<Void>, Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_create_handle'));
-final _smoke_Structs_AllTypesStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_release_handle'));
-final _smoke_Structs_AllTypesStruct_get_field_int8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_int8Field'));
-final _smoke_Structs_AllTypesStruct_get_field_uint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFielduint8Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_uint8Field'));
-final _smoke_Structs_AllTypesStruct_get_field_int16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_int16Field'));
-final _smoke_Structs_AllTypesStruct_get_field_uint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFielduint16Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint16 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_uint16Field'));
-final _smoke_Structs_AllTypesStruct_get_field_int32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_int32Field'));
-final _smoke_Structs_AllTypesStruct_get_field_uint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFielduint32Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_uint32Field'));
-final _smoke_Structs_AllTypesStruct_get_field_int64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_int64Field'));
-final _smoke_Structs_AllTypesStruct_get_field_uint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFielduint64Field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_uint64Field'));
-final _smoke_Structs_AllTypesStruct_get_field_floatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldfloatField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_floatField'));
-final _smoke_Structs_AllTypesStruct_get_field_doubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFielddoubleField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_doubleField'));
-final _smoke_Structs_AllTypesStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_stringField'));
-final _smoke_Structs_AllTypesStruct_get_field_booleanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldbooleanField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_booleanField'));
-final _smoke_Structs_AllTypesStruct_get_field_bytesField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldbytesField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_bytesField'));
-final _smoke_Structs_AllTypesStruct_get_field_pointField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsAlltypesstructGetFieldpointField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_field_pointField'));
 Pointer<Void> smoke_Structs_AllTypesStruct_toFfi(Structs_AllTypesStruct value) {
-  final _int8Field_handle = (value.int8Field);
-  final _uint8Field_handle = (value.uint8Field);
-  final _int16Field_handle = (value.int16Field);
-  final _uint16Field_handle = (value.uint16Field);
-  final _int32Field_handle = (value.int32Field);
-  final _uint32Field_handle = (value.uint32Field);
-  final _int64Field_handle = (value.int64Field);
-  final _uint64Field_handle = (value.uint64Field);
-  final _floatField_handle = (value.floatField);
-  final _doubleField_handle = (value.doubleField);
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _booleanField_handle = Boolean_toFfi(value.booleanField);
-  final _bytesField_handle = Blob_toFfi(value.bytesField);
-  final _pointField_handle = smoke_Structs_Point_toFfi(value.pointField);
-  final _result = _smoke_Structs_AllTypesStruct_create_handle(_int8Field_handle, _uint8Field_handle, _int16Field_handle, _uint16Field_handle, _int32Field_handle, _uint32Field_handle, _int64Field_handle, _uint64Field_handle, _floatField_handle, _doubleField_handle, _stringField_handle, _booleanField_handle, _bytesField_handle, _pointField_handle);
-  (_int8Field_handle);
-  (_uint8Field_handle);
-  (_int16Field_handle);
-  (_uint16Field_handle);
-  (_int32Field_handle);
-  (_uint32Field_handle);
-  (_int64Field_handle);
-  (_uint64Field_handle);
-  (_floatField_handle);
-  (_doubleField_handle);
-  String_releaseFfiHandle(_stringField_handle);
-  Boolean_releaseFfiHandle(_booleanField_handle);
-  Blob_releaseFfiHandle(_bytesField_handle);
-  smoke_Structs_Point_releaseFfiHandle(_pointField_handle);
+  final _int8FieldHandle = (value.int8Field);
+  final _uint8FieldHandle = (value.uint8Field);
+  final _int16FieldHandle = (value.int16Field);
+  final _uint16FieldHandle = (value.uint16Field);
+  final _int32FieldHandle = (value.int32Field);
+  final _uint32FieldHandle = (value.uint32Field);
+  final _int64FieldHandle = (value.int64Field);
+  final _uint64FieldHandle = (value.uint64Field);
+  final _floatFieldHandle = (value.floatField);
+  final _doubleFieldHandle = (value.doubleField);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _booleanFieldHandle = Boolean_toFfi(value.booleanField);
+  final _bytesFieldHandle = Blob_toFfi(value.bytesField);
+  final _pointFieldHandle = smoke_Structs_Point_toFfi(value.pointField);
+  final _result = _smokeStructsAlltypesstructCreateHandle(_int8FieldHandle, _uint8FieldHandle, _int16FieldHandle, _uint16FieldHandle, _int32FieldHandle, _uint32FieldHandle, _int64FieldHandle, _uint64FieldHandle, _floatFieldHandle, _doubleFieldHandle, _stringFieldHandle, _booleanFieldHandle, _bytesFieldHandle, _pointFieldHandle);
+  (_int8FieldHandle);
+  (_uint8FieldHandle);
+  (_int16FieldHandle);
+  (_uint16FieldHandle);
+  (_int32FieldHandle);
+  (_uint32FieldHandle);
+  (_int64FieldHandle);
+  (_uint64FieldHandle);
+  (_floatFieldHandle);
+  (_doubleFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
+  Boolean_releaseFfiHandle(_booleanFieldHandle);
+  Blob_releaseFfiHandle(_bytesFieldHandle);
+  smoke_Structs_Point_releaseFfiHandle(_pointFieldHandle);
   return _result;
 }
 Structs_AllTypesStruct smoke_Structs_AllTypesStruct_fromFfi(Pointer<Void> handle) {
-  final _int8Field_handle = _smoke_Structs_AllTypesStruct_get_field_int8Field(handle);
-  final _uint8Field_handle = _smoke_Structs_AllTypesStruct_get_field_uint8Field(handle);
-  final _int16Field_handle = _smoke_Structs_AllTypesStruct_get_field_int16Field(handle);
-  final _uint16Field_handle = _smoke_Structs_AllTypesStruct_get_field_uint16Field(handle);
-  final _int32Field_handle = _smoke_Structs_AllTypesStruct_get_field_int32Field(handle);
-  final _uint32Field_handle = _smoke_Structs_AllTypesStruct_get_field_uint32Field(handle);
-  final _int64Field_handle = _smoke_Structs_AllTypesStruct_get_field_int64Field(handle);
-  final _uint64Field_handle = _smoke_Structs_AllTypesStruct_get_field_uint64Field(handle);
-  final _floatField_handle = _smoke_Structs_AllTypesStruct_get_field_floatField(handle);
-  final _doubleField_handle = _smoke_Structs_AllTypesStruct_get_field_doubleField(handle);
-  final _stringField_handle = _smoke_Structs_AllTypesStruct_get_field_stringField(handle);
-  final _booleanField_handle = _smoke_Structs_AllTypesStruct_get_field_booleanField(handle);
-  final _bytesField_handle = _smoke_Structs_AllTypesStruct_get_field_bytesField(handle);
-  final _pointField_handle = _smoke_Structs_AllTypesStruct_get_field_pointField(handle);
+  final _int8FieldHandle = _smokeStructsAlltypesstructGetFieldint8Field(handle);
+  final _uint8FieldHandle = _smokeStructsAlltypesstructGetFielduint8Field(handle);
+  final _int16FieldHandle = _smokeStructsAlltypesstructGetFieldint16Field(handle);
+  final _uint16FieldHandle = _smokeStructsAlltypesstructGetFielduint16Field(handle);
+  final _int32FieldHandle = _smokeStructsAlltypesstructGetFieldint32Field(handle);
+  final _uint32FieldHandle = _smokeStructsAlltypesstructGetFielduint32Field(handle);
+  final _int64FieldHandle = _smokeStructsAlltypesstructGetFieldint64Field(handle);
+  final _uint64FieldHandle = _smokeStructsAlltypesstructGetFielduint64Field(handle);
+  final _floatFieldHandle = _smokeStructsAlltypesstructGetFieldfloatField(handle);
+  final _doubleFieldHandle = _smokeStructsAlltypesstructGetFielddoubleField(handle);
+  final _stringFieldHandle = _smokeStructsAlltypesstructGetFieldstringField(handle);
+  final _booleanFieldHandle = _smokeStructsAlltypesstructGetFieldbooleanField(handle);
+  final _bytesFieldHandle = _smokeStructsAlltypesstructGetFieldbytesField(handle);
+  final _pointFieldHandle = _smokeStructsAlltypesstructGetFieldpointField(handle);
   try {
     return Structs_AllTypesStruct(
-      (_int8Field_handle),
-      (_uint8Field_handle),
-      (_int16Field_handle),
-      (_uint16Field_handle),
-      (_int32Field_handle),
-      (_uint32Field_handle),
-      (_int64Field_handle),
-      (_uint64Field_handle),
-      (_floatField_handle),
-      (_doubleField_handle),
-      String_fromFfi(_stringField_handle),
-      Boolean_fromFfi(_booleanField_handle),
-      Blob_fromFfi(_bytesField_handle),
-      smoke_Structs_Point_fromFfi(_pointField_handle)
+      (_int8FieldHandle),
+      (_uint8FieldHandle),
+      (_int16FieldHandle),
+      (_uint16FieldHandle),
+      (_int32FieldHandle),
+      (_uint32FieldHandle),
+      (_int64FieldHandle),
+      (_uint64FieldHandle),
+      (_floatFieldHandle),
+      (_doubleFieldHandle),
+      String_fromFfi(_stringFieldHandle),
+      Boolean_fromFfi(_booleanFieldHandle),
+      Blob_fromFfi(_bytesFieldHandle),
+      smoke_Structs_Point_fromFfi(_pointFieldHandle)
     );
   } finally {
-    (_int8Field_handle);
-    (_uint8Field_handle);
-    (_int16Field_handle);
-    (_uint16Field_handle);
-    (_int32Field_handle);
-    (_uint32Field_handle);
-    (_int64Field_handle);
-    (_uint64Field_handle);
-    (_floatField_handle);
-    (_doubleField_handle);
-    String_releaseFfiHandle(_stringField_handle);
-    Boolean_releaseFfiHandle(_booleanField_handle);
-    Blob_releaseFfiHandle(_bytesField_handle);
-    smoke_Structs_Point_releaseFfiHandle(_pointField_handle);
+    (_int8FieldHandle);
+    (_uint8FieldHandle);
+    (_int16FieldHandle);
+    (_uint16FieldHandle);
+    (_int32FieldHandle);
+    (_uint32FieldHandle);
+    (_int64FieldHandle);
+    (_uint64FieldHandle);
+    (_floatFieldHandle);
+    (_doubleFieldHandle);
+    String_releaseFfiHandle(_stringFieldHandle);
+    Boolean_releaseFfiHandle(_booleanFieldHandle);
+    Blob_releaseFfiHandle(_bytesFieldHandle);
+    smoke_Structs_Point_releaseFfiHandle(_pointFieldHandle);
   }
 }
-void smoke_Structs_AllTypesStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_AllTypesStruct_release_handle(handle);
+void smoke_Structs_AllTypesStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsAlltypesstructReleaseHandle(handle);
 // Nullable Structs_AllTypesStruct
-final _smoke_Structs_AllTypesStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AllTypesStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_create_handle_nullable'));
-final _smoke_Structs_AllTypesStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AllTypesStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_release_handle_nullable'));
-final _smoke_Structs_AllTypesStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_AllTypesStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AllTypesStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_AllTypesStruct_toFfi_nullable(Structs_AllTypesStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_AllTypesStruct_toFfi(value);
-  final result = _smoke_Structs_AllTypesStruct_create_handle_nullable(_handle);
+  final result = _smoke_Structs_AllTypesStructCreateHandleNullable(_handle);
   smoke_Structs_AllTypesStruct_releaseFfiHandle(_handle);
   return result;
 }
 Structs_AllTypesStruct smoke_Structs_AllTypesStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_AllTypesStruct_get_value_nullable(handle);
+  final _handle = _smoke_Structs_AllTypesStructGetValueNullable(handle);
   final result = smoke_Structs_AllTypesStruct_fromFfi(_handle);
   smoke_Structs_AllTypesStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_AllTypesStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_AllTypesStruct_release_handle_nullable(handle);
+  _smoke_Structs_AllTypesStructReleaseHandleNullable(handle);
 // End of Structs_AllTypesStruct "private" section.
 class Structs_NestingImmutableStruct {
   Structs_AllTypesStruct structField;
   Structs_NestingImmutableStruct(this.structField);
 }
 // Structs_NestingImmutableStruct "private" section, not exported.
-final _smoke_Structs_NestingImmutableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsNestingimmutablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_NestingImmutableStruct_create_handle'));
-final _smoke_Structs_NestingImmutableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsNestingimmutablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_NestingImmutableStruct_release_handle'));
-final _smoke_Structs_NestingImmutableStruct_get_field_structField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsNestingimmutablestructGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_NestingImmutableStruct_get_field_structField'));
 Pointer<Void> smoke_Structs_NestingImmutableStruct_toFfi(Structs_NestingImmutableStruct value) {
-  final _structField_handle = smoke_Structs_AllTypesStruct_toFfi(value.structField);
-  final _result = _smoke_Structs_NestingImmutableStruct_create_handle(_structField_handle);
-  smoke_Structs_AllTypesStruct_releaseFfiHandle(_structField_handle);
+  final _structFieldHandle = smoke_Structs_AllTypesStruct_toFfi(value.structField);
+  final _result = _smokeStructsNestingimmutablestructCreateHandle(_structFieldHandle);
+  smoke_Structs_AllTypesStruct_releaseFfiHandle(_structFieldHandle);
   return _result;
 }
 Structs_NestingImmutableStruct smoke_Structs_NestingImmutableStruct_fromFfi(Pointer<Void> handle) {
-  final _structField_handle = _smoke_Structs_NestingImmutableStruct_get_field_structField(handle);
+  final _structFieldHandle = _smokeStructsNestingimmutablestructGetFieldstructField(handle);
   try {
     return Structs_NestingImmutableStruct(
-      smoke_Structs_AllTypesStruct_fromFfi(_structField_handle)
+      smoke_Structs_AllTypesStruct_fromFfi(_structFieldHandle)
     );
   } finally {
-    smoke_Structs_AllTypesStruct_releaseFfiHandle(_structField_handle);
+    smoke_Structs_AllTypesStruct_releaseFfiHandle(_structFieldHandle);
   }
 }
-void smoke_Structs_NestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_NestingImmutableStruct_release_handle(handle);
+void smoke_Structs_NestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsNestingimmutablestructReleaseHandle(handle);
 // Nullable Structs_NestingImmutableStruct
-final _smoke_Structs_NestingImmutableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_NestingImmutableStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_NestingImmutableStruct_create_handle_nullable'));
-final _smoke_Structs_NestingImmutableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_NestingImmutableStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_NestingImmutableStruct_release_handle_nullable'));
-final _smoke_Structs_NestingImmutableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_NestingImmutableStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_NestingImmutableStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_NestingImmutableStruct_toFfi_nullable(Structs_NestingImmutableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_NestingImmutableStruct_toFfi(value);
-  final result = _smoke_Structs_NestingImmutableStruct_create_handle_nullable(_handle);
+  final result = _smoke_Structs_NestingImmutableStructCreateHandleNullable(_handle);
   smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_handle);
   return result;
 }
 Structs_NestingImmutableStruct smoke_Structs_NestingImmutableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_NestingImmutableStruct_get_value_nullable(handle);
+  final _handle = _smoke_Structs_NestingImmutableStructGetValueNullable(handle);
   final result = smoke_Structs_NestingImmutableStruct_fromFfi(_handle);
   smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_NestingImmutableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_NestingImmutableStruct_release_handle_nullable(handle);
+  _smoke_Structs_NestingImmutableStructReleaseHandleNullable(handle);
 // End of Structs_NestingImmutableStruct "private" section.
 class Structs_DoubleNestingImmutableStruct {
   Structs_NestingImmutableStruct nestingStructField;
   Structs_DoubleNestingImmutableStruct(this.nestingStructField);
 }
 // Structs_DoubleNestingImmutableStruct "private" section, not exported.
-final _smoke_Structs_DoubleNestingImmutableStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsDoublenestingimmutablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_DoubleNestingImmutableStruct_create_handle'));
-final _smoke_Structs_DoubleNestingImmutableStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsDoublenestingimmutablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_DoubleNestingImmutableStruct_release_handle'));
-final _smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsDoublenestingimmutablestructGetFieldnestingStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField'));
 Pointer<Void> smoke_Structs_DoubleNestingImmutableStruct_toFfi(Structs_DoubleNestingImmutableStruct value) {
-  final _nestingStructField_handle = smoke_Structs_NestingImmutableStruct_toFfi(value.nestingStructField);
-  final _result = _smoke_Structs_DoubleNestingImmutableStruct_create_handle(_nestingStructField_handle);
-  smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_nestingStructField_handle);
+  final _nestingStructFieldHandle = smoke_Structs_NestingImmutableStruct_toFfi(value.nestingStructField);
+  final _result = _smokeStructsDoublenestingimmutablestructCreateHandle(_nestingStructFieldHandle);
+  smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_nestingStructFieldHandle);
   return _result;
 }
 Structs_DoubleNestingImmutableStruct smoke_Structs_DoubleNestingImmutableStruct_fromFfi(Pointer<Void> handle) {
-  final _nestingStructField_handle = _smoke_Structs_DoubleNestingImmutableStruct_get_field_nestingStructField(handle);
+  final _nestingStructFieldHandle = _smokeStructsDoublenestingimmutablestructGetFieldnestingStructField(handle);
   try {
     return Structs_DoubleNestingImmutableStruct(
-      smoke_Structs_NestingImmutableStruct_fromFfi(_nestingStructField_handle)
+      smoke_Structs_NestingImmutableStruct_fromFfi(_nestingStructFieldHandle)
     );
   } finally {
-    smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_nestingStructField_handle);
+    smoke_Structs_NestingImmutableStruct_releaseFfiHandle(_nestingStructFieldHandle);
   }
 }
-void smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_DoubleNestingImmutableStruct_release_handle(handle);
+void smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsDoublenestingimmutablestructReleaseHandle(handle);
 // Nullable Structs_DoubleNestingImmutableStruct
-final _smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_DoubleNestingImmutableStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable'));
-final _smoke_Structs_DoubleNestingImmutableStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_DoubleNestingImmutableStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_DoubleNestingImmutableStruct_release_handle_nullable'));
-final _smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_DoubleNestingImmutableStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable'));
 Pointer<Void> smoke_Structs_DoubleNestingImmutableStruct_toFfi_nullable(Structs_DoubleNestingImmutableStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_DoubleNestingImmutableStruct_toFfi(value);
-  final result = _smoke_Structs_DoubleNestingImmutableStruct_create_handle_nullable(_handle);
+  final result = _smoke_Structs_DoubleNestingImmutableStructCreateHandleNullable(_handle);
   smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle(_handle);
   return result;
 }
 Structs_DoubleNestingImmutableStruct smoke_Structs_DoubleNestingImmutableStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_DoubleNestingImmutableStruct_get_value_nullable(handle);
+  final _handle = _smoke_Structs_DoubleNestingImmutableStructGetValueNullable(handle);
   final result = smoke_Structs_DoubleNestingImmutableStruct_fromFfi(_handle);
   smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_DoubleNestingImmutableStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_DoubleNestingImmutableStruct_release_handle_nullable(handle);
+  _smoke_Structs_DoubleNestingImmutableStructReleaseHandleNullable(handle);
 // End of Structs_DoubleNestingImmutableStruct "private" section.
 class Structs_StructWithArrayOfImmutable {
   List<Structs_AllTypesStruct> arrayField;
   Structs_StructWithArrayOfImmutable(this.arrayField);
 }
 // Structs_StructWithArrayOfImmutable "private" section, not exported.
-final _smoke_Structs_StructWithArrayOfImmutable_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsStructwitharrayofimmutableCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_StructWithArrayOfImmutable_create_handle'));
-final _smoke_Structs_StructWithArrayOfImmutable_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsStructwitharrayofimmutableReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_StructWithArrayOfImmutable_release_handle'));
-final _smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsStructwitharrayofimmutableGetFieldarrayField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField'));
 Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi(Structs_StructWithArrayOfImmutable value) {
-  final _arrayField_handle = foobar_ListOf_smoke_Structs_AllTypesStruct_toFfi(value.arrayField);
-  final _result = _smoke_Structs_StructWithArrayOfImmutable_create_handle(_arrayField_handle);
-  foobar_ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
+  final _arrayFieldHandle = foobar_ListOf_smoke_Structs_AllTypesStruct_toFfi(value.arrayField);
+  final _result = _smokeStructsStructwitharrayofimmutableCreateHandle(_arrayFieldHandle);
+  foobar_ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayFieldHandle);
   return _result;
 }
 Structs_StructWithArrayOfImmutable smoke_Structs_StructWithArrayOfImmutable_fromFfi(Pointer<Void> handle) {
-  final _arrayField_handle = _smoke_Structs_StructWithArrayOfImmutable_get_field_arrayField(handle);
+  final _arrayFieldHandle = _smokeStructsStructwitharrayofimmutableGetFieldarrayField(handle);
   try {
     return Structs_StructWithArrayOfImmutable(
-      foobar_ListOf_smoke_Structs_AllTypesStruct_fromFfi(_arrayField_handle)
+      foobar_ListOf_smoke_Structs_AllTypesStruct_fromFfi(_arrayFieldHandle)
     );
   } finally {
-    foobar_ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayField_handle);
+    foobar_ListOf_smoke_Structs_AllTypesStruct_releaseFfiHandle(_arrayFieldHandle);
   }
 }
-void smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_StructWithArrayOfImmutable_release_handle(handle);
+void smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsStructwitharrayofimmutableReleaseHandle(handle);
 // Nullable Structs_StructWithArrayOfImmutable
-final _smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_StructWithArrayOfImmutableCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable'));
-final _smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_StructWithArrayOfImmutableReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable'));
-final _smoke_Structs_StructWithArrayOfImmutable_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_StructWithArrayOfImmutableGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_StructWithArrayOfImmutable_get_value_nullable'));
 Pointer<Void> smoke_Structs_StructWithArrayOfImmutable_toFfi_nullable(Structs_StructWithArrayOfImmutable value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_StructWithArrayOfImmutable_toFfi(value);
-  final result = _smoke_Structs_StructWithArrayOfImmutable_create_handle_nullable(_handle);
+  final result = _smoke_Structs_StructWithArrayOfImmutableCreateHandleNullable(_handle);
   smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(_handle);
   return result;
 }
 Structs_StructWithArrayOfImmutable smoke_Structs_StructWithArrayOfImmutable_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_StructWithArrayOfImmutable_get_value_nullable(handle);
+  final _handle = _smoke_Structs_StructWithArrayOfImmutableGetValueNullable(handle);
   final result = smoke_Structs_StructWithArrayOfImmutable_fromFfi(_handle);
   smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_StructWithArrayOfImmutable_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_StructWithArrayOfImmutable_release_handle_nullable(handle);
+  _smoke_Structs_StructWithArrayOfImmutableReleaseHandleNullable(handle);
 // End of Structs_StructWithArrayOfImmutable "private" section.
 @immutable
 class Structs_ImmutableStructWithCppAccessors {
@@ -619,135 +618,135 @@ class Structs_ImmutableStructWithCppAccessors {
   const Structs_ImmutableStructWithCppAccessors(this.stringField);
 }
 // Structs_ImmutableStructWithCppAccessors "private" section, not exported.
-final _smoke_Structs_ImmutableStructWithCppAccessors_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsImmutablestructwithcppaccessorsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ImmutableStructWithCppAccessors_create_handle'));
-final _smoke_Structs_ImmutableStructWithCppAccessors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsImmutablestructwithcppaccessorsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_ImmutableStructWithCppAccessors_release_handle'));
-final _smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsImmutablestructwithcppaccessorsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField'));
 Pointer<Void> smoke_Structs_ImmutableStructWithCppAccessors_toFfi(Structs_ImmutableStructWithCppAccessors value) {
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _result = _smoke_Structs_ImmutableStructWithCppAccessors_create_handle(_stringField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _result = _smokeStructsImmutablestructwithcppaccessorsCreateHandle(_stringFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 Structs_ImmutableStructWithCppAccessors smoke_Structs_ImmutableStructWithCppAccessors_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_Structs_ImmutableStructWithCppAccessors_get_field_stringField(handle);
+  final _stringFieldHandle = _smokeStructsImmutablestructwithcppaccessorsGetFieldstringField(handle);
   try {
     return Structs_ImmutableStructWithCppAccessors(
-      String_fromFfi(_stringField_handle)
+      String_fromFfi(_stringFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_ImmutableStructWithCppAccessors_release_handle(handle);
+void smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsImmutablestructwithcppaccessorsReleaseHandle(handle);
 // Nullable Structs_ImmutableStructWithCppAccessors
-final _smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ImmutableStructWithCppAccessorsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable'));
-final _smoke_Structs_ImmutableStructWithCppAccessors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ImmutableStructWithCppAccessorsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_ImmutableStructWithCppAccessors_release_handle_nullable'));
-final _smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_ImmutableStructWithCppAccessorsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable'));
 Pointer<Void> smoke_Structs_ImmutableStructWithCppAccessors_toFfi_nullable(Structs_ImmutableStructWithCppAccessors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_ImmutableStructWithCppAccessors_toFfi(value);
-  final result = _smoke_Structs_ImmutableStructWithCppAccessors_create_handle_nullable(_handle);
+  final result = _smoke_Structs_ImmutableStructWithCppAccessorsCreateHandleNullable(_handle);
   smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle(_handle);
   return result;
 }
 Structs_ImmutableStructWithCppAccessors smoke_Structs_ImmutableStructWithCppAccessors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_ImmutableStructWithCppAccessors_get_value_nullable(handle);
+  final _handle = _smoke_Structs_ImmutableStructWithCppAccessorsGetValueNullable(handle);
   final result = smoke_Structs_ImmutableStructWithCppAccessors_fromFfi(_handle);
   smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_ImmutableStructWithCppAccessors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_ImmutableStructWithCppAccessors_release_handle_nullable(handle);
+  _smoke_Structs_ImmutableStructWithCppAccessorsReleaseHandleNullable(handle);
 // End of Structs_ImmutableStructWithCppAccessors "private" section.
 class Structs_MutableStructWithCppAccessors {
   String stringField;
   Structs_MutableStructWithCppAccessors(this.stringField);
 }
 // Structs_MutableStructWithCppAccessors "private" section, not exported.
-final _smoke_Structs_MutableStructWithCppAccessors_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsMutablestructwithcppaccessorsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_MutableStructWithCppAccessors_create_handle'));
-final _smoke_Structs_MutableStructWithCppAccessors_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsMutablestructwithcppaccessorsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_MutableStructWithCppAccessors_release_handle'));
-final _smoke_Structs_MutableStructWithCppAccessors_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsMutablestructwithcppaccessorsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_MutableStructWithCppAccessors_get_field_stringField'));
 Pointer<Void> smoke_Structs_MutableStructWithCppAccessors_toFfi(Structs_MutableStructWithCppAccessors value) {
-  final _stringField_handle = String_toFfi(value.stringField);
-  final _result = _smoke_Structs_MutableStructWithCppAccessors_create_handle(_stringField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _stringFieldHandle = String_toFfi(value.stringField);
+  final _result = _smokeStructsMutablestructwithcppaccessorsCreateHandle(_stringFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 Structs_MutableStructWithCppAccessors smoke_Structs_MutableStructWithCppAccessors_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_Structs_MutableStructWithCppAccessors_get_field_stringField(handle);
+  final _stringFieldHandle = _smokeStructsMutablestructwithcppaccessorsGetFieldstringField(handle);
   try {
     return Structs_MutableStructWithCppAccessors(
-      String_fromFfi(_stringField_handle)
+      String_fromFfi(_stringFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smoke_Structs_MutableStructWithCppAccessors_release_handle(handle);
+void smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle(Pointer<Void> handle) => _smokeStructsMutablestructwithcppaccessorsReleaseHandle(handle);
 // Nullable Structs_MutableStructWithCppAccessors
-final _smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_MutableStructWithCppAccessorsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable'));
-final _smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_MutableStructWithCppAccessorsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable'));
-final _smoke_Structs_MutableStructWithCppAccessors_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_Structs_MutableStructWithCppAccessorsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_MutableStructWithCppAccessors_get_value_nullable'));
 Pointer<Void> smoke_Structs_MutableStructWithCppAccessors_toFfi_nullable(Structs_MutableStructWithCppAccessors value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_Structs_MutableStructWithCppAccessors_toFfi(value);
-  final result = _smoke_Structs_MutableStructWithCppAccessors_create_handle_nullable(_handle);
+  final result = _smoke_Structs_MutableStructWithCppAccessorsCreateHandleNullable(_handle);
   smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle(_handle);
   return result;
 }
 Structs_MutableStructWithCppAccessors smoke_Structs_MutableStructWithCppAccessors_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_Structs_MutableStructWithCppAccessors_get_value_nullable(handle);
+  final _handle = _smoke_Structs_MutableStructWithCppAccessorsGetValueNullable(handle);
   final result = smoke_Structs_MutableStructWithCppAccessors_fromFfi(_handle);
   smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_Structs_MutableStructWithCppAccessors_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_MutableStructWithCppAccessors_release_handle_nullable(handle);
+  _smoke_Structs_MutableStructWithCppAccessorsReleaseHandleNullable(handle);
 // End of Structs_MutableStructWithCppAccessors "private" section.
 // Structs "private" section, not exported.
-final _smoke_Structs_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_copy_handle'));
-final _smoke_Structs_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_release_handle'));
@@ -757,75 +756,75 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_Structs_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeStructsReleaseHandle(handle);
     handle = null;
   }
   static Structs_Point swapPointCoordinates(Structs_Point input) {
-    final _swapPointCoordinates_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point'));
-    final _input_handle = smoke_Structs_Point_toFfi(input);
-    final __result_handle = _swapPointCoordinates_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_Structs_Point_releaseFfiHandle(_input_handle);
+    final _swapPointCoordinatesFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point'));
+    final _inputHandle = smoke_Structs_Point_toFfi(input);
+    final __resultHandle = _swapPointCoordinatesFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Structs_Point_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_Structs_Point_fromFfi(__result_handle);
+      return smoke_Structs_Point_fromFfi(__resultHandle);
     } finally {
-      smoke_Structs_Point_releaseFfiHandle(__result_handle);
+      smoke_Structs_Point_releaseFfiHandle(__resultHandle);
     }
   }
   static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) {
-    final _returnAllTypesStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_returnAllTypesStruct__AllTypesStruct'));
-    final _input_handle = smoke_Structs_AllTypesStruct_toFfi(input);
-    final __result_handle = _returnAllTypesStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_Structs_AllTypesStruct_releaseFfiHandle(_input_handle);
+    final _returnAllTypesStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_returnAllTypesStruct__AllTypesStruct'));
+    final _inputHandle = smoke_Structs_AllTypesStruct_toFfi(input);
+    final __resultHandle = _returnAllTypesStructFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_Structs_AllTypesStruct_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_Structs_AllTypesStruct_fromFfi(__result_handle);
+      return smoke_Structs_AllTypesStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_Structs_AllTypesStruct_releaseFfiHandle(__result_handle);
+      smoke_Structs_AllTypesStruct_releaseFfiHandle(__resultHandle);
     }
   }
   static Point createPoint(double x, double y) {
-    final _createPoint_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_Structs_createPoint__Double_Double'));
-    final _x_handle = (x);
-    final _y_handle = (y);
-    final __result_handle = _createPoint_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
-    (_x_handle);
-    (_y_handle);
+    final _createPointFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_Structs_createPoint__Double_Double'));
+    final _xHandle = (x);
+    final _yHandle = (y);
+    final __resultHandle = _createPointFfi(__lib.LibraryContext.isolateId, _xHandle, _yHandle);
+    (_xHandle);
+    (_yHandle);
     try {
-      return smoke_TypeCollection_Point_fromFfi(__result_handle);
+      return smoke_TypeCollection_Point_fromFfi(__resultHandle);
     } finally {
-      smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
+      smoke_TypeCollection_Point_releaseFfiHandle(__resultHandle);
     }
   }
   static AllTypesStruct modifyAllTypesStruct(AllTypesStruct input) {
-    final _modifyAllTypesStruct_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_modifyAllTypesStruct__AllTypesStruct'));
-    final _input_handle = smoke_TypeCollection_AllTypesStruct_toFfi(input);
-    final __result_handle = _modifyAllTypesStruct_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_input_handle);
+    final _modifyAllTypesStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_modifyAllTypesStruct__AllTypesStruct'));
+    final _inputHandle = smoke_TypeCollection_AllTypesStruct_toFfi(input);
+    final __resultHandle = _modifyAllTypesStructFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_TypeCollection_AllTypesStruct_fromFfi(__result_handle);
+      return smoke_TypeCollection_AllTypesStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(__result_handle);
+      smoke_TypeCollection_AllTypesStruct_releaseFfiHandle(__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_Structs_toFfi(Structs value) =>
-  _smoke_Structs_copy_handle((value as __lib.NativeBase).handle);
+  _smokeStructsCopyHandle((value as __lib.NativeBase).handle);
 Structs smoke_Structs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as Structs;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_Structs_copy_handle(handle);
-  final result = Structs$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeStructsCopyHandle(handle);
+  final result = Structs$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_Structs_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_Structs_release_handle(handle);
+  _smokeStructsReleaseHandle(handle);
 Pointer<Void> smoke_Structs_toFfi_nullable(Structs value) =>
   value != null ? smoke_Structs_toFfi(value) : Pointer<Void>.fromAddress(0);
 Structs smoke_Structs_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_Structs_fromFfi(handle) : null;
 void smoke_Structs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_Structs_release_handle(handle);
+  _smokeStructsReleaseHandle(handle);
 // End of Structs "private" section.

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/route_utils.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class Route {
@@ -12,71 +11,71 @@ class Route {
   static final RouteType defaultType = RouteType.equestrian;
 }
 // Route "private" section, not exported.
-final _smoke_StructsWithConstants_Route_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithconstantsRouteCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Uint32),
     Pointer<Void> Function(Pointer<Void>, int)
   >('library_smoke_StructsWithConstants_Route_create_handle'));
-final _smoke_StructsWithConstants_Route_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithconstantsRouteReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructsWithConstants_Route_release_handle'));
-final _smoke_StructsWithConstants_Route_get_field_description = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithconstantsRouteGetFielddescription = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithConstants_Route_get_field_description'));
-final _smoke_StructsWithConstants_Route_get_field_type = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithconstantsRouteGetFieldtype = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructsWithConstants_Route_get_field_type'));
 Pointer<Void> smoke_StructsWithConstants_Route_toFfi(Route value) {
-  final _description_handle = String_toFfi(value.description);
-  final _type_handle = smoke_RouteUtils_RouteType_toFfi(value.type);
-  final _result = _smoke_StructsWithConstants_Route_create_handle(_description_handle, _type_handle);
-  String_releaseFfiHandle(_description_handle);
-  smoke_RouteUtils_RouteType_releaseFfiHandle(_type_handle);
+  final _descriptionHandle = String_toFfi(value.description);
+  final _typeHandle = smoke_RouteUtils_RouteType_toFfi(value.type);
+  final _result = _smokeStructswithconstantsRouteCreateHandle(_descriptionHandle, _typeHandle);
+  String_releaseFfiHandle(_descriptionHandle);
+  smoke_RouteUtils_RouteType_releaseFfiHandle(_typeHandle);
   return _result;
 }
 Route smoke_StructsWithConstants_Route_fromFfi(Pointer<Void> handle) {
-  final _description_handle = _smoke_StructsWithConstants_Route_get_field_description(handle);
-  final _type_handle = _smoke_StructsWithConstants_Route_get_field_type(handle);
+  final _descriptionHandle = _smokeStructswithconstantsRouteGetFielddescription(handle);
+  final _typeHandle = _smokeStructswithconstantsRouteGetFieldtype(handle);
   try {
     return Route(
-      String_fromFfi(_description_handle),
-      smoke_RouteUtils_RouteType_fromFfi(_type_handle)
+      String_fromFfi(_descriptionHandle),
+      smoke_RouteUtils_RouteType_fromFfi(_typeHandle)
     );
   } finally {
-    String_releaseFfiHandle(_description_handle);
-    smoke_RouteUtils_RouteType_releaseFfiHandle(_type_handle);
+    String_releaseFfiHandle(_descriptionHandle);
+    smoke_RouteUtils_RouteType_releaseFfiHandle(_typeHandle);
   }
 }
-void smoke_StructsWithConstants_Route_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructsWithConstants_Route_release_handle(handle);
+void smoke_StructsWithConstants_Route_releaseFfiHandle(Pointer<Void> handle) => _smokeStructswithconstantsRouteReleaseHandle(handle);
 // Nullable Route
-final _smoke_StructsWithConstants_Route_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithConstants_RouteCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithConstants_Route_create_handle_nullable'));
-final _smoke_StructsWithConstants_Route_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithConstants_RouteReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructsWithConstants_Route_release_handle_nullable'));
-final _smoke_StructsWithConstants_Route_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithConstants_RouteGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithConstants_Route_get_value_nullable'));
 Pointer<Void> smoke_StructsWithConstants_Route_toFfi_nullable(Route value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructsWithConstants_Route_toFfi(value);
-  final result = _smoke_StructsWithConstants_Route_create_handle_nullable(_handle);
+  final result = _smoke_StructsWithConstants_RouteCreateHandleNullable(_handle);
   smoke_StructsWithConstants_Route_releaseFfiHandle(_handle);
   return result;
 }
 Route smoke_StructsWithConstants_Route_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructsWithConstants_Route_get_value_nullable(handle);
+  final _handle = _smoke_StructsWithConstants_RouteGetValueNullable(handle);
   final result = smoke_StructsWithConstants_Route_fromFfi(_handle);
   smoke_StructsWithConstants_Route_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructsWithConstants_Route_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructsWithConstants_Route_release_handle_nullable(handle);
+  _smoke_StructsWithConstants_RouteReleaseHandleNullable(handle);
 // End of Route "private" section.

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -1,22 +1,21 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/validation_utils.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
-final _copy_return_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copyReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_release_handle'));
-final _copy_return_get_result = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copyReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_result'));
-final _copy_return_get_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copyReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_error'));
-final _copy_return_has_error = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copyReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_has_error'));
@@ -29,157 +28,157 @@ class Vector {
   Vector.copy(Vector other) : this._copy(_copy(other));
   Vector.create(int input) : this._copy(_create(input));
   double distanceTo(Vector other) {
-    final _distanceTo_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>), double Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_distanceTo__Vector'));
-    final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
+    final _distanceToFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>), double Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_distanceTo__Vector'));
+    final _otherHandle = smoke_StructsWithMethods_Vector_toFfi(other);
     final _handle = smoke_StructsWithMethods_Vector_toFfi(this);
-    final __result_handle = _distanceTo_ffi(_handle, __lib.LibraryContext.isolateId, _other_handle);
+    final __resultHandle = _distanceToFfi(_handle, __lib.LibraryContext.isolateId, _otherHandle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_handle);
-    smoke_StructsWithMethods_Vector_releaseFfiHandle(_other_handle);
+    smoke_StructsWithMethods_Vector_releaseFfiHandle(_otherHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   Vector add(Vector other) {
-    final _add_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_add__Vector'));
-    final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
+    final _addFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_add__Vector'));
+    final _otherHandle = smoke_StructsWithMethods_Vector_toFfi(other);
     final _handle = smoke_StructsWithMethods_Vector_toFfi(this);
-    final __result_handle = _add_ffi(_handle, __lib.LibraryContext.isolateId, _other_handle);
+    final __resultHandle = _addFfi(_handle, __lib.LibraryContext.isolateId, _otherHandle);
     smoke_StructsWithMethods_Vector_releaseFfiHandle(_handle);
-    smoke_StructsWithMethods_Vector_releaseFfiHandle(_other_handle);
+    smoke_StructsWithMethods_Vector_releaseFfiHandle(_otherHandle);
     try {
-      return smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
+      return smoke_StructsWithMethods_Vector_fromFfi(__resultHandle);
     } finally {
-      smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
+      smoke_StructsWithMethods_Vector_releaseFfiHandle(__resultHandle);
     }
   }
   static bool validate(double x, double y) {
-    final _validate_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Double, Double), int Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_validate__Double_Double'));
-    final _x_handle = (x);
-    final _y_handle = (y);
-    final __result_handle = _validate_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
-    (_x_handle);
-    (_y_handle);
+    final _validateFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Double, Double), int Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_validate__Double_Double'));
+    final _xHandle = (x);
+    final _yHandle = (y);
+    final __resultHandle = _validateFfi(__lib.LibraryContext.isolateId, _xHandle, _yHandle);
+    (_xHandle);
+    (_yHandle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   static Vector _$init(double x, double y) {
-    final _$init_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_create__Double_Double'));
-    final _x_handle = (x);
-    final _y_handle = (y);
-    final __result_handle = _$init_ffi(__lib.LibraryContext.isolateId, _x_handle, _y_handle);
-    (_x_handle);
-    (_y_handle);
+    final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Double, Double), Pointer<Void> Function(int, double, double)>('library_smoke_StructsWithMethods_Vector_create__Double_Double'));
+    final _xHandle = (x);
+    final _yHandle = (y);
+    final __resultHandle = _$initFfi(__lib.LibraryContext.isolateId, _xHandle, _yHandle);
+    (_xHandle);
+    (_yHandle);
     try {
-      return smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
+      return smoke_StructsWithMethods_Vector_fromFfi(__resultHandle);
     } finally {
-      smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
+      smoke_StructsWithMethods_Vector_releaseFfiHandle(__resultHandle);
     }
   }
   static Vector _copy(Vector other) {
-    final _copy_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_create__Vector'));
-    final _other_handle = smoke_StructsWithMethods_Vector_toFfi(other);
-    final __call_result_handle = _copy_ffi(__lib.LibraryContext.isolateId, _other_handle);
-    smoke_StructsWithMethods_Vector_releaseFfiHandle(_other_handle);
-    if (_copy_return_has_error(__call_result_handle) != 0) {
-        final __error_handle = _copy_return_get_error(__call_result_handle);
-        _copy_return_release_handle(__call_result_handle);
+    final _copyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_create__Vector'));
+    final _otherHandle = smoke_StructsWithMethods_Vector_toFfi(other);
+    final __callResultHandle = _copyFfi(__lib.LibraryContext.isolateId, _otherHandle);
+    smoke_StructsWithMethods_Vector_releaseFfiHandle(_otherHandle);
+    if (_copyReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _copyReturnGetError(__callResultHandle);
+        _copyReturnReleaseHandle(__callResultHandle);
         try {
-          throw ValidationException(smoke_ValidationUtils_ValidationErrorCode_fromFfi(__error_handle));
+          throw ValidationException(smoke_ValidationUtils_ValidationErrorCode_fromFfi(__errorHandle));
         } finally {
-          smoke_ValidationUtils_ValidationErrorCode_releaseFfiHandle(__error_handle);
+          smoke_ValidationUtils_ValidationErrorCode_releaseFfiHandle(__errorHandle);
         }
     }
-    final __result_handle = _copy_return_get_result(__call_result_handle);
-    _copy_return_release_handle(__call_result_handle);
+    final __resultHandle = _copyReturnGetResult(__callResultHandle);
+    _copyReturnReleaseHandle(__callResultHandle);
     try {
-      return smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
+      return smoke_StructsWithMethods_Vector_fromFfi(__resultHandle);
     } finally {
-      smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
+      smoke_StructsWithMethods_Vector_releaseFfiHandle(__resultHandle);
     }
   }
   static Vector _create(int input) {
-    final _create_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_StructsWithMethods_Vector_create__ULong'));
-    final _input_handle = (input);
-    final __result_handle = _create_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_StructsWithMethods_Vector_create__ULong'));
+    final _inputHandle = (input);
+    final __resultHandle = _createFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return smoke_StructsWithMethods_Vector_fromFfi(__result_handle);
+      return smoke_StructsWithMethods_Vector_fromFfi(__resultHandle);
     } finally {
-      smoke_StructsWithMethods_Vector_releaseFfiHandle(__result_handle);
+      smoke_StructsWithMethods_Vector_releaseFfiHandle(__resultHandle);
     }
   }
 }
 // Vector "private" section, not exported.
-final _smoke_StructsWithMethods_Vector_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithmethodsVectorCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
   >('library_smoke_StructsWithMethods_Vector_create_handle'));
-final _smoke_StructsWithMethods_Vector_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithmethodsVectorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_release_handle'));
-final _smoke_StructsWithMethods_Vector_get_field_x = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithmethodsVectorGetFieldx = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_get_field_x'));
-final _smoke_StructsWithMethods_Vector_get_field_y = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructswithmethodsVectorGetFieldy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_get_field_y'));
 Pointer<Void> smoke_StructsWithMethods_Vector_toFfi(Vector value) {
-  final _x_handle = (value.x);
-  final _y_handle = (value.y);
-  final _result = _smoke_StructsWithMethods_Vector_create_handle(_x_handle, _y_handle);
-  (_x_handle);
-  (_y_handle);
+  final _xHandle = (value.x);
+  final _yHandle = (value.y);
+  final _result = _smokeStructswithmethodsVectorCreateHandle(_xHandle, _yHandle);
+  (_xHandle);
+  (_yHandle);
   return _result;
 }
 Vector smoke_StructsWithMethods_Vector_fromFfi(Pointer<Void> handle) {
-  final _x_handle = _smoke_StructsWithMethods_Vector_get_field_x(handle);
-  final _y_handle = _smoke_StructsWithMethods_Vector_get_field_y(handle);
+  final _xHandle = _smokeStructswithmethodsVectorGetFieldx(handle);
+  final _yHandle = _smokeStructswithmethodsVectorGetFieldy(handle);
   try {
     return Vector._(
-      (_x_handle),
-      (_y_handle)
+      (_xHandle),
+      (_yHandle)
     );
   } finally {
-    (_x_handle);
-    (_y_handle);
+    (_xHandle);
+    (_yHandle);
   }
 }
-void smoke_StructsWithMethods_Vector_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructsWithMethods_Vector_release_handle(handle);
+void smoke_StructsWithMethods_Vector_releaseFfiHandle(Pointer<Void> handle) => _smokeStructswithmethodsVectorReleaseHandle(handle);
 // Nullable Vector
-final _smoke_StructsWithMethods_Vector_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithMethods_VectorCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create_handle_nullable'));
-final _smoke_StructsWithMethods_Vector_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithMethods_VectorReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_release_handle_nullable'));
-final _smoke_StructsWithMethods_Vector_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructsWithMethods_VectorGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_get_value_nullable'));
 Pointer<Void> smoke_StructsWithMethods_Vector_toFfi_nullable(Vector value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructsWithMethods_Vector_toFfi(value);
-  final result = _smoke_StructsWithMethods_Vector_create_handle_nullable(_handle);
+  final result = _smoke_StructsWithMethods_VectorCreateHandleNullable(_handle);
   smoke_StructsWithMethods_Vector_releaseFfiHandle(_handle);
   return result;
 }
 Vector smoke_StructsWithMethods_Vector_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructsWithMethods_Vector_get_value_nullable(handle);
+  final _handle = _smoke_StructsWithMethods_VectorGetValueNullable(handle);
   final result = smoke_StructsWithMethods_Vector_fromFfi(_handle);
   smoke_StructsWithMethods_Vector_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructsWithMethods_Vector_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructsWithMethods_Vector_release_handle_nullable(handle);
+  _smoke_StructsWithMethods_VectorReleaseHandleNullable(handle);
 // End of Vector "private" section.

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class SomeClass {
@@ -21,11 +20,11 @@ class SomeClass {
   static var $class = SomeClass$Impl();
 }
 // SomeClass "private" section, not exported.
-final _smoke_SomeClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSomeclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SomeClass_copy_handle'));
-final _smoke_SomeClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeSomeclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SomeClass_release_handle'));
@@ -35,103 +34,103 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_SomeClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeSomeclassReleaseHandle(handle);
     handle = null;
   }
   SomeClass fooBar() {
     final result = SomeClass$Impl(_fooBar());
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(result));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(result));
     return result;
   }
   Pointer<Void> _fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SomeClass_fooBar'));
-    final __result_handle = _fooBar_ffi(__lib.LibraryContext.isolateId);
-    return __result_handle;
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SomeClass_fooBar'));
+    final __resultHandle = _fooBarFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
   }
   @override
   voidFunction() {
-    final _voidFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SomeClass_voidFunction'));
+    final _voidFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SomeClass_voidFunction'));
     final _handle = this.handle;
-    final __result_handle = _voidFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   bool boolFunction() {
-    final _boolFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SomeClass_boolFunction'));
+    final _boolFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SomeClass_boolFunction'));
     final _handle = this.handle;
-    final __result_handle = _boolFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _boolFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   int intFunction() {
-    final _intFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SomeClass_intFunction'));
+    final _intFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SomeClass_intFunction'));
     final _handle = this.handle;
-    final __result_handle = _intFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _intFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String stringFunction() {
-    final _stringFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SomeClass_stringFunction'));
+    final _stringFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SomeClass_stringFunction'));
     final _handle = this.handle;
-    final __result_handle = _stringFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _stringFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   SomeClass classFunction() {
-    final _classFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SomeClass_classFunction'));
+    final _classFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SomeClass_classFunction'));
     final _handle = this.handle;
-    final __result_handle = _classFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _classFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_SomeClass_fromFfi(__result_handle);
+      return smoke_SomeClass_fromFfi(__resultHandle);
     } finally {
-      smoke_SomeClass_releaseFfiHandle(__result_handle);
+      smoke_SomeClass_releaseFfiHandle(__resultHandle);
     }
   }
   staticFunction() {
-    final _staticFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_SomeClass_staticFunction'));
-    final __result_handle = _staticFunction_ffi(__lib.LibraryContext.isolateId);
+    final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_SomeClass_staticFunction'));
+    final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_SomeClass_toFfi(SomeClass value) =>
-  _smoke_SomeClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeSomeclassCopyHandle((value as __lib.NativeBase).handle);
 SomeClass smoke_SomeClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as SomeClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_SomeClass_copy_handle(handle);
-  final result = SomeClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeSomeclassCopyHandle(handle);
+  final result = SomeClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_SomeClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_SomeClass_release_handle(handle);
+  _smokeSomeclassReleaseHandle(handle);
 Pointer<Void> smoke_SomeClass_toFfi_nullable(SomeClass value) =>
   value != null ? smoke_SomeClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 SomeClass smoke_SomeClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_SomeClass_fromFfi(handle) : null;
 void smoke_SomeClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_SomeClass_release_handle(handle);
+  _smokeSomeclassReleaseHandle(handle);
 // End of SomeClass "private" section.

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithConstructor {
@@ -16,72 +15,72 @@ class StructWithConstructor$Impl {
   StructWithConstructor._copy(StructWithConstructor _other) : this._(_other.field);
   StructWithConstructor() : this._copy(_fooBar());
   StructWithConstructor _fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_StructWithConstructor_fooBar'));
-    final __result_handle = _fooBar_ffi(__lib.LibraryContext.isolateId);
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_StructWithConstructor_fooBar'));
+    final __resultHandle = _fooBarFfi(__lib.LibraryContext.isolateId);
     try {
-      return smoke_StructWithConstructor_fromFfi(__result_handle);
+      return smoke_StructWithConstructor_fromFfi(__resultHandle);
     } finally {
-      smoke_StructWithConstructor_releaseFfiHandle(__result_handle);
+      smoke_StructWithConstructor_releaseFfiHandle(__resultHandle);
     }
   }
 }
 // StructWithConstructor "private" section, not exported.
-final _smoke_StructWithConstructor_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithconstructorCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithConstructor_create_handle'));
-final _smoke_StructWithConstructor_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithconstructorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithConstructor_release_handle'));
-final _smoke_StructWithConstructor_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithconstructorGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithConstructor_get_field_field'));
 Pointer<Void> smoke_StructWithConstructor_toFfi(StructWithConstructor value) {
-  final _field_handle = String_toFfi(value.field);
-  final _result = _smoke_StructWithConstructor_create_handle(_field_handle);
-  String_releaseFfiHandle(_field_handle);
+  final _fieldHandle = String_toFfi(value.field);
+  final _result = _smokeStructwithconstructorCreateHandle(_fieldHandle);
+  String_releaseFfiHandle(_fieldHandle);
   return _result;
 }
 StructWithConstructor smoke_StructWithConstructor_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_StructWithConstructor_get_field_field(handle);
+  final _fieldHandle = _smokeStructwithconstructorGetFieldfield(handle);
   try {
     return StructWithConstructor._(
-      String_fromFfi(_field_handle)
+      String_fromFfi(_fieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_field_handle);
+    String_releaseFfiHandle(_fieldHandle);
   }
 }
-void smoke_StructWithConstructor_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithConstructor_release_handle(handle);
+void smoke_StructWithConstructor_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithconstructorReleaseHandle(handle);
 // Nullable StructWithConstructor
-final _smoke_StructWithConstructor_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithConstructorCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithConstructor_create_handle_nullable'));
-final _smoke_StructWithConstructor_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithConstructorReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithConstructor_release_handle_nullable'));
-final _smoke_StructWithConstructor_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithConstructorGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithConstructor_get_value_nullable'));
 Pointer<Void> smoke_StructWithConstructor_toFfi_nullable(StructWithConstructor value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithConstructor_toFfi(value);
-  final result = _smoke_StructWithConstructor_create_handle_nullable(_handle);
+  final result = _smoke_StructWithConstructorCreateHandleNullable(_handle);
   smoke_StructWithConstructor_releaseFfiHandle(_handle);
   return result;
 }
 StructWithConstructor smoke_StructWithConstructor_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithConstructor_get_value_nullable(handle);
+  final _handle = _smoke_StructWithConstructorGetValueNullable(handle);
   final result = smoke_StructWithConstructor_fromFfi(_handle);
   smoke_StructWithConstructor_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithConstructor_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithConstructor_release_handle_nullable(handle);
+  _smoke_StructWithConstructorReleaseHandleNullable(handle);
 // End of StructWithConstructor "private" section.

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithMethods {
@@ -18,127 +17,127 @@ class StructWithMethods$Impl {
   String field;
   StructWithMethods(this.field);
   voidFunction() {
-    final _voidFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_voidFunction'));
+    final _voidFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_voidFunction'));
     final _handle = smoke_StructWithMethods_toFfi(this);
-    final __result_handle = _voidFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_StructWithMethods_releaseFfiHandle(_handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   bool boolFunction() {
-    final _boolFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_boolFunction'));
+    final _boolFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_boolFunction'));
     final _handle = smoke_StructWithMethods_toFfi(this);
-    final __result_handle = _boolFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _boolFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_StructWithMethods_releaseFfiHandle(_handle);
     try {
-      return Boolean_fromFfi(__result_handle);
+      return Boolean_fromFfi(__resultHandle);
     } finally {
-      Boolean_releaseFfiHandle(__result_handle);
+      Boolean_releaseFfiHandle(__resultHandle);
     }
   }
   int intFunction() {
-    final _intFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_intFunction'));
+    final _intFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_intFunction'));
     final _handle = smoke_StructWithMethods_toFfi(this);
-    final __result_handle = _intFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _intFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_StructWithMethods_releaseFfiHandle(_handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   String stringFunction() {
-    final _stringFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_stringFunction'));
+    final _stringFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_stringFunction'));
     final _handle = smoke_StructWithMethods_toFfi(this);
-    final __result_handle = _stringFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _stringFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_StructWithMethods_releaseFfiHandle(_handle);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   StructWithMethods structFunction() {
-    final _structFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_structFunction'));
+    final _structFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_structFunction'));
     final _handle = smoke_StructWithMethods_toFfi(this);
-    final __result_handle = _structFunction_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _structFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_StructWithMethods_releaseFfiHandle(_handle);
     try {
-      return smoke_StructWithMethods_fromFfi(__result_handle);
+      return smoke_StructWithMethods_fromFfi(__resultHandle);
     } finally {
-      smoke_StructWithMethods_releaseFfiHandle(__result_handle);
+      smoke_StructWithMethods_releaseFfiHandle(__resultHandle);
     }
   }
   staticFunction() {
-    final _staticFunction_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_StructWithMethods_staticFunction'));
-    final __result_handle = _staticFunction_ffi(__lib.LibraryContext.isolateId);
+    final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_StructWithMethods_staticFunction'));
+    final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 // StructWithMethods "private" section, not exported.
-final _smoke_StructWithMethods_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithmethodsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithMethods_create_handle'));
-final _smoke_StructWithMethods_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithmethodsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithMethods_release_handle'));
-final _smoke_StructWithMethods_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeStructwithmethodsGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithMethods_get_field_field'));
 Pointer<Void> smoke_StructWithMethods_toFfi(StructWithMethods value) {
-  final _field_handle = String_toFfi(value.field);
-  final _result = _smoke_StructWithMethods_create_handle(_field_handle);
-  String_releaseFfiHandle(_field_handle);
+  final _fieldHandle = String_toFfi(value.field);
+  final _result = _smokeStructwithmethodsCreateHandle(_fieldHandle);
+  String_releaseFfiHandle(_fieldHandle);
   return _result;
 }
 StructWithMethods smoke_StructWithMethods_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_StructWithMethods_get_field_field(handle);
+  final _fieldHandle = _smokeStructwithmethodsGetFieldfield(handle);
   try {
     return StructWithMethods(
-      String_fromFfi(_field_handle)
+      String_fromFfi(_fieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_field_handle);
+    String_releaseFfiHandle(_fieldHandle);
   }
 }
-void smoke_StructWithMethods_releaseFfiHandle(Pointer<Void> handle) => _smoke_StructWithMethods_release_handle(handle);
+void smoke_StructWithMethods_releaseFfiHandle(Pointer<Void> handle) => _smokeStructwithmethodsReleaseHandle(handle);
 // Nullable StructWithMethods
-final _smoke_StructWithMethods_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithMethodsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithMethods_create_handle_nullable'));
-final _smoke_StructWithMethods_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithMethodsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructWithMethods_release_handle_nullable'));
-final _smoke_StructWithMethods_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_StructWithMethodsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructWithMethods_get_value_nullable'));
 Pointer<Void> smoke_StructWithMethods_toFfi_nullable(StructWithMethods value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_StructWithMethods_toFfi(value);
-  final result = _smoke_StructWithMethods_create_handle_nullable(_handle);
+  final result = _smoke_StructWithMethodsCreateHandleNullable(_handle);
   smoke_StructWithMethods_releaseFfiHandle(_handle);
   return result;
 }
 StructWithMethods smoke_StructWithMethods_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_StructWithMethods_get_value_nullable(handle);
+  final _handle = _smoke_StructWithMethodsGetValueNullable(handle);
   final result = smoke_StructWithMethods_fromFfi(_handle);
   smoke_StructWithMethods_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_StructWithMethods_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_StructWithMethods_release_handle_nullable(handle);
+  _smoke_StructWithMethodsReleaseHandleNullable(handle);
 // End of StructWithMethods "private" section.

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class TypeDefs {
@@ -27,135 +26,135 @@ class TypeDefs_StructHavingAliasFieldDefinedBelow {
   TypeDefs_StructHavingAliasFieldDefinedBelow(this.field);
 }
 // TypeDefs_StructHavingAliasFieldDefinedBelow "private" section, not exported.
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsStructhavingaliasfielddefinedbelowCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle'));
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsStructhavingaliasfielddefinedbelowReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle'));
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsStructhavingaliasfielddefinedbelowGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field'));
 Pointer<Void> smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi(TypeDefs_StructHavingAliasFieldDefinedBelow value) {
-  final _field_handle = (value.field);
-  final _result = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle(_field_handle);
-  (_field_handle);
+  final _fieldHandle = (value.field);
+  final _result = _smokeTypedefsStructhavingaliasfielddefinedbelowCreateHandle(_fieldHandle);
+  (_fieldHandle);
   return _result;
 }
 TypeDefs_StructHavingAliasFieldDefinedBelow smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_fromFfi(Pointer<Void> handle) {
-  final _field_handle = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field(handle);
+  final _fieldHandle = _smokeTypedefsStructhavingaliasfielddefinedbelowGetFieldfield(handle);
   try {
     return TypeDefs_StructHavingAliasFieldDefinedBelow(
-      (_field_handle)
+      (_fieldHandle)
     );
   } finally {
-    (_field_handle);
+    (_fieldHandle);
   }
 }
-void smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle(handle);
+void smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle(Pointer<Void> handle) => _smokeTypedefsStructhavingaliasfielddefinedbelowReleaseHandle(handle);
 // Nullable TypeDefs_StructHavingAliasFieldDefinedBelow
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelowCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable'));
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelowReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle_nullable'));
-final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_StructHavingAliasFieldDefinedBelowGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable'));
 Pointer<Void> smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi_nullable(TypeDefs_StructHavingAliasFieldDefinedBelow value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_toFfi(value);
-  final result = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_create_handle_nullable(_handle);
+  final result = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelowCreateHandleNullable(_handle);
   smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle(_handle);
   return result;
 }
 TypeDefs_StructHavingAliasFieldDefinedBelow smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable(handle);
+  final _handle = _smoke_TypeDefs_StructHavingAliasFieldDefinedBelowGetValueNullable(handle);
   final result = smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_fromFfi(_handle);
   smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_release_handle_nullable(handle);
+  _smoke_TypeDefs_StructHavingAliasFieldDefinedBelowReleaseHandleNullable(handle);
 // End of TypeDefs_StructHavingAliasFieldDefinedBelow "private" section.
 class TypeDefs_TestStruct {
   String something;
   TypeDefs_TestStruct(this.something);
 }
 // TypeDefs_TestStruct "private" section, not exported.
-final _smoke_TypeDefs_TestStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsTeststructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_create_handle'));
-final _smoke_TypeDefs_TestStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsTeststructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_release_handle'));
-final _smoke_TypeDefs_TestStruct_get_field_something = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsTeststructGetFieldsomething = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_get_field_something'));
 Pointer<Void> smoke_TypeDefs_TestStruct_toFfi(TypeDefs_TestStruct value) {
-  final _something_handle = String_toFfi(value.something);
-  final _result = _smoke_TypeDefs_TestStruct_create_handle(_something_handle);
-  String_releaseFfiHandle(_something_handle);
+  final _somethingHandle = String_toFfi(value.something);
+  final _result = _smokeTypedefsTeststructCreateHandle(_somethingHandle);
+  String_releaseFfiHandle(_somethingHandle);
   return _result;
 }
 TypeDefs_TestStruct smoke_TypeDefs_TestStruct_fromFfi(Pointer<Void> handle) {
-  final _something_handle = _smoke_TypeDefs_TestStruct_get_field_something(handle);
+  final _somethingHandle = _smokeTypedefsTeststructGetFieldsomething(handle);
   try {
     return TypeDefs_TestStruct(
-      String_fromFfi(_something_handle)
+      String_fromFfi(_somethingHandle)
     );
   } finally {
-    String_releaseFfiHandle(_something_handle);
+    String_releaseFfiHandle(_somethingHandle);
   }
 }
-void smoke_TypeDefs_TestStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_TypeDefs_TestStruct_release_handle(handle);
+void smoke_TypeDefs_TestStruct_releaseFfiHandle(Pointer<Void> handle) => _smokeTypedefsTeststructReleaseHandle(handle);
 // Nullable TypeDefs_TestStruct
-final _smoke_TypeDefs_TestStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_TestStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_create_handle_nullable'));
-final _smoke_TypeDefs_TestStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_TestStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_release_handle_nullable'));
-final _smoke_TypeDefs_TestStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_TypeDefs_TestStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_get_value_nullable'));
 Pointer<Void> smoke_TypeDefs_TestStruct_toFfi_nullable(TypeDefs_TestStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_TypeDefs_TestStruct_toFfi(value);
-  final result = _smoke_TypeDefs_TestStruct_create_handle_nullable(_handle);
+  final result = _smoke_TypeDefs_TestStructCreateHandleNullable(_handle);
   smoke_TypeDefs_TestStruct_releaseFfiHandle(_handle);
   return result;
 }
 TypeDefs_TestStruct smoke_TypeDefs_TestStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_TypeDefs_TestStruct_get_value_nullable(handle);
+  final _handle = _smoke_TypeDefs_TestStructGetValueNullable(handle);
   final result = smoke_TypeDefs_TestStruct_fromFfi(_handle);
   smoke_TypeDefs_TestStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_TypeDefs_TestStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypeDefs_TestStruct_release_handle_nullable(handle);
+  _smoke_TypeDefs_TestStructReleaseHandleNullable(handle);
 // End of TypeDefs_TestStruct "private" section.
 // TypeDefs "private" section, not exported.
-final _smoke_TypeDefs_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_copy_handle'));
-final _smoke_TypeDefs_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeTypedefsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypeDefs_release_handle'));
@@ -165,119 +164,119 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_TypeDefs_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeTypedefsReleaseHandle(handle);
     handle = null;
   }
   static double methodWithPrimitiveTypeDef(double input) {
-    final _methodWithPrimitiveTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
-    final _input_handle = (input);
-    final __result_handle = _methodWithPrimitiveTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _methodWithPrimitiveTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
+    final _inputHandle = (input);
+    final __resultHandle = _methodWithPrimitiveTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
-    final _methodWithComplexTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct'));
-    final _input_handle = foobar_ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
-    final __result_handle = _methodWithComplexTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    foobar_ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
+    final _methodWithComplexTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_1smoke_1TypeDefs_1TestStruct'));
+    final _inputHandle = foobar_ListOf_smoke_TypeDefs_TestStruct_toFfi(input);
+    final __resultHandle = _methodWithComplexTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    foobar_ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(_inputHandle);
     try {
-      return foobar_ListOf_smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+      return foobar_ListOf_smoke_TypeDefs_TestStruct_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+      foobar_ListOf_smoke_TypeDefs_TestStruct_releaseFfiHandle(__resultHandle);
     }
   }
   static double returnNestedIntTypeDef(double input) {
-    final _returnNestedIntTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double'));
-    final _input_handle = (input);
-    final __result_handle = _returnNestedIntTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    (_input_handle);
+    final _returnNestedIntTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double'));
+    final _inputHandle = (input);
+    final __resultHandle = _returnNestedIntTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    (_inputHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
-    final _returnTestStructTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct'));
-    final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
-    final __result_handle = _returnTestStructTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
+    final _returnTestStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct'));
+    final _inputHandle = smoke_TypeDefs_TestStruct_toFfi(input);
+    final __resultHandle = _returnTestStructTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_TypeDefs_TestStruct_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+      return smoke_TypeDefs_TestStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+      smoke_TypeDefs_TestStruct_releaseFfiHandle(__resultHandle);
     }
   }
   static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
-    final _returnNestedStructTypeDef_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct'));
-    final _input_handle = smoke_TypeDefs_TestStruct_toFfi(input);
-    final __result_handle = _returnNestedStructTypeDef_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_TypeDefs_TestStruct_releaseFfiHandle(_input_handle);
+    final _returnNestedStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct'));
+    final _inputHandle = smoke_TypeDefs_TestStruct_toFfi(input);
+    final __resultHandle = _returnNestedStructTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_TypeDefs_TestStruct_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_TypeDefs_TestStruct_fromFfi(__result_handle);
+      return smoke_TypeDefs_TestStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_TypeDefs_TestStruct_releaseFfiHandle(__result_handle);
+      smoke_TypeDefs_TestStruct_releaseFfiHandle(__resultHandle);
     }
   }
   static Point returnTypeDefPointFromTypeCollection(Point input) {
-    final _returnTypeDefPointFromTypeCollection_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point'));
-    final _input_handle = smoke_TypeCollection_Point_toFfi(input);
-    final __result_handle = _returnTypeDefPointFromTypeCollection_ffi(__lib.LibraryContext.isolateId, _input_handle);
-    smoke_TypeCollection_Point_releaseFfiHandle(_input_handle);
+    final _returnTypeDefPointFromTypeCollectionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point'));
+    final _inputHandle = smoke_TypeCollection_Point_toFfi(input);
+    final __resultHandle = _returnTypeDefPointFromTypeCollectionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    smoke_TypeCollection_Point_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_TypeCollection_Point_fromFfi(__result_handle);
+      return smoke_TypeCollection_Point_fromFfi(__resultHandle);
     } finally {
-      smoke_TypeCollection_Point_releaseFfiHandle(__result_handle);
+      smoke_TypeCollection_Point_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   List<double> get primitiveTypeProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return foobar_ListOf_Double_fromFfi(__result_handle);
+      return foobar_ListOf_Double_fromFfi(__resultHandle);
     } finally {
-      foobar_ListOf_Double_releaseFfiHandle(__result_handle);
+      foobar_ListOf_Double_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set primitiveTypeProperty(List<double> value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double'));
-    final _value_handle = foobar_ListOf_Double_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double'));
+    final _valueHandle = foobar_ListOf_Double_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    foobar_ListOf_Double_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobar_ListOf_Double_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_TypeDefs_toFfi(TypeDefs value) =>
-  _smoke_TypeDefs_copy_handle((value as __lib.NativeBase).handle);
+  _smokeTypedefsCopyHandle((value as __lib.NativeBase).handle);
 TypeDefs smoke_TypeDefs_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as TypeDefs;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_TypeDefs_copy_handle(handle);
-  final result = TypeDefs$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeTypedefsCopyHandle(handle);
+  final result = TypeDefs$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_TypeDefs_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_TypeDefs_release_handle(handle);
+  _smokeTypedefsReleaseHandle(handle);
 Pointer<Void> smoke_TypeDefs_toFfi_nullable(TypeDefs value) =>
   value != null ? smoke_TypeDefs_toFfi(value) : Pointer<Void>.fromAddress(0);
 TypeDefs smoke_TypeDefs_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_TypeDefs_fromFfi(handle) : null;
 void smoke_TypeDefs_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_TypeDefs_release_handle(handle);
+  _smokeTypedefsReleaseHandle(handle);
 // End of TypeDefs "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
@@ -16,11 +15,11 @@ abstract class InternalClass {
   internal_fooBar();
 }
 // InternalClass "private" section, not exported.
-final _smoke_InternalClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalClass_copy_handle'));
-final _smoke_InternalClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClass_release_handle'));
@@ -30,40 +29,40 @@ class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_InternalClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeInternalclassReleaseHandle(handle);
     handle = null;
   }
   @override
   internal_fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));
     final _handle = this.handle;
-    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_InternalClass_toFfi(InternalClass value) =>
-  _smoke_InternalClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokeInternalclassCopyHandle((value as __lib.NativeBase).handle);
 InternalClass smoke_InternalClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as InternalClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_InternalClass_copy_handle(handle);
-  final result = InternalClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeInternalclassCopyHandle(handle);
+  final result = InternalClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_InternalClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_InternalClass_release_handle(handle);
+  _smokeInternalclassReleaseHandle(handle);
 Pointer<Void> smoke_InternalClass_toFfi_nullable(InternalClass value) =>
   value != null ? smoke_InternalClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 InternalClass smoke_InternalClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClass_fromFfi(handle) : null;
 void smoke_InternalClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_InternalClass_release_handle(handle);
+  _smokeInternalclassReleaseHandle(handle);
 // End of InternalClass "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
@@ -20,11 +19,11 @@ abstract class InternalClassWithFunctions {
   internal_fooBar();
 }
 // InternalClassWithFunctions "private" section, not exported.
-final _smoke_InternalClassWithFunctions_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclasswithfunctionsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalClassWithFunctions_copy_handle'));
-final _smoke_InternalClassWithFunctions_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclasswithfunctionsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithFunctions_release_handle'));
@@ -34,58 +33,58 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_InternalClassWithFunctions_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeInternalclasswithfunctionsReleaseHandle(handle);
     handle = null;
   }
   InternalClassWithFunctions$Impl.internal_make() : super(_make()) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   InternalClassWithFunctions$Impl.internal_remake(String foo) : super(_remake(foo)) {
-    __lib.ffi_cache_token(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
+    __lib.ffiCacheToken(handle, __lib.LibraryContext.isolateId, __lib.cacheObject(this));
   }
   @override
   internal_fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar'));
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar'));
     final _handle = this.handle;
-    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   static Pointer<Void> _make() {
-    final _make_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithFunctions_make'));
-    final __result_handle = _make_ffi(__lib.LibraryContext.isolateId);
-    return __result_handle;
+    final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithFunctions_make'));
+    final __resultHandle = _makeFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
   }
   static Pointer<Void> _remake(String foo) {
-    final _remake_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_InternalClassWithFunctions_make__String'));
-    final _foo_handle = String_toFfi(foo);
-    final __result_handle = _remake_ffi(__lib.LibraryContext.isolateId, _foo_handle);
-    String_releaseFfiHandle(_foo_handle);
-    return __result_handle;
+    final _remakeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_InternalClassWithFunctions_make__String'));
+    final _fooHandle = String_toFfi(foo);
+    final __resultHandle = _remakeFfi(__lib.LibraryContext.isolateId, _fooHandle);
+    String_releaseFfiHandle(_fooHandle);
+    return __resultHandle;
   }
 }
 Pointer<Void> smoke_InternalClassWithFunctions_toFfi(InternalClassWithFunctions value) =>
-  _smoke_InternalClassWithFunctions_copy_handle((value as __lib.NativeBase).handle);
+  _smokeInternalclasswithfunctionsCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithFunctions smoke_InternalClassWithFunctions_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as InternalClassWithFunctions;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_InternalClassWithFunctions_copy_handle(handle);
-  final result = InternalClassWithFunctions$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeInternalclasswithfunctionsCopyHandle(handle);
+  final result = InternalClassWithFunctions$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_InternalClassWithFunctions_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_InternalClassWithFunctions_release_handle(handle);
+  _smokeInternalclasswithfunctionsReleaseHandle(handle);
 Pointer<Void> smoke_InternalClassWithFunctions_toFfi_nullable(InternalClassWithFunctions value) =>
   value != null ? smoke_InternalClassWithFunctions_toFfi(value) : Pointer<Void>.fromAddress(0);
 InternalClassWithFunctions smoke_InternalClassWithFunctions_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClassWithFunctions_fromFfi(handle) : null;
 void smoke_InternalClassWithFunctions_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_InternalClassWithFunctions_release_handle(handle);
+  _smokeInternalclasswithfunctionsReleaseHandle(handle);
 // End of InternalClassWithFunctions "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
@@ -18,11 +17,11 @@ abstract class InternalClassWithStaticProperty {
   static set internal_fooBar(String value) { InternalClassWithStaticProperty$Impl.internal_fooBar = value; }
 }
 // InternalClassWithStaticProperty "private" section, not exported.
-final _smoke_InternalClassWithStaticProperty_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclasswithstaticpropertyCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalClassWithStaticProperty_copy_handle'));
-final _smoke_InternalClassWithStaticProperty_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalclasswithstaticpropertyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithStaticProperty_release_handle'));
@@ -32,49 +31,49 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_InternalClassWithStaticProperty_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeInternalclasswithstaticpropertyReleaseHandle(handle);
     handle = null;
   }
   static String get internal_fooBar {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));
-    final __result_handle = _get_ffi(__lib.LibraryContext.isolateId);
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));
+    final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   static set internal_fooBar(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String'));
-    final _value_handle = String_toFfi(value);
-    final __result_handle = _set_ffi(__lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String'));
+    final _valueHandle = String_toFfi(value);
+    final __resultHandle = _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi(InternalClassWithStaticProperty value) =>
-  _smoke_InternalClassWithStaticProperty_copy_handle((value as __lib.NativeBase).handle);
+  _smokeInternalclasswithstaticpropertyCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithStaticProperty smoke_InternalClassWithStaticProperty_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as InternalClassWithStaticProperty;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_InternalClassWithStaticProperty_copy_handle(handle);
-  final result = InternalClassWithStaticProperty$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokeInternalclasswithstaticpropertyCopyHandle(handle);
+  final result = InternalClassWithStaticProperty$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_InternalClassWithStaticProperty_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_InternalClassWithStaticProperty_release_handle(handle);
+  _smokeInternalclasswithstaticpropertyReleaseHandle(handle);
 Pointer<Void> smoke_InternalClassWithStaticProperty_toFfi_nullable(InternalClassWithStaticProperty value) =>
   value != null ? smoke_InternalClassWithStaticProperty_toFfi(value) : Pointer<Void>.fromAddress(0);
 InternalClassWithStaticProperty smoke_InternalClassWithStaticProperty_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalClassWithStaticProperty_fromFfi(handle) : null;
 void smoke_InternalClassWithStaticProperty_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_InternalClassWithStaticProperty_release_handle(handle);
+  _smokeInternalclasswithstaticpropertyReleaseHandle(handle);
 // End of InternalClassWithStaticProperty "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -3,12 +3,11 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalInterface {
-  InternalInterface() {}
+  InternalInterface();
   factory InternalInterface.fromLambdas({
     @required void Function() lambda_fooBar,
   }) => InternalInterface$Lambdas(
@@ -23,19 +22,19 @@ abstract class InternalInterface {
   internal_fooBar();
 }
 // InternalInterface "private" section, not exported.
-final _smoke_InternalInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalInterface_copy_handle'));
-final _smoke_InternalInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalInterface_release_handle'));
-final _smoke_InternalInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer, Pointer),
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_InternalInterface_create_proxy'));
-final _smoke_InternalInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokeInternalinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalInterface_get_type_id'));
@@ -56,19 +55,19 @@ class InternalInterface$Impl extends __lib.NativeBase implements InternalInterfa
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_InternalInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokeInternalinterfaceReleaseHandle(handle);
     handle = null;
   }
   @override
   internal_fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));
     final _handle = this.handle;
-    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
@@ -80,8 +79,8 @@ int _InternalInterface_fooBar_static(int _token) {
   return 0;
 }
 Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
-  if (value is __lib.NativeBase) return _smoke_InternalInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_InternalInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokeInternalinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeInternalinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
@@ -91,25 +90,25 @@ Pointer<Void> smoke_InternalInterface_toFfi(InternalInterface value) {
 }
 InternalInterface smoke_InternalInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as InternalInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_InternalInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_InternalInterface_copy_handle(handle);
+  final _typeIdHandle = _smokeInternalinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeInternalinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : InternalInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : InternalInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_InternalInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_InternalInterface_release_handle(handle);
+  _smokeInternalinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_InternalInterface_toFfi_nullable(InternalInterface value) =>
   value != null ? smoke_InternalInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 InternalInterface smoke_InternalInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_InternalInterface_fromFfi(handle) : null;
 void smoke_InternalInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_InternalInterface_release_handle(handle);
+  _smokeInternalinterfaceReleaseHandle(handle);
 // End of InternalInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PublicClass {
@@ -52,34 +51,34 @@ PublicClass_InternalEnum smoke_PublicClass_InternalEnum_fromFfi(int handle) {
   }
 }
 void smoke_PublicClass_InternalEnum_releaseFfiHandle(int handle) {}
-final _smoke_PublicClass_InternalEnum_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
   >('library_smoke_PublicClass_InternalEnum_create_handle_nullable'));
-final _smoke_PublicClass_InternalEnum_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalEnumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalEnum_release_handle_nullable'));
-final _smoke_PublicClass_InternalEnum_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalEnumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalEnum_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_InternalEnum_toFfi_nullable(PublicClass_InternalEnum value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_InternalEnum_toFfi(value);
-  final result = _smoke_PublicClass_InternalEnum_create_handle_nullable(_handle);
+  final result = _smoke_PublicClass_InternalEnumCreateHandleNullable(_handle);
   smoke_PublicClass_InternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 PublicClass_InternalEnum smoke_PublicClass_InternalEnum_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PublicClass_InternalEnum_get_value_nullable(handle);
+  final _handle = _smoke_PublicClass_InternalEnumGetValueNullable(handle);
   final result = smoke_PublicClass_InternalEnum_fromFfi(_handle);
   smoke_PublicClass_InternalEnum_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PublicClass_InternalEnum_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicClass_InternalEnum_release_handle_nullable(handle);
+  _smoke_PublicClass_InternalEnumReleaseHandleNullable(handle);
 // End of PublicClass_InternalEnum "private" section.
 /// @nodoc
 class PublicClass_InternalStruct {
@@ -88,64 +87,64 @@ class PublicClass_InternalStruct {
   PublicClass_InternalStruct(this.internal_stringField);
 }
 // PublicClass_InternalStruct "private" section, not exported.
-final _smoke_PublicClass_InternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_create_handle'));
-final _smoke_PublicClass_InternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassInternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_release_handle'));
-final _smoke_PublicClass_InternalStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassInternalstructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_get_field_stringField'));
 Pointer<Void> smoke_PublicClass_InternalStruct_toFfi(PublicClass_InternalStruct value) {
-  final _stringField_handle = String_toFfi(value.internal_stringField);
-  final _result = _smoke_PublicClass_InternalStruct_create_handle(_stringField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _stringFieldHandle = String_toFfi(value.internal_stringField);
+  final _result = _smokePublicclassInternalstructCreateHandle(_stringFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 PublicClass_InternalStruct smoke_PublicClass_InternalStruct_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_PublicClass_InternalStruct_get_field_stringField(handle);
+  final _stringFieldHandle = _smokePublicclassInternalstructGetFieldstringField(handle);
   try {
     return PublicClass_InternalStruct(
-      String_fromFfi(_stringField_handle)
+      String_fromFfi(_stringFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_PublicClass_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_InternalStruct_release_handle(handle);
+void smoke_PublicClass_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smokePublicclassInternalstructReleaseHandle(handle);
 // Nullable PublicClass_InternalStruct
-final _smoke_PublicClass_InternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_create_handle_nullable'));
-final _smoke_PublicClass_InternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_release_handle_nullable'));
-final _smoke_PublicClass_InternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_InternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_InternalStruct_toFfi_nullable(PublicClass_InternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_InternalStruct_toFfi(value);
-  final result = _smoke_PublicClass_InternalStruct_create_handle_nullable(_handle);
+  final result = _smoke_PublicClass_InternalStructCreateHandleNullable(_handle);
   smoke_PublicClass_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 PublicClass_InternalStruct smoke_PublicClass_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PublicClass_InternalStruct_get_value_nullable(handle);
+  final _handle = _smoke_PublicClass_InternalStructGetValueNullable(handle);
   final result = smoke_PublicClass_InternalStruct_fromFfi(_handle);
   smoke_PublicClass_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PublicClass_InternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicClass_InternalStruct_release_handle_nullable(handle);
+  _smoke_PublicClass_InternalStructReleaseHandleNullable(handle);
 // End of PublicClass_InternalStruct "private" section.
 class PublicClass_PublicStruct {
   /// @nodoc
@@ -153,64 +152,64 @@ class PublicClass_PublicStruct {
   PublicClass_PublicStruct(this.internal_internalField);
 }
 // PublicClass_PublicStruct "private" section, not exported.
-final _smoke_PublicClass_PublicStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassPublicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_create_handle'));
-final _smoke_PublicClass_PublicStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassPublicstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_release_handle'));
-final _smoke_PublicClass_PublicStruct_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassPublicstructGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_get_field_internalField'));
 Pointer<Void> smoke_PublicClass_PublicStruct_toFfi(PublicClass_PublicStruct value) {
-  final _internalField_handle = smoke_PublicClass_InternalStruct_toFfi(value.internal_internalField);
-  final _result = _smoke_PublicClass_PublicStruct_create_handle(_internalField_handle);
-  smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalField_handle);
+  final _internalFieldHandle = smoke_PublicClass_InternalStruct_toFfi(value.internal_internalField);
+  final _result = _smokePublicclassPublicstructCreateHandle(_internalFieldHandle);
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalFieldHandle);
   return _result;
 }
 PublicClass_PublicStruct smoke_PublicClass_PublicStruct_fromFfi(Pointer<Void> handle) {
-  final _internalField_handle = _smoke_PublicClass_PublicStruct_get_field_internalField(handle);
+  final _internalFieldHandle = _smokePublicclassPublicstructGetFieldinternalField(handle);
   try {
     return PublicClass_PublicStruct(
-      smoke_PublicClass_InternalStruct_fromFfi(_internalField_handle)
+      smoke_PublicClass_InternalStruct_fromFfi(_internalFieldHandle)
     );
   } finally {
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalField_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_internalFieldHandle);
   }
 }
-void smoke_PublicClass_PublicStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStruct_release_handle(handle);
+void smoke_PublicClass_PublicStruct_releaseFfiHandle(Pointer<Void> handle) => _smokePublicclassPublicstructReleaseHandle(handle);
 // Nullable PublicClass_PublicStruct
-final _smoke_PublicClass_PublicStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_create_handle_nullable'));
-final _smoke_PublicClass_PublicStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_release_handle_nullable'));
-final _smoke_PublicClass_PublicStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_PublicStruct_toFfi_nullable(PublicClass_PublicStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_PublicStruct_toFfi(value);
-  final result = _smoke_PublicClass_PublicStruct_create_handle_nullable(_handle);
+  final result = _smoke_PublicClass_PublicStructCreateHandleNullable(_handle);
   smoke_PublicClass_PublicStruct_releaseFfiHandle(_handle);
   return result;
 }
 PublicClass_PublicStruct smoke_PublicClass_PublicStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PublicClass_PublicStruct_get_value_nullable(handle);
+  final _handle = _smoke_PublicClass_PublicStructGetValueNullable(handle);
   final result = smoke_PublicClass_PublicStruct_fromFfi(_handle);
   smoke_PublicClass_PublicStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PublicClass_PublicStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicClass_PublicStruct_release_handle_nullable(handle);
+  _smoke_PublicClass_PublicStructReleaseHandleNullable(handle);
 // End of PublicClass_PublicStruct "private" section.
 class PublicClass_PublicStructWithInternalDefaults {
   /// @nodoc
@@ -221,80 +220,80 @@ class PublicClass_PublicStructWithInternalDefaults {
     : internal_internalField = "foo", publicField = publicField;
 }
 // PublicClass_PublicStructWithInternalDefaults "private" section, not exported.
-final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassPublicstructwithinternaldefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Float),
     Pointer<Void> Function(Pointer<Void>, double)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_create_handle'));
-final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassPublicstructwithinternaldefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_release_handle'));
-final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassPublicstructwithinternaldefaultsGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField'));
-final _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassPublicstructwithinternaldefaultsGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField'));
 Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(PublicClass_PublicStructWithInternalDefaults value) {
-  final _internalField_handle = String_toFfi(value.internal_internalField);
-  final _publicField_handle = (value.publicField);
-  final _result = _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle(_internalField_handle, _publicField_handle);
-  String_releaseFfiHandle(_internalField_handle);
-  (_publicField_handle);
+  final _internalFieldHandle = String_toFfi(value.internal_internalField);
+  final _publicFieldHandle = (value.publicField);
+  final _result = _smokePublicclassPublicstructwithinternaldefaultsCreateHandle(_internalFieldHandle, _publicFieldHandle);
+  String_releaseFfiHandle(_internalFieldHandle);
+  (_publicFieldHandle);
   return _result;
 }
 PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi(Pointer<Void> handle) {
-  final _internalField_handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_internalField(handle);
-  final _publicField_handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField(handle);
+  final _internalFieldHandle = _smokePublicclassPublicstructwithinternaldefaultsGetFieldinternalField(handle);
+  final _publicFieldHandle = _smokePublicclassPublicstructwithinternaldefaultsGetFieldpublicField(handle);
   try {
     return PublicClass_PublicStructWithInternalDefaults(
-      String_fromFfi(_internalField_handle),
-      (_publicField_handle)
+      String_fromFfi(_internalFieldHandle),
+      (_publicFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_internalField_handle);
-    (_publicField_handle);
+    String_releaseFfiHandle(_internalFieldHandle);
+    (_publicFieldHandle);
   }
 }
-void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle(handle);
+void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(Pointer<Void> handle) => _smokePublicclassPublicstructwithinternaldefaultsReleaseHandle(handle);
 // Nullable PublicClass_PublicStructWithInternalDefaults
-final _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructWithInternalDefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable'));
-final _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructWithInternalDefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable'));
-final _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicClass_PublicStructWithInternalDefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable'));
 Pointer<Void> smoke_PublicClass_PublicStructWithInternalDefaults_toFfi_nullable(PublicClass_PublicStructWithInternalDefaults value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicClass_PublicStructWithInternalDefaults_toFfi(value);
-  final result = _smoke_PublicClass_PublicStructWithInternalDefaults_create_handle_nullable(_handle);
+  final result = _smoke_PublicClass_PublicStructWithInternalDefaultsCreateHandleNullable(_handle);
   smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(_handle);
   return result;
 }
 PublicClass_PublicStructWithInternalDefaults smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable(handle);
+  final _handle = _smoke_PublicClass_PublicStructWithInternalDefaultsGetValueNullable(handle);
   final result = smoke_PublicClass_PublicStructWithInternalDefaults_fromFfi(_handle);
   smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PublicClass_PublicStructWithInternalDefaults_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicClass_PublicStructWithInternalDefaults_release_handle_nullable(handle);
+  _smoke_PublicClass_PublicStructWithInternalDefaultsReleaseHandleNullable(handle);
 // End of PublicClass_PublicStructWithInternalDefaults "private" section.
 // PublicClass "private" section, not exported.
-final _smoke_PublicClass_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_copy_handle'));
-final _smoke_PublicClass_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_release_handle'));
@@ -304,90 +303,90 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_PublicClass_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokePublicclassReleaseHandle(handle);
     handle = null;
   }
   @override
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input) {
-    final _internalMethod_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct'));
-    final _input_handle = smoke_PublicClass_InternalStruct_toFfi(input);
+    final _internalMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct'));
+    final _inputHandle = smoke_PublicClass_InternalStruct_toFfi(input);
     final _handle = this.handle;
-    final __result_handle = _internalMethod_ffi(_handle, __lib.LibraryContext.isolateId, _input_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(_input_handle);
+    final __resultHandle = _internalMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_inputHandle);
     try {
-      return smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+      return smoke_PublicClass_InternalStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+      smoke_PublicClass_InternalStruct_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   PublicClass_InternalStruct get internal_internalStructProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalStructProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalStructProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return smoke_PublicClass_InternalStruct_fromFfi(__result_handle);
+      return smoke_PublicClass_InternalStruct_fromFfi(__resultHandle);
     } finally {
-      smoke_PublicClass_InternalStruct_releaseFfiHandle(__result_handle);
+      smoke_PublicClass_InternalStruct_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set internal_internalStructProperty(PublicClass_InternalStruct value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct'));
-    final _value_handle = smoke_PublicClass_InternalStruct_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct'));
+    final _valueHandle = smoke_PublicClass_InternalStruct_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
   @override
   String get internalSetterProperty {
-    final _get_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalSetterProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalSetterProperty_get'));
     final _handle = this.handle;
-    final __result_handle = _get_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
-      return String_fromFfi(__result_handle);
+      return String_fromFfi(__resultHandle);
     } finally {
-      String_releaseFfiHandle(__result_handle);
+      String_releaseFfiHandle(__resultHandle);
     }
   }
   @override
   set internal_internalSetterProperty(String value) {
-    final _set_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String'));
-    final _value_handle = String_toFfi(value);
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String'));
+    final _valueHandle = String_toFfi(value);
     final _handle = this.handle;
-    final __result_handle = _set_ffi(_handle, __lib.LibraryContext.isolateId, _value_handle);
-    String_releaseFfiHandle(_value_handle);
+    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    String_releaseFfiHandle(_valueHandle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 Pointer<Void> smoke_PublicClass_toFfi(PublicClass value) =>
-  _smoke_PublicClass_copy_handle((value as __lib.NativeBase).handle);
+  _smokePublicclassCopyHandle((value as __lib.NativeBase).handle);
 PublicClass smoke_PublicClass_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as PublicClass;
   if (instance != null) return instance;
-  final _copied_handle = _smoke_PublicClass_copy_handle(handle);
-  final result = PublicClass$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+  final _copiedHandle = _smokePublicclassCopyHandle(handle);
+  final result = PublicClass$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_PublicClass_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PublicClass_release_handle(handle);
+  _smokePublicclassReleaseHandle(handle);
 Pointer<Void> smoke_PublicClass_toFfi_nullable(PublicClass value) =>
   value != null ? smoke_PublicClass_toFfi(value) : Pointer<Void>.fromAddress(0);
 PublicClass smoke_PublicClass_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PublicClass_fromFfi(handle) : null;
 void smoke_PublicClass_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicClass_release_handle(handle);
+  _smokePublicclassReleaseHandle(handle);
 // End of PublicClass "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/public_class.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PublicInterface {
@@ -21,79 +20,79 @@ class PublicInterface_InternalStruct {
   PublicInterface_InternalStruct(this.internal_fieldOfInternalType);
 }
 // PublicInterface_InternalStruct "private" section, not exported.
-final _smoke_PublicInterface_InternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicinterfaceInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_create_handle'));
-final _smoke_PublicInterface_InternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicinterfaceInternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_release_handle'));
-final _smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicinterfaceInternalstructGetFieldfieldOfInternalType = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType'));
 Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi(PublicInterface_InternalStruct value) {
-  final _fieldOfInternalType_handle = smoke_PublicClass_InternalStruct_toFfi(value.internal_fieldOfInternalType);
-  final _result = _smoke_PublicInterface_InternalStruct_create_handle(_fieldOfInternalType_handle);
-  smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalType_handle);
+  final _fieldOfInternalTypeHandle = smoke_PublicClass_InternalStruct_toFfi(value.internal_fieldOfInternalType);
+  final _result = _smokePublicinterfaceInternalstructCreateHandle(_fieldOfInternalTypeHandle);
+  smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalTypeHandle);
   return _result;
 }
 PublicInterface_InternalStruct smoke_PublicInterface_InternalStruct_fromFfi(Pointer<Void> handle) {
-  final _fieldOfInternalType_handle = _smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType(handle);
+  final _fieldOfInternalTypeHandle = _smokePublicinterfaceInternalstructGetFieldfieldOfInternalType(handle);
   try {
     return PublicInterface_InternalStruct(
-      smoke_PublicClass_InternalStruct_fromFfi(_fieldOfInternalType_handle)
+      smoke_PublicClass_InternalStruct_fromFfi(_fieldOfInternalTypeHandle)
     );
   } finally {
-    smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalType_handle);
+    smoke_PublicClass_InternalStruct_releaseFfiHandle(_fieldOfInternalTypeHandle);
   }
 }
-void smoke_PublicInterface_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicInterface_InternalStruct_release_handle(handle);
+void smoke_PublicInterface_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smokePublicinterfaceInternalstructReleaseHandle(handle);
 // Nullable PublicInterface_InternalStruct
-final _smoke_PublicInterface_InternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicInterface_InternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_create_handle_nullable'));
-final _smoke_PublicInterface_InternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicInterface_InternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_release_handle_nullable'));
-final _smoke_PublicInterface_InternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicInterface_InternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicInterface_InternalStruct_toFfi_nullable(PublicInterface_InternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicInterface_InternalStruct_toFfi(value);
-  final result = _smoke_PublicInterface_InternalStruct_create_handle_nullable(_handle);
+  final result = _smoke_PublicInterface_InternalStructCreateHandleNullable(_handle);
   smoke_PublicInterface_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 PublicInterface_InternalStruct smoke_PublicInterface_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PublicInterface_InternalStruct_get_value_nullable(handle);
+  final _handle = _smoke_PublicInterface_InternalStructGetValueNullable(handle);
   final result = smoke_PublicInterface_InternalStruct_fromFfi(_handle);
   smoke_PublicInterface_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PublicInterface_InternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicInterface_InternalStruct_release_handle_nullable(handle);
+  _smoke_PublicInterface_InternalStructReleaseHandleNullable(handle);
 // End of PublicInterface_InternalStruct "private" section.
 // PublicInterface "private" section, not exported.
-final _smoke_PublicInterface_copy_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_copy_handle'));
-final _smoke_PublicInterface_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicInterface_release_handle'));
-final _smoke_PublicInterface_create_proxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Int32, Pointer),
     Pointer<Void> Function(int, int, Pointer)
   >('library_smoke_PublicInterface_create_proxy'));
-final _smoke_PublicInterface_get_type_id = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_get_type_id'));
@@ -103,14 +102,14 @@ class PublicInterface$Impl extends __lib.NativeBase implements PublicInterface {
   void release() {
     if (handle == null) return;
     __lib.uncacheObject(this);
-    __lib.ffi_uncache_token(handle, __lib.LibraryContext.isolateId);
-    _smoke_PublicInterface_release_handle(handle);
+    __lib.ffiUncacheToken(handle, __lib.LibraryContext.isolateId);
+    _smokePublicinterfaceReleaseHandle(handle);
     handle = null;
   }
 }
 Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
-  if (value is __lib.NativeBase) return _smoke_PublicInterface_copy_handle((value as __lib.NativeBase).handle);
-  final result = _smoke_PublicInterface_create_proxy(
+  if (value is __lib.NativeBase) return _smokePublicinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokePublicinterfaceCreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi
@@ -119,25 +118,25 @@ Pointer<Void> smoke_PublicInterface_toFfi(PublicInterface value) {
 }
 PublicInterface smoke_PublicInterface_fromFfi(Pointer<Void> handle) {
   final isolateId = __lib.LibraryContext.isolateId;
-  final token = __lib.ffi_get_cached_token(handle, isolateId);
+  final token = __lib.ffiGetCachedToken(handle, isolateId);
   final instance = __lib.instanceCache[token] as PublicInterface;
   if (instance != null) return instance;
-  final _type_id_handle = _smoke_PublicInterface_get_type_id(handle);
-  final factoryConstructor = __lib.typeRepository[String_fromFfi(_type_id_handle)];
-  String_releaseFfiHandle(_type_id_handle);
-  final _copied_handle = _smoke_PublicInterface_copy_handle(handle);
+  final _typeIdHandle = _smokePublicinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[String_fromFfi(_typeIdHandle)];
+  String_releaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokePublicinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
-    ? factoryConstructor(_copied_handle)
-    : PublicInterface$Impl(_copied_handle);
-  __lib.ffi_cache_token(_copied_handle, isolateId, __lib.cacheObject(result));
+    ? factoryConstructor(_copiedHandle)
+    : PublicInterface$Impl(_copiedHandle);
+  __lib.ffiCacheToken(_copiedHandle, isolateId, __lib.cacheObject(result));
   return result;
 }
 void smoke_PublicInterface_releaseFfiHandle(Pointer<Void> handle) =>
-  _smoke_PublicInterface_release_handle(handle);
+  _smokePublicinterfaceReleaseHandle(handle);
 Pointer<Void> smoke_PublicInterface_toFfi_nullable(PublicInterface value) =>
   value != null ? smoke_PublicInterface_toFfi(value) : Pointer<Void>.fromAddress(0);
 PublicInterface smoke_PublicInterface_fromFfi_nullable(Pointer<Void> handle) =>
   handle.address != 0 ? smoke_PublicInterface_fromFfi(handle) : null;
 void smoke_PublicInterface_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicInterface_release_handle(handle);
+  _smokePublicinterfaceReleaseHandle(handle);
 // End of PublicInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class PublicStructWithNonDefaultInternalField {
@@ -13,80 +12,80 @@ class PublicStructWithNonDefaultInternalField {
     : defaultedField = 42, internal_internalField = internalField, publicField = publicField;
 }
 // PublicStructWithNonDefaultInternalField "private" section, not exported.
-final _smoke_PublicStructWithNonDefaultInternalField_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicstructwithnondefaultinternalfieldCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Pointer<Void>, Uint8),
     Pointer<Void> Function(int, Pointer<Void>, int)
   >('library_smoke_PublicStructWithNonDefaultInternalField_create_handle'));
-final _smoke_PublicStructWithNonDefaultInternalField_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicstructwithnondefaultinternalfieldReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_release_handle'));
-final _smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicstructwithnondefaultinternalfieldGetFielddefaultedField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Int32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField'));
-final _smoke_PublicStructWithNonDefaultInternalField_get_field_internalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicstructwithnondefaultinternalfieldGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_internalField'));
-final _smoke_PublicStructWithNonDefaultInternalField_get_field_publicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublicstructwithnondefaultinternalfieldGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_publicField'));
 Pointer<Void> smoke_PublicStructWithNonDefaultInternalField_toFfi(PublicStructWithNonDefaultInternalField value) {
-  final _defaultedField_handle = (value.defaultedField);
-  final _internalField_handle = String_toFfi(value.internal_internalField);
-  final _publicField_handle = Boolean_toFfi(value.publicField);
-  final _result = _smoke_PublicStructWithNonDefaultInternalField_create_handle(_defaultedField_handle, _internalField_handle, _publicField_handle);
-  (_defaultedField_handle);
-  String_releaseFfiHandle(_internalField_handle);
-  Boolean_releaseFfiHandle(_publicField_handle);
+  final _defaultedFieldHandle = (value.defaultedField);
+  final _internalFieldHandle = String_toFfi(value.internal_internalField);
+  final _publicFieldHandle = Boolean_toFfi(value.publicField);
+  final _result = _smokePublicstructwithnondefaultinternalfieldCreateHandle(_defaultedFieldHandle, _internalFieldHandle, _publicFieldHandle);
+  (_defaultedFieldHandle);
+  String_releaseFfiHandle(_internalFieldHandle);
+  Boolean_releaseFfiHandle(_publicFieldHandle);
   return _result;
 }
 PublicStructWithNonDefaultInternalField smoke_PublicStructWithNonDefaultInternalField_fromFfi(Pointer<Void> handle) {
-  final _defaultedField_handle = _smoke_PublicStructWithNonDefaultInternalField_get_field_defaultedField(handle);
-  final _internalField_handle = _smoke_PublicStructWithNonDefaultInternalField_get_field_internalField(handle);
-  final _publicField_handle = _smoke_PublicStructWithNonDefaultInternalField_get_field_publicField(handle);
+  final _defaultedFieldHandle = _smokePublicstructwithnondefaultinternalfieldGetFielddefaultedField(handle);
+  final _internalFieldHandle = _smokePublicstructwithnondefaultinternalfieldGetFieldinternalField(handle);
+  final _publicFieldHandle = _smokePublicstructwithnondefaultinternalfieldGetFieldpublicField(handle);
   try {
     return PublicStructWithNonDefaultInternalField(
-      (_defaultedField_handle),
-      String_fromFfi(_internalField_handle),
-      Boolean_fromFfi(_publicField_handle)
+      (_defaultedFieldHandle),
+      String_fromFfi(_internalFieldHandle),
+      Boolean_fromFfi(_publicFieldHandle)
     );
   } finally {
-    (_defaultedField_handle);
-    String_releaseFfiHandle(_internalField_handle);
-    Boolean_releaseFfiHandle(_publicField_handle);
+    (_defaultedFieldHandle);
+    String_releaseFfiHandle(_internalFieldHandle);
+    Boolean_releaseFfiHandle(_publicFieldHandle);
   }
 }
-void smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicStructWithNonDefaultInternalField_release_handle(handle);
+void smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle(Pointer<Void> handle) => _smokePublicstructwithnondefaultinternalfieldReleaseHandle(handle);
 // Nullable PublicStructWithNonDefaultInternalField
-final _smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicStructWithNonDefaultInternalFieldCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable'));
-final _smoke_PublicStructWithNonDefaultInternalField_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicStructWithNonDefaultInternalFieldReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_release_handle_nullable'));
-final _smoke_PublicStructWithNonDefaultInternalField_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicStructWithNonDefaultInternalFieldGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicStructWithNonDefaultInternalField_get_value_nullable'));
 Pointer<Void> smoke_PublicStructWithNonDefaultInternalField_toFfi_nullable(PublicStructWithNonDefaultInternalField value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicStructWithNonDefaultInternalField_toFfi(value);
-  final result = _smoke_PublicStructWithNonDefaultInternalField_create_handle_nullable(_handle);
+  final result = _smoke_PublicStructWithNonDefaultInternalFieldCreateHandleNullable(_handle);
   smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle(_handle);
   return result;
 }
 PublicStructWithNonDefaultInternalField smoke_PublicStructWithNonDefaultInternalField_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PublicStructWithNonDefaultInternalField_get_value_nullable(handle);
+  final _handle = _smoke_PublicStructWithNonDefaultInternalFieldGetValueNullable(handle);
   final result = smoke_PublicStructWithNonDefaultInternalField_fromFfi(_handle);
   smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PublicStructWithNonDefaultInternalField_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicStructWithNonDefaultInternalField_release_handle_nullable(handle);
+  _smoke_PublicStructWithNonDefaultInternalFieldReleaseHandleNullable(handle);
 // End of PublicStructWithNonDefaultInternalField "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:ffi/ffi.dart';
 import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
@@ -10,74 +9,74 @@ class InternalStruct {
   InternalStruct(this.internal_stringField);
   /// @nodoc
   internal_fooBar() {
-    final _fooBar_ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PublicTypeCollection_InternalStruct_fooBar'));
+    final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PublicTypeCollection_InternalStruct_fooBar'));
     final _handle = smoke_PublicTypeCollection_InternalStruct_toFfi(this);
-    final __result_handle = _fooBar_ffi(_handle, __lib.LibraryContext.isolateId);
+    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
     smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(_handle);
     try {
-      return (__result_handle);
+      return (__resultHandle);
     } finally {
-      (__result_handle);
+      (__resultHandle);
     }
   }
 }
 // InternalStruct "private" section, not exported.
-final _smoke_PublicTypeCollection_InternalStruct_create_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublictypecollectionInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicTypeCollection_InternalStruct_create_handle'));
-final _smoke_PublicTypeCollection_InternalStruct_release_handle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublictypecollectionInternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicTypeCollection_InternalStruct_release_handle'));
-final _smoke_PublicTypeCollection_InternalStruct_get_field_stringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smokePublictypecollectionInternalstructGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicTypeCollection_InternalStruct_get_field_stringField'));
 Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi(InternalStruct value) {
-  final _stringField_handle = String_toFfi(value.internal_stringField);
-  final _result = _smoke_PublicTypeCollection_InternalStruct_create_handle(_stringField_handle);
-  String_releaseFfiHandle(_stringField_handle);
+  final _stringFieldHandle = String_toFfi(value.internal_stringField);
+  final _result = _smokePublictypecollectionInternalstructCreateHandle(_stringFieldHandle);
+  String_releaseFfiHandle(_stringFieldHandle);
   return _result;
 }
 InternalStruct smoke_PublicTypeCollection_InternalStruct_fromFfi(Pointer<Void> handle) {
-  final _stringField_handle = _smoke_PublicTypeCollection_InternalStruct_get_field_stringField(handle);
+  final _stringFieldHandle = _smokePublictypecollectionInternalstructGetFieldstringField(handle);
   try {
     return InternalStruct(
-      String_fromFfi(_stringField_handle)
+      String_fromFfi(_stringFieldHandle)
     );
   } finally {
-    String_releaseFfiHandle(_stringField_handle);
+    String_releaseFfiHandle(_stringFieldHandle);
   }
 }
-void smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smoke_PublicTypeCollection_InternalStruct_release_handle(handle);
+void smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(Pointer<Void> handle) => _smokePublictypecollectionInternalstructReleaseHandle(handle);
 // Nullable InternalStruct
-final _smoke_PublicTypeCollection_InternalStruct_create_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicTypeCollection_InternalStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicTypeCollection_InternalStruct_create_handle_nullable'));
-final _smoke_PublicTypeCollection_InternalStruct_release_handle_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicTypeCollection_InternalStructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicTypeCollection_InternalStruct_release_handle_nullable'));
-final _smoke_PublicTypeCollection_InternalStruct_get_value_nullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _smoke_PublicTypeCollection_InternalStructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicTypeCollection_InternalStruct_get_value_nullable'));
 Pointer<Void> smoke_PublicTypeCollection_InternalStruct_toFfi_nullable(InternalStruct value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smoke_PublicTypeCollection_InternalStruct_toFfi(value);
-  final result = _smoke_PublicTypeCollection_InternalStruct_create_handle_nullable(_handle);
+  final result = _smoke_PublicTypeCollection_InternalStructCreateHandleNullable(_handle);
   smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 InternalStruct smoke_PublicTypeCollection_InternalStruct_fromFfi_nullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
-  final _handle = _smoke_PublicTypeCollection_InternalStruct_get_value_nullable(handle);
+  final _handle = _smoke_PublicTypeCollection_InternalStructGetValueNullable(handle);
   final result = smoke_PublicTypeCollection_InternalStruct_fromFfi(_handle);
   smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle(_handle);
   return result;
 }
 void smoke_PublicTypeCollection_InternalStruct_releaseFfiHandle_nullable(Pointer<Void> handle) =>
-  _smoke_PublicTypeCollection_InternalStruct_release_handle_nullable(handle);
+  _smoke_PublicTypeCollection_InternalStructReleaseHandleNullable(handle);
 // End of InternalStruct "private" section.


### PR DESCRIPTION
Updated Dart templates to remove unused "package:ffi/ffi.dart" from most of them. Updated Dart generator to exclude the
self-import from generic types conversion file.

Updated Dart templates to use FFI names converted to lowerCamelCase for variable names.

Smoke tests are updated in a separate commit.

See: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
