### PR TITLE
Fix more "dart analyze" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed another batch of Dart warnings from "dart analyze" static analysis tool.
+
 ## 8.13.3
 Release date: 2021-05-12
 ### Bug fixes:

--- a/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
@@ -109,15 +109,15 @@ final _localeReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_locale_release_handle'));
-final LocaleGetLanguageCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeGetLanguageCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('{{libraryName}}_locale_get_language_code'));
-final LocaleGetCountryCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeGetCountryCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('{{libraryName}}_locale_get_country_code'));
-final LocaleGetScriptCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeGetScriptCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('{{libraryName}}_locale_get_script_code'));
@@ -151,9 +151,9 @@ Locale localeFromFfi(Pointer<Void> handle) {
     return Locale.parse(Utf8.fromUtf8(languageTagCstring));
   }
 
-  final Pointer<Utf8> languageCodeCstring = LocaleGetLanguageCode(handle);
-  final Pointer<Utf8> countryCodeCstring = LocaleGetCountryCode(handle);
-  final Pointer<Utf8> scriptCodeCstring = LocaleGetScriptCode(handle);
+  final Pointer<Utf8> languageCodeCstring = _localeGetLanguageCode(handle);
+  final Pointer<Utf8> countryCodeCstring = _localeGetCountryCode(handle);
+  final Pointer<Utf8> scriptCodeCstring = _localeGetScriptCode(handle);
 
   return Locale.fromSubtags(
     languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -198,7 +198,7 @@ void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
     try {
       _{{resolveName}}Cache = {{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
     } finally {
-      {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
+      {{#set varName="__resultHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
     }
     _{{resolveName}}IsCached = true;
   }

--- a/gluecodium/src/main/resources/templates/dart/DartFfiReleaseHandle.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFfiReleaseHandle.mustache
@@ -18,14 +18,12 @@
   ! License-Filename: LICENSE
   !
   !}}
-__lib.LazyList(
-  {{varName}},
-  _{{resolveName container "Ffi"}}{{resolveName elementType "Ffi"}}LazyListGetSize({{varName}}),
-  (index) {
-    final __elementHandle = _{{resolveName container "Ffi"}}{{resolveName elementType "Ffi"}}LazyListGet({{varName}}, index);
-    final __elementResult = {{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__elementHandle);
-    {{#set varName="__elementHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
-    return __elementResult;
-  },
-  () => _{{resolveName container "Ffi"}}{{resolveName elementType "Ffi"}}LazyListReleaseHandle({{varName}})
-)
+{{#typeRef.type.actualType}}{{!!
+}}{{#instanceOf this "LimeBasicType"}}{{!!
+}}{{#if typeRef.isNullable}}{{resolveName typeId.toString "Ffi"}}ReleaseFfiHandleNullable({{varName}});{{/if}}{{!!
+}}{{#unless typeRef.isNullable}}{{#unless typeId.isNumericType}}{{!!
+}}{{#isNotEq typeId.toString "Void"}}{{resolveName typeId.toString "Ffi"}}ReleaseFfiHandle({{varName}});{{/isNotEq}}{{!!
+}}{{/unless}}{{/unless}}{{/instanceOf}}{{!!
+}}{{#notInstanceOf this "LimeBasicType"}}{{!!
+}}{{resolveName "Ffi"}}ReleaseFfiHandle{{#if typeRef.isNullable}}Nullable{{/if}}({{varName}});{{/notInstanceOf}}{{!!
+}}{{/typeRef.type.actualType}}

--- a/gluecodium/src/main/resources/templates/dart/DartFile.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFile.mustache
@@ -25,7 +25,6 @@
 {{/imports}}
 
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 
 import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
 

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -33,7 +33,7 @@
 {{#if isStruct}}{{#unless isStatic}}  {{resolveName parent "Ffi"}}ReleaseFfiHandle(_handle);
 {{/unless}}{{/if}}{{!!
 }}{{#parameters}}
-  {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle);
+  {{#resolveName}}{{#setJoin "varName" "_" this "Handle" delimiter=""}}{{>dart/DartFfiReleaseHandle}}{{/setJoin}}{{/resolveName}}
 {{/parameters}}
 {{#if thrownType}}
   if (_{{resolveName}}ReturnHasError(__callResultHandle) != 0) {
@@ -42,7 +42,7 @@
       try {
         throw {{resolveName exception}}({{#set call="FromFfi" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__errorHandle));
       } finally {
-        {{#set call="ReleaseFfiHandle" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__errorHandle);
+        {{#set typeRef=exception.errorType varName="__errorHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
       }
   }
   final __resultHandle = _{{resolveName}}ReturnGetResult(__callResultHandle);
@@ -70,7 +70,7 @@
 {{/if}}{{#unless typeRef.attributes.optimized}}try {
     return {{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
   } finally {
-    {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(__resultHandle);
+    {{#set varName="__resultHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
   }
 {{/unless}}{{/returnType}}{{!!
 }}{{/ffiReturnConversion}}

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -89,15 +89,15 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
     final _keyHandle = {{#set typeRef=keyType call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(entry.key);
     final _valueHandle = {{#set typeRef=valueType call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(entry.value);
     _{{resolveName "Ffi"}}Put(_result, _keyHandle, _valueHandle);
-    {{#set typeRef=keyType call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_keyHandle);
-    {{#set typeRef=valueType call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_valueHandle);
+    {{#set typeRef=keyType varName="_keyHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
+    {{#set typeRef=valueType varName="_valueHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
   }
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
   for (final element in value) {
     final _elementHandle = {{#set typeRef=elementType call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(element);
     _{{resolveName "Ffi"}}Insert(_result, _elementHandle);
-    {{#set typeRef=elementType call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_elementHandle);
+    {{#set typeRef=elementType varName="_elementHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
   }
 {{/notInstanceOf}}
   return _result;
@@ -115,8 +115,8 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
       result[{{#set typeRef=keyType call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_keyHandle)] =
         {{#set typeRef=valueType call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_valueHandle);
     } finally {
-      {{#set typeRef=keyType call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_keyHandle);
-      {{#set typeRef=valueType call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_valueHandle);
+      {{#set typeRef=keyType varName="_keyHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
+      {{#set typeRef=valueType varName="_valueHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
     }
 {{/instanceOf}}{{!!
 }}{{#notInstanceOf this "LimeMap"}}
@@ -124,7 +124,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
     try {
       result.add({{#set typeRef=elementType call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_elementHandle));
     } finally {
-      {{#set typeRef=elementType call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_elementHandle);
+      {{#set typeRef=elementType varName="_elementHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
     }
 {{/notInstanceOf}}
     _{{resolveName "Ffi"}}IteratorIncrement(_iteratorHandle);

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -177,7 +177,7 @@ int _{{resolveName parent}}{{resolveName}}Static({{!!
 {{#if thrownType}}
   bool _errorFlag = false;
 {{/if}}{{#unless returnType.isVoid}}
-  {{resolveName returnType.typeRef}} _resultObject = null;{{/unless}}
+  {{resolveName returnType.typeRef}} _resultObject;{{/unless}}
   try {
     {{#unless returnType.isVoid}}_resultObject = {{/unless}}{{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
@@ -197,7 +197,7 @@ int _{{resolveName parent}}{{resolveName}}Static({{!!
 {{/if}}
   } finally {
 {{#parameters}}
-    {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
+    {{#resolveName}}{{#set varName=this}}{{>dart/DartFfiReleaseHandle}}{{/set}}{{/resolveName}}
 {{/parameters}}{{!!
 }}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
     if (_resultObject != null) _resultObject.release();
@@ -222,7 +222,7 @@ int _{{resolveName parent}}{{resolveName}}SetStatic(int _token, {{resolveName ty
     (__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}} =
       {{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
   } finally {
-    {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
+    {{#set varName="_value"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
   }
   return 0;
 }

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -37,7 +37,6 @@ final _{{resolveName "Ffi"}}CreateProxy = __lib.catchArgumentError(() => __lib.n
   >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_create_proxy'));
 
 class {{resolveName}}$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   {{resolveName}}$Impl(this.handle);
 
@@ -48,21 +47,21 @@ class {{resolveName}}$Impl {
 {{/asFunction}}{{/set}}
 }
 
-{{#set parent=this}}{{#asFunction}}
-int _{{resolveName parent}}{{resolveName}}Static({{!!
+{{#set lambda=this}}{{#asFunction}}
+int _{{resolveName lambda "Ffi"}}{{resolveName}}Static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}) {
   {{#unless returnType.isVoid}}{{resolveName returnType.typeRef}} _resultObject;{{/unless}}
   try {
     {{#unless returnType.isVoid}}_resultObject = {{/unless}}{{!!
-  }}(__lib.instanceCache[_token] as {{resolveName parent}})({{#parameters}}{{!!
+  }}(__lib.instanceCache[_token] as {{resolveName lambda}})({{#parameters}}{{!!
   }}{{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#unless returnType.isVoid}}
     _result.value = {{#returnType}}{{#set call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_resultObject);{{/unless}}
   } finally {
 {{#parameters}}
-    {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
+    {{#resolveName}}{{#set varName=this}}{{>dart/DartFfiReleaseHandle}}{{/set}}{{/resolveName}}
 {{/parameters}}{{#instanceOf returnType.typeRef.type.actualType "LimeClass"}}
     if (_resultObject != null) _resultObject.release();
 {{/instanceOf}}{{#instanceOf returnType.typeRef.type.actualType "LimeInterface"}}
@@ -77,8 +76,8 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
   final result = _{{resolveName "Ffi"}}CreateProxy(
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
-    __lib.uncacheObjectFfi,{{#set parent=this}}{{#asFunction}}
-    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}{{resolveName}}Static, __lib.unknownError){{/asFunction}}{{/set}}
+    __lib.uncacheObjectFfi,{{#set lambda=this}}{{#asFunction}}
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName lambda "Ffi"}}{{resolveName}}Static, __lib.unknownError){{/asFunction}}{{/set}}
   );
 
   return result;

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -122,7 +122,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/unless}}{{/fields}}
   final _result = _{{resolveName "Ffi"}}CreateHandle({{#fields}}_{{resolveName}}Handle{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{#fields}}{{#unless typeRef.attributes.optimized}}
-  {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle);
+  {{#resolveName}}{{#setJoin "varName" "_" this "Handle" delimiter=""}}{{>dart/DartFfiReleaseHandle}}{{/setJoin}}{{/resolveName}}
 {{/unless}}{{/fields}}
   return _result;
 }
@@ -156,7 +156,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/unless}}
   } finally {
 {{#fields}}{{#unless typeRef.attributes.optimized}}
-    {{#set call="ReleaseFfiHandle"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle);
+    {{#resolveName}}{{#setJoin "varName" "_" this "Handle" delimiter=""}}{{>dart/DartFfiReleaseHandle}}{{/setJoin}}{{/resolveName}}
 {{/unless}}{{/fields}}
   }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnClass
 abstract class AttributesClass {
@@ -49,7 +48,6 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @OnPropertyInClass
@@ -75,7 +73,6 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnException
 class AttributesCrashException implements Exception {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnEnumeration
 enum AttributesEnum {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnInterface
 abstract class AttributesInterface {
@@ -87,7 +87,6 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @OnPropertyInInterface
@@ -111,7 +110,6 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -1,7 +1,5 @@
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnLambda
 typedef AttributesLambda = void Function();
@@ -19,7 +17,6 @@ final _smokeAttributeslambdaCreateProxy = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_AttributesLambda_create_proxy'));
 class AttributesLambda$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   AttributesLambda$Impl(this.handle);
   void release() => _smokeAttributeslambdaReleaseHandle(handle);
@@ -30,11 +27,10 @@ class AttributesLambda$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _AttributesLambdacallStatic(int _token) {
+int _smokeAttributeslambdacallStatic(int _token) {
   try {
     (__lib.instanceCache[_token] as AttributesLambda)();
   } finally {
@@ -46,7 +42,7 @@ Pointer<Void> smokeAttributeslambdaToFfi(AttributesLambda value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64)>(_AttributesLambdacallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64)>(_smokeAttributeslambdacallStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @OnStruct
 class AttributesStruct {
@@ -20,7 +19,6 @@ class AttributesStruct {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// Class comment
 @OnClass
@@ -119,7 +118,6 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @OnPropertyInClass
@@ -145,7 +143,6 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("")
 @OnClass
@@ -118,7 +117,6 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @OnPropertyInClass
@@ -144,7 +142,6 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -1,8 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class MultipleAttributesDart {
   /// Destroys the underlying native object.
@@ -58,7 +56,6 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -69,7 +66,6 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -80,7 +76,6 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -91,7 +86,6 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -102,7 +96,6 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -1,8 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SpecialAttributes {
   /// Destroys the underlying native object.
@@ -42,7 +40,6 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -53,7 +50,6 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
@@ -66,15 +66,15 @@ final _localeReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_locale_release_handle'));
-final LocaleGetLanguageCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeGetLanguageCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_language_code'));
-final LocaleGetCountryCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeGetCountryCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_country_code'));
-final LocaleGetScriptCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _localeGetScriptCode = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Utf8> Function(Pointer<Void>),
     Pointer<Utf8> Function(Pointer<Void>)
 >('library_locale_get_script_code'));
@@ -102,9 +102,9 @@ Locale localeFromFfi(Pointer<Void> handle) {
     // BCP 47 language tag takes precedence if present.
     return Locale.parse(Utf8.fromUtf8(languageTagCstring));
   }
-  final Pointer<Utf8> languageCodeCstring = LocaleGetLanguageCode(handle);
-  final Pointer<Utf8> countryCodeCstring = LocaleGetCountryCode(handle);
-  final Pointer<Utf8> scriptCodeCstring = LocaleGetScriptCode(handle);
+  final Pointer<Utf8> languageCodeCstring = _localeGetLanguageCode(handle);
+  final Pointer<Utf8> countryCodeCstring = _localeGetCountryCode(handle);
+  final Pointer<Utf8> scriptCodeCstring = _localeGetScriptCode(handle);
   return Locale.fromSubtags(
     languageCode: languageCodeCstring.address != 0 ? Utf8.fromUtf8(languageCodeCstring) : null,
     countryCode: countryCodeCstring.address != 0 ? Utf8.fromUtf8(countryCodeCstring) : null,

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class BasicTypes {
   /// Destroys the underlying native object.
@@ -68,110 +67,90 @@ class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
     final _floatFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Int32, Float), double Function(int, double)>('library_smoke_BasicTypes_floatFunction__Float'));
     final _inputHandle = (input);
     final __resultHandle = _floatFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static double doubleFunction(double input) {
     final _doubleFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_BasicTypes_doubleFunction__Double'));
     final _inputHandle = (input);
     final __resultHandle = _doubleFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int byteFunction(int input) {
     final _byteFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int8 Function(Int32, Int8), int Function(int, int)>('library_smoke_BasicTypes_byteFunction__Byte'));
     final _inputHandle = (input);
     final __resultHandle = _byteFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int shortFunction(int input) {
     final _shortFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int16 Function(Int32, Int16), int Function(int, int)>('library_smoke_BasicTypes_shortFunction__Short'));
     final _inputHandle = (input);
     final __resultHandle = _shortFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int intFunction(int input) {
     final _intFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('library_smoke_BasicTypes_intFunction__Int'));
     final _inputHandle = (input);
     final __resultHandle = _intFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int longFunction(int input) {
     final _longFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int64 Function(Int32, Int64), int Function(int, int)>('library_smoke_BasicTypes_longFunction__Long'));
     final _inputHandle = (input);
     final __resultHandle = _longFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int ubyteFunction(int input) {
     final _ubyteFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_ubyteFunction__UByte'));
     final _inputHandle = (input);
     final __resultHandle = _ubyteFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int ushortFunction(int input) {
     final _ushortFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint16 Function(Int32, Uint16), int Function(int, int)>('library_smoke_BasicTypes_ushortFunction__UShort'));
     final _inputHandle = (input);
     final __resultHandle = _ushortFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int uintFunction(int input) {
     final _uintFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_BasicTypes_uintFunction__UInt'));
     final _inputHandle = (input);
     final __resultHandle = _uintFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static int ulongFunction(int input) {
     final _ulongFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Int32, Uint64), int Function(int, int)>('library_smoke_BasicTypes_ulongFunction__ULong'));
     final _inputHandle = (input);
     final __resultHandle = _ulongFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 abstract class Comments {
@@ -231,7 +230,6 @@ final _smokeCommentsSomelambdaCreateProxy = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Comments_SomeLambda_create_proxy'));
 class Comments_SomeLambda$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Comments_SomeLambda$Impl(this.handle);
   void release() => _smokeCommentsSomelambdaReleaseHandle(handle);
@@ -242,22 +240,19 @@ class Comments_SomeLambda$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
-    (_p1Handle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _Comments_SomeLambdacallStatic(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
+int _smokeCommentsSomelambdacallStatic(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
   double _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as Comments_SomeLambda)(stringFromFfi(p0), (p1));
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
-    (p1);
   }
   return 0;
 }
@@ -266,7 +261,7 @@ Pointer<Void> smokeCommentsSomelambdaToFfi(Comments_SomeLambda value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_Comments_SomeLambdacallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_smokeCommentsSomelambdacallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -418,7 +413,6 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -431,7 +425,6 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -464,7 +457,6 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -475,7 +467,6 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -527,7 +518,6 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 abstract class CommentsInterface {
@@ -368,7 +368,6 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -381,7 +380,6 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -414,7 +412,6 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -425,7 +422,6 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   /// Gets some very useful property.
@@ -449,12 +445,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
 int _CommentsInterfacesomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -464,7 +459,7 @@ int _CommentsInterfacesomeMethodWithAllCommentsStatic(int _token, Pointer<Void> 
   return 0;
 }
 int _CommentsInterfacesomeMethodWithInputCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -474,7 +469,7 @@ int _CommentsInterfacesomeMethodWithInputCommentsStatic(int _token, Pointer<Void
   return 0;
 }
 int _CommentsInterfacesomeMethodWithOutputCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -484,7 +479,7 @@ int _CommentsInterfacesomeMethodWithOutputCommentsStatic(int _token, Pointer<Voi
   return 0;
 }
 int _CommentsInterfacesomeMethodWithNoCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -510,7 +505,7 @@ int _CommentsInterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic(int _token
   return 0;
 }
 int _CommentsInterfacesomeMethodWithoutInputParametersWithAllCommentsStatic(int _token, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
     _result.value = booleanToFfi(_resultObject);
@@ -519,7 +514,7 @@ int _CommentsInterfacesomeMethodWithoutInputParametersWithAllCommentsStatic(int 
   return 0;
 }
 int _CommentsInterfacesomeMethodWithoutInputParametersWithNoCommentsStatic(int _token, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// The nested types like [CommentsLinks.randomMethod2] don't need full name prefix, but it's
 /// possible to references other interfaces like [CommentsInterface] or other members
@@ -203,7 +202,6 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// First line.
 ///

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("")
 class DeprecatedWithNoMessage {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
@@ -269,7 +269,6 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   /// Gets the property but not accessors.
@@ -294,12 +293,11 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
 int _DeprecationCommentssomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("Unfortunately, this interface is deprecated.")
 abstract class DeprecationCommentsOnly {
@@ -235,12 +235,11 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
 int _DeprecationCommentsOnlysomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful class.
 /// @nodoc
@@ -187,7 +186,6 @@ final _smokeExcludedcommentsSomelambdaCreateProxy = __lib.catchArgumentError(() 
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_ExcludedComments_SomeLambda_create_proxy'));
 class ExcludedComments_SomeLambda$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   ExcludedComments_SomeLambda$Impl(this.handle);
   void release() => _smokeExcludedcommentsSomelambdaReleaseHandle(handle);
@@ -198,22 +196,19 @@ class ExcludedComments_SomeLambda$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
-    (_p1Handle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _ExcludedComments_SomeLambdacallStatic(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
+int _smokeExcludedcommentsSomelambdacallStatic(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
   double _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ExcludedComments_SomeLambda)(stringFromFfi(p0), (p1));
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
-    (p1);
   }
   return 0;
 }
@@ -222,7 +217,7 @@ Pointer<Void> smokeExcludedcommentsSomelambdaToFfi(ExcludedComments_SomeLambda v
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_ExcludedComments_SomeLambdacallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_smokeExcludedcommentsSomelambdacallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -333,7 +328,6 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -357,7 +351,6 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 /// @nodoc

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class ExcludedCommentsOnly {
@@ -163,7 +162,6 @@ final _smokeExcludedcommentsonlySomelambdaCreateProxy = __lib.catchArgumentError
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_create_proxy'));
 class ExcludedCommentsOnly_SomeLambda$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   ExcludedCommentsOnly_SomeLambda$Impl(this.handle);
   void release() => _smokeExcludedcommentsonlySomelambdaReleaseHandle(handle);
@@ -174,22 +172,19 @@ class ExcludedCommentsOnly_SomeLambda$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
-    (_p1Handle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _ExcludedCommentsOnly_SomeLambdacallStatic(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
+int _smokeExcludedcommentsonlySomelambdacallStatic(int _token, Pointer<Void> p0, int p1, Pointer<Double> _result) {
   double _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ExcludedCommentsOnly_SomeLambda)(stringFromFfi(p0), (p1));
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
-    (p1);
   }
   return 0;
 }
@@ -198,7 +193,7 @@ Pointer<Void> smokeExcludedcommentsonlySomelambdaToFfi(ExcludedCommentsOnly_Some
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_ExcludedCommentsOnly_SomeLambdacallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Int32, Pointer<Double>)>(_smokeExcludedcommentsonlySomelambdacallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -309,7 +304,6 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -333,7 +327,6 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -1,8 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This looks internal
 /// @nodoc
@@ -44,7 +42,6 @@ class InternalClassWithComments$Impl extends __lib.NativeBase implements Interna
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// Referencing some type [MapScene.loadSceneWithInt].
 abstract class MapScene {
@@ -29,7 +28,6 @@ final _smokeMapsceneLoadscenecallbackCreateProxy = __lib.catchArgumentError(() =
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_MapScene_LoadSceneCallback_create_proxy'));
 class MapScene_LoadSceneCallback$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   MapScene_LoadSceneCallback$Impl(this.handle);
   void release() => _smokeMapsceneLoadscenecallbackReleaseHandle(handle);
@@ -42,11 +40,10 @@ class MapScene_LoadSceneCallback$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _MapScene_LoadSceneCallbackcallStatic(int _token, Pointer<Void> p0) {
+int _smokeMapsceneLoadscenecallbackcallStatic(int _token, Pointer<Void> p0) {
   try {
     (__lib.instanceCache[_token] as MapScene_LoadSceneCallback)(stringFromFfiNullable(p0));
   } finally {
@@ -59,7 +56,7 @@ Pointer<Void> smokeMapsceneLoadscenecallbackToFfi(MapScene_LoadSceneCallback val
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_MapScene_LoadSceneCallbackcallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_smokeMapsceneLoadscenecallbackcallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -129,12 +126,10 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     final _callbackHandle = smokeMapsceneLoadscenecallbackToFfiNullable(callback);
     final _handle = this.handle;
     final __resultHandle = _loadSceneWithIntFfi(_handle, __lib.LibraryContext.isolateId, _mapSchemeHandle, _callbackHandle);
-    (_mapSchemeHandle);
     smokeMapsceneLoadscenecallbackReleaseFfiHandleNullable(_callbackHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -149,7 +144,6 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 ///
@@ -71,11 +70,9 @@ class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineCommen
     final _handle = this.handle;
     final __resultHandle = _someMethodWithLongCommentFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle, _ratioHandle);
     stringReleaseFfiHandle(_inputHandle);
-    (_ratioHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PlatformComments {
   /// Destroys the underlying native object.
@@ -200,7 +199,6 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -211,7 +209,6 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -246,7 +243,6 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UnicodeComments {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class CollectionConstants {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum StateEnum {
     off,

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ConstantsInterface {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
@@ -1,5 +1,4 @@
 import 'package:library/src/smoke/constants.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 final StateEnum fooBar = StateEnum.on;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class StructConstants {
   /// Destroys the underlying native object.
@@ -40,7 +39,6 @@ Pointer<Void> smokeStructconstantsSomestructToFfi(StructConstants_SomeStruct val
   final _floatFieldHandle = (value.floatField);
   final _result = _smokeStructconstantsSomestructCreateHandle(_stringFieldHandle, _floatFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
-  (_floatFieldHandle);
   return _result;
 }
 StructConstants_SomeStruct smokeStructconstantsSomestructFromFfi(Pointer<Void> handle) {
@@ -53,7 +51,6 @@ StructConstants_SomeStruct smokeStructconstantsSomestructFromFfi(Pointer<Void> h
     );
   } finally {
     stringReleaseFfiHandle(_stringFieldHandle);
-    (_floatFieldHandle);
   }
 }
 void smokeStructconstantsSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeStructconstantsSomestructReleaseHandle(handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Constructors {
   factory Constructors() => Constructors$Impl.$init();
@@ -157,7 +156,6 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
     final _barHandle = (bar);
     final __resultHandle = _fromMultiFfi(__lib.LibraryContext.isolateId, _fooHandle, _barHandle);
     stringReleaseFfiHandle(_fooHandle);
-    (_barHandle);
     return __resultHandle;
   }
   static Pointer<Void> _fromString(String input) {
@@ -189,7 +187,6 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_Constructors_create__ULong'));
     final _inputHandle = (input);
     final __resultHandle = _createFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     return __resultHandle;
   }
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SingleNamedConstructor {
   factory SingleNamedConstructor.fooBar() => SingleNamedConstructor$Impl.fooBar();

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SingleNamelessConstructor {
   factory SingleNamelessConstructor() => SingleNamelessConstructor$Impl.create();

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Dates {
   /// Destroys the underlying native object.
@@ -131,7 +130,6 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class DefaultValues {
   /// Destroys the underlying native object.
@@ -195,10 +194,6 @@ Pointer<Void> smokeDefaultvaluesStructwithdefaultsToFfi(DefaultValues_StructWith
   final _enumFieldHandle = smokeDefaultvaluesSomeenumToFfi(value.enumField);
   final _externalEnumFieldHandle = smokeDefaultvaluesExternalenumToFfi(value.externalEnumField);
   final _result = _smokeDefaultvaluesStructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle, _externalEnumFieldHandle);
-  (_intFieldHandle);
-  (_uintFieldHandle);
-  (_floatFieldHandle);
-  (_doubleFieldHandle);
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   smokeDefaultvaluesSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -226,10 +221,6 @@ DefaultValues_StructWithDefaults smokeDefaultvaluesStructwithdefaultsFromFfi(Poi
       smokeDefaultvaluesExternalenumFromFfi(_externalEnumFieldHandle)
     );
   } finally {
-    (_intFieldHandle);
-    (_uintFieldHandle);
-    (_floatFieldHandle);
-    (_doubleFieldHandle);
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
     smokeDefaultvaluesSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -435,12 +426,6 @@ Pointer<Void> smokeDefaultvaluesStructwithspecialdefaultsToFfi(DefaultValues_Str
   final _doubleInfinityFieldHandle = (value.doubleInfinityField);
   final _doubleNegativeInfinityFieldHandle = (value.doubleNegativeInfinityField);
   final _result = _smokeDefaultvaluesStructwithspecialdefaultsCreateHandle(_floatNanFieldHandle, _floatInfinityFieldHandle, _floatNegativeInfinityFieldHandle, _doubleNanFieldHandle, _doubleInfinityFieldHandle, _doubleNegativeInfinityFieldHandle);
-  (_floatNanFieldHandle);
-  (_floatInfinityFieldHandle);
-  (_floatNegativeInfinityFieldHandle);
-  (_doubleNanFieldHandle);
-  (_doubleInfinityFieldHandle);
-  (_doubleNegativeInfinityFieldHandle);
   return _result;
 }
 DefaultValues_StructWithSpecialDefaults smokeDefaultvaluesStructwithspecialdefaultsFromFfi(Pointer<Void> handle) {
@@ -460,12 +445,6 @@ DefaultValues_StructWithSpecialDefaults smokeDefaultvaluesStructwithspecialdefau
       (_doubleNegativeInfinityFieldHandle)
     );
   } finally {
-    (_floatNanFieldHandle);
-    (_floatInfinityFieldHandle);
-    (_floatNegativeInfinityFieldHandle);
-    (_doubleNanFieldHandle);
-    (_doubleInfinityFieldHandle);
-    (_doubleNegativeInfinityFieldHandle);
   }
 }
 void smokeDefaultvaluesStructwithspecialdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithspecialdefaultsReleaseHandle(handle);
@@ -645,7 +624,6 @@ Pointer<Void> smokeDefaultvaluesStructwithtypedefdefaultsToFfi(DefaultValues_Str
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _enumFieldHandle = smokeDefaultvaluesSomeenumToFfi(value.enumField);
   final _result = _smokeDefaultvaluesStructwithtypedefdefaultsCreateHandle(_longFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle);
-  (_longFieldHandle);
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   smokeDefaultvaluesSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -664,7 +642,6 @@ DefaultValues_StructWithTypedefDefaults smokeDefaultvaluesStructwithtypedefdefau
       smokeDefaultvaluesSomeenumFromFfi(_enumFieldHandle)
     );
   } finally {
-    (_longFieldHandle);
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
     smokeDefaultvaluesSomeenumReleaseFfiHandle(_enumFieldHandle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithAllDefaults {
   int intField;
@@ -31,7 +30,6 @@ Pointer<Void> smokeStructwithalldefaultsToFfi(StructWithAllDefaults value) {
   final _intFieldHandle = (value.intField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeStructwithalldefaultsCreateHandle(_intFieldHandle, _stringFieldHandle);
-  (_intFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
@@ -44,7 +42,6 @@ StructWithAllDefaults smokeStructwithalldefaultsFromFfi(Pointer<Void> handle) {
       stringFromFfi(_stringFieldHandle)
     );
   } finally {
-    (_intFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithCollectionDefaults {
   List<String> emptyListField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/something_enum.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithEnums {
   SomethingEnum firstField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -2,7 +2,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/types_with_defaults.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithInitializerDefaults {
   List<int> intsField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithSomeDefaults {
   int intField;
@@ -31,7 +30,6 @@ Pointer<Void> smokeStructwithsomedefaultsToFfi(StructWithSomeDefaults value) {
   final _intFieldHandle = (value.intField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeStructwithsomedefaultsCreateHandle(_intFieldHandle, _stringFieldHandle);
-  (_intFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
@@ -44,7 +42,6 @@ StructWithSomeDefaults smokeStructwithsomedefaultsFromFfi(Pointer<Void> handle) 
       (_intFieldHandle)
     );
   } finally {
-    (_intFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -1,8 +1,8 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/an_enum.dart';
 import 'package:library/src/smoke/default_values.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SomeEnum {
     fooValue,
@@ -121,10 +121,6 @@ Pointer<Void> smokeTypeswithdefaultsStructwithdefaultsToFfi(StructWithDefaults v
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _enumFieldHandle = smokeTypeswithdefaultsSomeenumToFfi(value.enumField);
   final _result = _smokeTypeswithdefaultsStructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle);
-  (_intFieldHandle);
-  (_uintFieldHandle);
-  (_floatFieldHandle);
-  (_doubleFieldHandle);
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   smokeTypeswithdefaultsSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -149,10 +145,6 @@ StructWithDefaults smokeTypeswithdefaultsStructwithdefaultsFromFfi(Pointer<Void>
       smokeTypeswithdefaultsSomeenumFromFfi(_enumFieldHandle)
     );
   } finally {
-    (_intFieldHandle);
-    (_uintFieldHandle);
-    (_floatFieldHandle);
-    (_doubleFieldHandle);
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
     smokeTypeswithdefaultsSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -254,10 +246,6 @@ Pointer<Void> smokeTypeswithdefaultsImmutablestructwithdefaultsToFfi(ImmutableSt
   final _enumFieldHandle = smokeTypeswithdefaultsSomeenumToFfi(value.enumField);
   final _externalEnumFieldHandle = smokeDefaultvaluesExternalenumToFfi(value.externalEnumField);
   final _result = _smokeTypeswithdefaultsImmutablestructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle, _enumFieldHandle, _externalEnumFieldHandle);
-  (_intFieldHandle);
-  (_uintFieldHandle);
-  (_floatFieldHandle);
-  (_doubleFieldHandle);
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   smokeTypeswithdefaultsSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -285,10 +273,6 @@ ImmutableStructWithDefaults smokeTypeswithdefaultsImmutablestructwithdefaultsFro
       smokeDefaultvaluesExternalenumFromFfi(_externalEnumFieldHandle)
     );
   } finally {
-    (_intFieldHandle);
-    (_uintFieldHandle);
-    (_floatFieldHandle);
-    (_doubleFieldHandle);
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
     smokeTypeswithdefaultsSomeenumReleaseFfiHandle(_enumFieldHandle);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum EnumStartsWithOne {
     first,

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Enums {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -3,7 +3,6 @@ import 'package:collection/collection.dart';
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SomeEnum {
     foo,
@@ -170,10 +169,6 @@ Pointer<Void> smokeEquatableEquatablestructToFfi(EquatableStruct value) {
   final _mapFieldHandle = foobarMapofIntToStringToFfi(value.mapField);
   final _result = _smokeEquatableEquatablestructCreateHandle(_boolFieldHandle, _intFieldHandle, _longFieldHandle, _floatFieldHandle, _doubleFieldHandle, _stringFieldHandle, _structFieldHandle, _enumFieldHandle, _arrayFieldHandle, _mapFieldHandle);
   booleanReleaseFfiHandle(_boolFieldHandle);
-  (_intFieldHandle);
-  (_longFieldHandle);
-  (_floatFieldHandle);
-  (_doubleFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   smokeEquatableNestedequatablestructReleaseFfiHandle(_structFieldHandle);
   smokeEquatableSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -207,10 +202,6 @@ EquatableStruct smokeEquatableEquatablestructFromFfi(Pointer<Void> handle) {
     );
   } finally {
     booleanReleaseFfiHandle(_boolFieldHandle);
-    (_intFieldHandle);
-    (_longFieldHandle);
-    (_floatFieldHandle);
-    (_doubleFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
     smokeEquatableNestedequatablestructReleaseFfiHandle(_structFieldHandle);
     smokeEquatableSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -499,4 +490,3 @@ NestedEquatableStruct smokeEquatableNestedequatablestructFromFfiNullable(Pointer
 void smokeEquatableNestedequatablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEquatableNestedequatablestructReleaseHandleNullable(handle);
 // End of NestedEquatableStruct "private" section.
-

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class EquatableInterface {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -3,7 +3,6 @@ import 'package:collection/collection.dart';
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class EquatableStructWithInternalFields {
   String publicField;

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
@@ -3,7 +3,6 @@ import 'package:collection/collection.dart';
 import 'package:library/src/smoke/non_equatable_class.dart';
 import 'package:library/src/smoke/non_equatable_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class SimpleEquatableStruct {
   NonEquatableClass classField;

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Errors {
   /// Destroys the underlying native object.
@@ -258,7 +257,6 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static methodWithExternalErrors() {
@@ -278,7 +276,6 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static String methodWithErrorsAndReturnValue() {
@@ -318,7 +315,6 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static String methodWithPayloadErrorAndReturnValue() {

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -4,8 +4,8 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ErrorsInterface {
   ErrorsInterface();
@@ -300,7 +300,6 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -322,7 +321,6 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -365,7 +363,6 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -416,7 +413,7 @@ int _ErrorsInterfacemethodWithExternalErrorsStatic(int _token, Pointer<Uint32> _
 }
 int _ErrorsInterfacemethodWithErrorsAndReturnValueStatic(int _token, Pointer<Pointer<Void>> _result, Pointer<Uint32> _error) {
   bool _errorFlag = false;
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrorsAndReturnValue();
     _result.value = stringToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -6,7 +6,6 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/package/interface.dart';
 import 'package:library/src/package/types.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Class implements Interface {
   factory Class() => Class$Impl.constructor();
@@ -111,7 +110,6 @@ class Class$Impl extends __lib.NativeBase implements Class {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Interface {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum Enum {
     naN

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/generic_types__conversion.dart
@@ -42,7 +42,6 @@ Pointer<Void> foobarListofByteToFfi(List<int> value) {
   for (final element in value) {
     final _elementHandle = (element);
     _foobarListofByteInsert(_result, _elementHandle);
-    (_elementHandle);
   }
   return _result;
 }
@@ -54,7 +53,6 @@ List<int> foobarListofByteFromFfi(Pointer<Void> handle) {
     try {
       result.add((_elementHandle));
     } finally {
-      (_elementHandle);
     }
     _foobarListofByteIteratorIncrement(_iteratorHandle);
   }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -1,8 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Enums {
   /// Destroys the underlying native object.
@@ -157,7 +155,6 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ExternalClass {
   /// Destroys the underlying native object.
@@ -154,11 +153,9 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;
     final __resultHandle = _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
-    (_someParameterHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ExternalInterface {
   ExternalInterface();
@@ -186,11 +186,9 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;
     final __resultHandle = _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
-    (_someParameterHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   String get someProperty {
@@ -208,7 +206,6 @@ int _ExternalInterfacesomeMethodStatic(int _token, int someParameter) {
   try {
     (__lib.instanceCache[_token] as ExternalInterface).someMethod((someParameter));
   } finally {
-    (someParameter);
   }
   return 0;
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -1,6 +1,5 @@
 import 'package:foo/bar.dart' as bar;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // HttpClientResponseCompressionState "private" section, not exported.
 int smokeCompressionstateToFfi(bar.HttpClientResponseCompressionState value) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
@@ -1,7 +1,5 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import '../color_converter.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class intInternal {
   double red;
@@ -44,10 +42,6 @@ Pointer<Void> smokeDartcolorToFfi(int valueExternal) {
   final _blueHandle = (value.blue);
   final _alphaHandle = (value.alpha);
   final _result = _smokeDartcolorCreateHandle(_redHandle, _greenHandle, _blueHandle, _alphaHandle);
-  (_redHandle);
-  (_greenHandle);
-  (_blueHandle);
-  (_alphaHandle);
   return _result;
 }
 int smokeDartcolorFromFfi(Pointer<Void> handle) {
@@ -64,10 +58,6 @@ int smokeDartcolorFromFfi(Pointer<Void> handle) {
     );
     return ColorConverter.convertFromInternal(resultInternal);
   } finally {
-    (_redHandle);
-    (_greenHandle);
-    (_blueHandle);
-    (_alphaHandle);
   }
 }
 void smokeDartcolorReleaseFfiHandle(Pointer<Void> handle) => _smokeDartcolorReleaseHandle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
@@ -1,7 +1,5 @@
 import 'dart:math' as math;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 // Rectangle<int> "private" section, not exported.
 final _smokeRectangleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -34,10 +32,6 @@ Pointer<Void> smokeRectangleToFfi(math.Rectangle<int> value) {
   final _widthHandle = (value.width);
   final _heightHandle = (value.height);
   final _result = _smokeRectangleCreateHandle(_leftHandle, _topHandle, _widthHandle, _heightHandle);
-  (_leftHandle);
-  (_topHandle);
-  (_widthHandle);
-  (_heightHandle);
   return _result;
 }
 math.Rectangle<int> smokeRectangleFromFfi(Pointer<Void> handle) {
@@ -53,10 +47,6 @@ math.Rectangle<int> smokeRectangleFromFfi(Pointer<Void> handle) {
       (_heightHandle)
     );
   } finally {
-    (_leftHandle);
-    (_topHandle);
-    (_widthHandle);
-    (_heightHandle);
   }
 }
 void smokeRectangleReleaseFfiHandle(Pointer<Void> handle) => _smokeRectangleReleaseHandle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -1,6 +1,5 @@
 import '../season_converter.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum StringInternal {
     winter,

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Structs {
   /// Destroys the underlying native object.
@@ -128,7 +127,6 @@ final _smokeStructsAnotherexternalstructGetFieldintField = __lib.catchArgumentEr
 Pointer<Void> smokeStructsAnotherexternalstructToFfi(Structs_AnotherExternalStruct value) {
   final _intFieldHandle = (value.intField);
   final _result = _smokeStructsAnotherexternalstructCreateHandle(_intFieldHandle);
-  (_intFieldHandle);
   return _result;
 }
 Structs_AnotherExternalStruct smokeStructsAnotherexternalstructFromFfi(Pointer<Void> handle) {
@@ -138,7 +136,6 @@ Structs_AnotherExternalStruct smokeStructsAnotherexternalstructFromFfi(Pointer<V
       (_intFieldHandle)
     );
   } finally {
-    (_intFieldHandle);
   }
 }
 void smokeStructsAnotherexternalstructReleaseFfiHandle(Pointer<Void> handle) => _smokeStructsAnotherexternalstructReleaseHandle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -7,7 +7,6 @@ import 'package:library/src/smoke/int.dart';
 import 'package:library/src/smoke/rectangle_int_.dart';
 import 'package:library/src/smoke/string.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseDartExternalTypes {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/generic_types__conversion.dart
@@ -45,7 +45,6 @@ Pointer<Void> foobarListofFloatToFfi(List<double> value) {
   for (final element in value) {
     final _elementHandle = (element);
     _foobarListofFloatInsert(_result, _elementHandle);
-    (_elementHandle);
   }
   return _result;
 }
@@ -57,7 +56,6 @@ List<double> foobarListofFloatFromFfi(Pointer<Void> handle) {
     try {
       result.add((_elementHandle));
     } finally {
-      (_elementHandle);
     }
     _foobarListofFloatIteratorIncrement(_iteratorHandle);
   }
@@ -130,7 +128,6 @@ Pointer<Void> foobarListofIntToFfi(List<int> value) {
   for (final element in value) {
     final _elementHandle = (element);
     _foobarListofIntInsert(_result, _elementHandle);
-    (_elementHandle);
   }
   return _result;
 }
@@ -142,7 +139,6 @@ List<int> foobarListofIntFromFfi(Pointer<Void> handle) {
     try {
       result.add((_elementHandle));
     } finally {
-      (_elementHandle);
     }
     _foobarListofIntIteratorIncrement(_iteratorHandle);
   }
@@ -300,7 +296,6 @@ Pointer<Void> foobarListofUbyteToFfi(List<int> value) {
   for (final element in value) {
     final _elementHandle = (element);
     _foobarListofUbyteInsert(_result, _elementHandle);
-    (_elementHandle);
   }
   return _result;
 }
@@ -312,7 +307,6 @@ List<int> foobarListofUbyteFromFfi(Pointer<Void> handle) {
     try {
       result.add((_elementHandle));
     } finally {
-      (_elementHandle);
     }
     _foobarListofUbyteIteratorIncrement(_iteratorHandle);
   }
@@ -1495,8 +1489,6 @@ Pointer<Void> foobarMapofFloatToDoubleToFfi(Map<double, double> value) {
     final _keyHandle = (entry.key);
     final _valueHandle = (entry.value);
     _foobarMapofFloatToDoublePut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
-    (_valueHandle);
   }
   return _result;
 }
@@ -1510,8 +1502,6 @@ Map<double, double> foobarMapofFloatToDoubleFromFfi(Pointer<Void> handle) {
       result[(_keyHandle)] =
         (_valueHandle);
     } finally {
-      (_keyHandle);
-      (_valueHandle);
     }
     _foobarMapofFloatToDoubleIteratorIncrement(_iteratorHandle);
   }
@@ -1589,7 +1579,6 @@ Pointer<Void> foobarMapofIntToBooleanToFfi(Map<int, bool> value) {
     final _keyHandle = (entry.key);
     final _valueHandle = booleanToFfi(entry.value);
     _foobarMapofIntToBooleanPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     booleanReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -1604,7 +1593,6 @@ Map<int, bool> foobarMapofIntToBooleanFromFfi(Pointer<Void> handle) {
       result[(_keyHandle)] =
         booleanFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       booleanReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToBooleanIteratorIncrement(_iteratorHandle);
@@ -1683,7 +1671,6 @@ Pointer<Void> foobarMapofIntToFoobarListofIntToFfi(Map<int, List<int>> value) {
     final _keyHandle = (entry.key);
     final _valueHandle = foobarListofIntToFfi(entry.value);
     _foobarMapofIntToFoobarListofIntPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     foobarListofIntReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -1698,7 +1685,6 @@ Map<int, List<int>> foobarMapofIntToFoobarListofIntFromFfi(Pointer<Void> handle)
       result[(_keyHandle)] =
         foobarListofIntFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       foobarListofIntReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToFoobarListofIntIteratorIncrement(_iteratorHandle);
@@ -1777,7 +1763,6 @@ Pointer<Void> foobarMapofIntToFoobarMapofIntToBooleanToFfi(Map<int, Map<int, boo
     final _keyHandle = (entry.key);
     final _valueHandle = foobarMapofIntToBooleanToFfi(entry.value);
     _foobarMapofIntToFoobarMapofIntToBooleanPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     foobarMapofIntToBooleanReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -1792,7 +1777,6 @@ Map<int, Map<int, bool>> foobarMapofIntToFoobarMapofIntToBooleanFromFfi(Pointer<
       result[(_keyHandle)] =
         foobarMapofIntToBooleanFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       foobarMapofIntToBooleanReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToFoobarMapofIntToBooleanIteratorIncrement(_iteratorHandle);
@@ -1871,7 +1855,6 @@ Pointer<Void> foobarMapofIntToFoobarSetofIntToFfi(Map<int, Set<int>> value) {
     final _keyHandle = (entry.key);
     final _valueHandle = foobarSetofIntToFfi(entry.value);
     _foobarMapofIntToFoobarSetofIntPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     foobarSetofIntReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -1886,7 +1869,6 @@ Map<int, Set<int>> foobarMapofIntToFoobarSetofIntFromFfi(Pointer<Void> handle) {
       result[(_keyHandle)] =
         foobarSetofIntFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       foobarSetofIntReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToFoobarSetofIntIteratorIncrement(_iteratorHandle);
@@ -1965,7 +1947,6 @@ Pointer<Void> foobarMapofIntToSmokeDummyclassToFfi(Map<int, DummyClass> value) {
     final _keyHandle = (entry.key);
     final _valueHandle = smokeDummyclassToFfi(entry.value);
     _foobarMapofIntToSmokeDummyclassPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     smokeDummyclassReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -1980,7 +1961,6 @@ Map<int, DummyClass> foobarMapofIntToSmokeDummyclassFromFfi(Pointer<Void> handle
       result[(_keyHandle)] =
         smokeDummyclassFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       smokeDummyclassReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToSmokeDummyclassIteratorIncrement(_iteratorHandle);
@@ -2059,7 +2039,6 @@ Pointer<Void> foobarMapofIntToSmokeDummyinterfaceToFfi(Map<int, DummyInterface> 
     final _keyHandle = (entry.key);
     final _valueHandle = smokeDummyinterfaceToFfi(entry.value);
     _foobarMapofIntToSmokeDummyinterfacePut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     smokeDummyinterfaceReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -2074,7 +2053,6 @@ Map<int, DummyInterface> foobarMapofIntToSmokeDummyinterfaceFromFfi(Pointer<Void
       result[(_keyHandle)] =
         smokeDummyinterfaceFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       smokeDummyinterfaceReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToSmokeDummyinterfaceIteratorIncrement(_iteratorHandle);
@@ -2153,7 +2131,6 @@ Pointer<Void> foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumToFf
     final _keyHandle = (entry.key);
     final _valueHandle = smokeGenerictypeswithcompoundtypesExternalenumToFfi(entry.value);
     _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     smokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -2168,7 +2145,6 @@ Map<int, GenericTypesWithCompoundTypes_ExternalEnum> foobarMapofIntToSmokeGeneri
       result[(_keyHandle)] =
         smokeGenerictypeswithcompoundtypesExternalenumFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       smokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumIteratorIncrement(_iteratorHandle);
@@ -2247,7 +2223,6 @@ Pointer<Void> foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumToFfi(Ma
     final _keyHandle = (entry.key);
     final _valueHandle = smokeGenerictypeswithcompoundtypesSomeenumToFfi(entry.value);
     _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     smokeGenerictypeswithcompoundtypesSomeenumReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -2262,7 +2237,6 @@ Map<int, GenericTypesWithCompoundTypes_SomeEnum> foobarMapofIntToSmokeGenerictyp
       result[(_keyHandle)] =
         smokeGenerictypeswithcompoundtypesSomeenumFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       smokeGenerictypeswithcompoundtypesSomeenumReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofIntToSmokeGenerictypeswithcompoundtypesSomeenumIteratorIncrement(_iteratorHandle);
@@ -2623,7 +2597,6 @@ Pointer<Void> foobarMapofUbyteToStringToFfi(Map<int, String> value) {
     final _keyHandle = (entry.key);
     final _valueHandle = stringToFfi(entry.value);
     _foobarMapofUbyteToStringPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     stringReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -2638,7 +2611,6 @@ Map<int, String> foobarMapofUbyteToStringFromFfi(Pointer<Void> handle) {
       result[(_keyHandle)] =
         stringFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       stringReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofUbyteToStringIteratorIncrement(_iteratorHandle);
@@ -3182,7 +3154,6 @@ Pointer<Void> foobarSetofFloatToFfi(Set<double> value) {
   for (final element in value) {
     final _elementHandle = (element);
     _foobarSetofFloatInsert(_result, _elementHandle);
-    (_elementHandle);
   }
   return _result;
 }
@@ -3194,7 +3165,6 @@ Set<double> foobarSetofFloatFromFfi(Pointer<Void> handle) {
     try {
       result.add((_elementHandle));
     } finally {
-      (_elementHandle);
     }
     _foobarSetofFloatIteratorIncrement(_iteratorHandle);
   }
@@ -3267,7 +3237,6 @@ Pointer<Void> foobarSetofIntToFfi(Set<int> value) {
   for (final element in value) {
     final _elementHandle = (element);
     _foobarSetofIntInsert(_result, _elementHandle);
-    (_elementHandle);
   }
   return _result;
 }
@@ -3279,7 +3248,6 @@ Set<int> foobarSetofIntFromFfi(Pointer<Void> handle) {
     try {
       result.add((_elementHandle));
     } finally {
-      (_elementHandle);
     }
     _foobarSetofIntIteratorIncrement(_iteratorHandle);
   }
@@ -3437,7 +3405,6 @@ Pointer<Void> foobarSetofUbyteToFfi(Set<int> value) {
   for (final element in value) {
     final _elementHandle = (element);
     _foobarSetofUbyteInsert(_result, _elementHandle);
-    (_elementHandle);
   }
   return _result;
 }
@@ -3449,7 +3416,6 @@ Set<int> foobarSetofUbyteFromFfi(Pointer<Void> handle) {
     try {
       result.add((_elementHandle));
     } finally {
-      (_elementHandle);
     }
     _foobarSetofUbyteIteratorIncrement(_iteratorHandle);
   }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithBasicTypes {
   /// Destroys the underlying native object.
@@ -226,7 +225,6 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -250,7 +248,6 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -274,7 +271,6 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -5,7 +5,6 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/dummy_class.dart';
 import 'package:library/src/smoke/dummy_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithCompoundTypes {
   /// Destroys the underlying native object.
@@ -160,7 +159,6 @@ final _smokeGenerictypeswithcompoundtypesBasicstructGetFieldvalue = __lib.catchA
 Pointer<Void> smokeGenerictypeswithcompoundtypesBasicstructToFfi(GenericTypesWithCompoundTypes_BasicStruct value) {
   final _valueHandle = (value.value);
   final _result = _smokeGenerictypeswithcompoundtypesBasicstructCreateHandle(_valueHandle);
-  (_valueHandle);
   return _result;
 }
 GenericTypesWithCompoundTypes_BasicStruct smokeGenerictypeswithcompoundtypesBasicstructFromFfi(Pointer<Void> handle) {
@@ -170,7 +168,6 @@ GenericTypesWithCompoundTypes_BasicStruct smokeGenerictypeswithcompoundtypesBasi
       (_valueHandle)
     );
   } finally {
-    (_valueHandle);
   }
 }
 void smokeGenerictypeswithcompoundtypesBasicstructReleaseFfiHandle(Pointer<Void> handle) => _smokeGenerictypeswithcompoundtypesBasicstructReleaseHandle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithGenericTypes {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -5,7 +5,6 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseOptimizedList {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_lazy_list.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 @immutable
 class UseOptimizedListStruct {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildClassFromClass implements ParentClass {
   /// Destroys the underlying native object.
@@ -45,7 +44,6 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildClassFromInterface implements ParentInterface {
   /// Destroys the underlying native object.
@@ -45,7 +44,6 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -56,7 +54,6 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -80,7 +77,6 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -3,8 +3,8 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildInterface implements ParentInterface {
   ChildInterface();
@@ -85,7 +85,6 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -96,7 +95,6 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   String get rootProperty {
@@ -118,7 +116,6 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -6,7 +6,6 @@ import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildWithParentClassReferences implements ParentWithClassReferences {
   /// Destroys the underlying native object.
@@ -70,7 +69,6 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ParentClass {
   /// Destroys the underlying native object.
@@ -46,7 +45,6 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -70,7 +68,6 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ParentInterface {
   ParentInterface();
@@ -79,7 +79,6 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   String get rootProperty {
@@ -101,7 +100,6 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SimpleClass {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SimpleInterface {
   SimpleInterface();
@@ -91,7 +91,7 @@ class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
   }
 }
 int _SimpleInterfacegetStringValueStatic(int _token, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
     _result.value = stringToFfi(_resultObject);
@@ -100,7 +100,7 @@ int _SimpleInterfacegetStringValueStatic(int _token, Pointer<Pointer<Void>> _res
   return 0;
 }
 int _SimpleInterfaceuseSimpleInterfaceStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  SimpleInterface _resultObject = null;
+  SimpleInterface _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(smokeSimpleinterfaceFromFfi(input));
     _result.value = smokeSimpleinterfaceToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/simple_class.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithClass {
   SimpleClass classInstance;

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/simple_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithInterface {
   SimpleInterface interfaceInstance;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ClassWithInternalLambda {
   /// Destroys the underlying native object.
@@ -28,7 +27,6 @@ final _smokeClasswithinternallambdaInternallambdaCreateProxy = __lib.catchArgume
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_ClassWithInternalLambda_InternalLambda_create_proxy'));
 class ClassWithInternalLambda_InternalLambda$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   ClassWithInternalLambda_InternalLambda$Impl(this.handle);
   void release() => _smokeClasswithinternallambdaInternallambdaReleaseHandle(handle);
@@ -45,7 +43,7 @@ class ClassWithInternalLambda_InternalLambda$Impl {
     }
   }
 }
-int _ClassWithInternalLambda_InternalLambdacallStatic(int _token, Pointer<Void> p0, Pointer<Uint8> _result) {
+int _smokeClasswithinternallambdaInternallambdacallStatic(int _token, Pointer<Void> p0, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ClassWithInternalLambda_InternalLambda)(stringFromFfi(p0));
@@ -60,7 +58,7 @@ Pointer<Void> smokeClasswithinternallambdaInternallambdaToFfi(ClassWithInternalL
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_ClassWithInternalLambda_InternalLambdacallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_smokeClasswithinternallambdaInternallambdacallStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Lambdas {
   /// Destroys the underlying native object.
@@ -29,7 +28,6 @@ final _smokeLambdasProducerCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Producer_create_proxy'));
 class Lambdas_Producer$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Producer$Impl(this.handle);
   void release() => _smokeLambdasProducerReleaseHandle(handle);
@@ -44,7 +42,7 @@ class Lambdas_Producer$Impl {
     }
   }
 }
-int _Lambdas_ProducercallStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeLambdasProducercallStatic(int _token, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as Lambdas_Producer)();
@@ -58,7 +56,7 @@ Pointer<Void> smokeLambdasProducerToFfi(Lambdas_Producer value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_Lambdas_ProducercallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeLambdasProducercallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -118,7 +116,6 @@ final _smokeLambdasConfuserCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Confuser_create_proxy'));
 class Lambdas_Confuser$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Confuser$Impl(this.handle);
   void release() => _smokeLambdasConfuserReleaseHandle(handle);
@@ -135,7 +132,7 @@ class Lambdas_Confuser$Impl {
     }
   }
 }
-int _Lambdas_ConfusercallStatic(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
+int _smokeLambdasConfusercallStatic(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
   Lambdas_Producer _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as Lambdas_Confuser)(stringFromFfi(p0));
@@ -150,7 +147,7 @@ Pointer<Void> smokeLambdasConfuserToFfi(Lambdas_Confuser value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_ConfusercallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdasConfusercallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -209,7 +206,6 @@ final _smokeLambdasConsumerCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Consumer_create_proxy'));
 class Lambdas_Consumer$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Consumer$Impl(this.handle);
   void release() => _smokeLambdasConsumerReleaseHandle(handle);
@@ -222,11 +218,10 @@ class Lambdas_Consumer$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _Lambdas_ConsumercallStatic(int _token, Pointer<Void> p0) {
+int _smokeLambdasConsumercallStatic(int _token, Pointer<Void> p0) {
   try {
     (__lib.instanceCache[_token] as Lambdas_Consumer)(stringFromFfi(p0));
   } finally {
@@ -239,7 +234,7 @@ Pointer<Void> smokeLambdasConsumerToFfi(Lambdas_Consumer value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_Lambdas_ConsumercallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_smokeLambdasConsumercallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -298,7 +293,6 @@ final _smokeLambdasIndexerCreateProxy = __lib.catchArgumentError(() => __lib.nat
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_Indexer_create_proxy'));
 class Lambdas_Indexer$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_Indexer$Impl(this.handle);
   void release() => _smokeLambdasIndexerReleaseHandle(handle);
@@ -309,22 +303,19 @@ class Lambdas_Indexer$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
-    (_p1Handle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _Lambdas_IndexercallStatic(int _token, Pointer<Void> p0, double p1, Pointer<Int32> _result) {
+int _smokeLambdasIndexercallStatic(int _token, Pointer<Void> p0, double p1, Pointer<Int32> _result) {
   int _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as Lambdas_Indexer)(stringFromFfi(p0), (p1));
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
-    (p1);
   }
   return 0;
 }
@@ -333,7 +324,7 @@ Pointer<Void> smokeLambdasIndexerToFfi(Lambdas_Indexer value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Float, Pointer<Int32>)>(_Lambdas_IndexercallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Float, Pointer<Int32>)>(_smokeLambdasIndexercallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -392,7 +383,6 @@ final _smokeLambdasNullableconfuserCreateProxy = __lib.catchArgumentError(() => 
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_Lambdas_NullableConfuser_create_proxy'));
 class Lambdas_NullableConfuser$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   Lambdas_NullableConfuser$Impl(this.handle);
   void release() => _smokeLambdasNullableconfuserReleaseHandle(handle);
@@ -409,7 +399,7 @@ class Lambdas_NullableConfuser$Impl {
     }
   }
 }
-int _Lambdas_NullableConfusercallStatic(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
+int _smokeLambdasNullableconfusercallStatic(int _token, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
   Lambdas_Producer _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as Lambdas_NullableConfuser)(stringFromFfiNullable(p0));
@@ -424,7 +414,7 @@ Pointer<Void> smokeLambdasNullableconfuserToFfi(Lambdas_NullableConfuser value) 
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_Lambdas_NullableConfusercallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdasNullableconfusercallStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -1,10 +1,8 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/lambdas_declaration_order.dart';
 import 'package:library/src/smoke/lambdas_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class LambdasWithStructuredTypes {
   /// Destroys the underlying native object.
@@ -30,7 +28,6 @@ final _smokeLambdaswithstructuredtypesClasscallbackCreateProxy = __lib.catchArgu
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy'));
 class LambdasWithStructuredTypes_ClassCallback$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_ClassCallback$Impl(this.handle);
   void release() => _smokeLambdaswithstructuredtypesClasscallbackReleaseHandle(handle);
@@ -43,11 +40,10 @@ class LambdasWithStructuredTypes_ClassCallback$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _LambdasWithStructuredTypes_ClassCallbackcallStatic(int _token, Pointer<Void> p0) {
+int _smokeLambdaswithstructuredtypesClasscallbackcallStatic(int _token, Pointer<Void> p0) {
   try {
     (__lib.instanceCache[_token] as LambdasWithStructuredTypes_ClassCallback)(smokeLambdasinterfaceFromFfi(p0));
   } finally {
@@ -60,7 +56,7 @@ Pointer<Void> smokeLambdaswithstructuredtypesClasscallbackToFfi(LambdasWithStruc
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_ClassCallbackcallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_smokeLambdaswithstructuredtypesClasscallbackcallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -119,7 +115,6 @@ final _smokeLambdaswithstructuredtypesStructcallbackCreateProxy = __lib.catchArg
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_proxy'));
 class LambdasWithStructuredTypes_StructCallback$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_StructCallback$Impl(this.handle);
   void release() => _smokeLambdaswithstructuredtypesStructcallbackReleaseHandle(handle);
@@ -132,11 +127,10 @@ class LambdasWithStructuredTypes_StructCallback$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
-int _LambdasWithStructuredTypes_StructCallbackcallStatic(int _token, Pointer<Void> p0) {
+int _smokeLambdaswithstructuredtypesStructcallbackcallStatic(int _token, Pointer<Void> p0) {
   try {
     (__lib.instanceCache[_token] as LambdasWithStructuredTypes_StructCallback)(smokeLambdasdeclarationorderSomestructFromFfi(p0));
   } finally {
@@ -149,7 +143,7 @@ Pointer<Void> smokeLambdaswithstructuredtypesStructcallbackToFfi(LambdasWithStru
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_LambdasWithStructuredTypes_StructCallbackcallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Void>)>(_smokeLambdaswithstructuredtypesStructcallbackcallStatic, __lib.unknownError)
   );
   return result;
 }
@@ -222,7 +216,6 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -235,7 +228,6 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 typedef StandaloneProducer = String Function();
 // StandaloneProducer "private" section, not exported.
@@ -18,7 +17,6 @@ final _smokeStandaloneproducerCreateProxy = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(int, int, Pointer, Pointer)
   >('library_smoke_StandaloneProducer_create_proxy'));
 class StandaloneProducer$Impl {
-  Pointer<Void> get _handle => handle;
   final Pointer<Void> handle;
   StandaloneProducer$Impl(this.handle);
   void release() => _smokeStandaloneproducerReleaseHandle(handle);
@@ -33,7 +31,7 @@ class StandaloneProducer$Impl {
     }
   }
 }
-int _StandaloneProducercallStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeStandaloneproducercallStatic(int _token, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as StandaloneProducer)();
@@ -47,7 +45,7 @@ Pointer<Void> smokeStandaloneproducerToFfi(StandaloneProducer value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_StandaloneProducercallStatic, __lib.unknownError)
+    Pointer.fromFunction<Int64 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeStandaloneproducercallStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -4,8 +4,8 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class CalculatorListener {
   CalculatorListener();
@@ -56,7 +56,6 @@ final _smokeCalculatorlistenerResultstructGetFieldresult = __lib.catchArgumentEr
 Pointer<Void> smokeCalculatorlistenerResultstructToFfi(CalculatorListener_ResultStruct value) {
   final _resultHandle = (value.result);
   final _result = _smokeCalculatorlistenerResultstructCreateHandle(_resultHandle);
-  (_resultHandle);
   return _result;
 }
 CalculatorListener_ResultStruct smokeCalculatorlistenerResultstructFromFfi(Pointer<Void> handle) {
@@ -66,7 +65,6 @@ CalculatorListener_ResultStruct smokeCalculatorlistenerResultstructFromFfi(Point
       (_resultHandle)
     );
   } finally {
-    (_resultHandle);
   }
 }
 void smokeCalculatorlistenerResultstructReleaseFfiHandle(Pointer<Void> handle) => _smokeCalculatorlistenerResultstructReleaseHandle(handle);
@@ -169,11 +167,9 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
     final __resultHandle = _onCalculationResultFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
-    (_calculationResultHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -182,11 +178,9 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
     final __resultHandle = _onCalculationResultConstFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
-    (_calculationResultHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -199,7 +193,6 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -212,7 +205,6 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -225,7 +217,6 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -238,7 +229,6 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
@@ -246,7 +236,6 @@ int _CalculatorListeneronCalculationResultStatic(int _token, double calculationR
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResult((calculationResult));
   } finally {
-    (calculationResult);
   }
   return 0;
 }
@@ -254,7 +243,6 @@ int _CalculatorListeneronCalculationResultConstStatic(int _token, double calcula
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultConst((calculationResult));
   } finally {
-    (calculationResult);
   }
   return 0;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class InterfaceWithStatic {
   InterfaceWithStatic();
@@ -114,7 +114,6 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static String get staticProperty {
@@ -134,12 +133,11 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
 int _InterfaceWithStaticregularFunctionStatic(int _token, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as InterfaceWithStatic).regularFunction();
     _result.value = stringToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -5,8 +5,8 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenerWithProperties {
   ListenerWithProperties();
@@ -140,7 +140,6 @@ final _smokeListenerwithpropertiesResultstructGetFieldresult = __lib.catchArgume
 Pointer<Void> smokeListenerwithpropertiesResultstructToFfi(ListenerWithProperties_ResultStruct value) {
   final _resultHandle = (value.result);
   final _result = _smokeListenerwithpropertiesResultstructCreateHandle(_resultHandle);
-  (_resultHandle);
   return _result;
 }
 ListenerWithProperties_ResultStruct smokeListenerwithpropertiesResultstructFromFfi(Pointer<Void> handle) {
@@ -150,7 +149,6 @@ ListenerWithProperties_ResultStruct smokeListenerwithpropertiesResultstructFromF
       (_resultHandle)
     );
   } finally {
-    (_resultHandle);
   }
 }
 void smokeListenerwithpropertiesResultstructReleaseFfiHandle(Pointer<Void> handle) => _smokeListenerwithpropertiesResultstructReleaseHandle(handle);
@@ -292,7 +290,6 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   CalculationResult get packedMessage {
@@ -314,7 +311,6 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   ListenerWithProperties_ResultStruct get structuredMessage {
@@ -336,7 +332,6 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   ListenerWithProperties_ResultEnum get enumeratedMessage {
@@ -358,7 +353,6 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   List<String> get arrayedMessage {
@@ -380,7 +374,6 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   Map<String, double> get mappedMessage {
@@ -402,7 +395,6 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   Uint8List get bufferedMessage {
@@ -424,7 +416,6 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -4,8 +4,8 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenersWithReturnValues {
   ListenersWithReturnValues();
@@ -118,7 +118,6 @@ final _smokeListenerswithreturnvaluesResultstructGetFieldresult = __lib.catchArg
 Pointer<Void> smokeListenerswithreturnvaluesResultstructToFfi(ListenersWithReturnValues_ResultStruct value) {
   final _resultHandle = (value.result);
   final _result = _smokeListenerswithreturnvaluesResultstructCreateHandle(_resultHandle);
-  (_resultHandle);
   return _result;
 }
 ListenersWithReturnValues_ResultStruct smokeListenerswithreturnvaluesResultstructFromFfi(Pointer<Void> handle) {
@@ -128,7 +127,6 @@ ListenersWithReturnValues_ResultStruct smokeListenerswithreturnvaluesResultstruc
       (_resultHandle)
     );
   } finally {
-    (_resultHandle);
   }
 }
 void smokeListenerswithreturnvaluesResultstructReleaseFfiHandle(Pointer<Void> handle) => _smokeListenerswithreturnvaluesResultstructReleaseHandle(handle);
@@ -238,7 +236,6 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -309,7 +306,7 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
   }
 }
 int _ListenersWithReturnValuesfetchDataDoubleStatic(int _token, Pointer<Double> _result) {
-  double _resultObject = null;
+  double _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
     _result.value = (_resultObject);
@@ -318,7 +315,7 @@ int _ListenersWithReturnValuesfetchDataDoubleStatic(int _token, Pointer<Double> 
   return 0;
 }
 int _ListenersWithReturnValuesfetchDataStringStatic(int _token, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
     _result.value = stringToFfi(_resultObject);
@@ -327,7 +324,7 @@ int _ListenersWithReturnValuesfetchDataStringStatic(int _token, Pointer<Pointer<
   return 0;
 }
 int _ListenersWithReturnValuesfetchDataStructStatic(int _token, Pointer<Pointer<Void>> _result) {
-  ListenersWithReturnValues_ResultStruct _resultObject = null;
+  ListenersWithReturnValues_ResultStruct _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
     _result.value = smokeListenerswithreturnvaluesResultstructToFfi(_resultObject);
@@ -336,7 +333,7 @@ int _ListenersWithReturnValuesfetchDataStructStatic(int _token, Pointer<Pointer<
   return 0;
 }
 int _ListenersWithReturnValuesfetchDataEnumStatic(int _token, Pointer<Uint32> _result) {
-  ListenersWithReturnValues_ResultEnum _resultObject = null;
+  ListenersWithReturnValues_ResultEnum _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
     _result.value = smokeListenerswithreturnvaluesResultenumToFfi(_resultObject);
@@ -345,7 +342,7 @@ int _ListenersWithReturnValuesfetchDataEnumStatic(int _token, Pointer<Uint32> _r
   return 0;
 }
 int _ListenersWithReturnValuesfetchDataArrayStatic(int _token, Pointer<Pointer<Void>> _result) {
-  List<double> _resultObject = null;
+  List<double> _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
     _result.value = foobarListofDoubleToFfi(_resultObject);
@@ -354,7 +351,7 @@ int _ListenersWithReturnValuesfetchDataArrayStatic(int _token, Pointer<Pointer<V
   return 0;
 }
 int _ListenersWithReturnValuesfetchDataMapStatic(int _token, Pointer<Pointer<Void>> _result) {
-  Map<String, double> _resultObject = null;
+  Map<String, double> _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
     _result.value = foobarMapofStringToDoubleToFfi(_resultObject);
@@ -363,7 +360,7 @@ int _ListenersWithReturnValuesfetchDataMapStatic(int _token, Pointer<Pointer<Voi
   return 0;
 }
 int _ListenersWithReturnValuesfetchDataInstanceStatic(int _token, Pointer<Pointer<Void>> _result) {
-  CalculationResult _resultObject = null;
+  CalculationResult _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
     _result.value = smokeCalculationresultToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Locales {
   /// Destroys the underlying native object.
@@ -132,7 +131,6 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class MethodOverloads {
   /// Destroys the underlying native object.
@@ -48,8 +47,6 @@ Pointer<Void> smokeMethodoverloadsPointToFfi(MethodOverloads_Point value) {
   final _xHandle = (value.x);
   final _yHandle = (value.y);
   final _result = _smokeMethodoverloadsPointCreateHandle(_xHandle, _yHandle);
-  (_xHandle);
-  (_yHandle);
   return _result;
 }
 MethodOverloads_Point smokeMethodoverloadsPointFromFfi(Pointer<Void> handle) {
@@ -61,8 +58,6 @@ MethodOverloads_Point smokeMethodoverloadsPointFromFfi(Pointer<Void> handle) {
       (_yHandle)
     );
   } finally {
-    (_xHandle);
-    (_yHandle);
   }
 }
 void smokeMethodoverloadsPointReleaseFfiHandle(Pointer<Void> handle) => _smokeMethodoverloadsPointReleaseHandle(handle);
@@ -134,7 +129,6 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
     final _inputHandle = (input);
     final _handle = this.handle;
     final __resultHandle = _isBooleanByteFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {
@@ -177,7 +171,6 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
     final _handle = this.handle;
     final __resultHandle = _isBooleanMultiFfi(_handle, __lib.LibraryContext.isolateId, _input1Handle, _input2Handle, _input3Handle, _input4Handle);
     booleanReleaseFfiHandle(_input1Handle);
-    (_input2Handle);
     stringReleaseFfiHandle(_input3Handle);
     smokeMethodoverloadsPointReleaseFfiHandle(_input4Handle);
     try {

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -1,8 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SpecialNames {
   /// Destroys the underlying native object.
@@ -42,7 +40,6 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -53,7 +50,6 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -64,7 +60,6 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -75,7 +70,6 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum FreeEnum {
     foo,

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_exception.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_exception.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/smoke/free_enum.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class FreeException implements Exception {
   final FreeEnum error;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
@@ -1,7 +1,5 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/free_enum.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class FreePoint {
   double x;
@@ -41,8 +39,6 @@ Pointer<Void> smokeFreepointToFfi(FreePoint value) {
   final _xHandle = (value.x);
   final _yHandle = (value.y);
   final _result = _smokeFreepointCreateHandle(_xHandle, _yHandle);
-  (_xHandle);
-  (_yHandle);
   return _result;
 }
 FreePoint smokeFreepointFromFfi(Pointer<Void> handle) {
@@ -54,8 +50,6 @@ FreePoint smokeFreepointFromFfi(Pointer<Void> handle) {
       (_yHandle)
     );
   } finally {
-    (_xHandle);
-    (_yHandle);
   }
 }
 void smokeFreepointReleaseFfiHandle(Pointer<Void> handle) => _smokeFreepointReleaseHandle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/outer_class.dart';
 import 'package:library/src/smoke/outer_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class LevelOne {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterClass {
   /// Destroys the underlying native object.
@@ -142,7 +142,7 @@ class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterCl
   }
 }
 int _OuterClass_InnerInterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(stringFromFfi(input));
     _result.value = stringToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -3,8 +3,8 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterClassWithInheritance implements ParentClass {
   /// Destroys the underlying native object.
@@ -143,7 +143,7 @@ class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase imp
   }
 }
 int _OuterClassWithInheritance_InnerInterfacebazStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterClassWithInheritance_InnerInterface).baz(stringFromFfi(input));
     _result.value = stringToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterInterface {
   OuterInterface();
@@ -148,7 +148,7 @@ class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements Out
   }
 }
 int _OuterInterface_InnerInterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(stringFromFfi(input));
     _result.value = stringToFfi(_resultObject);
@@ -244,7 +244,7 @@ class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
   }
 }
 int _OuterInterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterInterface).foo(stringFromFfi(input));
     _result.value = stringToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -5,8 +5,8 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 final _doNothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
@@ -43,7 +43,6 @@ class OuterStruct {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
@@ -121,7 +120,6 @@ class OuterStruct_InnerStruct {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
@@ -310,7 +308,7 @@ class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterS
   }
 }
 int _OuterStruct_InnerInterfacebarBazStatic(int _token, Pointer<Pointer<Void>> _result) {
-  Map<String, Uint8List> _resultObject = null;
+  Map<String, Uint8List> _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterStruct_InnerInterface).barBaz();
     _result.value = foobarMapofStringToBlobToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -5,7 +5,6 @@ import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseFreeTypes {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/generic_types__conversion.dart
@@ -214,7 +214,6 @@ Pointer<Void> foobarMapofIntToNullableSmokeNullableSomestructToFfi(Map<int, Null
     final _keyHandle = (entry.key);
     final _valueHandle = smokeNullableSomestructToFfiNullable(entry.value);
     _foobarMapofIntToNullableSmokeNullableSomestructPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     smokeNullableSomestructReleaseFfiHandleNullable(_valueHandle);
   }
   return _result;
@@ -229,7 +228,6 @@ Map<int, Nullable_SomeStruct> foobarMapofIntToNullableSmokeNullableSomestructFro
       result[(_keyHandle)] =
         smokeNullableSomestructFromFfiNullable(_valueHandle);
     } finally {
-      (_keyHandle);
       smokeNullableSomestructReleaseFfiHandleNullable(_valueHandle);
     }
     _foobarMapofIntToNullableSmokeNullableSomestructIteratorIncrement(_iteratorHandle);
@@ -308,7 +306,6 @@ Pointer<Void> foobarMapofLongToStringToFfi(Map<int, String> value) {
     final _keyHandle = (entry.key);
     final _valueHandle = stringToFfi(entry.value);
     _foobarMapofLongToStringPut(_result, _keyHandle, _valueHandle);
-    (_keyHandle);
     stringReleaseFfiHandle(_valueHandle);
   }
   return _result;
@@ -323,7 +320,6 @@ Map<int, String> foobarMapofLongToStringFromFfi(Pointer<Void> handle) {
       result[(_keyHandle)] =
         stringFromFfi(_valueHandle);
     } finally {
-      (_keyHandle);
       stringReleaseFfiHandle(_valueHandle);
     }
     _foobarMapofLongToStringIteratorIncrement(_iteratorHandle);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/some_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Nullable {
   /// Destroys the underlying native object.
@@ -614,7 +613,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -638,7 +636,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -662,7 +659,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -686,7 +682,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -710,7 +705,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -734,7 +728,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -758,7 +751,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -782,7 +774,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -806,7 +797,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -830,7 +820,6 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class NestedPackages {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/wee_types.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeInterface {
   factory weeInterface.make(String makeParameter) => weeInterface$Impl.make(makeParameter);
@@ -66,7 +65,6 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -75,11 +73,9 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
     final _valueHandle = (value);
     final _handle = this.handle;
     final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
-    (_valueHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeListener {
   weeListener();
@@ -67,7 +67,6 @@ class weeListener$Impl extends __lib.NativeBase implements weeListener {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum werrEnum {
     WEE_ITEM

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class CachedProperties {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -5,7 +5,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/properties_interface.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Properties {
   /// Destroys the underlying native object.
@@ -111,7 +110,6 @@ final _smokePropertiesExamplestructGetFieldvalue = __lib.catchArgumentError(() =
 Pointer<Void> smokePropertiesExamplestructToFfi(Properties_ExampleStruct value) {
   final _valueHandle = (value.value);
   final _result = _smokePropertiesExamplestructCreateHandle(_valueHandle);
-  (_valueHandle);
   return _result;
 }
 Properties_ExampleStruct smokePropertiesExamplestructFromFfi(Pointer<Void> handle) {
@@ -121,7 +119,6 @@ Properties_ExampleStruct smokePropertiesExamplestructFromFfi(Pointer<Void> handl
       (_valueHandle)
     );
   } finally {
-    (_valueHandle);
   }
 }
 void smokePropertiesExamplestructReleaseFfiHandle(Pointer<Void> handle) => _smokePropertiesExamplestructReleaseHandle(handle);
@@ -182,7 +179,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -191,11 +187,9 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _valueHandle = (value);
     final _handle = this.handle;
     final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
-    (_valueHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -206,7 +200,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -230,7 +223,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -254,7 +246,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -278,7 +269,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -302,7 +292,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -326,7 +315,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -350,7 +338,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static String get staticProperty {
@@ -370,7 +357,6 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static Properties_ExampleStruct get staticReadonlyProperty {

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PropertiesInterface {
   PropertiesInterface();
@@ -42,7 +42,6 @@ final _smokePropertiesinterfaceExamplestructGetFieldvalue = __lib.catchArgumentE
 Pointer<Void> smokePropertiesinterfaceExamplestructToFfi(PropertiesInterface_ExampleStruct value) {
   final _valueHandle = (value.value);
   final _result = _smokePropertiesinterfaceExamplestructCreateHandle(_valueHandle);
-  (_valueHandle);
   return _result;
 }
 PropertiesInterface_ExampleStruct smokePropertiesinterfaceExamplestructFromFfi(Pointer<Void> handle) {
@@ -52,7 +51,6 @@ PropertiesInterface_ExampleStruct smokePropertiesinterfaceExamplestructFromFfi(P
       (_valueHandle)
     );
   } finally {
-    (_valueHandle);
   }
 }
 void smokePropertiesinterfaceExamplestructReleaseFfiHandle(Pointer<Void> handle) => _smokePropertiesinterfaceExamplestructReleaseHandle(handle);
@@ -146,7 +144,6 @@ class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInt
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -1,8 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class EnableIfEnabled {
   /// Destroys the underlying native object.
@@ -43,7 +41,6 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static enableIfUnquotedList() {
@@ -52,7 +49,6 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static enableIfQuoted() {
@@ -61,7 +57,6 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static enableIfQuotedList() {
@@ -70,7 +65,6 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static enableIfTagged() {
@@ -79,7 +73,6 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static enableIfTaggedList() {
@@ -88,7 +81,6 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static enableIfMixedList() {
@@ -97,7 +89,6 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class EnableIfSkipped {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -3,8 +3,8 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/skip_proxy.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class InheritFromSkipped implements SkipProxy {
   InheritFromSkipped();
@@ -133,7 +133,6 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   bool get isSkippedInSwift {
@@ -155,12 +154,11 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
 int _InheritFromSkippednotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as InheritFromSkipped).notInJava(stringFromFfi(input));
     _result.value = stringToFfi(_resultObject);
@@ -170,7 +168,7 @@ int _InheritFromSkippednotInJavaStatic(int _token, Pointer<Void> input, Pointer<
   return 0;
 }
 int _InheritFromSkippednotInSwiftStatic(int _token, int input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as InheritFromSkipped).notInSwift(booleanFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SkipEnumeratorAutoTag {
     one,

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 enum SkipEnumeratorExplicitTag {
     zero,
@@ -67,4 +66,3 @@ SkipEnumeratorExplicitTag smokeSkipenumeratorexplicittagFromFfiNullable(Pointer<
 void smokeSkipenumeratorexplicittagReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipenumeratorexplicittagReleaseHandleNullable(handle);
 // End of SkipEnumeratorExplicitTag "private" section.
-

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipFunctions {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipProxy {
   SkipProxy();
@@ -138,7 +138,6 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   bool get isSkippedInSwift {
@@ -160,12 +159,11 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }
 int _SkipProxynotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
-  String _resultObject = null;
+  String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SkipProxy).notInJava(stringFromFfi(input));
     _result.value = stringToFfi(_resultObject);
@@ -175,7 +173,7 @@ int _SkipProxynotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<V
   return 0;
 }
 int _SkipProxynotInSwiftStatic(int _token, int input, Pointer<Uint8> _result) {
-  bool _resultObject = null;
+  bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SkipProxy).notInSwift(booleanFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipTagsOnly {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipTypes {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
@@ -1,4 +1,3 @@
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 final bool placeHolder = true;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -4,8 +4,8 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class Structs {
   /// Destroys the underlying native object.
@@ -103,8 +103,6 @@ Pointer<Void> smokeStructsPointToFfi(Structs_Point value) {
   final _xHandle = (value.x);
   final _yHandle = (value.y);
   final _result = _smokeStructsPointCreateHandle(_xHandle, _yHandle);
-  (_xHandle);
-  (_yHandle);
   return _result;
 }
 Structs_Point smokeStructsPointFromFfi(Pointer<Void> handle) {
@@ -116,8 +114,6 @@ Structs_Point smokeStructsPointFromFfi(Pointer<Void> handle) {
       (_yHandle)
     );
   } finally {
-    (_xHandle);
-    (_yHandle);
   }
 }
 void smokeStructsPointReleaseFfiHandle(Pointer<Void> handle) => _smokeStructsPointReleaseHandle(handle);
@@ -324,16 +320,6 @@ Pointer<Void> smokeStructsAlltypesstructToFfi(Structs_AllTypesStruct value) {
   final _bytesFieldHandle = blobToFfi(value.bytesField);
   final _pointFieldHandle = smokeStructsPointToFfi(value.pointField);
   final _result = _smokeStructsAlltypesstructCreateHandle(_int8FieldHandle, _uint8FieldHandle, _int16FieldHandle, _uint16FieldHandle, _int32FieldHandle, _uint32FieldHandle, _int64FieldHandle, _uint64FieldHandle, _floatFieldHandle, _doubleFieldHandle, _stringFieldHandle, _booleanFieldHandle, _bytesFieldHandle, _pointFieldHandle);
-  (_int8FieldHandle);
-  (_uint8FieldHandle);
-  (_int16FieldHandle);
-  (_uint16FieldHandle);
-  (_int32FieldHandle);
-  (_uint32FieldHandle);
-  (_int64FieldHandle);
-  (_uint64FieldHandle);
-  (_floatFieldHandle);
-  (_doubleFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   booleanReleaseFfiHandle(_booleanFieldHandle);
   blobReleaseFfiHandle(_bytesFieldHandle);
@@ -373,16 +359,6 @@ Structs_AllTypesStruct smokeStructsAlltypesstructFromFfi(Pointer<Void> handle) {
       smokeStructsPointFromFfi(_pointFieldHandle)
     );
   } finally {
-    (_int8FieldHandle);
-    (_uint8FieldHandle);
-    (_int16FieldHandle);
-    (_uint16FieldHandle);
-    (_int32FieldHandle);
-    (_uint32FieldHandle);
-    (_int64FieldHandle);
-    (_uint64FieldHandle);
-    (_floatFieldHandle);
-    (_doubleFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
     booleanReleaseFfiHandle(_booleanFieldHandle);
     blobReleaseFfiHandle(_bytesFieldHandle);
@@ -787,8 +763,6 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
     final _xHandle = (x);
     final _yHandle = (y);
     final __resultHandle = _createPointFfi(__lib.LibraryContext.isolateId, _xHandle, _yHandle);
-    (_xHandle);
-    (_yHandle);
     try {
       return smokeTypecollectionPointFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/route_utils.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class Route {
   String description;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -1,7 +1,6 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/validation_utils.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 final _copyReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
@@ -37,7 +36,6 @@ class Vector {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   Vector add(Vector other) {
@@ -58,8 +56,6 @@ class Vector {
     final _xHandle = (x);
     final _yHandle = (y);
     final __resultHandle = _validateFfi(__lib.LibraryContext.isolateId, _xHandle, _yHandle);
-    (_xHandle);
-    (_yHandle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {
@@ -71,8 +67,6 @@ class Vector {
     final _xHandle = (x);
     final _yHandle = (y);
     final __resultHandle = _$initFfi(__lib.LibraryContext.isolateId, _xHandle, _yHandle);
-    (_xHandle);
-    (_yHandle);
     try {
       return smokeStructswithmethodsVectorFromFfi(__resultHandle);
     } finally {
@@ -105,7 +99,6 @@ class Vector {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_StructsWithMethods_Vector_create__ULong'));
     final _inputHandle = (input);
     final __resultHandle = _createFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return smokeStructswithmethodsVectorFromFfi(__resultHandle);
     } finally {
@@ -134,8 +127,6 @@ Pointer<Void> smokeStructswithmethodsVectorToFfi(Vector value) {
   final _xHandle = (value.x);
   final _yHandle = (value.y);
   final _result = _smokeStructswithmethodsVectorCreateHandle(_xHandle, _yHandle);
-  (_xHandle);
-  (_yHandle);
   return _result;
 }
 Vector smokeStructswithmethodsVectorFromFfi(Pointer<Void> handle) {
@@ -147,8 +138,6 @@ Vector smokeStructswithmethodsVectorFromFfi(Pointer<Void> handle) {
       (_yHandle)
     );
   } finally {
-    (_xHandle);
-    (_yHandle);
   }
 }
 void smokeStructswithmethodsVectorReleaseFfiHandle(Pointer<Void> handle) => _smokeStructswithmethodsVectorReleaseHandle(handle);

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class SomeClass {
   factory SomeClass() => $class.fooBar();
@@ -56,7 +55,6 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -78,7 +76,6 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -109,7 +106,6 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithConstructor {
   String field;

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class StructWithMethods {
   String field;
@@ -24,7 +23,6 @@ class StructWithMethods$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   bool boolFunction() {
@@ -46,7 +44,6 @@ class StructWithMethods$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   String stringFunction() {
@@ -77,7 +74,6 @@ class StructWithMethods$Impl {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -4,7 +4,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class TypeDefs {
   /// Destroys the underlying native object.
@@ -41,7 +40,6 @@ final _smokeTypedefsStructhavingaliasfielddefinedbelowGetFieldfield = __lib.catc
 Pointer<Void> smokeTypedefsStructhavingaliasfielddefinedbelowToFfi(TypeDefs_StructHavingAliasFieldDefinedBelow value) {
   final _fieldHandle = (value.field);
   final _result = _smokeTypedefsStructhavingaliasfielddefinedbelowCreateHandle(_fieldHandle);
-  (_fieldHandle);
   return _result;
 }
 TypeDefs_StructHavingAliasFieldDefinedBelow smokeTypedefsStructhavingaliasfielddefinedbelowFromFfi(Pointer<Void> handle) {
@@ -51,7 +49,6 @@ TypeDefs_StructHavingAliasFieldDefinedBelow smokeTypedefsStructhavingaliasfieldd
       (_fieldHandle)
     );
   } finally {
-    (_fieldHandle);
   }
 }
 void smokeTypedefsStructhavingaliasfielddefinedbelowReleaseFfiHandle(Pointer<Void> handle) => _smokeTypedefsStructhavingaliasfielddefinedbelowReleaseHandle(handle);
@@ -172,11 +169,9 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     final _methodWithPrimitiveTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _methodWithPrimitiveTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
@@ -194,11 +189,9 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     final _returnNestedIntTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _returnNestedIntTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
-    (_inputHandle);
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
@@ -255,7 +248,6 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -1,8 +1,6 @@
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalClass {
@@ -41,7 +39,6 @@ class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalClassWithFunctions {
@@ -51,7 +50,6 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   static Pointer<Void> _make() {

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalClassWithStaticProperty {
@@ -52,7 +51,6 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -2,8 +2,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalInterface {
@@ -67,7 +67,6 @@ class InternalInterface$Impl extends __lib.NativeBase implements InternalInterfa
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -2,7 +2,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PublicClass {
   /// Destroys the underlying native object.
@@ -241,7 +240,6 @@ Pointer<Void> smokePublicclassPublicstructwithinternaldefaultsToFfi(PublicClass_
   final _publicFieldHandle = (value.publicField);
   final _result = _smokePublicclassPublicstructwithinternaldefaultsCreateHandle(_internalFieldHandle, _publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);
-  (_publicFieldHandle);
   return _result;
 }
 PublicClass_PublicStructWithInternalDefaults smokePublicclassPublicstructwithinternaldefaultsFromFfi(Pointer<Void> handle) {
@@ -254,7 +252,6 @@ PublicClass_PublicStructWithInternalDefaults smokePublicclassPublicstructwithint
     );
   } finally {
     stringReleaseFfiHandle(_internalFieldHandle);
-    (_publicFieldHandle);
   }
 }
 void smokePublicclassPublicstructwithinternaldefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokePublicclassPublicstructwithinternaldefaultsReleaseHandle(handle);
@@ -341,7 +338,6 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
   @override
@@ -365,7 +361,6 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -3,8 +3,8 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/public_class.dart';
-import 'dart:ffi';
 import 'package:meta/meta.dart';
+import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 abstract class PublicInterface {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 class PublicStructWithNonDefaultInternalField {
   int defaultedField;
@@ -37,7 +36,6 @@ Pointer<Void> smokePublicstructwithnondefaultinternalfieldToFfi(PublicStructWith
   final _internalFieldHandle = stringToFfi(value.internal_internalField);
   final _publicFieldHandle = booleanToFfi(value.publicField);
   final _result = _smokePublicstructwithnondefaultinternalfieldCreateHandle(_defaultedFieldHandle, _internalFieldHandle, _publicFieldHandle);
-  (_defaultedFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);
   booleanReleaseFfiHandle(_publicFieldHandle);
   return _result;
@@ -53,7 +51,6 @@ PublicStructWithNonDefaultInternalField smokePublicstructwithnondefaultinternalf
       booleanFromFfi(_publicFieldHandle)
     );
   } finally {
-    (_defaultedFieldHandle);
     stringReleaseFfiHandle(_internalFieldHandle);
     booleanReleaseFfiHandle(_publicFieldHandle);
   }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -1,6 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
-import 'package:meta/meta.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 class InternalStruct {
@@ -16,7 +15,6 @@ class InternalStruct {
     try {
       return (__resultHandle);
     } finally {
-      (__resultHandle);
     }
   }
 }


### PR DESCRIPTION
 Fixed more warnings from "dart analyze" static analysis tool:
    * fixed unused "meta/meta" import by moving it from being hard-coded in a template to being dynamically resolved by an
    import resolver.
    * fixed unused "built_in_types_conversion" import by omitting it for non-nullable numeric types and `void`.
    * fixed lowerCamelCase for `Locale` functions in "DartBuiltIntTypesConversion" template.
    * fixed a warning about meaningless code produced for basic types "release FFI handle" call by updating templates to
    generate nothing for these calls instead.

See: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
