### PR TITLE
 Update Dart generator to generate void return type explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Updated Dart generator to generate `void` function return type explicitly.
+
 ## 9.1.0
 Release date: 2021-05-31
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -40,6 +40,7 @@ import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
@@ -64,6 +65,7 @@ internal class DartNameResolver(
             is LimeComment -> resolveComment(element)
             is TypeId -> resolveBasicType(element)
             is LimeVisibility -> resolveVisibility(element)
+            is LimeReturnType -> resolveName(element.typeRef)
             is LimeBasicType -> resolveBasicType(element.typeId)
             is LimeValue -> resolveValue(element)
             is LimeGenericType -> resolveGenericType(element)

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
@@ -19,10 +19,8 @@
   !
   !}}
 {{#if isStatic}}{{#unless ignoreStatic}}static {{/unless}}{{/if}}{{!!
-}}{{#if isConstructor}}{{#if isStruct}}{{>ffiReturnDeclaration}}{{/if}}{{!!
+}}{{#if isConstructor}}{{#if isStruct}}{{resolveName returnType}} {{/if}}{{!!
 }}{{#unless isStruct}}Pointer<Void> {{/unless}}{{/if}}{{!!
-}}{{#unless isConstructor}}{{>ffiReturnDeclaration}}{{/unless}}{{!!
+}}{{#unless isConstructor}}{{resolveName returnType}} {{/unless}}{{!!
 }}{{#if isConstructor}}_{{/if}}{{#unless isConstructor}}{{resolveName visibility}}{{/unless}}{{resolveName}}({{!!
-}}{{#parameters}}{{>dart/DartAttributesInline}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
-
-}}{{+ffiReturnDeclaration}}{{#returnType}}{{#unless isVoid}}{{resolveName typeRef}} {{/unless}}{{/returnType}}{{/ffiReturnDeclaration}}
+}}{{#parameters}}{{>dart/DartAttributesInline}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -11,7 +11,7 @@ abstract class AttributesClass {
   @OnConstInClass
   static final bool pi = false;
   @OnFunctionInClass
-  veryFun(@OnParameterInClass String param);
+  void veryFun(@OnParameterInClass String param);
   @OnPropertyInClass
   String get prop;
   @OnPropertyInClass
@@ -35,7 +35,7 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
   @override
   void release() {}
   @override
-  veryFun(@OnParameterInClass String param) {
+  void veryFun(@OnParameterInClass String param) {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_veryFun__String'));
     final _paramHandle = stringToFfi(param);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -22,7 +22,7 @@ abstract class AttributesInterface {
   @OnConstInInterface
   static final bool pi = false;
   @OnFunctionInInterface
-  veryFun(@OnParameterInInterface String param);
+  void veryFun(@OnParameterInInterface String param);
   @OnPropertyInInterface
   String get prop;
   @OnPropertyInInterface
@@ -61,7 +61,7 @@ class AttributesInterface$Lambdas implements AttributesInterface {
   @override
   void release() {}
   @override
-  veryFun(@OnParameterInInterface String param) =>
+  void veryFun(@OnParameterInInterface String param) =>
     veryFunLambda(param);
   @override
   String get prop => propGetLambda();
@@ -73,7 +73,7 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
   @override
   void release() {}
   @override
-  veryFun(@OnParameterInInterface String param) {
+  void veryFun(@OnParameterInInterface String param) {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_veryFun__String'));
     final _paramHandle = stringToFfi(param);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -20,7 +20,7 @@ class AttributesLambda$Impl {
   final Pointer<Void> handle;
   AttributesLambda$Impl(this.handle);
   void release() => _smokeAttributeslambdaReleaseHandle(handle);
-  call() {
+  void call() {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesLambda_call'));
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId);
@@ -84,4 +84,3 @@ AttributesLambda? smokeAttributeslambdaFromFfiNullable(Pointer<Void> handle) {
 void smokeAttributeslambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributeslambdaReleaseHandleNullable(handle);
 // End of AttributesLambda "private" section.
-

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
@@ -9,7 +9,7 @@ class AttributesStruct {
   @OnConstInStruct
   static final bool pi = false;
   @OnFunctionInStruct
-  veryFun(@OnParameterInStruct String param) {
+  void veryFun(@OnParameterInStruct String param) {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesStruct_veryFun__String'));
     final _paramHandle = stringToFfi(param);
     final _handle = smokeAttributesstructToFfi(this);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -15,7 +15,7 @@ abstract class AttributesWithComments {
   /// Function comment
   ///
   @OnFunctionInClass
-  veryFun();
+  void veryFun();
   /// Getter comment
   @OnPropertyInClass
   String get prop;
@@ -107,7 +107,7 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
   @override
   void release() {}
   @override
-  veryFun() {
+  void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_veryFun'));
     final _handle = this.handle;
     final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -14,7 +14,7 @@ abstract class AttributesWithDeprecated {
   static final bool pi = false;
   @Deprecated("")
   @OnFunctionInClass
-  veryFun();
+  void veryFun();
   @Deprecated("")
   @OnPropertyInClass
   String get prop;
@@ -106,7 +106,7 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
   @override
   void release() {}
   @override
-  veryFun() {
+  void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_veryFun'));
     final _handle = this.handle;
     final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -8,24 +8,24 @@ abstract class MultipleAttributesDart {
   void release();
   @Foo
   @Bar
-  noLists2();
+  void noLists2();
   @Foo
   @Bar
   @Baz
-  noLists3();
+  void noLists3();
   @Foo
   @Bar
   @Baz
-  listFirst();
+  void listFirst();
   @Foo
   @Bar
   @Baz
-  listSecond();
+  void listSecond();
   @Foo
   @Bar
   @Baz
   @Fizz
-  twoLists();
+  void twoLists();
 }
 // MultipleAttributesDart "private" section, not exported.
 final _smokeMultipleattributesdartRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -45,7 +45,7 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
   @override
   void release() {}
   @override
-  noLists2() {
+  void noLists2() {
     final _noLists2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists2'));
     final _handle = this.handle;
     final __resultHandle = _noLists2Ffi(_handle, __lib.LibraryContext.isolateId);
@@ -55,7 +55,7 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     }
   }
   @override
-  noLists3() {
+  void noLists3() {
     final _noLists3Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists3'));
     final _handle = this.handle;
     final __resultHandle = _noLists3Ffi(_handle, __lib.LibraryContext.isolateId);
@@ -65,7 +65,7 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     }
   }
   @override
-  listFirst() {
+  void listFirst() {
     final _listFirstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listFirst'));
     final _handle = this.handle;
     final __resultHandle = _listFirstFfi(_handle, __lib.LibraryContext.isolateId);
@@ -75,7 +75,7 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     }
   }
   @override
-  listSecond() {
+  void listSecond() {
     final _listSecondFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listSecond'));
     final _handle = this.handle;
     final __resultHandle = _listSecondFfi(_handle, __lib.LibraryContext.isolateId);
@@ -85,7 +85,7 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     }
   }
   @override
-  twoLists() {
+  void twoLists() {
     final _twoListsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_twoLists'));
     final _handle = this.handle;
     final __resultHandle = _twoListsFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -7,9 +7,9 @@ abstract class SpecialAttributes {
   @Deprecated("Does nothing")
   void release();
   @Deprecated("foo\nbar")
-  withEscaping();
+  void withEscaping();
   @HackMerm -rf *
-  withLineBreak();
+  void withLineBreak();
 }
 // SpecialAttributes "private" section, not exported.
 final _smokeSpecialattributesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -29,7 +29,7 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
   @override
   void release() {}
   @override
-  withEscaping() {
+  void withEscaping() {
     final _withEscapingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withEscaping'));
     final _handle = this.handle;
     final __resultHandle = _withEscapingFfi(_handle, __lib.LibraryContext.isolateId);
@@ -39,7 +39,7 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
     }
   }
   @override
-  withLineBreak() {
+  void withLineBreak() {
     final _withLineBreakFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withLineBreak'));
     final _handle = this.handle;
     final __resultHandle = _withLineBreakFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -36,10 +36,10 @@ abstract class Comments {
   ///
   /// [input] Very useful input parameter
   ///
-  someMethodWithoutReturnTypeWithAllComments(String input);
+  void someMethodWithoutReturnTypeWithAllComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
-  someMethodWithoutReturnTypeWithNoComments(String input);
+  void someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
   ///
   /// Returns [bool]. Usefulness of the input
@@ -48,10 +48,10 @@ abstract class Comments {
   /// This is some very useful method that measures the usefulness of something.
   ///
   bool someMethodWithoutInputParametersWithNoComments();
-  someMethodWithNothing();
+  void someMethodWithNothing();
   /// This is some very useful method that does nothing.
   ///
-  someMethodWithoutReturnTypeOrInputParameters();
+  void someMethodWithoutReturnTypeOrInputParameters();
   /// [documented] nicely documented
   ///
   String oneParameterCommentOnly(String undocumented, String documented);
@@ -398,7 +398,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  someMethodWithoutReturnTypeWithAllComments(String input) {
+  void someMethodWithoutReturnTypeWithAllComments(String input) {
     final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -410,7 +410,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  someMethodWithoutReturnTypeWithNoComments(String input) {
+  void someMethodWithoutReturnTypeWithNoComments(String input) {
     final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -444,7 +444,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  someMethodWithNothing() {
+  void someMethodWithNothing() {
     final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
@@ -454,7 +454,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  someMethodWithoutReturnTypeOrInputParameters() {
+  void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -63,10 +63,10 @@ abstract class CommentsInterface {
   ///
   /// [input] Very useful input parameter
   ///
-  someMethodWithoutReturnTypeWithAllComments(String input);
+  void someMethodWithoutReturnTypeWithAllComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
-  someMethodWithoutReturnTypeWithNoComments(String input);
+  void someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
   ///
   /// Returns [bool]. Usefulness of the input
@@ -75,10 +75,10 @@ abstract class CommentsInterface {
   /// This is some very useful method that measures the usefulness of something.
   ///
   bool someMethodWithoutInputParametersWithNoComments();
-  someMethodWithNothing();
+  void someMethodWithNothing();
   /// This is some very useful method that does nothing.
   ///
-  someMethodWithoutReturnTypeOrInputParameters();
+  void someMethodWithoutReturnTypeOrInputParameters();
   /// Gets some very useful property.
   bool get isSomeProperty;
   /// Sets some very useful property.
@@ -275,10 +275,10 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   bool someMethodWithNoComments(String input) =>
     someMethodWithNoCommentsLambda(input);
   @override
-  someMethodWithoutReturnTypeWithAllComments(String input) =>
+  void someMethodWithoutReturnTypeWithAllComments(String input) =>
     someMethodWithoutReturnTypeWithAllCommentsLambda(input);
   @override
-  someMethodWithoutReturnTypeWithNoComments(String input) =>
+  void someMethodWithoutReturnTypeWithNoComments(String input) =>
     someMethodWithoutReturnTypeWithNoCommentsLambda(input);
   @override
   bool someMethodWithoutInputParametersWithAllComments() =>
@@ -287,10 +287,10 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   bool someMethodWithoutInputParametersWithNoComments() =>
     someMethodWithoutInputParametersWithNoCommentsLambda();
   @override
-  someMethodWithNothing() =>
+  void someMethodWithNothing() =>
     someMethodWithNothingLambda();
   @override
-  someMethodWithoutReturnTypeOrInputParameters() =>
+  void someMethodWithoutReturnTypeOrInputParameters() =>
     someMethodWithoutReturnTypeOrInputParametersLambda();
   @override
   bool get isSomeProperty => isSomePropertyGetLambda();
@@ -354,7 +354,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  someMethodWithoutReturnTypeWithAllComments(String input) {
+  void someMethodWithoutReturnTypeWithAllComments(String input) {
     final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -366,7 +366,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  someMethodWithoutReturnTypeWithNoComments(String input) {
+  void someMethodWithoutReturnTypeWithNoComments(String input) {
     final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -400,7 +400,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  someMethodWithNothing() {
+  void someMethodWithNothing() {
     final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
@@ -410,7 +410,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  someMethodWithoutReturnTypeOrInputParameters() {
+  void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -59,7 +59,7 @@ abstract class CommentsLinks {
   /// * this one: [CommentsLinks.randomMethod2]
   /// * ambiguous one: [CommentsLinks.randomMethod2]
   ///
-  randomMethod2(String text, bool flag);
+  void randomMethod2(String text, bool flag);
 }
 /// Links also work in:
 class CommentsLinks_RandomStruct {
@@ -187,7 +187,7 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
     }
   }
   @override
-  randomMethod2(String text, bool flag) {
+  void randomMethod2(String text, bool flag) {
     final _randomMethod2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__String_Boolean'));
     final _textHandle = stringToFfi(text);
     final _flagHandle = booleanToFfi(flag);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -25,7 +25,7 @@ abstract class ExcludedComments {
   /// This is some very useful method that does nothing.
   ///
   /// @nodoc
-  someMethodWithoutReturnTypeOrInputParameters();
+  void someMethodWithoutReturnTypeOrInputParameters();
   /// Gets some very useful property.
   /// @nodoc
   bool get isSomeProperty;
@@ -315,7 +315,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     }
   }
   @override
-  someMethodWithoutReturnTypeOrInputParameters() {
+  void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -13,7 +13,7 @@ abstract class ExcludedCommentsOnly {
   /// @nodoc
   bool someMethodWithAllComments(String inputParameter);
   /// @nodoc
-  someMethodWithoutReturnTypeOrInputParameters();
+  void someMethodWithoutReturnTypeOrInputParameters();
   /// @nodoc
   bool get isSomeProperty;
   /// @nodoc
@@ -291,7 +291,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     }
   }
   @override
-  someMethodWithoutReturnTypeOrInputParameters() {
+  void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -11,7 +11,7 @@ abstract class InternalClassWithComments {
   /// This is definitely internal
   ///
   /// @nodoc
-  internal_doNothing();
+  void internal_doNothing();
 }
 // InternalClassWithComments "private" section, not exported.
 final _smokeInternalclasswithcommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -31,7 +31,7 @@ class InternalClassWithComments$Impl extends __lib.NativeBase implements Interna
   @override
   void release() {}
   @override
-  internal_doNothing() {
+  void internal_doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));
     final _handle = this.handle;
     final __resultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -8,8 +8,8 @@ abstract class MapScene {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback);
-  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback);
+  void loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback);
+  void loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback);
 }
 typedef MapScene_LoadSceneCallback = void Function(String?);
 // MapScene_LoadSceneCallback "private" section, not exported.
@@ -29,7 +29,7 @@ class MapScene_LoadSceneCallback$Impl {
   final Pointer<Void> handle;
   MapScene_LoadSceneCallback$Impl(this.handle);
   void release() => _smokeMapsceneLoadscenecallbackReleaseHandle(handle);
-  call(String? p0) {
+  void call(String? p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MapScene_LoadSceneCallback_call__String'));
     final _p0Handle = stringToFfiNullable(p0);
     final _handle = this.handle;
@@ -114,7 +114,7 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
   @override
   void release() {}
   @override
-  loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback) {
+  void loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback) {
     final _loadSceneWithIntFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_MapScene_loadScene__Int_LoadSceneCallback'));
     final _mapSchemeHandle = (mapScheme);
     final _callbackHandle = smokeMapsceneLoadscenecallbackToFfiNullable(callback);
@@ -127,7 +127,7 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     }
   }
   @override
-  loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback) {
+  void loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback) {
     final _loadSceneWithStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MapScene_loadScene__String_LoadSceneCallback'));
     final _configurationFileHandle = stringToFfi(configurationFile);
     final _callbackHandle = smokeMapsceneLoadscenecallbackToFfiNullable(callback);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -9,10 +9,10 @@ abstract class PlatformComments {
   void release();
   /// This is some very useless method that cannot have overloads.
   ///
-  doNothing();
+  void doNothing();
   /// Colors everything in fuchsia.
   ///
-  doMagic();
+  void doMagic();
   /// This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
   ///
   /// [input] Very useful parameter that \[\esc@pe{s}\]
@@ -23,7 +23,7 @@ abstract class PlatformComments {
   ///
   bool someMethodWithAllComments(String input);
   @Deprecated("A very useless method that is deprecated.")
-  someDeprecatedMethod();
+  void someDeprecatedMethod();
 }
 enum PlatformComments_SomeEnum {
     useless,
@@ -188,7 +188,7 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
   @override
   void release() {}
   @override
-  doNothing() {
+  void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));
     final _handle = this.handle;
     final __resultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
@@ -198,7 +198,7 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
     }
   }
   @override
-  doMagic() {
+  void doMagic() {
     final _doMagicFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic'));
     final _handle = this.handle;
     final __resultHandle = _doMagicFfi(_handle, __lib.LibraryContext.isolateId);
@@ -232,7 +232,7 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
     }
   }
   @override
-  someDeprecatedMethod() {
+  void someDeprecatedMethod() {
     final _someDeprecatedMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod'));
     final _handle = this.handle;
     final __resultHandle = _someDeprecatedMethodFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -9,10 +9,10 @@ abstract class Errors {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  static methodWithErrors() => Errors$Impl.methodWithErrors();
-  static methodWithExternalErrors() => Errors$Impl.methodWithExternalErrors();
+  static void methodWithErrors() => Errors$Impl.methodWithErrors();
+  static void methodWithExternalErrors() => Errors$Impl.methodWithExternalErrors();
   static String methodWithErrorsAndReturnValue() => Errors$Impl.methodWithErrorsAndReturnValue();
-  static methodWithPayloadError() => Errors$Impl.methodWithPayloadError();
+  static void methodWithPayloadError() => Errors$Impl.methodWithPayloadError();
   static String methodWithPayloadErrorAndReturnValue() => Errors$Impl.methodWithPayloadErrorAndReturnValue();
 }
 enum Errors_InternalErrorCode {
@@ -236,7 +236,7 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
   Errors$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {}
-  static methodWithErrors() {
+  static void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
     final __callResultHandle = _methodWithErrorsFfi(__lib.LibraryContext.isolateId);
     if (_methodWithErrorsReturnHasError(__callResultHandle) != 0) {
@@ -255,7 +255,7 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
     } finally {
     }
   }
-  static methodWithExternalErrors() {
+  static void methodWithExternalErrors() {
     final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors'));
     final __callResultHandle = _methodWithExternalErrorsFfi(__lib.LibraryContext.isolateId);
     if (_methodWithExternalErrorsReturnHasError(__callResultHandle) != 0) {
@@ -294,7 +294,7 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
       stringReleaseFfiHandle(__resultHandle);
     }
   }
-  static methodWithPayloadError() {
+  static void methodWithPayloadError() {
     final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError'));
     final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
     if (_methodWithPayloadErrorReturnHasError(__callResultHandle) != 0) {

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -20,10 +20,10 @@ abstract class ErrorsInterface {
   /// @nodoc
   @Deprecated("Does nothing")
   void release() {}
-  methodWithErrors();
-  methodWithExternalErrors();
+  void methodWithErrors();
+  void methodWithExternalErrors();
   String methodWithErrorsAndReturnValue();
-  static methodWithPayloadError() => ErrorsInterface$Impl.methodWithPayloadError();
+  static void methodWithPayloadError() => ErrorsInterface$Impl.methodWithPayloadError();
   static String methodWithPayloadErrorAndReturnValue() => ErrorsInterface$Impl.methodWithPayloadErrorAndReturnValue();
 }
 enum ErrorsInterface_InternalError {
@@ -263,10 +263,10 @@ class ErrorsInterface$Lambdas implements ErrorsInterface {
   @override
   void release() {}
   @override
-  methodWithErrors() =>
+  void methodWithErrors() =>
     methodWithErrorsLambda();
   @override
-  methodWithExternalErrors() =>
+  void methodWithExternalErrors() =>
     methodWithExternalErrorsLambda();
   @override
   String methodWithErrorsAndReturnValue() =>
@@ -277,7 +277,7 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
   @override
   void release() {}
   @override
-  methodWithErrors() {
+  void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors'));
     final _handle = this.handle;
     final __callResultHandle = _methodWithErrorsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -298,7 +298,7 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
     }
   }
   @override
-  methodWithExternalErrors() {
+  void methodWithExternalErrors() {
     final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithExternalErrors'));
     final _handle = this.handle;
     final __callResultHandle = _methodWithExternalErrorsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -341,7 +341,7 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
     }
   }
   @override
-  static methodWithPayloadError() {
+  static void methodWithPayloadError() {
     final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError'));
     final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
     if (_methodWithPayloadErrorReturnHasError(__callResultHandle) != 0) {

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -6,7 +6,7 @@ abstract class Enums {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  static methodWithExternalEnum(Enums_ExternalEnum input) => Enums$Impl.methodWithExternalEnum(input);
+  static void methodWithExternalEnum(Enums_ExternalEnum input) => Enums$Impl.methodWithExternalEnum(input);
 }
 enum Enums_ExternalEnum {
     fooValue,
@@ -143,7 +143,7 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
   Enums$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {}
-  static methodWithExternalEnum(Enums_ExternalEnum input) {
+  static void methodWithExternalEnum(Enums_ExternalEnum input) {
     final _methodWithExternalEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum'));
     final _inputHandle = smokeEnumsExternalenumToFfi(input);
     final __resultHandle = _methodWithExternalEnumFfi(__lib.LibraryContext.isolateId, _inputHandle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -7,7 +7,7 @@ abstract class ExternalClass {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  someMethod(int someParameter);
+  void someMethod(int someParameter);
   String get someProperty;
 }
 enum ExternalClass_SomeEnum {
@@ -144,7 +144,7 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
   @override
   void release() {}
   @override
-  someMethod(int someParameter) {
+  void someMethod(int someParameter) {
     final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalClass_someMethod__Byte'));
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -16,7 +16,7 @@ abstract class ExternalInterface {
   /// @nodoc
   @Deprecated("Does nothing")
   void release() {}
-  someMethod(int someParameter);
+  void someMethod(int someParameter);
   String get someProperty;
 }
 enum ExternalInterface_SomeEnum {
@@ -166,7 +166,7 @@ class ExternalInterface$Lambdas implements ExternalInterface {
   @override
   void release() {}
   @override
-  someMethod(int someParameter) =>
+  void someMethod(int someParameter) =>
     someMethodLambda(someParameter);
   @override
   String get someProperty => somePropertyGetLambda();
@@ -176,7 +176,7 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
   @override
   void release() {}
   @override
-  someMethod(int someParameter) {
+  void someMethod(int someParameter) {
     final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalInterface_someMethod__Byte'));
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -9,7 +9,7 @@ abstract class ChildClassFromClass implements ParentClass {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  childClassMethod();
+  void childClassMethod();
 }
 // ChildClassFromClass "private" section, not exported.
 final _smokeChildclassfromclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -33,7 +33,7 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
   @override
   void release() {}
   @override
-  childClassMethod() {
+  void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod'));
     final _handle = this.handle;
     final __resultHandle = _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -9,7 +9,7 @@ abstract class ChildClassFromInterface implements ParentInterface {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  childClassMethod();
+  void childClassMethod();
 }
 // ChildClassFromInterface "private" section, not exported.
 final _smokeChildclassfrominterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -33,7 +33,7 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
   @override
   void release() {}
   @override
-  childClassMethod() {
+  void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));
     final _handle = this.handle;
     final __resultHandle = _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
@@ -43,7 +43,7 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
     }
   }
   @override
-  rootMethod() {
+  void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
     final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -21,7 +21,7 @@ abstract class ChildInterface implements ParentInterface {
   /// @nodoc
   @Deprecated("Does nothing")
   void release() {}
-  childMethod();
+  void childMethod();
 }
 // ChildInterface "private" section, not exported.
 final _smokeChildinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -58,10 +58,10 @@ class ChildInterface$Lambdas implements ChildInterface {
   @override
   void release() {}
   @override
-  rootMethod() =>
+  void rootMethod() =>
     rootMethodLambda();
   @override
-  childMethod() =>
+  void childMethod() =>
     childMethodLambda();
   @override
   String get rootProperty => rootPropertyGetLambda();
@@ -73,7 +73,7 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
   @override
   void release() {}
   @override
-  rootMethod() {
+  void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
     final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
@@ -83,7 +83,7 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
     }
   }
   @override
-  childMethod() {
+  void childMethod() {
     final _childMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod'));
     final _handle = this.handle;
     final __resultHandle = _childMethodFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -8,7 +8,7 @@ abstract class ParentClass {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  rootMethod();
+  void rootMethod();
   String get rootProperty;
   set rootProperty(String value);
 }
@@ -34,7 +34,7 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
   @override
   void release() {}
   @override
-  rootMethod() {
+  void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod'));
     final _handle = this.handle;
     final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -18,7 +18,7 @@ abstract class ParentInterface {
   /// @nodoc
   @Deprecated("Does nothing")
   void release() {}
-  rootMethod();
+  void rootMethod();
   String get rootProperty;
   set rootProperty(String value);
 }
@@ -55,7 +55,7 @@ class ParentInterface$Lambdas implements ParentInterface {
   @override
   void release() {}
   @override
-  rootMethod() =>
+  void rootMethod() =>
     rootMethodLambda();
   @override
   String get rootProperty => rootPropertyGetLambda();
@@ -67,7 +67,7 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
   @override
   void release() {}
   @override
-  rootMethod() {
+  void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
     final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -203,7 +203,7 @@ class Lambdas_Consumer$Impl {
   final Pointer<Void> handle;
   Lambdas_Consumer$Impl(this.handle);
   void release() => _smokeLambdasConsumerReleaseHandle(handle);
-  call(String p0) {
+  void call(String p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String'));
     final _p0Handle = stringToFfi(p0);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -8,8 +8,8 @@ abstract class LambdasWithStructuredTypes {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  doClassStuff(LambdasWithStructuredTypes_ClassCallback callback);
-  doStructStuff(LambdasWithStructuredTypes_StructCallback callback);
+  void doClassStuff(LambdasWithStructuredTypes_ClassCallback callback);
+  void doStructStuff(LambdasWithStructuredTypes_StructCallback callback);
 }
 typedef LambdasWithStructuredTypes_ClassCallback = void Function(LambdasInterface);
 // LambdasWithStructuredTypes_ClassCallback "private" section, not exported.
@@ -29,7 +29,7 @@ class LambdasWithStructuredTypes_ClassCallback$Impl {
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_ClassCallback$Impl(this.handle);
   void release() => _smokeLambdaswithstructuredtypesClasscallbackReleaseHandle(handle);
-  call(LambdasInterface p0) {
+  void call(LambdasInterface p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface'));
     final _p0Handle = smokeLambdasinterfaceToFfi(p0);
     final _handle = this.handle;
@@ -114,7 +114,7 @@ class LambdasWithStructuredTypes_StructCallback$Impl {
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_StructCallback$Impl(this.handle);
   void release() => _smokeLambdaswithstructuredtypesStructcallbackReleaseHandle(handle);
-  call(LambdasDeclarationOrder_SomeStruct p0) {
+  void call(LambdasDeclarationOrder_SomeStruct p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct'));
     final _p0Handle = smokeLambdasdeclarationorderSomestructToFfi(p0);
     final _handle = this.handle;
@@ -199,7 +199,7 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
   @override
   void release() {}
   @override
-  doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
+  void doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
     final _doClassStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback'));
     final _callbackHandle = smokeLambdaswithstructuredtypesClasscallbackToFfi(callback);
     final _handle = this.handle;
@@ -211,7 +211,7 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
     }
   }
   @override
-  doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
+  void doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
     final _doStructStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback'));
     final _callbackHandle = smokeLambdaswithstructuredtypesStructcallbackToFfi(callback);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -26,12 +26,12 @@ abstract class CalculatorListener {
   /// @nodoc
   @Deprecated("Does nothing")
   void release() {}
-  onCalculationResult(double calculationResult);
-  onCalculationResultConst(double calculationResult);
-  onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult);
-  onCalculationResultArray(List<double> calculationResult);
-  onCalculationResultMap(Map<String, double> calculationResults);
-  onCalculationResultInstance(CalculationResult calculationResult);
+  void onCalculationResult(double calculationResult);
+  void onCalculationResultConst(double calculationResult);
+  void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult);
+  void onCalculationResultArray(List<double> calculationResult);
+  void onCalculationResultMap(Map<String, double> calculationResults);
+  void onCalculationResultInstance(CalculationResult calculationResult);
 }
 class CalculatorListener_ResultStruct {
   double result;
@@ -134,22 +134,22 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   @override
   void release() {}
   @override
-  onCalculationResult(double calculationResult) =>
+  void onCalculationResult(double calculationResult) =>
     onCalculationResultLambda(calculationResult);
   @override
-  onCalculationResultConst(double calculationResult) =>
+  void onCalculationResultConst(double calculationResult) =>
     onCalculationResultConstLambda(calculationResult);
   @override
-  onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) =>
+  void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) =>
     onCalculationResultStructLambda(calculationResult);
   @override
-  onCalculationResultArray(List<double> calculationResult) =>
+  void onCalculationResultArray(List<double> calculationResult) =>
     onCalculationResultArrayLambda(calculationResult);
   @override
-  onCalculationResultMap(Map<String, double> calculationResults) =>
+  void onCalculationResultMap(Map<String, double> calculationResults) =>
     onCalculationResultMapLambda(calculationResults);
   @override
-  onCalculationResultInstance(CalculationResult calculationResult) =>
+  void onCalculationResultInstance(CalculationResult calculationResult) =>
     onCalculationResultInstanceLambda(calculationResult);
 }
 class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorListener {
@@ -157,7 +157,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
   @override
   void release() {}
   @override
-  onCalculationResult(double calculationResult) {
+  void onCalculationResult(double calculationResult) {
     final _onCalculationResultFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResult__Double'));
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
@@ -168,7 +168,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     }
   }
   @override
-  onCalculationResultConst(double calculationResult) {
+  void onCalculationResultConst(double calculationResult) {
     final _onCalculationResultConstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double'));
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
@@ -179,7 +179,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     }
   }
   @override
-  onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
+  void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
     final _onCalculationResultStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct'));
     final _calculationResultHandle = smokeCalculatorlistenerResultstructToFfi(calculationResult);
     final _handle = this.handle;
@@ -191,7 +191,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     }
   }
   @override
-  onCalculationResultArray(List<double> calculationResult) {
+  void onCalculationResultArray(List<double> calculationResult) {
     final _onCalculationResultArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double'));
     final _calculationResultHandle = foobarListofDoubleToFfi(calculationResult);
     final _handle = this.handle;
@@ -203,7 +203,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     }
   }
   @override
-  onCalculationResultMap(Map<String, double> calculationResults) {
+  void onCalculationResultMap(Map<String, double> calculationResults) {
     final _onCalculationResultMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double'));
     final _calculationResultsHandle = foobarMapofStringToDoubleToFfi(calculationResults);
     final _handle = this.handle;
@@ -215,7 +215,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     }
   }
   @override
-  onCalculationResultInstance(CalculationResult calculationResult) {
+  void onCalculationResultInstance(CalculationResult calculationResult) {
     final _onCalculationResultInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult'));
     final _calculationResultHandle = smokeCalculationresultToFfi(calculationResult);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -6,10 +6,10 @@ abstract class SpecialNames {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  create();
-  reallyRelease();
-  createProxy();
-  Uppercase();
+  void create();
+  void reallyRelease();
+  void createProxy();
+  void Uppercase();
 }
 // SpecialNames "private" section, not exported.
 final _smokeSpecialnamesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -29,7 +29,7 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
   @override
   void release() {}
   @override
-  create() {
+  void create() {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create'));
     final _handle = this.handle;
     final __resultHandle = _createFfi(_handle, __lib.LibraryContext.isolateId);
@@ -39,7 +39,7 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     }
   }
   @override
-  reallyRelease() {
+  void reallyRelease() {
     final _reallyReleaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release'));
     final _handle = this.handle;
     final __resultHandle = _reallyReleaseFfi(_handle, __lib.LibraryContext.isolateId);
@@ -49,7 +49,7 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     }
   }
   @override
-  createProxy() {
+  void createProxy() {
     final _createProxyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy'));
     final _handle = this.handle;
     final __resultHandle = _createProxyFfi(_handle, __lib.LibraryContext.isolateId);
@@ -59,7 +59,7 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     }
   }
   @override
-  Uppercase() {
+  void Uppercase() {
     final _UppercaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase'));
     final _handle = this.handle;
     final __resultHandle = _UppercaseFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -24,7 +24,7 @@ final _doNothingReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibr
 class OuterStruct {
   String field;
   OuterStruct(this.field);
-  doNothing() {
+  void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_doNothing'));
     final _handle = smokeOuterstructToFfi(this);
     final __callResultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
@@ -112,7 +112,7 @@ class OuterStruct_InstantiationException implements Exception {
 class OuterStruct_InnerStruct {
   List<DateTime> otherField;
   OuterStruct_InnerStruct(this.otherField);
-  doSomething() {
+  void doSomething() {
     final _doSomethingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerStruct_doSomething'));
     final _handle = smokeOuterstructInnerstructToFfi(this);
     final __resultHandle = _doSomethingFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -14,7 +14,7 @@ abstract class weeListener {
   /// @nodoc
   @Deprecated("Does nothing")
   void release() {}
-  WeeMethod(String WeeParameter);
+  void WeeMethod(String WeeParameter);
 }
 // weeListener "private" section, not exported.
 final _smokePlatformnameslistenerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -45,7 +45,7 @@ class weeListener$Lambdas implements weeListener {
   @override
   void release() {}
   @override
-  WeeMethod(String WeeParameter) =>
+  void WeeMethod(String WeeParameter) =>
     WeeMethodLambda(WeeParameter);
 }
 class weeListener$Impl extends __lib.NativeBase implements weeListener {
@@ -53,7 +53,7 @@ class weeListener$Impl extends __lib.NativeBase implements weeListener {
   @override
   void release() {}
   @override
-  WeeMethod(String WeeParameter) {
+  void WeeMethod(String WeeParameter) {
     final _WeeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String'));
     final _WeeParameterHandle = stringToFfi(WeeParameter);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -6,13 +6,13 @@ abstract class EnableIfEnabled {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  static enableIfUnquoted() => EnableIfEnabled$Impl.enableIfUnquoted();
-  static enableIfUnquotedList() => EnableIfEnabled$Impl.enableIfUnquotedList();
-  static enableIfQuoted() => EnableIfEnabled$Impl.enableIfQuoted();
-  static enableIfQuotedList() => EnableIfEnabled$Impl.enableIfQuotedList();
-  static enableIfTagged() => EnableIfEnabled$Impl.enableIfTagged();
-  static enableIfTaggedList() => EnableIfEnabled$Impl.enableIfTaggedList();
-  static enableIfMixedList() => EnableIfEnabled$Impl.enableIfMixedList();
+  static void enableIfUnquoted() => EnableIfEnabled$Impl.enableIfUnquoted();
+  static void enableIfUnquotedList() => EnableIfEnabled$Impl.enableIfUnquotedList();
+  static void enableIfQuoted() => EnableIfEnabled$Impl.enableIfQuoted();
+  static void enableIfQuotedList() => EnableIfEnabled$Impl.enableIfQuotedList();
+  static void enableIfTagged() => EnableIfEnabled$Impl.enableIfTagged();
+  static void enableIfTaggedList() => EnableIfEnabled$Impl.enableIfTaggedList();
+  static void enableIfMixedList() => EnableIfEnabled$Impl.enableIfMixedList();
 }
 // EnableIfEnabled "private" section, not exported.
 final _smokeEnableifenabledRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -31,7 +31,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
   EnableIfEnabled$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {}
-  static enableIfUnquoted() {
+  static void enableIfUnquoted() {
     final _enableIfUnquotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquoted'));
     final __resultHandle = _enableIfUnquotedFfi(__lib.LibraryContext.isolateId);
     try {
@@ -39,7 +39,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     } finally {
     }
   }
-  static enableIfUnquotedList() {
+  static void enableIfUnquotedList() {
     final _enableIfUnquotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquotedList'));
     final __resultHandle = _enableIfUnquotedListFfi(__lib.LibraryContext.isolateId);
     try {
@@ -47,7 +47,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     } finally {
     }
   }
-  static enableIfQuoted() {
+  static void enableIfQuoted() {
     final _enableIfQuotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuoted'));
     final __resultHandle = _enableIfQuotedFfi(__lib.LibraryContext.isolateId);
     try {
@@ -55,7 +55,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     } finally {
     }
   }
-  static enableIfQuotedList() {
+  static void enableIfQuotedList() {
     final _enableIfQuotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuotedList'));
     final __resultHandle = _enableIfQuotedListFfi(__lib.LibraryContext.isolateId);
     try {
@@ -63,7 +63,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     } finally {
     }
   }
-  static enableIfTagged() {
+  static void enableIfTagged() {
     final _enableIfTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTagged'));
     final __resultHandle = _enableIfTaggedFfi(__lib.LibraryContext.isolateId);
     try {
@@ -71,7 +71,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     } finally {
     }
   }
-  static enableIfTaggedList() {
+  static void enableIfTaggedList() {
     final _enableIfTaggedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTaggedList'));
     final __resultHandle = _enableIfTaggedListFfi(__lib.LibraryContext.isolateId);
     try {
@@ -79,7 +79,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
     } finally {
     }
   }
-  static enableIfMixedList() {
+  static void enableIfMixedList() {
     final _enableIfMixedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfMixedList'));
     final __resultHandle = _enableIfMixedListFfi(__lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -8,12 +8,12 @@ class SomeClass {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
-  voidFunction();
+  void voidFunction();
   bool boolFunction();
   int intFunction();
   String stringFunction();
   SomeClass classFunction();
-  static staticFunction() => $class.staticFunction();
+  static void staticFunction() => $class.staticFunction();
   static var $class = SomeClass$Impl();
 }
 // SomeClass "private" section, not exported.
@@ -45,7 +45,7 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
     return __resultHandle;
   }
   @override
-  voidFunction() {
+  void voidFunction() {
     final _voidFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SomeClass_voidFunction'));
     final _handle = this.handle;
     final __resultHandle = _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
@@ -97,7 +97,7 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
       smokeSomeclassReleaseFfiHandle(__resultHandle);
     }
   }
-  staticFunction() {
+  void staticFunction() {
     final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_SomeClass_staticFunction'));
     final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
@@ -4,18 +4,18 @@ import 'package:library/src/builtin_types__conversion.dart';
 class StructWithMethods {
   String field;
   StructWithMethods(this.field);
-  voidFunction();
+  void voidFunction();
   bool boolFunction();
   int intFunction();
   String stringFunction();
   StructWithMethods structFunction();
-  static staticFunction() => $class.staticFunction();
+  static void staticFunction() => $class.staticFunction();
   static var $class = StructWithMethods$Impl();
 }
 class StructWithMethods$Impl {
   String field;
   StructWithMethods(this.field);
-  voidFunction() {
+  void voidFunction() {
     final _voidFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_voidFunction'));
     final _handle = smokeStructwithmethodsToFfi(this);
     final __resultHandle = _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
@@ -68,7 +68,7 @@ class StructWithMethods$Impl {
       smokeStructwithmethodsReleaseFfiHandle(__resultHandle);
     }
   }
-  staticFunction() {
+  void staticFunction() {
     final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_StructWithMethods_staticFunction'));
     final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
     try {

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -8,7 +8,7 @@ abstract class InternalClass {
   @Deprecated("Does nothing")
   void release();
   /// @nodoc
-  internal_fooBar();
+  void internal_fooBar();
 }
 // InternalClass "private" section, not exported.
 final _smokeInternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -28,7 +28,7 @@ class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
   @override
   void release() {}
   @override
-  internal_fooBar() {
+  void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));
     final _handle = this.handle;
     final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -13,7 +13,7 @@ abstract class InternalClassWithFunctions {
   @Deprecated("Does nothing")
   void release();
   /// @nodoc
-  internal_fooBar();
+  void internal_fooBar();
 }
 // InternalClassWithFunctions "private" section, not exported.
 final _smokeInternalclasswithfunctionsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -41,7 +41,7 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
     _smokeInternalclasswithfunctionsRegisterFinalizer(handle, __lib.LibraryContext.isolateId, this);
   }
   @override
-  internal_fooBar() {
+  void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar'));
     final _handle = this.handle;
     final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -16,7 +16,7 @@ abstract class InternalInterface {
   @Deprecated("Does nothing")
   void release() {}
   /// @nodoc
-  internal_fooBar();
+  void internal_fooBar();
 }
 // InternalInterface "private" section, not exported.
 final _smokeInternalinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -47,7 +47,7 @@ class InternalInterface$Lambdas implements InternalInterface {
   @override
   void release() {}
   @override
-  internal_fooBar() =>
+  void internal_fooBar() =>
     fooBarLambda();
 }
 class InternalInterface$Impl extends __lib.NativeBase implements InternalInterface {
@@ -55,7 +55,7 @@ class InternalInterface$Impl extends __lib.NativeBase implements InternalInterfa
   @override
   void release() {}
   @override
-  internal_fooBar() {
+  void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));
     final _handle = this.handle;
     final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -7,7 +7,7 @@ class InternalStruct {
   String internal_stringField;
   InternalStruct(this.internal_stringField);
   /// @nodoc
-  internal_fooBar() {
+  void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PublicTypeCollection_InternalStruct_fooBar'));
     final _handle = smokePublictypecollectionInternalstructToFfi(this);
     final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);


### PR DESCRIPTION
Updated Dart name resolver and "function signature" template to explicitly generate `void` function return type, instead
of generating nothing as before. While the old code worked correctly, "no type" is technically `dynamic`, not `void`,
and thus has less compile-type checks than the proper `void` type.

Smoke tests are updated in a separate commit.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>