### PR TITLE
Fix generated Dart code for "stubs" mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug fixes:
   * Fixed runtime issues in Java when a 'null' is returned from C++ for a non-nullable `Blob`.
   * Updated Dart generator to generate `void` function return type explicitly.  
+  * Fixed compilation issues in Dart generated for testable "stubs" mode.
 
 ## 9.1.0
 Release date: 2021-05-31

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-{{#unless testableMode}}abstract {{/unless}}class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
+abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
 {{#set parent=this}}{{#constructors}}
 {{>dart/DartRedirectConstructor}}
 {{/constructors}}{{/set}}
@@ -38,7 +38,7 @@
 {{/properties}}{{/set}}{{!!
 }}{{#if testableMode}}
 
-  static var $class = {{resolveName}}$Impl();
+  static var $class = {{resolveName}}$Impl(null);
 {{/if}}
 }
 

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -27,7 +27,7 @@
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 {{#if attributes.immutable}}
 @immutable{{/if}}
-class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
+abstract class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
 {{>dartFieldsAndConstants}}
 {{#set parent=this isStruct=true}}{{#constructors}}
 {{>dart/DartRedirectConstructor}}
@@ -36,7 +36,8 @@ class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
 {{>dart/DartRedirectFunction}}
 {{/unless}}{{/functions}}{{/set}}
 
-  static var $class = {{resolveName}}{{#if external.dart.converter}}Internal{{/if}}$Impl();
+  static var $class = {{resolveName}}{{#if external.dart.converter}}Internal{{/if}}$Impl{{#if constructors}}._{{/if}}({{!!
+  }}{{#fields}}null{{#if iter.hasNext}}, {{/if}}{{/fields}});
 }
 
 {{/if}}{{!!
@@ -45,7 +46,8 @@ class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
 {{#if attributes.immutable}}
 @immutable{{/if}}
 class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{#if testableMode}}$Impl{{/if}} {
-{{>dartFieldsAndConstants}}
+{{#if testableMode}}{{#set implSuffix="$Impl" struct=this}}{{#struct}}{{>dartFieldsAndConstants}}{{/struct}}{{/set}}{{/if}}{{!!
+}}{{#unless testableMode}}{{>dartFieldsAndConstants}}{{/unless}}
 {{#set parent=this isStruct=true ignoreStatic=testableMode}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
 {{prefixPartial "dartConstructor" "  "}}
@@ -134,7 +136,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/fields}}{{/set}}
   try {
 {{#if external.dart.converter}}
-    final resultInternal = {{resolveName}}Internal{{#if constructors}}._{{/if}}(
+    final resultInternal = {{resolveName}}Internal{{#if testableMode}}$Impl{{/if}}{{#if constructors}}._{{/if}}(
 {{#set container=this}}{{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}{{/set}}
@@ -169,7 +171,8 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 
 // End of {{resolveName}} "private" section.{{!!
 
-}}{{+dartConstructor}}{{#if attributes.immutable}}const {{/if}}{{resolveName parent}}{{#unless attributes.dart.default}}{{!!
+}}{{+dartConstructor}}{{#if attributes.immutable}}const {{/if}}{{resolveName parent}}{{#if testableMode}}$Impl{{/if}}{{!!
+}}{{#unless attributes.dart.default}}{{!!
 }}{{#isEq constructors.size 1}}{{#if attributes.dart.name}}.{{resolveName visibility}}{{resolveName}}{{/if}}{{!!
 }}{{#unless attributes.dart.name}}{{#if visibility.isInternal}}.{{resolveName visibility}}{{/if}}{{/unless}}{{/isEq}}{{!!
 }}{{#isNotEq constructors.size 1}}.{{resolveName visibility}}{{resolveName}}{{/isNotEq}}{{!!
@@ -205,20 +208,20 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 {{/fields}}
 {{/unless}}{{/resolveName}}{{/unless}}{{!!
 }}{{#if attributes.dart.positionalDefaults initializedFields}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}({{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}({{!!
   }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}, {{/uninitializedFields}}{{!!
   }}[{{#initializedFields}}{{resolveName typeRef}} {{resolveName}} = {{>constPrefix}}{{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/initializedFields}}])
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
 {{/if}}{{!!
 }}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
 }}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/unless}}
-{{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
+{{#if constructors}}  {{resolveName}}{{#if testableMode}}$Impl{{/if}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}{{#unless constructors}}{{#if initializedFields}}
-  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}.withDefaults({{!!
-  }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
+  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
+  }}.withDefaults({{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
     }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
 {{/if}}{{/unless}}{{/if}}

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -3,7 +3,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-class SomeClass {
+abstract class SomeClass {
   factory SomeClass() => $class.fooBar();
   /// @nodoc
   @Deprecated("Does nothing")
@@ -14,7 +14,7 @@ class SomeClass {
   String stringFunction();
   SomeClass classFunction();
   static void staticFunction() => $class.staticFunction();
-  static var $class = SomeClass$Impl();
+  static var $class = SomeClass$Impl(null);
 }
 // SomeClass "private" section, not exported.
 final _smokeSomeclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_constructor.dart
@@ -1,18 +1,18 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-class StructWithConstructor {
+abstract class StructWithConstructor {
   String field;
   StructWithConstructor._(this.field);
-  StructWithConstructor._copy(StructWithConstructor _other) : this._(_other.field);
+  StructWithConstructor$Impl._copy(StructWithConstructor _other) : this._(_other.field);
   factory StructWithConstructor() => $class.fooBar();
-  static var $class = StructWithConstructor$Impl();
+  static var $class = StructWithConstructor$Impl._(null);
 }
 class StructWithConstructor$Impl {
   String field;
-  StructWithConstructor._(this.field);
-  StructWithConstructor._copy(StructWithConstructor _other) : this._(_other.field);
-  StructWithConstructor() : this._copy(_fooBar());
+  StructWithConstructor$Impl._(this.field);
+  StructWithConstructor$Impl._copy(StructWithConstructor _other) : this._(_other.field);
+  StructWithConstructor$Impl() : this._copy(_fooBar());
   StructWithConstructor _fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_StructWithConstructor_fooBar'));
     final __resultHandle = _fooBarFfi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
@@ -1,7 +1,7 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-class StructWithMethods {
+abstract class StructWithMethods {
   String field;
   StructWithMethods(this.field);
   void voidFunction();
@@ -10,11 +10,11 @@ class StructWithMethods {
   String stringFunction();
   StructWithMethods structFunction();
   static void staticFunction() => $class.staticFunction();
-  static var $class = StructWithMethods$Impl();
+  static var $class = StructWithMethods$Impl(null);
 }
 class StructWithMethods$Impl {
   String field;
-  StructWithMethods(this.field);
+  StructWithMethods$Impl(this.field);
   void voidFunction() {
     final _voidFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_voidFunction'));
     final _handle = smokeStructwithmethodsToFfi(this);


### PR DESCRIPTION
Updated Dart templates for the testable "stubs" mode to correctly generate abstract classes for both classes and
structs, as well as correctly creating an additional "$Impl" struct class for structs.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>