### PR TITLE
Make 'fromLambdas()' ctor nameless in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Generated Dart code now supports null safety.
 ### Breaking changes:
   * Generated Dart code now requires minimum Dart version 2.12.0.
+  * In Dart, factory constructor `fromLambdas()` that is generated for interfaces was renamed into a nameless factory
+    constructor. Its signature was changed from using named "required" parameters to using positional parameters.
 
 ## 8.13.5
 Release date: 2021-05-27

--- a/functional-tests/functional/dart/test/CppConstMethods_test.dart
+++ b/functional-tests/functional/dart/test/CppConstMethods_test.dart
@@ -24,9 +24,12 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("CppConstMethods");
 
-class CppConstCallback extends CppConstInterface {
+class CppConstCallback implements CppConstInterface {
   @override
   String getFoo() => "FOO";
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/ExternalTypes_test.dart
+++ b/functional-tests/functional/dart/test/ExternalTypes_test.dart
@@ -27,9 +27,12 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("ExternalTypes");
 
-class MyDartClass extends MyClass {
+class MyDartClass implements MyClass {
   @override
   int foo() => 77;
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/InterfaceWithStatic_test.dart
+++ b/functional-tests/functional/dart/test/InterfaceWithStatic_test.dart
@@ -24,12 +24,15 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("InterfaceWithStatic");
 
-class InterfaceWithStaticImpl extends InterfaceWithStatic {
+class InterfaceWithStaticImpl implements InterfaceWithStatic {
   @override
   String regularFunction() => "buzz1";
 
   @override
   String regularProperty = "buzz2";
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/Interfaces_test.dart
+++ b/functional-tests/functional/dart/test/Interfaces_test.dart
@@ -125,9 +125,9 @@ void main() {
   });
   _testSuite.test("Delegator with functions", () {
     String stringValue = "";
-    final delegator = SimpleInterfaceOne.fromLambdas(
-      lambda_setStringValue: (value) { stringValue = value; },
-      lambda_getStringValue: () => stringValue
+    final delegator = SimpleInterfaceOne(
+      (value) { stringValue = value; },
+      () => stringValue
     );
 
     delegator.setStringValue("foo");
@@ -137,9 +137,9 @@ void main() {
   });
   _testSuite.test("Delegator with property", () {
     String stringValue = "";
-    final delegator = InterfaceWithProperty.fromLambdas(
-      lambda_stringProperty_set: (value) { stringValue = value; },
-      lambda_stringProperty_get: () => stringValue
+    final delegator = InterfaceWithProperty(
+      () => stringValue,
+      (value) { stringValue = value; }
     );
 
     delegator.stringProperty = "foo";

--- a/functional-tests/functional/dart/test/ListenersWithAttributes_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithAttributes_test.dart
@@ -26,9 +26,12 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("ListenersWithAttributes");
 
-class TestMessagePackage extends MessagePackage {
+class TestMessagePackage implements MessagePackage {
   @override
   String unpackMessage() => "Works";
+
+  @override
+  release() {}
 }
 
 class TestListener implements ListenerWithAttributes {

--- a/functional-tests/functional/dart/test/ListenersWithErrors_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithErrors_test.dart
@@ -25,7 +25,7 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("ListenersWithErrors");
 
-class TestListener extends ErrorsInInterface {
+class TestListener implements ErrorsInInterface {
   String _message = "Doesn't work";
 
   @override
@@ -43,9 +43,12 @@ class TestListener extends ErrorsInInterface {
   void setMessageWithPayload(String value) {
     _message = value;
   }
+
+  @override
+  release() {}
 }
 
-class ThrowingListener extends ErrorsInInterface {
+class ThrowingListener implements ErrorsInInterface {
   String _message = "Doesn't work";
 
   @override
@@ -67,6 +70,9 @@ class ThrowingListener extends ErrorsInInterface {
   void setMessageWithPayload(String value) {
     throw WithPayloadException(Payload(42, "foo"));
   }
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/ListenersWithReturnValues_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithReturnValues_test.dart
@@ -26,12 +26,15 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("ListenersWithReturnValues");
 
-class TestMessagePackage extends MessagePackage {
+class TestMessagePackage implements MessagePackage {
   @override
   String unpackMessage() => "Works";
+
+  @override
+  release() {}
 }
 
-class TestListener extends ListenerWithReturn {
+class TestListener implements ListenerWithReturn {
   @override
   String getMessage() => "Works";
 
@@ -57,6 +60,9 @@ class TestListener extends ListenerWithReturn {
 
   @override
   Uint8List getBufferedMessage() => Uint8List.fromList(utf8.encode("Works"));
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/Listeners_test.dart
+++ b/functional-tests/functional/dart/test/Listeners_test.dart
@@ -24,7 +24,7 @@ import "../test_suite.dart";
 
 final _testSuite = TestSuite("Listeners");
 
-class MessageListener extends StringListener {
+class MessageListener implements StringListener {
   @override
   void onMessage(String message) {}
 
@@ -33,12 +33,17 @@ class MessageListener extends StringListener {
 
   @override
   void onStructMessage(StringListenerStringStruct message) {}
+
+  @override
+  release() {}
 }
 
-class RouteImpl extends Route {
+class RouteImpl implements Route {
+  @override
+  release() {}
 }
 
-class RouteProviderImpl extends RouteProvider {
+class RouteProviderImpl implements RouteProvider {
   static bool setRouteWasRun = false;
   static bool setRouteCouldCast = false;
 
@@ -48,6 +53,9 @@ class RouteProviderImpl extends RouteProvider {
     setRouteCouldCast = route is RouteImpl;
     route.release();
   }
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -21,24 +21,22 @@
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
-  {{resolveName}}();
-
-  factory {{resolveName}}.fromLambdas({
+  factory {{resolveName}}(
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
-    required {{>dart/DartLambdaType}} lambda_{{resolveName}},
+    {{>dart/DartLambdaType}} {{resolveName}}Lambda,
 {{/unless}}{{/each}}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#set property=this}}{{#getter}}
-    required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_get{{#if setter}},
+    {{>dart/DartLambdaType}} {{resolveName property}}GetLambda{{#if setter}},
 {{/if}}{{/getter}}{{#setter}}
-    required {{>dart/DartLambdaType}} lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+    {{>dart/DartLambdaType}} {{resolveName property}}SetLambda{{/setter}}{{#if iter.hasNext}},
 {{/if}}{{/set}}{{/unless}}{{/each}}
 
-  }) => {{resolveName}}$Lambdas(
+  ) => {{resolveName}}$Lambdas(
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
-    lambda_{{resolveName}},
+    {{resolveName}}Lambda,
 {{/unless}}{{/each}}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#set property=this}}{{#getter}}
-    lambda_{{resolveName property}}_get{{#if setter}},
+    {{resolveName property}}GetLambda{{#if setter}},
 {{/if}}{{/getter}}{{#setter}}
-    lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+    {{resolveName property}}SetLambda{{/setter}}{{#if iter.hasNext}},
 {{/if}}{{/set}}{{/unless}}{{/each}}
 
   );
@@ -104,22 +102,22 @@ final _{{resolveName "Ffi"}}GetTypeId = __lib.catchArgumentError(() => __lib.nat
 }}{{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
 class {{resolveName}}$Lambdas implements {{resolveName}} {
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
-  {{>dart/DartLambdaType}} lambda_{{resolveName}};
+  {{>dart/DartLambdaType}} {{resolveName}}Lambda;
 {{/unless}}{{/each}}
 {{#each inheritedProperties properties}}{{#unless isStatic}}{{#set property=this}}
-{{#getter}}  {{>dart/DartLambdaType}} lambda_{{resolveName property}}_get;
+{{#getter}}  {{>dart/DartLambdaType}} {{resolveName property}}GetLambda;
 {{/getter}}{{!!
-}}{{#setter}}  {{>dart/DartLambdaType}} lambda_{{resolveName property}}_set;
+}}{{#setter}}  {{>dart/DartLambdaType}} {{resolveName property}}SetLambda;
 {{/setter}}
 {{/set}}{{/unless}}{{/each}}
 
   {{resolveName}}$Lambdas(
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
-    this.lambda_{{resolveName}},
+    this.{{resolveName}}Lambda,
 {{/unless}}{{/each}}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#set property=this}}{{#getter}}
-    this.lambda_{{resolveName property}}_get{{#if setter}},
+    this.{{resolveName property}}GetLambda{{#if setter}},
 {{/if}}{{/getter}}{{#setter}}
-    this.lambda_{{resolveName property}}_set{{/setter}}{{#if iter.hasNext}},
+    this.{{resolveName property}}SetLambda{{/setter}}{{#if iter.hasNext}},
 {{/if}}{{/set}}{{/unless}}{{/each}}
 
   );
@@ -130,14 +128,14 @@ class {{resolveName}}$Lambdas implements {{resolveName}} {
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
   @override
   {{>dart/DartFunctionSignature}} =>
-    lambda_{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
+    {{resolveName}}Lambda({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/unless}}{{/each}}
 {{#each inheritedProperties properties}}{{#unless isStatic}}
   @override
-  {{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} => lambda_{{resolveName}}_get();
+  {{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} => {{resolveName}}GetLambda();
 {{#if setter}}
   @override
-  set {{resolveName visibility}}{{resolveName}}({{resolveName typeRef}} value) => lambda_{{resolveName}}_set(value);
+  set {{resolveName visibility}}{{resolveName}}({{resolveName typeRef}} value) => {{resolveName}}SetLambda(value);
 {{/if}}
 {{/unless}}{{/each}}
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -7,15 +7,14 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 @OnInterface
 abstract class AttributesInterface {
-  AttributesInterface();
-  factory AttributesInterface.fromLambdas({
-    required void Function(String) lambda_veryFun,
-    required String Function() lambda_prop_get,
-    required void Function(String) lambda_prop_set
-  }) => AttributesInterface$Lambdas(
-    lambda_veryFun,
-    lambda_prop_get,
-    lambda_prop_set
+  factory AttributesInterface(
+    void Function(String) veryFunLambda,
+    String Function() propGetLambda,
+    void Function(String) propSetLambda
+  ) => AttributesInterface$Lambdas(
+    veryFunLambda,
+    propGetLambda,
+    propSetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -49,23 +48,23 @@ final _smokeAttributesinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesInterface_get_type_id'));
 class AttributesInterface$Lambdas implements AttributesInterface {
-  void Function(String) lambda_veryFun;
-  String Function() lambda_prop_get;
-  void Function(String) lambda_prop_set;
+  void Function(String) veryFunLambda;
+  String Function() propGetLambda;
+  void Function(String) propSetLambda;
   AttributesInterface$Lambdas(
-    this.lambda_veryFun,
-    this.lambda_prop_get,
-    this.lambda_prop_set
+    this.veryFunLambda,
+    this.propGetLambda,
+    this.propSetLambda
   );
   @override
   void release() {}
   @override
   veryFun(@OnParameterInInterface String param) =>
-    lambda_veryFun(param);
+    veryFunLambda(param);
   @override
-  String get prop => lambda_prop_get();
+  String get prop => propGetLambda();
   @override
-  set prop(String value) => lambda_prop_set(value);
+  set prop(String value) => propSetLambda(value);
 }
 class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInterface {
   AttributesInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -7,33 +7,32 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// This is some very useful interface.
 abstract class CommentsInterface {
-  CommentsInterface();
-  factory CommentsInterface.fromLambdas({
-    required bool Function(String) lambda_someMethodWithAllComments,
-    required bool Function(String) lambda_someMethodWithInputComments,
-    required bool Function(String) lambda_someMethodWithOutputComments,
-    required bool Function(String) lambda_someMethodWithNoComments,
-    required void Function(String) lambda_someMethodWithoutReturnTypeWithAllComments,
-    required void Function(String) lambda_someMethodWithoutReturnTypeWithNoComments,
-    required bool Function() lambda_someMethodWithoutInputParametersWithAllComments,
-    required bool Function() lambda_someMethodWithoutInputParametersWithNoComments,
-    required void Function() lambda_someMethodWithNothing,
-    required void Function() lambda_someMethodWithoutReturnTypeOrInputParameters,
-    required bool Function() lambda_isSomeProperty_get,
-    required void Function(bool) lambda_isSomeProperty_set
-  }) => CommentsInterface$Lambdas(
-    lambda_someMethodWithAllComments,
-    lambda_someMethodWithInputComments,
-    lambda_someMethodWithOutputComments,
-    lambda_someMethodWithNoComments,
-    lambda_someMethodWithoutReturnTypeWithAllComments,
-    lambda_someMethodWithoutReturnTypeWithNoComments,
-    lambda_someMethodWithoutInputParametersWithAllComments,
-    lambda_someMethodWithoutInputParametersWithNoComments,
-    lambda_someMethodWithNothing,
-    lambda_someMethodWithoutReturnTypeOrInputParameters,
-    lambda_isSomeProperty_get,
-    lambda_isSomeProperty_set
+  factory CommentsInterface(
+    bool Function(String) someMethodWithAllCommentsLambda,
+    bool Function(String) someMethodWithInputCommentsLambda,
+    bool Function(String) someMethodWithOutputCommentsLambda,
+    bool Function(String) someMethodWithNoCommentsLambda,
+    void Function(String) someMethodWithoutReturnTypeWithAllCommentsLambda,
+    void Function(String) someMethodWithoutReturnTypeWithNoCommentsLambda,
+    bool Function() someMethodWithoutInputParametersWithAllCommentsLambda,
+    bool Function() someMethodWithoutInputParametersWithNoCommentsLambda,
+    void Function() someMethodWithNothingLambda,
+    void Function() someMethodWithoutReturnTypeOrInputParametersLambda,
+    bool Function() isSomePropertyGetLambda,
+    void Function(bool) isSomePropertySetLambda
+  ) => CommentsInterface$Lambdas(
+    someMethodWithAllCommentsLambda,
+    someMethodWithInputCommentsLambda,
+    someMethodWithOutputCommentsLambda,
+    someMethodWithNoCommentsLambda,
+    someMethodWithoutReturnTypeWithAllCommentsLambda,
+    someMethodWithoutReturnTypeWithNoCommentsLambda,
+    someMethodWithoutInputParametersWithAllCommentsLambda,
+    someMethodWithoutInputParametersWithNoCommentsLambda,
+    someMethodWithNothingLambda,
+    someMethodWithoutReturnTypeOrInputParametersLambda,
+    isSomePropertyGetLambda,
+    isSomePropertySetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -233,68 +232,68 @@ final _smokeCommentsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_get_type_id'));
 class CommentsInterface$Lambdas implements CommentsInterface {
-  bool Function(String) lambda_someMethodWithAllComments;
-  bool Function(String) lambda_someMethodWithInputComments;
-  bool Function(String) lambda_someMethodWithOutputComments;
-  bool Function(String) lambda_someMethodWithNoComments;
-  void Function(String) lambda_someMethodWithoutReturnTypeWithAllComments;
-  void Function(String) lambda_someMethodWithoutReturnTypeWithNoComments;
-  bool Function() lambda_someMethodWithoutInputParametersWithAllComments;
-  bool Function() lambda_someMethodWithoutInputParametersWithNoComments;
-  void Function() lambda_someMethodWithNothing;
-  void Function() lambda_someMethodWithoutReturnTypeOrInputParameters;
-  bool Function() lambda_isSomeProperty_get;
-  void Function(bool) lambda_isSomeProperty_set;
+  bool Function(String) someMethodWithAllCommentsLambda;
+  bool Function(String) someMethodWithInputCommentsLambda;
+  bool Function(String) someMethodWithOutputCommentsLambda;
+  bool Function(String) someMethodWithNoCommentsLambda;
+  void Function(String) someMethodWithoutReturnTypeWithAllCommentsLambda;
+  void Function(String) someMethodWithoutReturnTypeWithNoCommentsLambda;
+  bool Function() someMethodWithoutInputParametersWithAllCommentsLambda;
+  bool Function() someMethodWithoutInputParametersWithNoCommentsLambda;
+  void Function() someMethodWithNothingLambda;
+  void Function() someMethodWithoutReturnTypeOrInputParametersLambda;
+  bool Function() isSomePropertyGetLambda;
+  void Function(bool) isSomePropertySetLambda;
   CommentsInterface$Lambdas(
-    this.lambda_someMethodWithAllComments,
-    this.lambda_someMethodWithInputComments,
-    this.lambda_someMethodWithOutputComments,
-    this.lambda_someMethodWithNoComments,
-    this.lambda_someMethodWithoutReturnTypeWithAllComments,
-    this.lambda_someMethodWithoutReturnTypeWithNoComments,
-    this.lambda_someMethodWithoutInputParametersWithAllComments,
-    this.lambda_someMethodWithoutInputParametersWithNoComments,
-    this.lambda_someMethodWithNothing,
-    this.lambda_someMethodWithoutReturnTypeOrInputParameters,
-    this.lambda_isSomeProperty_get,
-    this.lambda_isSomeProperty_set
+    this.someMethodWithAllCommentsLambda,
+    this.someMethodWithInputCommentsLambda,
+    this.someMethodWithOutputCommentsLambda,
+    this.someMethodWithNoCommentsLambda,
+    this.someMethodWithoutReturnTypeWithAllCommentsLambda,
+    this.someMethodWithoutReturnTypeWithNoCommentsLambda,
+    this.someMethodWithoutInputParametersWithAllCommentsLambda,
+    this.someMethodWithoutInputParametersWithNoCommentsLambda,
+    this.someMethodWithNothingLambda,
+    this.someMethodWithoutReturnTypeOrInputParametersLambda,
+    this.isSomePropertyGetLambda,
+    this.isSomePropertySetLambda
   );
   @override
   void release() {}
   @override
   bool someMethodWithAllComments(String input) =>
-    lambda_someMethodWithAllComments(input);
+    someMethodWithAllCommentsLambda(input);
   @override
   bool someMethodWithInputComments(String input) =>
-    lambda_someMethodWithInputComments(input);
+    someMethodWithInputCommentsLambda(input);
   @override
   bool someMethodWithOutputComments(String input) =>
-    lambda_someMethodWithOutputComments(input);
+    someMethodWithOutputCommentsLambda(input);
   @override
   bool someMethodWithNoComments(String input) =>
-    lambda_someMethodWithNoComments(input);
+    someMethodWithNoCommentsLambda(input);
   @override
   someMethodWithoutReturnTypeWithAllComments(String input) =>
-    lambda_someMethodWithoutReturnTypeWithAllComments(input);
+    someMethodWithoutReturnTypeWithAllCommentsLambda(input);
   @override
   someMethodWithoutReturnTypeWithNoComments(String input) =>
-    lambda_someMethodWithoutReturnTypeWithNoComments(input);
+    someMethodWithoutReturnTypeWithNoCommentsLambda(input);
   @override
   bool someMethodWithoutInputParametersWithAllComments() =>
-    lambda_someMethodWithoutInputParametersWithAllComments();
+    someMethodWithoutInputParametersWithAllCommentsLambda();
   @override
   bool someMethodWithoutInputParametersWithNoComments() =>
-    lambda_someMethodWithoutInputParametersWithNoComments();
+    someMethodWithoutInputParametersWithNoCommentsLambda();
   @override
   someMethodWithNothing() =>
-    lambda_someMethodWithNothing();
+    someMethodWithNothingLambda();
   @override
   someMethodWithoutReturnTypeOrInputParameters() =>
-    lambda_someMethodWithoutReturnTypeOrInputParameters();
+    someMethodWithoutReturnTypeOrInputParametersLambda();
   @override
-  bool get isSomeProperty => lambda_isSomeProperty_get();
+  bool get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
+  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
 }
 class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterface {
   CommentsInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -8,19 +8,18 @@ import 'package:meta/meta.dart';
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 abstract class DeprecationComments {
-  DeprecationComments();
-  factory DeprecationComments.fromLambdas({
-    required bool Function(String) lambda_someMethodWithAllComments,
-    required bool Function() lambda_isSomeProperty_get,
-    required void Function(bool) lambda_isSomeProperty_set,
-    required String Function() lambda_propertyButNotAccessors_get,
-    required void Function(String) lambda_propertyButNotAccessors_set
-  }) => DeprecationComments$Lambdas(
-    lambda_someMethodWithAllComments,
-    lambda_isSomeProperty_get,
-    lambda_isSomeProperty_set,
-    lambda_propertyButNotAccessors_get,
-    lambda_propertyButNotAccessors_set
+  factory DeprecationComments(
+    bool Function(String) someMethodWithAllCommentsLambda,
+    bool Function() isSomePropertyGetLambda,
+    void Function(bool) isSomePropertySetLambda,
+    String Function() propertyButNotAccessorsGetLambda,
+    void Function(String) propertyButNotAccessorsSetLambda
+  ) => DeprecationComments$Lambdas(
+    someMethodWithAllCommentsLambda,
+    isSomePropertyGetLambda,
+    isSomePropertySetLambda,
+    propertyButNotAccessorsGetLambda,
+    propertyButNotAccessorsSetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -197,31 +196,31 @@ final _smokeDeprecationcommentsGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_get_type_id'));
 class DeprecationComments$Lambdas implements DeprecationComments {
-  bool Function(String) lambda_someMethodWithAllComments;
-  bool Function() lambda_isSomeProperty_get;
-  void Function(bool) lambda_isSomeProperty_set;
-  String Function() lambda_propertyButNotAccessors_get;
-  void Function(String) lambda_propertyButNotAccessors_set;
+  bool Function(String) someMethodWithAllCommentsLambda;
+  bool Function() isSomePropertyGetLambda;
+  void Function(bool) isSomePropertySetLambda;
+  String Function() propertyButNotAccessorsGetLambda;
+  void Function(String) propertyButNotAccessorsSetLambda;
   DeprecationComments$Lambdas(
-    this.lambda_someMethodWithAllComments,
-    this.lambda_isSomeProperty_get,
-    this.lambda_isSomeProperty_set,
-    this.lambda_propertyButNotAccessors_get,
-    this.lambda_propertyButNotAccessors_set
+    this.someMethodWithAllCommentsLambda,
+    this.isSomePropertyGetLambda,
+    this.isSomePropertySetLambda,
+    this.propertyButNotAccessorsGetLambda,
+    this.propertyButNotAccessorsSetLambda
   );
   @override
   void release() {}
   @override
   bool someMethodWithAllComments(String input) =>
-    lambda_someMethodWithAllComments(input);
+    someMethodWithAllCommentsLambda(input);
   @override
-  bool get isSomeProperty => lambda_isSomeProperty_get();
+  bool get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
+  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
   @override
-  String get propertyButNotAccessors => lambda_propertyButNotAccessors_get();
+  String get propertyButNotAccessors => propertyButNotAccessorsGetLambda();
   @override
-  set propertyButNotAccessors(String value) => lambda_propertyButNotAccessors_set(value);
+  set propertyButNotAccessors(String value) => propertyButNotAccessorsSetLambda(value);
 }
 class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationComments {
   DeprecationComments$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -7,15 +7,14 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 @Deprecated("Unfortunately, this interface is deprecated.")
 abstract class DeprecationCommentsOnly {
-  DeprecationCommentsOnly();
-  factory DeprecationCommentsOnly.fromLambdas({
-    required bool Function(String) lambda_someMethodWithAllComments,
-    required bool Function() lambda_isSomeProperty_get,
-    required void Function(bool) lambda_isSomeProperty_set
-  }) => DeprecationCommentsOnly$Lambdas(
-    lambda_someMethodWithAllComments,
-    lambda_isSomeProperty_get,
-    lambda_isSomeProperty_set
+  factory DeprecationCommentsOnly(
+    bool Function(String) someMethodWithAllCommentsLambda,
+    bool Function() isSomePropertyGetLambda,
+    void Function(bool) isSomePropertySetLambda
+  ) => DeprecationCommentsOnly$Lambdas(
+    someMethodWithAllCommentsLambda,
+    isSomePropertyGetLambda,
+    isSomePropertySetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -173,23 +172,23 @@ final _smokeDeprecationcommentsonlyGetTypeId = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_get_type_id'));
 class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
-  bool Function(String) lambda_someMethodWithAllComments;
-  bool Function() lambda_isSomeProperty_get;
-  void Function(bool) lambda_isSomeProperty_set;
+  bool Function(String) someMethodWithAllCommentsLambda;
+  bool Function() isSomePropertyGetLambda;
+  void Function(bool) isSomePropertySetLambda;
   DeprecationCommentsOnly$Lambdas(
-    this.lambda_someMethodWithAllComments,
-    this.lambda_isSomeProperty_get,
-    this.lambda_isSomeProperty_set
+    this.someMethodWithAllCommentsLambda,
+    this.isSomePropertyGetLambda,
+    this.isSomePropertySetLambda
   );
   @override
   void release() {}
   @override
   bool someMethodWithAllComments(String input) =>
-    lambda_someMethodWithAllComments(input);
+    someMethodWithAllCommentsLambda(input);
   @override
-  bool get isSomeProperty => lambda_isSomeProperty_get();
+  bool get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => lambda_isSomeProperty_set(value);
+  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
 }
 class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements DeprecationCommentsOnly {
   DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -8,15 +8,14 @@ import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'package:meta/meta.dart';
 abstract class ErrorsInterface {
-  ErrorsInterface();
-  factory ErrorsInterface.fromLambdas({
-    required void Function() lambda_methodWithErrors,
-    required void Function() lambda_methodWithExternalErrors,
-    required String Function() lambda_methodWithErrorsAndReturnValue,
-  }) => ErrorsInterface$Lambdas(
-    lambda_methodWithErrors,
-    lambda_methodWithExternalErrors,
-    lambda_methodWithErrorsAndReturnValue,
+  factory ErrorsInterface(
+    void Function() methodWithErrorsLambda,
+    void Function() methodWithExternalErrorsLambda,
+    String Function() methodWithErrorsAndReturnValueLambda,
+  ) => ErrorsInterface$Lambdas(
+    methodWithErrorsLambda,
+    methodWithExternalErrorsLambda,
+    methodWithErrorsAndReturnValueLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -251,25 +250,25 @@ final _methodWithPayloadErrorAndReturnValueReturnHasError = __lib.catchArgumentE
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error'));
 class ErrorsInterface$Lambdas implements ErrorsInterface {
-  void Function() lambda_methodWithErrors;
-  void Function() lambda_methodWithExternalErrors;
-  String Function() lambda_methodWithErrorsAndReturnValue;
+  void Function() methodWithErrorsLambda;
+  void Function() methodWithExternalErrorsLambda;
+  String Function() methodWithErrorsAndReturnValueLambda;
   ErrorsInterface$Lambdas(
-    this.lambda_methodWithErrors,
-    this.lambda_methodWithExternalErrors,
-    this.lambda_methodWithErrorsAndReturnValue,
+    this.methodWithErrorsLambda,
+    this.methodWithExternalErrorsLambda,
+    this.methodWithErrorsAndReturnValueLambda,
   );
   @override
   void release() {}
   @override
   methodWithErrors() =>
-    lambda_methodWithErrors();
+    methodWithErrorsLambda();
   @override
   methodWithExternalErrors() =>
-    lambda_methodWithExternalErrors();
+    methodWithExternalErrorsLambda();
   @override
   String methodWithErrorsAndReturnValue() =>
-    lambda_methodWithErrorsAndReturnValue();
+    methodWithErrorsAndReturnValueLambda();
 }
 class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
   ErrorsInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -6,13 +6,12 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class ExternalInterface {
-  ExternalInterface();
-  factory ExternalInterface.fromLambdas({
-    required void Function(int) lambda_someMethod,
-    required String Function() lambda_someProperty_get
-  }) => ExternalInterface$Lambdas(
-    lambda_someMethod,
-    lambda_someProperty_get
+  factory ExternalInterface(
+    void Function(int) someMethodLambda,
+    String Function() somePropertyGetLambda
+  ) => ExternalInterface$Lambdas(
+    someMethodLambda,
+    somePropertyGetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -156,19 +155,19 @@ final _smokeExternalinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_get_type_id'));
 class ExternalInterface$Lambdas implements ExternalInterface {
-  void Function(int) lambda_someMethod;
-  String Function() lambda_someProperty_get;
+  void Function(int) someMethodLambda;
+  String Function() somePropertyGetLambda;
   ExternalInterface$Lambdas(
-    this.lambda_someMethod,
-    this.lambda_someProperty_get
+    this.someMethodLambda,
+    this.somePropertyGetLambda
   );
   @override
   void release() {}
   @override
   someMethod(int someParameter) =>
-    lambda_someMethod(someParameter);
+    someMethodLambda(someParameter);
   @override
-  String get someProperty => lambda_someProperty_get();
+  String get someProperty => somePropertyGetLambda();
 }
 class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterface {
   ExternalInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -7,17 +7,16 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'package:meta/meta.dart';
 abstract class ChildInterface implements ParentInterface {
-  ChildInterface();
-  factory ChildInterface.fromLambdas({
-    required void Function() lambda_rootMethod,
-    required void Function() lambda_childMethod,
-    required String Function() lambda_rootProperty_get,
-    required void Function(String) lambda_rootProperty_set
-  }) => ChildInterface$Lambdas(
-    lambda_rootMethod,
-    lambda_childMethod,
-    lambda_rootProperty_get,
-    lambda_rootProperty_set
+  factory ChildInterface(
+    void Function() rootMethodLambda,
+    void Function() childMethodLambda,
+    String Function() rootPropertyGetLambda,
+    void Function(String) rootPropertySetLambda
+  ) => ChildInterface$Lambdas(
+    rootMethodLambda,
+    childMethodLambda,
+    rootPropertyGetLambda,
+    rootPropertySetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -44,28 +43,28 @@ final _smokeChildinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativ
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildInterface_get_type_id'));
 class ChildInterface$Lambdas implements ChildInterface {
-  void Function() lambda_rootMethod;
-  void Function() lambda_childMethod;
-  String Function() lambda_rootProperty_get;
-  void Function(String) lambda_rootProperty_set;
+  void Function() rootMethodLambda;
+  void Function() childMethodLambda;
+  String Function() rootPropertyGetLambda;
+  void Function(String) rootPropertySetLambda;
   ChildInterface$Lambdas(
-    this.lambda_rootMethod,
-    this.lambda_childMethod,
-    this.lambda_rootProperty_get,
-    this.lambda_rootProperty_set
+    this.rootMethodLambda,
+    this.childMethodLambda,
+    this.rootPropertyGetLambda,
+    this.rootPropertySetLambda
   );
   @override
   void release() {}
   @override
   rootMethod() =>
-    lambda_rootMethod();
+    rootMethodLambda();
   @override
   childMethod() =>
-    lambda_childMethod();
+    childMethodLambda();
   @override
-  String get rootProperty => lambda_rootProperty_get();
+  String get rootProperty => rootPropertyGetLambda();
   @override
-  set rootProperty(String value) => lambda_rootProperty_set(value);
+  set rootProperty(String value) => rootPropertySetLambda(value);
 }
 class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
   ChildInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -6,15 +6,14 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class ParentInterface {
-  ParentInterface();
-  factory ParentInterface.fromLambdas({
-    required void Function() lambda_rootMethod,
-    required String Function() lambda_rootProperty_get,
-    required void Function(String) lambda_rootProperty_set
-  }) => ParentInterface$Lambdas(
-    lambda_rootMethod,
-    lambda_rootProperty_get,
-    lambda_rootProperty_set
+  factory ParentInterface(
+    void Function() rootMethodLambda,
+    String Function() rootPropertyGetLambda,
+    void Function(String) rootPropertySetLambda
+  ) => ParentInterface$Lambdas(
+    rootMethodLambda,
+    rootPropertyGetLambda,
+    rootPropertySetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -43,23 +42,23 @@ final _smokeParentinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentInterface_get_type_id'));
 class ParentInterface$Lambdas implements ParentInterface {
-  void Function() lambda_rootMethod;
-  String Function() lambda_rootProperty_get;
-  void Function(String) lambda_rootProperty_set;
+  void Function() rootMethodLambda;
+  String Function() rootPropertyGetLambda;
+  void Function(String) rootPropertySetLambda;
   ParentInterface$Lambdas(
-    this.lambda_rootMethod,
-    this.lambda_rootProperty_get,
-    this.lambda_rootProperty_set
+    this.rootMethodLambda,
+    this.rootPropertyGetLambda,
+    this.rootPropertySetLambda
   );
   @override
   void release() {}
   @override
   rootMethod() =>
-    lambda_rootMethod();
+    rootMethodLambda();
   @override
-  String get rootProperty => lambda_rootProperty_get();
+  String get rootProperty => rootPropertyGetLambda();
   @override
-  set rootProperty(String value) => lambda_rootProperty_set(value);
+  set rootProperty(String value) => rootPropertySetLambda(value);
 }
 class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
   ParentInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -6,13 +6,12 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class SimpleInterface {
-  SimpleInterface();
-  factory SimpleInterface.fromLambdas({
-    required String Function() lambda_getStringValue,
-    required SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface,
-  }) => SimpleInterface$Lambdas(
-    lambda_getStringValue,
-    lambda_useSimpleInterface,
+  factory SimpleInterface(
+    String Function() getStringValueLambda,
+    SimpleInterface Function(SimpleInterface) useSimpleInterfaceLambda,
+  ) => SimpleInterface$Lambdas(
+    getStringValueLambda,
+    useSimpleInterfaceLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -40,20 +39,20 @@ final _smokeSimpleinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleInterface_get_type_id'));
 class SimpleInterface$Lambdas implements SimpleInterface {
-  String Function() lambda_getStringValue;
-  SimpleInterface Function(SimpleInterface) lambda_useSimpleInterface;
+  String Function() getStringValueLambda;
+  SimpleInterface Function(SimpleInterface) useSimpleInterfaceLambda;
   SimpleInterface$Lambdas(
-    this.lambda_getStringValue,
-    this.lambda_useSimpleInterface,
+    this.getStringValueLambda,
+    this.useSimpleInterfaceLambda,
   );
   @override
   void release() {}
   @override
   String getStringValue() =>
-    lambda_getStringValue();
+    getStringValueLambda();
   @override
   SimpleInterface useSimpleInterface(SimpleInterface input) =>
-    lambda_useSimpleInterface(input);
+    useSimpleInterfaceLambda(input);
 }
 class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
   SimpleInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -8,21 +8,20 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'package:meta/meta.dart';
 abstract class CalculatorListener {
-  CalculatorListener();
-  factory CalculatorListener.fromLambdas({
-    required void Function(double) lambda_onCalculationResult,
-    required void Function(double) lambda_onCalculationResultConst,
-    required void Function(CalculatorListener_ResultStruct) lambda_onCalculationResultStruct,
-    required void Function(List<double>) lambda_onCalculationResultArray,
-    required void Function(Map<String, double>) lambda_onCalculationResultMap,
-    required void Function(CalculationResult) lambda_onCalculationResultInstance,
-  }) => CalculatorListener$Lambdas(
-    lambda_onCalculationResult,
-    lambda_onCalculationResultConst,
-    lambda_onCalculationResultStruct,
-    lambda_onCalculationResultArray,
-    lambda_onCalculationResultMap,
-    lambda_onCalculationResultInstance,
+  factory CalculatorListener(
+    void Function(double) onCalculationResultLambda,
+    void Function(double) onCalculationResultConstLambda,
+    void Function(CalculatorListener_ResultStruct) onCalculationResultStructLambda,
+    void Function(List<double>) onCalculationResultArrayLambda,
+    void Function(Map<String, double>) onCalculationResultMapLambda,
+    void Function(CalculationResult) onCalculationResultInstanceLambda,
+  ) => CalculatorListener$Lambdas(
+    onCalculationResultLambda,
+    onCalculationResultConstLambda,
+    onCalculationResultStructLambda,
+    onCalculationResultArrayLambda,
+    onCalculationResultMapLambda,
+    onCalculationResultInstanceLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -116,40 +115,40 @@ final _smokeCalculatorlistenerGetTypeId = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_get_type_id'));
 class CalculatorListener$Lambdas implements CalculatorListener {
-  void Function(double) lambda_onCalculationResult;
-  void Function(double) lambda_onCalculationResultConst;
-  void Function(CalculatorListener_ResultStruct) lambda_onCalculationResultStruct;
-  void Function(List<double>) lambda_onCalculationResultArray;
-  void Function(Map<String, double>) lambda_onCalculationResultMap;
-  void Function(CalculationResult) lambda_onCalculationResultInstance;
+  void Function(double) onCalculationResultLambda;
+  void Function(double) onCalculationResultConstLambda;
+  void Function(CalculatorListener_ResultStruct) onCalculationResultStructLambda;
+  void Function(List<double>) onCalculationResultArrayLambda;
+  void Function(Map<String, double>) onCalculationResultMapLambda;
+  void Function(CalculationResult) onCalculationResultInstanceLambda;
   CalculatorListener$Lambdas(
-    this.lambda_onCalculationResult,
-    this.lambda_onCalculationResultConst,
-    this.lambda_onCalculationResultStruct,
-    this.lambda_onCalculationResultArray,
-    this.lambda_onCalculationResultMap,
-    this.lambda_onCalculationResultInstance,
+    this.onCalculationResultLambda,
+    this.onCalculationResultConstLambda,
+    this.onCalculationResultStructLambda,
+    this.onCalculationResultArrayLambda,
+    this.onCalculationResultMapLambda,
+    this.onCalculationResultInstanceLambda,
   );
   @override
   void release() {}
   @override
   onCalculationResult(double calculationResult) =>
-    lambda_onCalculationResult(calculationResult);
+    onCalculationResultLambda(calculationResult);
   @override
   onCalculationResultConst(double calculationResult) =>
-    lambda_onCalculationResultConst(calculationResult);
+    onCalculationResultConstLambda(calculationResult);
   @override
   onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) =>
-    lambda_onCalculationResultStruct(calculationResult);
+    onCalculationResultStructLambda(calculationResult);
   @override
   onCalculationResultArray(List<double> calculationResult) =>
-    lambda_onCalculationResultArray(calculationResult);
+    onCalculationResultArrayLambda(calculationResult);
   @override
   onCalculationResultMap(Map<String, double> calculationResults) =>
-    lambda_onCalculationResultMap(calculationResults);
+    onCalculationResultMapLambda(calculationResults);
   @override
   onCalculationResultInstance(CalculationResult calculationResult) =>
-    lambda_onCalculationResultInstance(calculationResult);
+    onCalculationResultInstanceLambda(calculationResult);
 }
 class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorListener {
   CalculatorListener$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -6,15 +6,14 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class InterfaceWithStatic {
-  InterfaceWithStatic();
-  factory InterfaceWithStatic.fromLambdas({
-    required String Function() lambda_regularFunction,
-    required String Function() lambda_regularProperty_get,
-    required void Function(String) lambda_regularProperty_set,
-  }) => InterfaceWithStatic$Lambdas(
-    lambda_regularFunction,
-    lambda_regularProperty_get,
-    lambda_regularProperty_set,
+  factory InterfaceWithStatic(
+    String Function() regularFunctionLambda,
+    String Function() regularPropertyGetLambda,
+    void Function(String) regularPropertySetLambda,
+  ) => InterfaceWithStatic$Lambdas(
+    regularFunctionLambda,
+    regularPropertyGetLambda,
+    regularPropertySetLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -46,23 +45,23 @@ final _smokeInterfacewithstaticGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InterfaceWithStatic_get_type_id'));
 class InterfaceWithStatic$Lambdas implements InterfaceWithStatic {
-  String Function() lambda_regularFunction;
-  String Function() lambda_regularProperty_get;
-  void Function(String) lambda_regularProperty_set;
+  String Function() regularFunctionLambda;
+  String Function() regularPropertyGetLambda;
+  void Function(String) regularPropertySetLambda;
   InterfaceWithStatic$Lambdas(
-    this.lambda_regularFunction,
-    this.lambda_regularProperty_get,
-    this.lambda_regularProperty_set,
+    this.regularFunctionLambda,
+    this.regularPropertyGetLambda,
+    this.regularPropertySetLambda,
   );
   @override
   void release() {}
   @override
   String regularFunction() =>
-    lambda_regularFunction();
+    regularFunctionLambda();
   @override
-  String get regularProperty => lambda_regularProperty_get();
+  String get regularProperty => regularPropertyGetLambda();
   @override
-  set regularProperty(String value) => lambda_regularProperty_set(value);
+  set regularProperty(String value) => regularPropertySetLambda(value);
 }
 class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWithStatic {
   InterfaceWithStatic$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -9,37 +9,36 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'package:meta/meta.dart';
 abstract class ListenerWithProperties {
-  ListenerWithProperties();
-  factory ListenerWithProperties.fromLambdas({
-    required String Function() lambda_message_get,
-    required void Function(String) lambda_message_set,
-    required CalculationResult Function() lambda_packedMessage_get,
-    required void Function(CalculationResult) lambda_packedMessage_set,
-    required ListenerWithProperties_ResultStruct Function() lambda_structuredMessage_get,
-    required void Function(ListenerWithProperties_ResultStruct) lambda_structuredMessage_set,
-    required ListenerWithProperties_ResultEnum Function() lambda_enumeratedMessage_get,
-    required void Function(ListenerWithProperties_ResultEnum) lambda_enumeratedMessage_set,
-    required List<String> Function() lambda_arrayedMessage_get,
-    required void Function(List<String>) lambda_arrayedMessage_set,
-    required Map<String, double> Function() lambda_mappedMessage_get,
-    required void Function(Map<String, double>) lambda_mappedMessage_set,
-    required Uint8List Function() lambda_bufferedMessage_get,
-    required void Function(Uint8List) lambda_bufferedMessage_set
-  }) => ListenerWithProperties$Lambdas(
-    lambda_message_get,
-    lambda_message_set,
-    lambda_packedMessage_get,
-    lambda_packedMessage_set,
-    lambda_structuredMessage_get,
-    lambda_structuredMessage_set,
-    lambda_enumeratedMessage_get,
-    lambda_enumeratedMessage_set,
-    lambda_arrayedMessage_get,
-    lambda_arrayedMessage_set,
-    lambda_mappedMessage_get,
-    lambda_mappedMessage_set,
-    lambda_bufferedMessage_get,
-    lambda_bufferedMessage_set
+  factory ListenerWithProperties(
+    String Function() messageGetLambda,
+    void Function(String) messageSetLambda,
+    CalculationResult Function() packedMessageGetLambda,
+    void Function(CalculationResult) packedMessageSetLambda,
+    ListenerWithProperties_ResultStruct Function() structuredMessageGetLambda,
+    void Function(ListenerWithProperties_ResultStruct) structuredMessageSetLambda,
+    ListenerWithProperties_ResultEnum Function() enumeratedMessageGetLambda,
+    void Function(ListenerWithProperties_ResultEnum) enumeratedMessageSetLambda,
+    List<String> Function() arrayedMessageGetLambda,
+    void Function(List<String>) arrayedMessageSetLambda,
+    Map<String, double> Function() mappedMessageGetLambda,
+    void Function(Map<String, double>) mappedMessageSetLambda,
+    Uint8List Function() bufferedMessageGetLambda,
+    void Function(Uint8List) bufferedMessageSetLambda
+  ) => ListenerWithProperties$Lambdas(
+    messageGetLambda,
+    messageSetLambda,
+    packedMessageGetLambda,
+    packedMessageSetLambda,
+    structuredMessageGetLambda,
+    structuredMessageSetLambda,
+    enumeratedMessageGetLambda,
+    enumeratedMessageSetLambda,
+    arrayedMessageGetLambda,
+    arrayedMessageSetLambda,
+    mappedMessageGetLambda,
+    mappedMessageSetLambda,
+    bufferedMessageGetLambda,
+    bufferedMessageSetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -200,66 +199,66 @@ final _smokeListenerwithpropertiesGetTypeId = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_get_type_id'));
 class ListenerWithProperties$Lambdas implements ListenerWithProperties {
-  String Function() lambda_message_get;
-  void Function(String) lambda_message_set;
-  CalculationResult Function() lambda_packedMessage_get;
-  void Function(CalculationResult) lambda_packedMessage_set;
-  ListenerWithProperties_ResultStruct Function() lambda_structuredMessage_get;
-  void Function(ListenerWithProperties_ResultStruct) lambda_structuredMessage_set;
-  ListenerWithProperties_ResultEnum Function() lambda_enumeratedMessage_get;
-  void Function(ListenerWithProperties_ResultEnum) lambda_enumeratedMessage_set;
-  List<String> Function() lambda_arrayedMessage_get;
-  void Function(List<String>) lambda_arrayedMessage_set;
-  Map<String, double> Function() lambda_mappedMessage_get;
-  void Function(Map<String, double>) lambda_mappedMessage_set;
-  Uint8List Function() lambda_bufferedMessage_get;
-  void Function(Uint8List) lambda_bufferedMessage_set;
+  String Function() messageGetLambda;
+  void Function(String) messageSetLambda;
+  CalculationResult Function() packedMessageGetLambda;
+  void Function(CalculationResult) packedMessageSetLambda;
+  ListenerWithProperties_ResultStruct Function() structuredMessageGetLambda;
+  void Function(ListenerWithProperties_ResultStruct) structuredMessageSetLambda;
+  ListenerWithProperties_ResultEnum Function() enumeratedMessageGetLambda;
+  void Function(ListenerWithProperties_ResultEnum) enumeratedMessageSetLambda;
+  List<String> Function() arrayedMessageGetLambda;
+  void Function(List<String>) arrayedMessageSetLambda;
+  Map<String, double> Function() mappedMessageGetLambda;
+  void Function(Map<String, double>) mappedMessageSetLambda;
+  Uint8List Function() bufferedMessageGetLambda;
+  void Function(Uint8List) bufferedMessageSetLambda;
   ListenerWithProperties$Lambdas(
-    this.lambda_message_get,
-    this.lambda_message_set,
-    this.lambda_packedMessage_get,
-    this.lambda_packedMessage_set,
-    this.lambda_structuredMessage_get,
-    this.lambda_structuredMessage_set,
-    this.lambda_enumeratedMessage_get,
-    this.lambda_enumeratedMessage_set,
-    this.lambda_arrayedMessage_get,
-    this.lambda_arrayedMessage_set,
-    this.lambda_mappedMessage_get,
-    this.lambda_mappedMessage_set,
-    this.lambda_bufferedMessage_get,
-    this.lambda_bufferedMessage_set
+    this.messageGetLambda,
+    this.messageSetLambda,
+    this.packedMessageGetLambda,
+    this.packedMessageSetLambda,
+    this.structuredMessageGetLambda,
+    this.structuredMessageSetLambda,
+    this.enumeratedMessageGetLambda,
+    this.enumeratedMessageSetLambda,
+    this.arrayedMessageGetLambda,
+    this.arrayedMessageSetLambda,
+    this.mappedMessageGetLambda,
+    this.mappedMessageSetLambda,
+    this.bufferedMessageGetLambda,
+    this.bufferedMessageSetLambda
   );
   @override
   void release() {}
   @override
-  String get message => lambda_message_get();
+  String get message => messageGetLambda();
   @override
-  set message(String value) => lambda_message_set(value);
+  set message(String value) => messageSetLambda(value);
   @override
-  CalculationResult get packedMessage => lambda_packedMessage_get();
+  CalculationResult get packedMessage => packedMessageGetLambda();
   @override
-  set packedMessage(CalculationResult value) => lambda_packedMessage_set(value);
+  set packedMessage(CalculationResult value) => packedMessageSetLambda(value);
   @override
-  ListenerWithProperties_ResultStruct get structuredMessage => lambda_structuredMessage_get();
+  ListenerWithProperties_ResultStruct get structuredMessage => structuredMessageGetLambda();
   @override
-  set structuredMessage(ListenerWithProperties_ResultStruct value) => lambda_structuredMessage_set(value);
+  set structuredMessage(ListenerWithProperties_ResultStruct value) => structuredMessageSetLambda(value);
   @override
-  ListenerWithProperties_ResultEnum get enumeratedMessage => lambda_enumeratedMessage_get();
+  ListenerWithProperties_ResultEnum get enumeratedMessage => enumeratedMessageGetLambda();
   @override
-  set enumeratedMessage(ListenerWithProperties_ResultEnum value) => lambda_enumeratedMessage_set(value);
+  set enumeratedMessage(ListenerWithProperties_ResultEnum value) => enumeratedMessageSetLambda(value);
   @override
-  List<String> get arrayedMessage => lambda_arrayedMessage_get();
+  List<String> get arrayedMessage => arrayedMessageGetLambda();
   @override
-  set arrayedMessage(List<String> value) => lambda_arrayedMessage_set(value);
+  set arrayedMessage(List<String> value) => arrayedMessageSetLambda(value);
   @override
-  Map<String, double> get mappedMessage => lambda_mappedMessage_get();
+  Map<String, double> get mappedMessage => mappedMessageGetLambda();
   @override
-  set mappedMessage(Map<String, double> value) => lambda_mappedMessage_set(value);
+  set mappedMessage(Map<String, double> value) => mappedMessageSetLambda(value);
   @override
-  Uint8List get bufferedMessage => lambda_bufferedMessage_get();
+  Uint8List get bufferedMessage => bufferedMessageGetLambda();
   @override
-  set bufferedMessage(Uint8List value) => lambda_bufferedMessage_set(value);
+  set bufferedMessage(Uint8List value) => bufferedMessageSetLambda(value);
 }
 class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWithProperties {
   ListenerWithProperties$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -8,23 +8,22 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
 import 'package:meta/meta.dart';
 abstract class ListenersWithReturnValues {
-  ListenersWithReturnValues();
-  factory ListenersWithReturnValues.fromLambdas({
-    required double Function() lambda_fetchDataDouble,
-    required String Function() lambda_fetchDataString,
-    required ListenersWithReturnValues_ResultStruct Function() lambda_fetchDataStruct,
-    required ListenersWithReturnValues_ResultEnum Function() lambda_fetchDataEnum,
-    required List<double> Function() lambda_fetchDataArray,
-    required Map<String, double> Function() lambda_fetchDataMap,
-    required CalculationResult Function() lambda_fetchDataInstance,
-  }) => ListenersWithReturnValues$Lambdas(
-    lambda_fetchDataDouble,
-    lambda_fetchDataString,
-    lambda_fetchDataStruct,
-    lambda_fetchDataEnum,
-    lambda_fetchDataArray,
-    lambda_fetchDataMap,
-    lambda_fetchDataInstance,
+  factory ListenersWithReturnValues(
+    double Function() fetchDataDoubleLambda,
+    String Function() fetchDataStringLambda,
+    ListenersWithReturnValues_ResultStruct Function() fetchDataStructLambda,
+    ListenersWithReturnValues_ResultEnum Function() fetchDataEnumLambda,
+    List<double> Function() fetchDataArrayLambda,
+    Map<String, double> Function() fetchDataMapLambda,
+    CalculationResult Function() fetchDataInstanceLambda,
+  ) => ListenersWithReturnValues$Lambdas(
+    fetchDataDoubleLambda,
+    fetchDataStringLambda,
+    fetchDataStructLambda,
+    fetchDataEnumLambda,
+    fetchDataArrayLambda,
+    fetchDataMapLambda,
+    fetchDataInstanceLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -178,45 +177,45 @@ final _smokeListenerswithreturnvaluesGetTypeId = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_get_type_id'));
 class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
-  double Function() lambda_fetchDataDouble;
-  String Function() lambda_fetchDataString;
-  ListenersWithReturnValues_ResultStruct Function() lambda_fetchDataStruct;
-  ListenersWithReturnValues_ResultEnum Function() lambda_fetchDataEnum;
-  List<double> Function() lambda_fetchDataArray;
-  Map<String, double> Function() lambda_fetchDataMap;
-  CalculationResult Function() lambda_fetchDataInstance;
+  double Function() fetchDataDoubleLambda;
+  String Function() fetchDataStringLambda;
+  ListenersWithReturnValues_ResultStruct Function() fetchDataStructLambda;
+  ListenersWithReturnValues_ResultEnum Function() fetchDataEnumLambda;
+  List<double> Function() fetchDataArrayLambda;
+  Map<String, double> Function() fetchDataMapLambda;
+  CalculationResult Function() fetchDataInstanceLambda;
   ListenersWithReturnValues$Lambdas(
-    this.lambda_fetchDataDouble,
-    this.lambda_fetchDataString,
-    this.lambda_fetchDataStruct,
-    this.lambda_fetchDataEnum,
-    this.lambda_fetchDataArray,
-    this.lambda_fetchDataMap,
-    this.lambda_fetchDataInstance,
+    this.fetchDataDoubleLambda,
+    this.fetchDataStringLambda,
+    this.fetchDataStructLambda,
+    this.fetchDataEnumLambda,
+    this.fetchDataArrayLambda,
+    this.fetchDataMapLambda,
+    this.fetchDataInstanceLambda,
   );
   @override
   void release() {}
   @override
   double fetchDataDouble() =>
-    lambda_fetchDataDouble();
+    fetchDataDoubleLambda();
   @override
   String fetchDataString() =>
-    lambda_fetchDataString();
+    fetchDataStringLambda();
   @override
   ListenersWithReturnValues_ResultStruct fetchDataStruct() =>
-    lambda_fetchDataStruct();
+    fetchDataStructLambda();
   @override
   ListenersWithReturnValues_ResultEnum fetchDataEnum() =>
-    lambda_fetchDataEnum();
+    fetchDataEnumLambda();
   @override
   List<double> fetchDataArray() =>
-    lambda_fetchDataArray();
+    fetchDataArrayLambda();
   @override
   Map<String, double> fetchDataMap() =>
-    lambda_fetchDataMap();
+    fetchDataMapLambda();
   @override
   CalculationResult fetchDataInstance() =>
-    lambda_fetchDataInstance();
+    fetchDataInstanceLambda();
 }
 class ListenersWithReturnValues$Impl extends __lib.NativeBase implements ListenersWithReturnValues {
   ListenersWithReturnValues$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -76,11 +76,10 @@ void smokeOuterclassInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclassInnerclassReleaseHandle(handle);
 // End of OuterClass_InnerClass "private" section.
 abstract class OuterClass_InnerInterface {
-  OuterClass_InnerInterface();
-  factory OuterClass_InnerInterface.fromLambdas({
-    required String Function(String) lambda_foo,
-  }) => OuterClass_InnerInterface$Lambdas(
-    lambda_foo,
+  factory OuterClass_InnerInterface(
+    String Function(String) fooLambda,
+  ) => OuterClass_InnerInterface$Lambdas(
+    fooLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -107,15 +106,15 @@ final _smokeOuterclassInnerinterfaceGetTypeId = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerInterface_get_type_id'));
 class OuterClass_InnerInterface$Lambdas implements OuterClass_InnerInterface {
-  String Function(String) lambda_foo;
+  String Function(String) fooLambda;
   OuterClass_InnerInterface$Lambdas(
-    this.lambda_foo,
+    this.fooLambda,
   );
   @override
   void release() {}
   @override
   String foo(String input) =>
-    lambda_foo(input);
+    fooLambda(input);
 }
 class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterClass_InnerInterface {
   OuterClass_InnerInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -77,11 +77,10 @@ void smokeOuterclasswithinheritanceInnerclassReleaseFfiHandleNullable(Pointer<Vo
   _smokeOuterclasswithinheritanceInnerclassReleaseHandle(handle);
 // End of OuterClassWithInheritance_InnerClass "private" section.
 abstract class OuterClassWithInheritance_InnerInterface {
-  OuterClassWithInheritance_InnerInterface();
-  factory OuterClassWithInheritance_InnerInterface.fromLambdas({
-    required String Function(String) lambda_baz,
-  }) => OuterClassWithInheritance_InnerInterface$Lambdas(
-    lambda_baz,
+  factory OuterClassWithInheritance_InnerInterface(
+    String Function(String) bazLambda,
+  ) => OuterClassWithInheritance_InnerInterface$Lambdas(
+    bazLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -108,15 +107,15 @@ final _smokeOuterclasswithinheritanceInnerinterfaceGetTypeId = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerInterface_get_type_id'));
 class OuterClassWithInheritance_InnerInterface$Lambdas implements OuterClassWithInheritance_InnerInterface {
-  String Function(String) lambda_baz;
+  String Function(String) bazLambda;
   OuterClassWithInheritance_InnerInterface$Lambdas(
-    this.lambda_baz,
+    this.bazLambda,
   );
   @override
   void release() {}
   @override
   String baz(String input) =>
-    lambda_baz(input);
+    bazLambda(input);
 }
 class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerInterface {
   OuterClassWithInheritance_InnerInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -6,11 +6,10 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class OuterInterface {
-  OuterInterface();
-  factory OuterInterface.fromLambdas({
-    required String Function(String) lambda_foo,
-  }) => OuterInterface$Lambdas(
-    lambda_foo,
+  factory OuterInterface(
+    String Function(String) fooLambda,
+  ) => OuterInterface$Lambdas(
+    fooLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -82,11 +81,10 @@ void smokeOuterinterfaceInnerclassReleaseFfiHandleNullable(Pointer<Void> handle)
   _smokeOuterinterfaceInnerclassReleaseHandle(handle);
 // End of OuterInterface_InnerClass "private" section.
 abstract class OuterInterface_InnerInterface {
-  OuterInterface_InnerInterface();
-  factory OuterInterface_InnerInterface.fromLambdas({
-    required String Function(String) lambda_foo,
-  }) => OuterInterface_InnerInterface$Lambdas(
-    lambda_foo,
+  factory OuterInterface_InnerInterface(
+    String Function(String) fooLambda,
+  ) => OuterInterface_InnerInterface$Lambdas(
+    fooLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -113,15 +111,15 @@ final _smokeOuterinterfaceInnerinterfaceGetTypeId = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerInterface_get_type_id'));
 class OuterInterface_InnerInterface$Lambdas implements OuterInterface_InnerInterface {
-  String Function(String) lambda_foo;
+  String Function(String) fooLambda;
   OuterInterface_InnerInterface$Lambdas(
-    this.lambda_foo,
+    this.fooLambda,
   );
   @override
   void release() {}
   @override
   String foo(String input) =>
-    lambda_foo(input);
+    fooLambda(input);
 }
 class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements OuterInterface_InnerInterface {
   OuterInterface_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
@@ -209,15 +207,15 @@ final _smokeOuterinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativ
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_get_type_id'));
 class OuterInterface$Lambdas implements OuterInterface {
-  String Function(String) lambda_foo;
+  String Function(String) fooLambda;
   OuterInterface$Lambdas(
-    this.lambda_foo,
+    this.fooLambda,
   );
   @override
   void release() {}
   @override
   String foo(String input) =>
-    lambda_foo(input);
+    fooLambda(input);
 }
 class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
   OuterInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -244,11 +244,10 @@ void smokeOuterstructInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerclassReleaseHandle(handle);
 // End of OuterStruct_InnerClass "private" section.
 abstract class OuterStruct_InnerInterface {
-  OuterStruct_InnerInterface();
-  factory OuterStruct_InnerInterface.fromLambdas({
-    required Map<String, Uint8List> Function() lambda_barBaz,
-  }) => OuterStruct_InnerInterface$Lambdas(
-    lambda_barBaz,
+  factory OuterStruct_InnerInterface(
+    Map<String, Uint8List> Function() barBazLambda,
+  ) => OuterStruct_InnerInterface$Lambdas(
+    barBazLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -275,15 +274,15 @@ final _smokeOuterstructInnerinterfaceGetTypeId = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerInterface_get_type_id'));
 class OuterStruct_InnerInterface$Lambdas implements OuterStruct_InnerInterface {
-  Map<String, Uint8List> Function() lambda_barBaz;
+  Map<String, Uint8List> Function() barBazLambda;
   OuterStruct_InnerInterface$Lambdas(
-    this.lambda_barBaz,
+    this.barBazLambda,
   );
   @override
   void release() {}
   @override
   Map<String, Uint8List> barBaz() =>
-    lambda_barBaz();
+    barBazLambda();
 }
 class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterStruct_InnerInterface {
   OuterStruct_InnerInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -6,11 +6,10 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class weeListener {
-  weeListener();
-  factory weeListener.fromLambdas({
-    required void Function(String) lambda_WeeMethod,
-  }) => weeListener$Lambdas(
-    lambda_WeeMethod,
+  factory weeListener(
+    void Function(String) WeeMethodLambda,
+  ) => weeListener$Lambdas(
+    WeeMethodLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -37,15 +36,15 @@ final _smokePlatformnameslistenerGetTypeId = __lib.catchArgumentError(() => __li
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNamesListener_get_type_id'));
 class weeListener$Lambdas implements weeListener {
-  void Function(String) lambda_WeeMethod;
+  void Function(String) WeeMethodLambda;
   weeListener$Lambdas(
-    this.lambda_WeeMethod,
+    this.WeeMethodLambda,
   );
   @override
   void release() {}
   @override
   WeeMethod(String WeeParameter) =>
-    lambda_WeeMethod(WeeParameter);
+    WeeMethodLambda(WeeParameter);
 }
 class weeListener$Impl extends __lib.NativeBase implements weeListener {
   weeListener$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -6,13 +6,12 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class PropertiesInterface {
-  PropertiesInterface();
-  factory PropertiesInterface.fromLambdas({
-    required PropertiesInterface_ExampleStruct Function() lambda_structProperty_get,
-    required void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set
-  }) => PropertiesInterface$Lambdas(
-    lambda_structProperty_get,
-    lambda_structProperty_set
+  factory PropertiesInterface(
+    PropertiesInterface_ExampleStruct Function() structPropertyGetLambda,
+    void Function(PropertiesInterface_ExampleStruct) structPropertySetLambda
+  ) => PropertiesInterface$Lambdas(
+    structPropertyGetLambda,
+    structPropertySetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -102,18 +101,18 @@ final _smokePropertiesinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_get_type_id'));
 class PropertiesInterface$Lambdas implements PropertiesInterface {
-  PropertiesInterface_ExampleStruct Function() lambda_structProperty_get;
-  void Function(PropertiesInterface_ExampleStruct) lambda_structProperty_set;
+  PropertiesInterface_ExampleStruct Function() structPropertyGetLambda;
+  void Function(PropertiesInterface_ExampleStruct) structPropertySetLambda;
   PropertiesInterface$Lambdas(
-    this.lambda_structProperty_get,
-    this.lambda_structProperty_set
+    this.structPropertyGetLambda,
+    this.structPropertySetLambda
   );
   @override
   void release() {}
   @override
-  PropertiesInterface_ExampleStruct get structProperty => lambda_structProperty_get();
+  PropertiesInterface_ExampleStruct get structProperty => structPropertyGetLambda();
   @override
-  set structProperty(PropertiesInterface_ExampleStruct value) => lambda_structProperty_set(value);
+  set structProperty(PropertiesInterface_ExampleStruct value) => structPropertySetLambda(value);
 }
 class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInterface {
   PropertiesInterface$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -7,21 +7,20 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/skip_proxy.dart';
 import 'package:meta/meta.dart';
 abstract class InheritFromSkipped implements SkipProxy {
-  InheritFromSkipped();
-  factory InheritFromSkipped.fromLambdas({
-    required String Function(String) lambda_notInJava,
-    required bool Function(bool) lambda_notInSwift,
-    required String Function() lambda_skippedInJava_get,
-    required void Function(String) lambda_skippedInJava_set,
-    required bool Function() lambda_isSkippedInSwift_get,
-    required void Function(bool) lambda_isSkippedInSwift_set
-  }) => InheritFromSkipped$Lambdas(
-    lambda_notInJava,
-    lambda_notInSwift,
-    lambda_skippedInJava_get,
-    lambda_skippedInJava_set,
-    lambda_isSkippedInSwift_get,
-    lambda_isSkippedInSwift_set
+  factory InheritFromSkipped(
+    String Function(String) notInJavaLambda,
+    bool Function(bool) notInSwiftLambda,
+    String Function() skippedInJavaGetLambda,
+    void Function(String) skippedInJavaSetLambda,
+    bool Function() isSkippedInSwiftGetLambda,
+    void Function(bool) isSkippedInSwiftSetLambda
+  ) => InheritFromSkipped$Lambdas(
+    notInJavaLambda,
+    notInSwiftLambda,
+    skippedInJavaGetLambda,
+    skippedInJavaSetLambda,
+    isSkippedInSwiftGetLambda,
+    isSkippedInSwiftSetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -47,36 +46,36 @@ final _smokeInheritfromskippedGetTypeId = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InheritFromSkipped_get_type_id'));
 class InheritFromSkipped$Lambdas implements InheritFromSkipped {
-  String Function(String) lambda_notInJava;
-  bool Function(bool) lambda_notInSwift;
-  String Function() lambda_skippedInJava_get;
-  void Function(String) lambda_skippedInJava_set;
-  bool Function() lambda_isSkippedInSwift_get;
-  void Function(bool) lambda_isSkippedInSwift_set;
+  String Function(String) notInJavaLambda;
+  bool Function(bool) notInSwiftLambda;
+  String Function() skippedInJavaGetLambda;
+  void Function(String) skippedInJavaSetLambda;
+  bool Function() isSkippedInSwiftGetLambda;
+  void Function(bool) isSkippedInSwiftSetLambda;
   InheritFromSkipped$Lambdas(
-    this.lambda_notInJava,
-    this.lambda_notInSwift,
-    this.lambda_skippedInJava_get,
-    this.lambda_skippedInJava_set,
-    this.lambda_isSkippedInSwift_get,
-    this.lambda_isSkippedInSwift_set
+    this.notInJavaLambda,
+    this.notInSwiftLambda,
+    this.skippedInJavaGetLambda,
+    this.skippedInJavaSetLambda,
+    this.isSkippedInSwiftGetLambda,
+    this.isSkippedInSwiftSetLambda
   );
   @override
   void release() {}
   @override
   String notInJava(String input) =>
-    lambda_notInJava(input);
+    notInJavaLambda(input);
   @override
   bool notInSwift(bool input) =>
-    lambda_notInSwift(input);
+    notInSwiftLambda(input);
   @override
-  String get skippedInJava => lambda_skippedInJava_get();
+  String get skippedInJava => skippedInJavaGetLambda();
   @override
-  set skippedInJava(String value) => lambda_skippedInJava_set(value);
+  set skippedInJava(String value) => skippedInJavaSetLambda(value);
   @override
-  bool get isSkippedInSwift => lambda_isSkippedInSwift_get();
+  bool get isSkippedInSwift => isSkippedInSwiftGetLambda();
   @override
-  set isSkippedInSwift(bool value) => lambda_isSkippedInSwift_set(value);
+  set isSkippedInSwift(bool value) => isSkippedInSwiftSetLambda(value);
 }
 class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSkipped {
   InheritFromSkipped$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -6,21 +6,20 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class SkipProxy {
-  SkipProxy();
-  factory SkipProxy.fromLambdas({
-    required String Function(String) lambda_notInJava,
-    required bool Function(bool) lambda_notInSwift,
-    required String Function() lambda_skippedInJava_get,
-    required void Function(String) lambda_skippedInJava_set,
-    required bool Function() lambda_isSkippedInSwift_get,
-    required void Function(bool) lambda_isSkippedInSwift_set
-  }) => SkipProxy$Lambdas(
-    lambda_notInJava,
-    lambda_notInSwift,
-    lambda_skippedInJava_get,
-    lambda_skippedInJava_set,
-    lambda_isSkippedInSwift_get,
-    lambda_isSkippedInSwift_set
+  factory SkipProxy(
+    String Function(String) notInJavaLambda,
+    bool Function(bool) notInSwiftLambda,
+    String Function() skippedInJavaGetLambda,
+    void Function(String) skippedInJavaSetLambda,
+    bool Function() isSkippedInSwiftGetLambda,
+    void Function(bool) isSkippedInSwiftSetLambda
+  ) => SkipProxy$Lambdas(
+    notInJavaLambda,
+    notInSwiftLambda,
+    skippedInJavaGetLambda,
+    skippedInJavaSetLambda,
+    isSkippedInSwiftGetLambda,
+    isSkippedInSwiftSetLambda
   );
   /// Destroys the underlying native object.
   ///
@@ -52,36 +51,36 @@ final _smokeSkipproxyGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibr
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipProxy_get_type_id'));
 class SkipProxy$Lambdas implements SkipProxy {
-  String Function(String) lambda_notInJava;
-  bool Function(bool) lambda_notInSwift;
-  String Function() lambda_skippedInJava_get;
-  void Function(String) lambda_skippedInJava_set;
-  bool Function() lambda_isSkippedInSwift_get;
-  void Function(bool) lambda_isSkippedInSwift_set;
+  String Function(String) notInJavaLambda;
+  bool Function(bool) notInSwiftLambda;
+  String Function() skippedInJavaGetLambda;
+  void Function(String) skippedInJavaSetLambda;
+  bool Function() isSkippedInSwiftGetLambda;
+  void Function(bool) isSkippedInSwiftSetLambda;
   SkipProxy$Lambdas(
-    this.lambda_notInJava,
-    this.lambda_notInSwift,
-    this.lambda_skippedInJava_get,
-    this.lambda_skippedInJava_set,
-    this.lambda_isSkippedInSwift_get,
-    this.lambda_isSkippedInSwift_set
+    this.notInJavaLambda,
+    this.notInSwiftLambda,
+    this.skippedInJavaGetLambda,
+    this.skippedInJavaSetLambda,
+    this.isSkippedInSwiftGetLambda,
+    this.isSkippedInSwiftSetLambda
   );
   @override
   void release() {}
   @override
   String notInJava(String input) =>
-    lambda_notInJava(input);
+    notInJavaLambda(input);
   @override
   bool notInSwift(bool input) =>
-    lambda_notInSwift(input);
+    notInSwiftLambda(input);
   @override
-  String get skippedInJava => lambda_skippedInJava_get();
+  String get skippedInJava => skippedInJavaGetLambda();
   @override
-  set skippedInJava(String value) => lambda_skippedInJava_set(value);
+  set skippedInJava(String value) => skippedInJavaSetLambda(value);
   @override
-  bool get isSkippedInSwift => lambda_isSkippedInSwift_get();
+  bool get isSkippedInSwift => isSkippedInSwiftGetLambda();
   @override
-  set isSkippedInSwift(bool value) => lambda_isSkippedInSwift_set(value);
+  set isSkippedInSwift(bool value) => isSkippedInSwiftSetLambda(value);
 }
 class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
   SkipProxy$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -7,11 +7,10 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// @nodoc
 abstract class InternalInterface {
-  InternalInterface();
-  factory InternalInterface.fromLambdas({
-    required void Function() lambda_fooBar,
-  }) => InternalInterface$Lambdas(
-    lambda_fooBar,
+  factory InternalInterface(
+    void Function() fooBarLambda,
+  ) => InternalInterface$Lambdas(
+    fooBarLambda,
   );
   /// Destroys the underlying native object.
   ///
@@ -39,15 +38,15 @@ final _smokeInternalinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalInterface_get_type_id'));
 class InternalInterface$Lambdas implements InternalInterface {
-  void Function() lambda_fooBar;
+  void Function() fooBarLambda;
   InternalInterface$Lambdas(
-    this.lambda_fooBar,
+    this.fooBarLambda,
   );
   @override
   void release() {}
   @override
   internal_fooBar() =>
-    lambda_fooBar();
+    fooBarLambda();
 }
 class InternalInterface$Impl extends __lib.NativeBase implements InternalInterface {
   InternalInterface$Impl(Pointer<Void> handle) : super(handle);


### PR DESCRIPTION
 Updated DartInterface template to:
    * remove the existing nameless non-factory constructor
    * "rename" `fromLambdas()` constructor into a nameless factory constructor
    * make the parameters of this constructor nameless, with names conforming to lowerSnakeCase

    Updated usages of this constructor in functional tests. Smoke tests are updated in a separate commit.

Resolves: #915
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
