### PR TITLE
Run Dart functional tests on Ubuntu 20 on CI

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -201,10 +201,9 @@ jobs:
           ./scripts/build-swift-namerules --publish
         working-directory: functional-tests
 
-
   dart:
     name: Dart
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -243,7 +242,7 @@ jobs:
 
   dart-asan:
     name: Dart with AddressSanitizer
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -280,6 +279,8 @@ jobs:
           export PATH=${PATH}:${PWD}/depot_tools:${DART_BIN}
           DART_VERSION=2.12.0
           if [ ! -d "${DART_ROOT}/bin" ]; then
+            sudo apt install -y python2
+            sudo update-alternatives --install /usr/bin/python python /usr/bin/python2 1
             git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
             mkdir dart-sdk
             pushd dart-sdk

--- a/functional-tests/functional/dart/CMakeLists.txt
+++ b/functional-tests/functional/dart/CMakeLists.txt
@@ -53,6 +53,7 @@ add_custom_target(test_dart ALL
 add_test(NAME unit_tests_dart COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_dart $<TARGET_FILE:functional>)
 
 if(BUILD_DART_WITH_ASAN)
+    find_library(LIBASAN NAMES asan libasan.so.5 libasan.so.4 REQUIRED)
     set_tests_properties(unit_tests_dart PROPERTIES
-        ENVIRONMENT "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libasan.so.4")
+        ENVIRONMENT "LD_PRELOAD=${LIBASAN}")
 endif()


### PR DESCRIPTION
Recent update to GitHub Actions CI image for Ubuntu 18 broke one of the functional tests for Dart. The same test does
not fail locally, does not fail on the old image (which is no longer accessible), and does not fail on Ubuntu 20.
Considering all of the above, this looks to be a CI configuration problem, not an issue in the generated code.

As a workaround, updated CI config to use Ubuntu 20 image for Dart functional tests CI jobs. Also updated CMake script
for these tests to autodetect "libasan" path, as it differs slightly between different versions of Ubuntu.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>