### PR TITLE
Fix another group of Dart static analysis warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed remaining Dart warnings from "dart analyze" static analysis tool.
+
 ## 8.13.4
 Release date: 2021-05-21
 ### Bug fixes:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -22,12 +22,17 @@ package com.here.gluecodium.generator.dart
 import com.here.gluecodium.generator.dart.DartImport.ImportType
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeException
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CONVERTER_IMPORT_NAME
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.IMPORT_PATH_NAME
+import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypesCollection
 
 internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolverBase() {
 
@@ -35,12 +40,17 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
     private val typeRepositoryImport = DartImport("$srcPath/_type_repository", "__lib")
     private val tokenCacheImport = DartImport("$srcPath/_token_cache", "__lib")
     private val nativeBaseImport = DartImport("$srcPath/_native_base", "__lib")
+    private val libraryContextImport = DartImport("$srcPath/_library_context", "__lib")
 
     private val classInterfaceImports =
         listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport, nativeBaseImport)
 
-    override fun resolveElementImports(limeElement: LimeElement): List<DartImport> =
-        when {
+    override fun resolveElementImports(limeElement: LimeElement): List<DartImport> {
+        if (limeElement is LimeTypesCollection || limeElement is LimeException || limeElement is LimeTypeAlias ||
+            limeElement is LimeConstant
+        ) return emptyList()
+
+        return when {
             limeElement is LimeLambda -> listOf(tokenCacheImport)
             limeElement is LimeStruct && limeElement.external?.dart == null -> resolveStructImports(limeElement)
             limeElement is LimeInterface -> classInterfaceImports + metaPackageImport
@@ -51,11 +61,14 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
         } + listOfNotNull(
             resolveExternalImport(limeElement, IMPORT_PATH_NAME, useAlias = true),
             resolveExternalImport(limeElement, CONVERTER_IMPORT_NAME, useAlias = false)
-        )
+        ) + listOf(ffiSystemImport, libraryContextImport)
+    }
 
     private fun resolveStructImports(limeStruct: LimeStruct): List<DartImport> {
         val result = mutableListOf<DartImport>()
-        if (limeStruct.attributes.have(LimeAttributeType.EQUATABLE)) {
+        if (limeStruct.attributes.have(LimeAttributeType.EQUATABLE) &&
+            limeStruct.fields.any { it.typeRef.type.actualType is LimeGenericType }
+        ) {
             result += listOf(collectionSystemImport, collectionPackageImport)
         }
         if (limeStruct.attributes.have(LimeAttributeType.IMMUTABLE)) {
@@ -68,5 +81,6 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
         private val collectionSystemImport = DartImport("collection", importType = ImportType.SYSTEM)
         private val collectionPackageImport = DartImport("collection/collection")
         private val metaPackageImport = DartImport("meta/meta")
+        private val ffiSystemImport = DartImport("ffi", importType = ImportType.SYSTEM)
     }
 }

--- a/gluecodium/src/main/resources/templates/dart/DartFile.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFile.mustache
@@ -24,10 +24,6 @@
 {{>dart/DartImport}}
 {{/imports}}
 
-import 'dart:ffi';
-
-import 'package:{{libraryName}}/src/_library_context.dart' as __lib;
-
 {{#model}}
 {{include contentTemplate}}
 {{/model}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -169,7 +169,7 @@ class {{resolveName}}$Impl extends __lib.NativeBase implements {{resolveName}} {
 }
 
 {{#set parent=this}}{{#each inheritedFunctions functions}}{{#unless isStatic}}
-int _{{resolveName parent}}{{resolveName}}Static({{!!
+int _{{resolveName parent "Ffi"}}{{resolveName}}Static({{!!
 }}int _token{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef "FfiDartTypes"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
 }}{{#unless returnType.isVoid}}, Pointer<{{resolveName returnType.typeRef "FfiApiTypes"}}> _result{{/unless}}{{!!
@@ -210,14 +210,14 @@ int _{{resolveName parent}}{{resolveName}}Static({{!!
 {{/unless}}{{/each}}
 
 {{#each inheritedProperties properties}}{{#unless isStatic}}
-int _{{resolveName parent}}{{resolveName}}GetStatic(int _token, Pointer<{{resolveName typeRef "FfiApiTypes"}}> _result) {
+int _{{resolveName parent "Ffi"}}{{resolveName}}GetStatic(int _token, Pointer<{{resolveName typeRef "FfiApiTypes"}}> _result) {
   _result.value = {{#set call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{!!
   }}(__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}});
   return 0;
 }
 {{#if setter}}
 
-int _{{resolveName parent}}{{resolveName}}SetStatic(int _token, {{resolveName typeRef "FfiDartTypes"}} _value) {
+int _{{resolveName parent "Ffi"}}{{resolveName}}SetStatic(int _token, {{resolveName typeRef "FfiDartTypes"}} _value) {
   try {
     (__lib.instanceCache[_token] as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}} =
       {{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
@@ -236,10 +236,10 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi{{#set parent=this}}{{#each inheritedFunctions functions}}{{#unless isStatic}},
-    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}{{resolveName}}Static, __lib.unknownError){{!!
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent "Ffi"}}{{resolveName}}Static, __lib.unknownError){{!!
     }}{{/unless}}{{/each}}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#set property=this}}{{#getter}},
-    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}{{resolveName property}}GetStatic, __lib.unknownError){{/getter}}{{#setter}},
-    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent}}{{resolveName property}}SetStatic, __lib.unknownError){{/setter}}{{!!
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent "Ffi"}}{{resolveName property}}GetStatic, __lib.unknownError){{/getter}}{{#setter}},
+    Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName parent "Ffi"}}{{resolveName property}}SetStatic, __lib.unknownError){{/setter}}{{!!
     }}{{/set}}{{/unless}}{{/each}}{{/set}}
   );
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 @OnClass
 abstract class AttributesClass {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_crash_exception.dart
@@ -1,6 +1,4 @@
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 @OnException
 class AttributesCrashException implements Exception {
   final String error;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 @OnInterface
 abstract class AttributesInterface {
   AttributesInterface();
@@ -113,7 +113,7 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
     }
   }
 }
-int _AttributesInterfaceveryFunStatic(int _token, Pointer<Void> param) {
+int _smokeAttributesinterfaceveryFunStatic(int _token, Pointer<Void> param) {
   try {
     (__lib.instanceCache[_token] as AttributesInterface).veryFun(stringFromFfi(param));
   } finally {
@@ -121,11 +121,11 @@ int _AttributesInterfaceveryFunStatic(int _token, Pointer<Void> param) {
   }
   return 0;
 }
-int _AttributesInterfacepropGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeAttributesinterfacepropGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as AttributesInterface).prop);
   return 0;
 }
-int _AttributesInterfacepropSetStatic(int _token, Pointer<Void> _value) {
+int _smokeAttributesinterfacepropSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as AttributesInterface).prop =
       stringFromFfi(_value);
@@ -140,9 +140,9 @@ Pointer<Void> smokeAttributesinterfaceToFfi(AttributesInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_AttributesInterfaceveryFunStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_AttributesInterfacepropGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_AttributesInterfacepropSetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeAttributesinterfaceveryFunStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeAttributesinterfacepropGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeAttributesinterfacepropSetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 @OnLambda
 typedef AttributesLambda = void Function();
 // AttributesLambda "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 @OnStruct
 class AttributesStruct {
   @OnField

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// Class comment
 @OnClass
 abstract class AttributesWithComments {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("")
 @OnClass
 abstract class AttributesWithDeprecated {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class MultipleAttributesDart {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class SpecialAttributes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class BasicTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 abstract class Comments {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 abstract class CommentsInterface {
   CommentsInterface();
@@ -448,7 +448,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
 }
-int _CommentsInterfacesomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+int _smokeCommentsinterfacesomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithAllComments(stringFromFfi(input));
@@ -458,7 +458,7 @@ int _CommentsInterfacesomeMethodWithAllCommentsStatic(int _token, Pointer<Void> 
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithInputCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+int _smokeCommentsinterfacesomeMethodWithInputCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithInputComments(stringFromFfi(input));
@@ -468,7 +468,7 @@ int _CommentsInterfacesomeMethodWithInputCommentsStatic(int _token, Pointer<Void
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithOutputCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+int _smokeCommentsinterfacesomeMethodWithOutputCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithOutputComments(stringFromFfi(input));
@@ -478,7 +478,7 @@ int _CommentsInterfacesomeMethodWithOutputCommentsStatic(int _token, Pointer<Voi
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithNoCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+int _smokeCommentsinterfacesomeMethodWithNoCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNoComments(stringFromFfi(input));
@@ -488,7 +488,7 @@ int _CommentsInterfacesomeMethodWithNoCommentsStatic(int _token, Pointer<Void> i
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithoutReturnTypeWithAllCommentsStatic(int _token, Pointer<Void> input) {
+int _smokeCommentsinterfacesomeMethodWithoutReturnTypeWithAllCommentsStatic(int _token, Pointer<Void> input) {
   try {
     (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithAllComments(stringFromFfi(input));
   } finally {
@@ -496,7 +496,7 @@ int _CommentsInterfacesomeMethodWithoutReturnTypeWithAllCommentsStatic(int _toke
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic(int _token, Pointer<Void> input) {
+int _smokeCommentsinterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic(int _token, Pointer<Void> input) {
   try {
     (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeWithNoComments(stringFromFfi(input));
   } finally {
@@ -504,7 +504,7 @@ int _CommentsInterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic(int _token
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithoutInputParametersWithAllCommentsStatic(int _token, Pointer<Uint8> _result) {
+int _smokeCommentsinterfacesomeMethodWithoutInputParametersWithAllCommentsStatic(int _token, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
@@ -513,7 +513,7 @@ int _CommentsInterfacesomeMethodWithoutInputParametersWithAllCommentsStatic(int 
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithoutInputParametersWithNoCommentsStatic(int _token, Pointer<Uint8> _result) {
+int _smokeCommentsinterfacesomeMethodWithoutInputParametersWithNoCommentsStatic(int _token, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
@@ -522,25 +522,25 @@ int _CommentsInterfacesomeMethodWithoutInputParametersWithNoCommentsStatic(int _
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithNothingStatic(int _token) {
+int _smokeCommentsinterfacesomeMethodWithNothingStatic(int _token) {
   try {
     (__lib.instanceCache[_token] as CommentsInterface).someMethodWithNothing();
   } finally {
   }
   return 0;
 }
-int _CommentsInterfacesomeMethodWithoutReturnTypeOrInputParametersStatic(int _token) {
+int _smokeCommentsinterfacesomeMethodWithoutReturnTypeOrInputParametersStatic(int _token) {
   try {
     (__lib.instanceCache[_token] as CommentsInterface).someMethodWithoutReturnTypeOrInputParameters();
   } finally {
   }
   return 0;
 }
-int _CommentsInterfaceisSomePropertyGetStatic(int _token, Pointer<Uint8> _result) {
+int _smokeCommentsinterfaceisSomePropertyGetStatic(int _token, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((__lib.instanceCache[_token] as CommentsInterface).isSomeProperty);
   return 0;
 }
-int _CommentsInterfaceisSomePropertySetStatic(int _token, int _value) {
+int _smokeCommentsinterfaceisSomePropertySetStatic(int _token, int _value) {
   try {
     (__lib.instanceCache[_token] as CommentsInterface).isSomeProperty =
       booleanFromFfi(_value);
@@ -555,18 +555,18 @@ Pointer<Void> smokeCommentsinterfaceToFfi(CommentsInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterfacesomeMethodWithAllCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterfacesomeMethodWithInputCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterfacesomeMethodWithOutputCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_CommentsInterfacesomeMethodWithNoCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_CommentsInterfacesomeMethodWithoutReturnTypeWithAllCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_CommentsInterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_CommentsInterfacesomeMethodWithoutInputParametersWithAllCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_CommentsInterfacesomeMethodWithoutInputParametersWithNoCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64)>(_CommentsInterfacesomeMethodWithNothingStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64)>(_CommentsInterfacesomeMethodWithoutReturnTypeOrInputParametersStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_CommentsInterfaceisSomePropertyGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_CommentsInterfaceisSomePropertySetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_smokeCommentsinterfacesomeMethodWithAllCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_smokeCommentsinterfacesomeMethodWithInputCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_smokeCommentsinterfacesomeMethodWithOutputCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_smokeCommentsinterfacesomeMethodWithNoCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeCommentsinterfacesomeMethodWithoutReturnTypeWithAllCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeCommentsinterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_smokeCommentsinterfacesomeMethodWithoutInputParametersWithAllCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_smokeCommentsinterfacesomeMethodWithoutInputParametersWithNoCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64)>(_smokeCommentsinterfacesomeMethodWithNothingStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64)>(_smokeCommentsinterfacesomeMethodWithoutReturnTypeOrInputParametersStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_smokeCommentsinterfaceisSomePropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_smokeCommentsinterfaceisSomePropertySetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// The nested types like [CommentsLinks.randomMethod2] don't need full name prefix, but it's
 /// possible to references other interfaces like [CommentsInterface] or other members
 /// [Comments.someMethodWithAllComments].

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 /// First line.
 ///
 /// Second line.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 @Deprecated("")
 class DeprecatedWithNoMessage {
   String field;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 abstract class DeprecationComments {
@@ -296,7 +296,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
     }
   }
 }
-int _DeprecationCommentssomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+int _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as DeprecationComments).someMethodWithAllComments(stringFromFfi(input));
@@ -306,11 +306,11 @@ int _DeprecationCommentssomeMethodWithAllCommentsStatic(int _token, Pointer<Void
   }
   return 0;
 }
-int _DeprecationCommentsisSomePropertyGetStatic(int _token, Pointer<Uint8> _result) {
+int _smokeDeprecationcommentsisSomePropertyGetStatic(int _token, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((__lib.instanceCache[_token] as DeprecationComments).isSomeProperty);
   return 0;
 }
-int _DeprecationCommentsisSomePropertySetStatic(int _token, int _value) {
+int _smokeDeprecationcommentsisSomePropertySetStatic(int _token, int _value) {
   try {
     (__lib.instanceCache[_token] as DeprecationComments).isSomeProperty =
       booleanFromFfi(_value);
@@ -319,11 +319,11 @@ int _DeprecationCommentsisSomePropertySetStatic(int _token, int _value) {
   }
   return 0;
 }
-int _DeprecationCommentspropertyButNotAccessorsGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeDeprecationcommentspropertyButNotAccessorsGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as DeprecationComments).propertyButNotAccessors);
   return 0;
 }
-int _DeprecationCommentspropertyButNotAccessorsSetStatic(int _token, Pointer<Void> _value) {
+int _smokeDeprecationcommentspropertyButNotAccessorsSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as DeprecationComments).propertyButNotAccessors =
       stringFromFfi(_value);
@@ -338,11 +338,11 @@ Pointer<Void> smokeDeprecationcommentsToFfi(DeprecationComments value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_DeprecationCommentssomeMethodWithAllCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_DeprecationCommentsisSomePropertyGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_DeprecationCommentsisSomePropertySetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_DeprecationCommentspropertyButNotAccessorsGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_DeprecationCommentspropertyButNotAccessorsSetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_smokeDeprecationcommentssomeMethodWithAllCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_smokeDeprecationcommentsisSomePropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_smokeDeprecationcommentsisSomePropertySetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeDeprecationcommentspropertyButNotAccessorsGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeDeprecationcommentspropertyButNotAccessorsSetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 @Deprecated("Unfortunately, this interface is deprecated.")
 abstract class DeprecationCommentsOnly {
   DeprecationCommentsOnly();
@@ -238,7 +238,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
     }
   }
 }
-int _DeprecationCommentsOnlysomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
+int _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(int _token, Pointer<Void> input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as DeprecationCommentsOnly).someMethodWithAllComments(stringFromFfi(input));
@@ -248,11 +248,11 @@ int _DeprecationCommentsOnlysomeMethodWithAllCommentsStatic(int _token, Pointer<
   }
   return 0;
 }
-int _DeprecationCommentsOnlyisSomePropertyGetStatic(int _token, Pointer<Uint8> _result) {
+int _smokeDeprecationcommentsonlyisSomePropertyGetStatic(int _token, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((__lib.instanceCache[_token] as DeprecationCommentsOnly).isSomeProperty);
   return 0;
 }
-int _DeprecationCommentsOnlyisSomePropertySetStatic(int _token, int _value) {
+int _smokeDeprecationcommentsonlyisSomePropertySetStatic(int _token, int _value) {
   try {
     (__lib.instanceCache[_token] as DeprecationCommentsOnly).isSomeProperty =
       booleanFromFfi(_value);
@@ -267,9 +267,9 @@ Pointer<Void> smokeDeprecationcommentsonlyToFfi(DeprecationCommentsOnly value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_DeprecationCommentsOnlysomeMethodWithAllCommentsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_DeprecationCommentsOnlyisSomePropertyGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_DeprecationCommentsOnlyisSomePropertySetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Uint8>)>(_smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_smokeDeprecationcommentsonlyisSomePropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_smokeDeprecationcommentsonlyisSomePropertySetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful class.
 /// @nodoc
 abstract class ExcludedComments {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 /// @nodoc
 abstract class ExcludedCommentsInterface {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class ExcludedCommentsOnly {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 /// This looks internal
 /// @nodoc
 abstract class InternalClassWithComments {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// Referencing some type [MapScene.loadSceneWithInt].
 abstract class MapScene {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// This is some very useful interface.
 ///
 /// There is a lot to say about this interface.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class PlatformComments {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class UnicodeComments {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class CollectionConstants {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class ConstantsInterface {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/cross_file_constants.dart
@@ -1,4 +1,2 @@
 import 'package:library/src/smoke/constants.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 final StateEnum fooBar = StateEnum.on;

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class StructConstants {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Constructors {
   factory Constructors() => Constructors$Impl.$init();
   factory Constructors.fromOther(Constructors other) => Constructors$Impl.fromOther(other);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class SingleNamedConstructor {
   factory SingleNamedConstructor.fooBar() => SingleNamedConstructor$Impl.fooBar();
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class SingleNamelessConstructor {
   factory SingleNamelessConstructor() => SingleNamelessConstructor$Impl.create();
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Dates {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class DefaultValues {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 class StructWithAllDefaults {
   int intField;
   String stringField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/builtin_types__conversion.dart';
-import 'package:library/src/generic_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 class StructWithCollectionDefaults {
   List<String> emptyListField;
   Map<String, String> emptyMapField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/smoke/something_enum.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/something_enum.dart';
 class StructWithEnums {
   SomethingEnum firstField;
   SomethingEnum explicitField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/types_with_defaults.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 class StructWithInitializerDefaults {
   List<int> intsField;
   List<double> floatsField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 class StructWithSomeDefaults {
   int intField;
   String stringField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/an_enum.dart';
 import 'package:library/src/smoke/default_values.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 enum SomeEnum {
     fooValue,
     barValue

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Enums {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -1,9 +1,9 @@
 import 'dart:collection';
+import 'dart:ffi';
 import 'package:collection/collection.dart';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 enum SomeEnum {
     foo,
     bar

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class EquatableInterface {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -1,9 +1,9 @@
 import 'dart:collection';
+import 'dart:ffi';
 import 'package:collection/collection.dart';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 class EquatableStructWithInternalFields {
   String publicField;
   /// @nodoc

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/simple_equatable_struct.dart
@@ -1,9 +1,7 @@
-import 'dart:collection';
-import 'package:collection/collection.dart';
-import 'package:library/src/smoke/non_equatable_class.dart';
-import 'package:library/src/smoke/non_equatable_interface.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/non_equatable_class.dart';
+import 'package:library/src/smoke/non_equatable_interface.dart';
 class SimpleEquatableStruct {
   NonEquatableClass classField;
   NonEquatableInterface interfaceField;

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Errors {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
@@ -5,8 +7,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ErrorsInterface {
   ErrorsInterface();
   factory ErrorsInterface.fromLambdas({
@@ -387,7 +387,7 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
     }
   }
 }
-int _ErrorsInterfacemethodWithErrorsStatic(int _token, Pointer<Uint32> _error) {
+int _smokeErrorsinterfacemethodWithErrorsStatic(int _token, Pointer<Uint32> _error) {
   bool _errorFlag = false;
   try {
     (__lib.instanceCache[_token] as ErrorsInterface).methodWithErrors();
@@ -399,7 +399,7 @@ int _ErrorsInterfacemethodWithErrorsStatic(int _token, Pointer<Uint32> _error) {
   }
   return _errorFlag ? 1 : 0;
 }
-int _ErrorsInterfacemethodWithExternalErrorsStatic(int _token, Pointer<Uint32> _error) {
+int _smokeErrorsinterfacemethodWithExternalErrorsStatic(int _token, Pointer<Uint32> _error) {
   bool _errorFlag = false;
   try {
     (__lib.instanceCache[_token] as ErrorsInterface).methodWithExternalErrors();
@@ -411,7 +411,7 @@ int _ErrorsInterfacemethodWithExternalErrorsStatic(int _token, Pointer<Uint32> _
   }
   return _errorFlag ? 1 : 0;
 }
-int _ErrorsInterfacemethodWithErrorsAndReturnValueStatic(int _token, Pointer<Pointer<Void>> _result, Pointer<Uint32> _error) {
+int _smokeErrorsinterfacemethodWithErrorsAndReturnValueStatic(int _token, Pointer<Pointer<Void>> _result, Pointer<Uint32> _error) {
   bool _errorFlag = false;
   String _resultObject;
   try {
@@ -431,9 +431,9 @@ Pointer<Void> smokeErrorsinterfaceToFfi(ErrorsInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_ErrorsInterfacemethodWithErrorsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_ErrorsInterfacemethodWithExternalErrorsStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>, Pointer<Uint32>)>(_ErrorsInterfacemethodWithErrorsAndReturnValueStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_smokeErrorsinterfacemethodWithErrorsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_smokeErrorsinterfacemethodWithExternalErrorsStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>, Pointer<Uint32>)>(_smokeErrorsinterfacemethodWithErrorsAndReturnValueStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
@@ -5,8 +7,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/package/interface.dart';
 import 'package:library/src/package/types.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Class implements Interface {
   factory Class() => Class$Impl.constructor();
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Interface {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class Enums {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ExternalClass {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ExternalInterface {
   ExternalInterface();
   factory ExternalInterface.fromLambdas({
@@ -202,14 +202,14 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
     }
   }
 }
-int _ExternalInterfacesomeMethodStatic(int _token, int someParameter) {
+int _smokeExternalinterfacesomeMethodStatic(int _token, int someParameter) {
   try {
     (__lib.instanceCache[_token] as ExternalInterface).someMethod((someParameter));
   } finally {
   }
   return 0;
 }
-int _ExternalInterfacesomePropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeExternalinterfacesomePropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as ExternalInterface).someProperty);
   return 0;
 }
@@ -219,8 +219,8 @@ Pointer<Void> smokeExternalinterfaceToFfi(ExternalInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Int8)>(_ExternalInterfacesomeMethodStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ExternalInterfacesomePropertyGetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Int8)>(_smokeExternalinterfacesomeMethodStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeExternalinterfacesomePropertyGetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -1,5 +1,5 @@
-import 'package:foo/bar.dart' as bar;
 import 'dart:ffi';
+import 'package:foo/bar.dart' as bar;
 import 'package:library/src/_library_context.dart' as __lib;
 // HttpClientResponseCompressionState "private" section, not exported.
 int smokeCompressionstateToFfi(bar.HttpClientResponseCompressionState value) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/int.dart
@@ -1,6 +1,6 @@
-import '../color_converter.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import '../color_converter.dart';
 class intInternal {
   double red;
   double green;

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/rectangle_int_.dart
@@ -1,5 +1,5 @@
-import 'dart:math' as math;
 import 'dart:ffi';
+import 'dart:math' as math;
 import 'package:library/src/_library_context.dart' as __lib;
 // Rectangle<int> "private" section, not exported.
 final _smokeRectangleCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -1,6 +1,6 @@
-import '../season_converter.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import '../season_converter.dart';
 enum StringInternal {
     winter,
     spring,

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Structs {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -1,13 +1,13 @@
+import 'dart:ffi';
 import 'dart:math' as math;
 import 'package:foo/bar.dart' as bar;
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/http_client_response_compression_state.dart';
 import 'package:library/src/smoke/int.dart';
 import 'package:library/src/smoke/rectangle_int_.dart';
 import 'package:library/src/smoke/string.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseDartExternalTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithBasicTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/dummy_class.dart';
 import 'package:library/src/smoke/dummy_interface.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithCompoundTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class GenericTypesWithGenericTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
 import 'package:library/src/_lazy_list.dart' as __lib;
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseOptimizedList {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list_struct.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
 import 'package:library/src/_lazy_list.dart' as __lib;
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 @immutable
 class UseOptimizedListStruct {
   final List<VeryBigStruct> structs;

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildClassFromClass implements ParentClass {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildClassFromInterface implements ParentInterface {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildInterface implements ParentInterface {
   ChildInterface();
   factory ChildInterface.fromLambdas({
@@ -119,25 +119,25 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
     }
   }
 }
-int _ChildInterfacerootMethodStatic(int _token) {
+int _smokeChildinterfacerootMethodStatic(int _token) {
   try {
     (__lib.instanceCache[_token] as ChildInterface).rootMethod();
   } finally {
   }
   return 0;
 }
-int _ChildInterfacechildMethodStatic(int _token) {
+int _smokeChildinterfacechildMethodStatic(int _token) {
   try {
     (__lib.instanceCache[_token] as ChildInterface).childMethod();
   } finally {
   }
   return 0;
 }
-int _ChildInterfacerootPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeChildinterfacerootPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as ChildInterface).rootProperty);
   return 0;
 }
-int _ChildInterfacerootPropertySetStatic(int _token, Pointer<Void> _value) {
+int _smokeChildinterfacerootPropertySetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ChildInterface).rootProperty =
       stringFromFfi(_value);
@@ -152,10 +152,10 @@ Pointer<Void> smokeChildinterfaceToFfi(ChildInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64)>(_ChildInterfacerootMethodStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64)>(_ChildInterfacechildMethodStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ChildInterfacerootPropertyGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ChildInterfacerootPropertySetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64)>(_smokeChildinterfacerootMethodStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64)>(_smokeChildinterfacechildMethodStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeChildinterfacerootPropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeChildinterfacerootPropertySetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
@@ -5,8 +7,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ChildWithParentClassReferences implements ParentWithClassReferences {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ParentClass {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ParentInterface {
   ParentInterface();
   factory ParentInterface.fromLambdas({
@@ -103,18 +103,18 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
     }
   }
 }
-int _ParentInterfacerootMethodStatic(int _token) {
+int _smokeParentinterfacerootMethodStatic(int _token) {
   try {
     (__lib.instanceCache[_token] as ParentInterface).rootMethod();
   } finally {
   }
   return 0;
 }
-int _ParentInterfacerootPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeParentinterfacerootPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as ParentInterface).rootProperty);
   return 0;
 }
-int _ParentInterfacerootPropertySetStatic(int _token, Pointer<Void> _value) {
+int _smokeParentinterfacerootPropertySetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ParentInterface).rootProperty =
       stringFromFfi(_value);
@@ -129,9 +129,9 @@ Pointer<Void> smokeParentinterfaceToFfi(ParentInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64)>(_ParentInterfacerootMethodStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ParentInterfacerootPropertyGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ParentInterfacerootPropertySetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64)>(_smokeParentinterfacerootMethodStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeParentinterfacerootPropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeParentinterfacerootPropertySetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class SimpleClass {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class SimpleInterface {
   SimpleInterface();
   factory SimpleInterface.fromLambdas({
@@ -90,7 +90,7 @@ class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
     }
   }
 }
-int _SimpleInterfacegetStringValueStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeSimpleinterfacegetStringValueStatic(int _token, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SimpleInterface).getStringValue();
@@ -99,7 +99,7 @@ int _SimpleInterfacegetStringValueStatic(int _token, Pointer<Pointer<Void>> _res
   }
   return 0;
 }
-int _SimpleInterfaceuseSimpleInterfaceStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+int _smokeSimpleinterfaceuseSimpleInterfaceStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   SimpleInterface _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SimpleInterface).useSimpleInterface(smokeSimpleinterfaceFromFfi(input));
@@ -116,8 +116,8 @@ Pointer<Void> smokeSimpleinterfaceToFfi(SimpleInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_SimpleInterfacegetStringValueStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_SimpleInterfaceuseSimpleInterfaceStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeSimpleinterfacegetStringValueStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeSimpleinterfaceuseSimpleInterfaceStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_class.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/smoke/simple_class.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/simple_class.dart';
 class StructWithClass {
   SimpleClass classInstance;
   StructWithClass(this.classInstance);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/struct_with_interface.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/smoke/simple_interface.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/simple_interface.dart';
 class StructWithInterface {
   SimpleInterface interfaceInstance;
   StructWithInterface(this.interfaceInstance);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ClassWithInternalLambda {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Lambdas {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/lambdas_declaration_order.dart';
 import 'package:library/src/smoke/lambdas_interface.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class LambdasWithStructuredTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 typedef StandaloneProducer = String Function();
 // StandaloneProducer "private" section, not exported.
 final _smokeStandaloneproducerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
@@ -5,8 +7,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class CalculatorListener {
   CalculatorListener();
   factory CalculatorListener.fromLambdas({
@@ -232,21 +232,21 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     }
   }
 }
-int _CalculatorListeneronCalculationResultStatic(int _token, double calculationResult) {
+int _smokeCalculatorlisteneronCalculationResultStatic(int _token, double calculationResult) {
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResult((calculationResult));
   } finally {
   }
   return 0;
 }
-int _CalculatorListeneronCalculationResultConstStatic(int _token, double calculationResult) {
+int _smokeCalculatorlisteneronCalculationResultConstStatic(int _token, double calculationResult) {
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultConst((calculationResult));
   } finally {
   }
   return 0;
 }
-int _CalculatorListeneronCalculationResultStructStatic(int _token, Pointer<Void> calculationResult) {
+int _smokeCalculatorlisteneronCalculationResultStructStatic(int _token, Pointer<Void> calculationResult) {
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultStruct(smokeCalculatorlistenerResultstructFromFfi(calculationResult));
   } finally {
@@ -254,7 +254,7 @@ int _CalculatorListeneronCalculationResultStructStatic(int _token, Pointer<Void>
   }
   return 0;
 }
-int _CalculatorListeneronCalculationResultArrayStatic(int _token, Pointer<Void> calculationResult) {
+int _smokeCalculatorlisteneronCalculationResultArrayStatic(int _token, Pointer<Void> calculationResult) {
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultArray(foobarListofDoubleFromFfi(calculationResult));
   } finally {
@@ -262,7 +262,7 @@ int _CalculatorListeneronCalculationResultArrayStatic(int _token, Pointer<Void> 
   }
   return 0;
 }
-int _CalculatorListeneronCalculationResultMapStatic(int _token, Pointer<Void> calculationResults) {
+int _smokeCalculatorlisteneronCalculationResultMapStatic(int _token, Pointer<Void> calculationResults) {
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultMap(foobarMapofStringToDoubleFromFfi(calculationResults));
   } finally {
@@ -270,7 +270,7 @@ int _CalculatorListeneronCalculationResultMapStatic(int _token, Pointer<Void> ca
   }
   return 0;
 }
-int _CalculatorListeneronCalculationResultInstanceStatic(int _token, Pointer<Void> calculationResult) {
+int _smokeCalculatorlisteneronCalculationResultInstanceStatic(int _token, Pointer<Void> calculationResult) {
   try {
     (__lib.instanceCache[_token] as CalculatorListener).onCalculationResultInstance(smokeCalculationresultFromFfi(calculationResult));
   } finally {
@@ -284,12 +284,12 @@ Pointer<Void> smokeCalculatorlistenerToFfi(CalculatorListener value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Double)>(_CalculatorListeneronCalculationResultStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Double)>(_CalculatorListeneronCalculationResultConstStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_CalculatorListeneronCalculationResultStructStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_CalculatorListeneronCalculationResultArrayStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_CalculatorListeneronCalculationResultMapStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_CalculatorListeneronCalculationResultInstanceStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Double)>(_smokeCalculatorlisteneronCalculationResultStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Double)>(_smokeCalculatorlisteneronCalculationResultConstStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeCalculatorlisteneronCalculationResultStructStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeCalculatorlisteneronCalculationResultArrayStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeCalculatorlisteneronCalculationResultMapStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeCalculatorlisteneronCalculationResultInstanceStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class InterfaceWithStatic {
   InterfaceWithStatic();
   factory InterfaceWithStatic.fromLambdas({
@@ -136,7 +136,7 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
     }
   }
 }
-int _InterfaceWithStaticregularFunctionStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeInterfacewithstaticregularFunctionStatic(int _token, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as InterfaceWithStatic).regularFunction();
@@ -145,11 +145,11 @@ int _InterfaceWithStaticregularFunctionStatic(int _token, Pointer<Pointer<Void>>
   }
   return 0;
 }
-int _InterfaceWithStaticregularPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeInterfacewithstaticregularPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as InterfaceWithStatic).regularProperty);
   return 0;
 }
-int _InterfaceWithStaticregularPropertySetStatic(int _token, Pointer<Void> _value) {
+int _smokeInterfacewithstaticregularPropertySetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as InterfaceWithStatic).regularProperty =
       stringFromFfi(_value);
@@ -164,9 +164,9 @@ Pointer<Void> smokeInterfacewithstaticToFfi(InterfaceWithStatic value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_InterfaceWithStaticregularFunctionStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_InterfaceWithStaticregularPropertyGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_InterfaceWithStaticregularPropertySetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeInterfacewithstaticregularFunctionStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeInterfacewithstaticregularPropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeInterfacewithstaticregularPropertySetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -1,4 +1,6 @@
+import 'dart:ffi';
 import 'dart:typed_data';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
@@ -6,8 +8,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenerWithProperties {
   ListenerWithProperties();
   factory ListenerWithProperties.fromLambdas({
@@ -419,11 +419,11 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     }
   }
 }
-int _ListenerWithPropertiesmessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerwithpropertiesmessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as ListenerWithProperties).message);
   return 0;
 }
-int _ListenerWithPropertiesmessageSetStatic(int _token, Pointer<Void> _value) {
+int _smokeListenerwithpropertiesmessageSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ListenerWithProperties).message =
       stringFromFfi(_value);
@@ -432,11 +432,11 @@ int _ListenerWithPropertiesmessageSetStatic(int _token, Pointer<Void> _value) {
   }
   return 0;
 }
-int _ListenerWithPropertiespackedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerwithpropertiespackedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = smokeCalculationresultToFfi((__lib.instanceCache[_token] as ListenerWithProperties).packedMessage);
   return 0;
 }
-int _ListenerWithPropertiespackedMessageSetStatic(int _token, Pointer<Void> _value) {
+int _smokeListenerwithpropertiespackedMessageSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ListenerWithProperties).packedMessage =
       smokeCalculationresultFromFfi(_value);
@@ -445,11 +445,11 @@ int _ListenerWithPropertiespackedMessageSetStatic(int _token, Pointer<Void> _val
   }
   return 0;
 }
-int _ListenerWithPropertiesstructuredMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerwithpropertiesstructuredMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = smokeListenerwithpropertiesResultstructToFfi((__lib.instanceCache[_token] as ListenerWithProperties).structuredMessage);
   return 0;
 }
-int _ListenerWithPropertiesstructuredMessageSetStatic(int _token, Pointer<Void> _value) {
+int _smokeListenerwithpropertiesstructuredMessageSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ListenerWithProperties).structuredMessage =
       smokeListenerwithpropertiesResultstructFromFfi(_value);
@@ -458,11 +458,11 @@ int _ListenerWithPropertiesstructuredMessageSetStatic(int _token, Pointer<Void> 
   }
   return 0;
 }
-int _ListenerWithPropertiesenumeratedMessageGetStatic(int _token, Pointer<Uint32> _result) {
+int _smokeListenerwithpropertiesenumeratedMessageGetStatic(int _token, Pointer<Uint32> _result) {
   _result.value = smokeListenerwithpropertiesResultenumToFfi((__lib.instanceCache[_token] as ListenerWithProperties).enumeratedMessage);
   return 0;
 }
-int _ListenerWithPropertiesenumeratedMessageSetStatic(int _token, int _value) {
+int _smokeListenerwithpropertiesenumeratedMessageSetStatic(int _token, int _value) {
   try {
     (__lib.instanceCache[_token] as ListenerWithProperties).enumeratedMessage =
       smokeListenerwithpropertiesResultenumFromFfi(_value);
@@ -471,11 +471,11 @@ int _ListenerWithPropertiesenumeratedMessageSetStatic(int _token, int _value) {
   }
   return 0;
 }
-int _ListenerWithPropertiesarrayedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerwithpropertiesarrayedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = foobarListofStringToFfi((__lib.instanceCache[_token] as ListenerWithProperties).arrayedMessage);
   return 0;
 }
-int _ListenerWithPropertiesarrayedMessageSetStatic(int _token, Pointer<Void> _value) {
+int _smokeListenerwithpropertiesarrayedMessageSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ListenerWithProperties).arrayedMessage =
       foobarListofStringFromFfi(_value);
@@ -484,11 +484,11 @@ int _ListenerWithPropertiesarrayedMessageSetStatic(int _token, Pointer<Void> _va
   }
   return 0;
 }
-int _ListenerWithPropertiesmappedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerwithpropertiesmappedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = foobarMapofStringToDoubleToFfi((__lib.instanceCache[_token] as ListenerWithProperties).mappedMessage);
   return 0;
 }
-int _ListenerWithPropertiesmappedMessageSetStatic(int _token, Pointer<Void> _value) {
+int _smokeListenerwithpropertiesmappedMessageSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ListenerWithProperties).mappedMessage =
       foobarMapofStringToDoubleFromFfi(_value);
@@ -497,11 +497,11 @@ int _ListenerWithPropertiesmappedMessageSetStatic(int _token, Pointer<Void> _val
   }
   return 0;
 }
-int _ListenerWithPropertiesbufferedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerwithpropertiesbufferedMessageGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = blobToFfi((__lib.instanceCache[_token] as ListenerWithProperties).bufferedMessage);
   return 0;
 }
-int _ListenerWithPropertiesbufferedMessageSetStatic(int _token, Pointer<Void> _value) {
+int _smokeListenerwithpropertiesbufferedMessageSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as ListenerWithProperties).bufferedMessage =
       blobFromFfi(_value);
@@ -516,20 +516,20 @@ Pointer<Void> smokeListenerwithpropertiesToFfi(ListenerWithProperties value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithPropertiesmessageGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ListenerWithPropertiesmessageSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithPropertiespackedMessageGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ListenerWithPropertiespackedMessageSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithPropertiesstructuredMessageGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ListenerWithPropertiesstructuredMessageSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_ListenerWithPropertiesenumeratedMessageGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint32)>(_ListenerWithPropertiesenumeratedMessageSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithPropertiesarrayedMessageGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ListenerWithPropertiesarrayedMessageSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithPropertiesmappedMessageGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ListenerWithPropertiesmappedMessageSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenerWithPropertiesbufferedMessageGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_ListenerWithPropertiesbufferedMessageSetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerwithpropertiesmessageGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeListenerwithpropertiesmessageSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerwithpropertiespackedMessageGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeListenerwithpropertiespackedMessageSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerwithpropertiesstructuredMessageGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeListenerwithpropertiesstructuredMessageSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_smokeListenerwithpropertiesenumeratedMessageGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint32)>(_smokeListenerwithpropertiesenumeratedMessageSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerwithpropertiesarrayedMessageGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeListenerwithpropertiesarrayedMessageSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerwithpropertiesmappedMessageGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeListenerwithpropertiesmappedMessageSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerwithpropertiesbufferedMessageGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeListenerwithpropertiesbufferedMessageSetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
@@ -5,8 +7,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class ListenersWithReturnValues {
   ListenersWithReturnValues();
   factory ListenersWithReturnValues.fromLambdas({
@@ -305,7 +305,7 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
     }
   }
 }
-int _ListenersWithReturnValuesfetchDataDoubleStatic(int _token, Pointer<Double> _result) {
+int _smokeListenerswithreturnvaluesfetchDataDoubleStatic(int _token, Pointer<Double> _result) {
   double _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataDouble();
@@ -314,7 +314,7 @@ int _ListenersWithReturnValuesfetchDataDoubleStatic(int _token, Pointer<Double> 
   }
   return 0;
 }
-int _ListenersWithReturnValuesfetchDataStringStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerswithreturnvaluesfetchDataStringStatic(int _token, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataString();
@@ -323,7 +323,7 @@ int _ListenersWithReturnValuesfetchDataStringStatic(int _token, Pointer<Pointer<
   }
   return 0;
 }
-int _ListenersWithReturnValuesfetchDataStructStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerswithreturnvaluesfetchDataStructStatic(int _token, Pointer<Pointer<Void>> _result) {
   ListenersWithReturnValues_ResultStruct _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataStruct();
@@ -332,7 +332,7 @@ int _ListenersWithReturnValuesfetchDataStructStatic(int _token, Pointer<Pointer<
   }
   return 0;
 }
-int _ListenersWithReturnValuesfetchDataEnumStatic(int _token, Pointer<Uint32> _result) {
+int _smokeListenerswithreturnvaluesfetchDataEnumStatic(int _token, Pointer<Uint32> _result) {
   ListenersWithReturnValues_ResultEnum _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataEnum();
@@ -341,7 +341,7 @@ int _ListenersWithReturnValuesfetchDataEnumStatic(int _token, Pointer<Uint32> _r
   }
   return 0;
 }
-int _ListenersWithReturnValuesfetchDataArrayStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerswithreturnvaluesfetchDataArrayStatic(int _token, Pointer<Pointer<Void>> _result) {
   List<double> _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataArray();
@@ -350,7 +350,7 @@ int _ListenersWithReturnValuesfetchDataArrayStatic(int _token, Pointer<Pointer<V
   }
   return 0;
 }
-int _ListenersWithReturnValuesfetchDataMapStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerswithreturnvaluesfetchDataMapStatic(int _token, Pointer<Pointer<Void>> _result) {
   Map<String, double> _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataMap();
@@ -359,7 +359,7 @@ int _ListenersWithReturnValuesfetchDataMapStatic(int _token, Pointer<Pointer<Voi
   }
   return 0;
 }
-int _ListenersWithReturnValuesfetchDataInstanceStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeListenerswithreturnvaluesfetchDataInstanceStatic(int _token, Pointer<Pointer<Void>> _result) {
   CalculationResult _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as ListenersWithReturnValues).fetchDataInstance();
@@ -375,13 +375,13 @@ Pointer<Void> smokeListenerswithreturnvaluesToFfi(ListenersWithReturnValues valu
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Double>)>(_ListenersWithReturnValuesfetchDataDoubleStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValuesfetchDataStringStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValuesfetchDataStructStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_ListenersWithReturnValuesfetchDataEnumStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValuesfetchDataArrayStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValuesfetchDataMapStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_ListenersWithReturnValuesfetchDataInstanceStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Double>)>(_smokeListenerswithreturnvaluesfetchDataDoubleStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerswithreturnvaluesfetchDataStringStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerswithreturnvaluesfetchDataStructStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint32>)>(_smokeListenerswithreturnvaluesfetchDataEnumStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerswithreturnvaluesfetchDataArrayStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerswithreturnvaluesfetchDataMapStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeListenerswithreturnvaluesfetchDataInstanceStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
 import 'package:intl/locale.dart';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Locales {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class MethodOverloads {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class SpecialNames {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_exception.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_exception.dart
@@ -1,6 +1,4 @@
 import 'package:library/src/smoke/free_enum.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 class FreeException implements Exception {
   final FreeEnum error;
   FreeException(this.error);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_point.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/smoke/free_enum.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/free_enum.dart';
 class FreePoint {
   double x;
   double y;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/outer_class.dart';
 import 'package:library/src/smoke/outer_interface.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class LevelOne {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterClass {
   /// Destroys the underlying native object.
   ///
@@ -141,7 +141,7 @@ class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterCl
     }
   }
 }
-int _OuterClass_InnerInterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+int _smokeOuterclassInnerinterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterClass_InnerInterface).foo(stringFromFfi(input));
@@ -157,7 +157,7 @@ Pointer<Void> smokeOuterclassInnerinterfaceToFfi(OuterClass_InnerInterface value
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClass_InnerInterfacefooStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterclassInnerinterfacefooStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterClassWithInheritance implements ParentClass {
   /// Destroys the underlying native object.
   ///
@@ -142,7 +142,7 @@ class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase imp
     }
   }
 }
-int _OuterClassWithInheritance_InnerInterfacebazStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+int _smokeOuterclasswithinheritanceInnerinterfacebazStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterClassWithInheritance_InnerInterface).baz(stringFromFfi(input));
@@ -158,7 +158,7 @@ Pointer<Void> smokeOuterclasswithinheritanceInnerinterfaceToFfi(OuterClassWithIn
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterClassWithInheritance_InnerInterfacebazStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterclasswithinheritanceInnerinterfacebazStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class OuterInterface {
   OuterInterface();
   factory OuterInterface.fromLambdas({
@@ -147,7 +147,7 @@ class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements Out
     }
   }
 }
-int _OuterInterface_InnerInterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+int _smokeOuterinterfaceInnerinterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterInterface_InnerInterface).foo(stringFromFfi(input));
@@ -163,7 +163,7 @@ Pointer<Void> smokeOuterinterfaceInnerinterfaceToFfi(OuterInterface_InnerInterfa
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterface_InnerInterfacefooStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterinterfaceInnerinterfacefooStatic, __lib.unknownError)
   );
   return result;
 }
@@ -243,7 +243,7 @@ class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
     }
   }
 }
-int _OuterInterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+int _smokeOuterinterfacefooStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterInterface).foo(stringFromFfi(input));
@@ -259,7 +259,7 @@ Pointer<Void> smokeOuterinterfaceToFfi(OuterInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_OuterInterfacefooStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterinterfacefooStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -1,13 +1,13 @@
+import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:intl/locale.dart';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 final _doNothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -307,7 +307,7 @@ class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterS
     }
   }
 }
-int _OuterStruct_InnerInterfacebarBazStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeOuterstructInnerinterfacebarBazStatic(int _token, Pointer<Pointer<Void>> _result) {
   Map<String, Uint8List> _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as OuterStruct_InnerInterface).barBaz();
@@ -322,7 +322,7 @@ Pointer<Void> smokeOuterstructInnerinterfaceToFfi(OuterStruct_InnerInterface val
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_OuterStruct_InnerInterfacebarBazStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeOuterstructInnerinterfacebarBazStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class UseFreeTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/some_interface.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Nullable {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class NestedPackages {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -1,9 +1,9 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/wee_types.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeInterface {
   factory weeInterface.make(String makeParameter) => weeInterface$Impl.make(makeParameter);
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class weeListener {
   weeListener();
   factory weeListener.fromLambdas({
@@ -70,7 +70,7 @@ class weeListener$Impl extends __lib.NativeBase implements weeListener {
     }
   }
 }
-int _weeListenerWeeMethodStatic(int _token, Pointer<Void> WeeParameter) {
+int _smokePlatformnameslistenerWeeMethodStatic(int _token, Pointer<Void> WeeParameter) {
   try {
     (__lib.instanceCache[_token] as weeListener).WeeMethod(stringFromFfi(WeeParameter));
   } finally {
@@ -84,7 +84,7 @@ Pointer<Void> smokePlatformnameslistenerToFfi(weeListener value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_weeListenerWeeMethodStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokePlatformnameslistenerWeeMethodStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 enum werrEnum {
     WEE_ITEM
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
 import 'dart:typed_data';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class CachedProperties {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
 import 'dart:typed_data';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/properties_interface.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Properties {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class PropertiesInterface {
   PropertiesInterface();
   factory PropertiesInterface.fromLambdas({
@@ -147,11 +147,11 @@ class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInt
     }
   }
 }
-int _PropertiesInterfacestructPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokePropertiesinterfacestructPropertyGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = smokePropertiesinterfaceExamplestructToFfi((__lib.instanceCache[_token] as PropertiesInterface).structProperty);
   return 0;
 }
-int _PropertiesInterfacestructPropertySetStatic(int _token, Pointer<Void> _value) {
+int _smokePropertiesinterfacestructPropertySetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as PropertiesInterface).structProperty =
       smokePropertiesinterfaceExamplestructFromFfi(_value);
@@ -166,8 +166,8 @@ Pointer<Void> smokePropertiesinterfaceToFfi(PropertiesInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_PropertiesInterfacestructPropertyGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_PropertiesInterfacestructPropertySetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokePropertiesinterfacestructPropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokePropertiesinterfacestructPropertySetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class EnableIfEnabled {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class EnableIfSkipped {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/skip_proxy.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class InheritFromSkipped implements SkipProxy {
   InheritFromSkipped();
   factory InheritFromSkipped.fromLambdas({
@@ -157,7 +157,7 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
     }
   }
 }
-int _InheritFromSkippednotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+int _smokeInheritfromskippednotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as InheritFromSkipped).notInJava(stringFromFfi(input));
@@ -167,7 +167,7 @@ int _InheritFromSkippednotInJavaStatic(int _token, Pointer<Void> input, Pointer<
   }
   return 0;
 }
-int _InheritFromSkippednotInSwiftStatic(int _token, int input, Pointer<Uint8> _result) {
+int _smokeInheritfromskippednotInSwiftStatic(int _token, int input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as InheritFromSkipped).notInSwift(booleanFromFfi(input));
@@ -177,11 +177,11 @@ int _InheritFromSkippednotInSwiftStatic(int _token, int input, Pointer<Uint8> _r
   }
   return 0;
 }
-int _InheritFromSkippedskippedInJavaGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeInheritfromskippedskippedInJavaGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as InheritFromSkipped).skippedInJava);
   return 0;
 }
-int _InheritFromSkippedskippedInJavaSetStatic(int _token, Pointer<Void> _value) {
+int _smokeInheritfromskippedskippedInJavaSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as InheritFromSkipped).skippedInJava =
       stringFromFfi(_value);
@@ -190,11 +190,11 @@ int _InheritFromSkippedskippedInJavaSetStatic(int _token, Pointer<Void> _value) 
   }
   return 0;
 }
-int _InheritFromSkippedisSkippedInSwiftGetStatic(int _token, Pointer<Uint8> _result) {
+int _smokeInheritfromskippedisSkippedInSwiftGetStatic(int _token, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((__lib.instanceCache[_token] as InheritFromSkipped).isSkippedInSwift);
   return 0;
 }
-int _InheritFromSkippedisSkippedInSwiftSetStatic(int _token, int _value) {
+int _smokeInheritfromskippedisSkippedInSwiftSetStatic(int _token, int _value) {
   try {
     (__lib.instanceCache[_token] as InheritFromSkipped).isSkippedInSwift =
       booleanFromFfi(_value);
@@ -209,12 +209,12 @@ Pointer<Void> smokeInheritfromskippedToFfi(InheritFromSkipped value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_InheritFromSkippednotInJavaStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8, Pointer<Uint8>)>(_InheritFromSkippednotInSwiftStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_InheritFromSkippedskippedInJavaGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_InheritFromSkippedskippedInJavaSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_InheritFromSkippedisSkippedInSwiftGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_InheritFromSkippedisSkippedInSwiftSetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeInheritfromskippednotInJavaStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8, Pointer<Uint8>)>(_smokeInheritfromskippednotInSwiftStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeInheritfromskippedskippedInJavaGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeInheritfromskippedskippedInJavaSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_smokeInheritfromskippedisSkippedInSwiftGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_smokeInheritfromskippedisSkippedInSwiftSetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipFunctions {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipProxy {
   SkipProxy();
   factory SkipProxy.fromLambdas({
@@ -162,7 +162,7 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
     }
   }
 }
-int _SkipProxynotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
+int _smokeSkipproxynotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SkipProxy).notInJava(stringFromFfi(input));
@@ -172,7 +172,7 @@ int _SkipProxynotInJavaStatic(int _token, Pointer<Void> input, Pointer<Pointer<V
   }
   return 0;
 }
-int _SkipProxynotInSwiftStatic(int _token, int input, Pointer<Uint8> _result) {
+int _smokeSkipproxynotInSwiftStatic(int _token, int input, Pointer<Uint8> _result) {
   bool _resultObject;
   try {
     _resultObject = (__lib.instanceCache[_token] as SkipProxy).notInSwift(booleanFromFfi(input));
@@ -182,11 +182,11 @@ int _SkipProxynotInSwiftStatic(int _token, int input, Pointer<Uint8> _result) {
   }
   return 0;
 }
-int _SkipProxyskippedInJavaGetStatic(int _token, Pointer<Pointer<Void>> _result) {
+int _smokeSkipproxyskippedInJavaGetStatic(int _token, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((__lib.instanceCache[_token] as SkipProxy).skippedInJava);
   return 0;
 }
-int _SkipProxyskippedInJavaSetStatic(int _token, Pointer<Void> _value) {
+int _smokeSkipproxyskippedInJavaSetStatic(int _token, Pointer<Void> _value) {
   try {
     (__lib.instanceCache[_token] as SkipProxy).skippedInJava =
       stringFromFfi(_value);
@@ -195,11 +195,11 @@ int _SkipProxyskippedInJavaSetStatic(int _token, Pointer<Void> _value) {
   }
   return 0;
 }
-int _SkipProxyisSkippedInSwiftGetStatic(int _token, Pointer<Uint8> _result) {
+int _smokeSkipproxyisSkippedInSwiftGetStatic(int _token, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((__lib.instanceCache[_token] as SkipProxy).isSkippedInSwift);
   return 0;
 }
-int _SkipProxyisSkippedInSwiftSetStatic(int _token, int _value) {
+int _smokeSkipproxyisSkippedInSwiftSetStatic(int _token, int _value) {
   try {
     (__lib.instanceCache[_token] as SkipProxy).isSkippedInSwift =
       booleanFromFfi(_value);
@@ -214,12 +214,12 @@ Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_SkipProxynotInJavaStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8, Pointer<Uint8>)>(_SkipProxynotInSwiftStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_SkipProxyskippedInJavaGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_SkipProxyskippedInJavaSetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_SkipProxyisSkippedInSwiftGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_SkipProxyisSkippedInSwiftSetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeSkipproxynotInJavaStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8, Pointer<Uint8>)>(_smokeSkipproxynotInSwiftStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Pointer<Void>>)>(_smokeSkipproxyskippedInJavaGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Void>)>(_smokeSkipproxyskippedInJavaSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Pointer<Uint8>)>(_smokeSkipproxyisSkippedInSwiftGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Uint64, Uint8)>(_smokeSkipproxyisSkippedInSwiftSetStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 abstract class SkipTagsOnly {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class SkipTypes {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types_tags.dart
@@ -1,3 +1,1 @@
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 final bool placeHolder = true;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -1,12 +1,12 @@
+import 'dart:ffi';
 import 'dart:typed_data';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class Structs {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_constants.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/builtin_types__conversion.dart';
-import 'package:library/src/smoke/route_utils.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/route_utils.dart';
 class Route {
   String description;
   RouteType type;

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/builtin_types__conversion.dart';
-import 'package:library/src/smoke/validation_utils.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/validation_utils.dart';
 final _copyReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 class SomeClass {
   factory SomeClass() => $class.fooBar();
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 class StructWithConstructor {
   String field;
   StructWithConstructor._(this.field);

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 class StructWithMethods {
   String field;
   StructWithMethods(this.field);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class TypeDefs {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -1,7 +1,7 @@
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
 /// @nodoc
 abstract class InternalClass {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalClassWithFunctions {
   /// @nodoc

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalClassWithStaticProperty {
   /// Destroys the underlying native object.

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -1,10 +1,10 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 /// @nodoc
 abstract class InternalInterface {
   InternalInterface();
@@ -70,7 +70,7 @@ class InternalInterface$Impl extends __lib.NativeBase implements InternalInterfa
     }
   }
 }
-int _InternalInterfacefooBarStatic(int _token) {
+int _smokeInternalinterfacefooBarStatic(int _token) {
   try {
     (__lib.instanceCache[_token] as InternalInterface).internal_fooBar();
   } finally {
@@ -83,7 +83,7 @@ Pointer<Void> smokeInternalinterfaceToFfi(InternalInterface value) {
     __lib.cacheObject(value),
     __lib.LibraryContext.isolateId,
     __lib.uncacheObjectFfi,
-    Pointer.fromFunction<Uint8 Function(Uint64)>(_InternalInterfacefooBarStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Uint64)>(_smokeInternalinterfacefooBarStatic, __lib.unknownError)
   );
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -1,8 +1,8 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class PublicClass {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -1,11 +1,11 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/public_class.dart';
 import 'package:meta/meta.dart';
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
 abstract class PublicInterface {
   /// Destroys the underlying native object.
   ///

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 class PublicStructWithNonDefaultInternalField {
   int defaultedField;
   /// @nodoc

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -1,6 +1,6 @@
-import 'package:library/src/builtin_types__conversion.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
 /// @nodoc
 class InternalStruct {
   /// @nodoc


### PR DESCRIPTION
Fixed Dart warnings from "dart analyze" static analysis tool:
    * unused "dart:collection" imports for `@Equatable` structs (unless there are fields of collection types)
    * unused "dart:ffi" and "library context" imports for Exception types
    * lowerSnakeCase for internal static helpers for interfaces

See: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
