### PR TITLE
Fix usage of `Locale` hash function in C++ sets and maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added automatic finalization for lambdas in Dart.
+### Bug fixes:
+  * Fixed `Locale` hash usage for maps and sets in C++.
 
 ## 9.1.1
 Release date: 2021-06-02

--- a/functional-tests/functional/input/lime/Locales.lime
+++ b/functional-tests/functional/input/lime/Locales.lime
@@ -36,3 +36,10 @@ struct LocalesStruct {
 
     static fun localesStructRoundTrip(input: LocalesStruct): LocalesStruct
 }
+
+class LocaleGenerics {
+    static fun localeListRoundTrip(input: List<Locale>): List<Locale>
+    static fun localeSetRoundTrip(input: Set<Locale>): Set<Locale>
+    static fun localeKeysMapRoundTrip(input: Map<Locale, String>): Map<Locale, String>
+    static fun localeValuesMapRoundTrip(input: Map<String, Locale>): Map<String, Locale>
+}

--- a/functional-tests/functional/input/src/cpp/Locales.cpp
+++ b/functional-tests/functional/input/src/cpp/Locales.cpp
@@ -19,61 +19,90 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/Locales.h"
+#include "test/LocaleGenerics.h"
 #include "test/LocalesStruct.h"
 
 namespace test
 {
-lorem_ipsum::test::Locale s_locale = lorem_ipsum::test::Locale(std::string{"foo"}, "bar", "baz");
+using namespace lorem_ipsum::test;
+
+Locale s_locale = Locale(std::string{"foo"}, "bar", "baz");
 std::string nonsense = "@#$%";
 
-lorem_ipsum::test::Locale
-Locales::locale_round_trip(const lorem_ipsum::test::Locale& input) {
+// Locales
+
+Locale
+Locales::locale_round_trip(const Locale& input) {
     return input;
 }
 
-lorem_ipsum::test::Locale
-Locales::locale_round_trip_strip_tag(const lorem_ipsum::test::Locale& input) {
-    return lorem_ipsum::test::Locale(input.language_code, input.country_code, input.script_code);
+Locale
+Locales::locale_round_trip_strip_tag(const Locale& input) {
+    return Locale(input.language_code, input.country_code, input.script_code);
 }
 
-lorem_ipsum::test::optional<lorem_ipsum::test::Locale>
-Locales::locale_round_trip_nullable(
-    const lorem_ipsum::test::optional<lorem_ipsum::test::Locale>& input) {
+optional<Locale>
+Locales::locale_round_trip_nullable(const optional<Locale>& input) {
     return input;
 }
 
-lorem_ipsum::test::Locale
+Locale
 Locales::get_locale_property() {
     return s_locale;
 }
 
 void
-Locales::set_locale_property(const lorem_ipsum::test::Locale& value) {
+Locales::set_locale_property(const Locale& value) {
     s_locale = value;
 }
 
-lorem_ipsum::test::Locale
+Locale
 Locales::get_locale_with_malformed_tag() {
-    return lorem_ipsum::test::Locale(nonsense);
+    return Locale(nonsense);
 }
 
-lorem_ipsum::test::Locale
+Locale
 Locales::get_locale_with_malformed_language() {
-    return lorem_ipsum::test::Locale(nonsense, "bar", "baz");
+    return Locale(nonsense, "bar", "baz");
 }
 
-lorem_ipsum::test::Locale
+Locale
 Locales::get_locale_with_malformed_country() {
-    return lorem_ipsum::test::Locale("foo", nonsense, "baz");
+    return Locale("foo", nonsense, "baz");
 }
 
-lorem_ipsum::test::Locale
+Locale
 Locales::get_locale_with_malformed_script() {
-    return lorem_ipsum::test::Locale("foo", "bar", nonsense);
+    return Locale("foo", "bar", nonsense);
 }
+
+// LocalesStruct
 
 LocalesStruct
 LocalesStruct::locales_struct_round_trip(const LocalesStruct& input) {
+    return input;
+}
+
+// LocaleGenerics
+
+std::vector<Locale>
+LocaleGenerics::locale_list_round_trip(const std::vector<Locale>& input) {
+    return input;
+}
+
+std::unordered_set<Locale, hash<Locale>>
+LocaleGenerics::locale_set_round_trip(const std::unordered_set<Locale, hash<Locale>>& input) {
+    return input;
+}
+
+std::unordered_map<Locale, std::string, hash<Locale>>
+LocaleGenerics::locale_keys_map_round_trip(
+    const std::unordered_map<Locale, std::string, hash<Locale>>& input) {
+    return input;
+}
+
+std::unordered_map<std::string, Locale>
+LocaleGenerics::locale_values_map_round_trip(const std::unordered_map<std::string, Locale>& input) {
     return input;
 }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppLibraryIncludes.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppLibraryIncludes.kt
@@ -21,6 +21,7 @@ package com.here.gluecodium.generator.cpp
 
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 object CppLibraryIncludes {
@@ -39,8 +40,13 @@ object CppLibraryIncludes {
     val UTILITY = Include.createSystemInclude("utility")
 
     fun hasStdHash(limeType: LimeTypeRef): Boolean {
-        val actualType = limeType.type.actualType as? LimeBasicType ?: return false
-        return actualType.typeId != LimeBasicType.TypeId.BLOB &&
-            actualType.typeId != LimeBasicType.TypeId.DATE
+        val basicType = limeType.type.actualType
+        return when {
+            basicType !is LimeBasicType -> false
+            basicType.typeId.isNumericType -> true
+            basicType.typeId == TypeId.BOOLEAN -> true
+            basicType.typeId == TypeId.STRING -> true
+            else -> false
+        }
     }
 }

--- a/gluecodium/src/test/resources/smoke/locales/input/Locales.lime
+++ b/gluecodium/src/test/resources/smoke/locales/input/Locales.lime
@@ -25,6 +25,8 @@ class Locales {
     typealias LocaleTypeDef = Locale
     typealias LocaleArray = List<Locale>
     typealias LocaleMap = Map<String, Locale>
+    typealias LocaleSet = Set<Locale>
+    typealias LocaleKeyMap = Map<Locale, String>
 
     fun localeMethod(input: Locale): Locale
 

--- a/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/GenericCollections.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/cbridge/src/GenericCollections.cpp
@@ -6,9 +6,11 @@
 #include "gluecodium/Locale.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
 #include "gluecodium/VectorHash.h"
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <new>
 _baseRef foobar_ArrayOf__Locale_create_handle() {
@@ -38,6 +40,44 @@ void foobar_ArrayOf__Locale_release_optional_handle(_baseRef handle) {
 }
 _baseRef foobar_ArrayOf__Locale_unwrap_optional_handle(_baseRef handle) {
     return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector< ::gluecodium::Locale >>*>( handle ) );
+}
+_baseRef foobar_MapOf__Locale_To__String_create_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >() );
+}
+void foobar_MapOf__Locale_To__String_release_handle(_baseRef handle) {
+    delete get_pointer<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >>(handle);
+}
+_baseRef foobar_MapOf__Locale_To__String_iterator(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >::iterator( get_pointer<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >>(handle)->begin() ) );
+}
+void foobar_MapOf__Locale_To__String_iterator_release_handle(_baseRef iterator_handle) {
+    delete reinterpret_cast<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle );
+}
+void foobar_MapOf__Locale_To__String_put(_baseRef handle, _baseRef key, _baseRef value) {
+    (*get_pointer<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >>(handle)).emplace(Conversion<::gluecodium::Locale>::toCpp(key), Conversion<::std::string>::toCpp(value));
+}
+bool foobar_MapOf__Locale_To__String_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
+    return *reinterpret_cast<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >>(handle)->end();
+}
+void foobar_MapOf__Locale_To__String_iterator_increment(_baseRef iterator_handle) {
+    ++*reinterpret_cast<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle );
+}
+_baseRef foobar_MapOf__Locale_To__String_iterator_key(_baseRef iterator_handle) {
+    auto& key = (*reinterpret_cast<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle ))->first;
+    return Conversion<::gluecodium::Locale>::toBaseRef(key);
+}
+_baseRef foobar_MapOf__Locale_To__String_iterator_value(_baseRef iterator_handle) {
+    auto& value = (*reinterpret_cast<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::string>::toBaseRef(value);
+}
+_baseRef foobar_MapOf__Locale_To__String_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >>( ::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >( ) ) );
+}
+void foobar_MapOf__Locale_To__String_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >>*>( handle );
+}
+_baseRef foobar_MapOf__Locale_To__String_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >>*>( handle ) );
 }
 _baseRef foobar_MapOf__String_To__Locale_create_handle() {
     return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map< ::std::string, ::gluecodium::Locale >() );
@@ -76,4 +116,38 @@ void foobar_MapOf__String_To__Locale_release_optional_handle(_baseRef handle) {
 }
 _baseRef foobar_MapOf__String_To__Locale_unwrap_optional_handle(_baseRef handle) {
     return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map< ::std::string, ::gluecodium::Locale >>*>( handle ) );
+}
+_baseRef foobar_SetOf__Locale_create_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >() );
+}
+void foobar_SetOf__Locale_release_handle(_baseRef handle) {
+    delete get_pointer<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>(handle);
+}
+void foobar_SetOf__Locale_insert(_baseRef handle, _baseRef value) {
+    (*get_pointer<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>(handle)).insert(::std::move(Conversion<::gluecodium::Locale>::toCpp(value)));
+}
+_baseRef foobar_SetOf__Locale_iterator(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >::iterator( get_pointer<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>(handle)->begin() ) );
+}
+void foobar_SetOf__Locale_iterator_release_handle(_baseRef iterator_handle) {
+    delete reinterpret_cast<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle );
+}
+bool foobar_SetOf__Locale_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
+    return *reinterpret_cast<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>(handle)->end();
+}
+void foobar_SetOf__Locale_iterator_increment(_baseRef iterator_handle) {
+    ++*reinterpret_cast<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle );
+}
+_baseRef foobar_SetOf__Locale_iterator_get(_baseRef iterator_handle) {
+    auto& value = **reinterpret_cast<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >::iterator*>( iterator_handle );
+    return Conversion<::gluecodium::Locale>::referenceBaseRef(value);
+}
+_baseRef foobar_SetOf__Locale_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>( ::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >( ) ) );
+}
+void foobar_SetOf__Locale_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>*>( handle );
+}
+_baseRef foobar_SetOf__Locale_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>*>( handle ) );
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
+++ b/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
@@ -6,9 +6,11 @@
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Locale.h"
 #include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
 #include "gluecodium/VectorHash.h"
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Locales {
@@ -19,6 +21,8 @@ public:
     using LocaleTypeDef = ::gluecodium::Locale;
     using LocaleArray = ::std::vector< ::gluecodium::Locale >;
     using LocaleMap = ::std::unordered_map< ::std::string, ::gluecodium::Locale >;
+    using LocaleSet = ::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >;
+    using LocaleKeyMap = ::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >;
     struct _GLUECODIUM_CPP_EXPORT LocaleStruct {
         ::gluecodium::Locale locale_field;
         LocaleStruct( );

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/ffi/GenericTypesConversion.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/ffi/GenericTypesConversion.cpp
@@ -2,9 +2,11 @@
 #include "ConversionBase.h"
 #include "gluecodium/Locale.h"
 #include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
 #include "gluecodium/VectorHash.h"
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <memory>
 #include <new>
@@ -72,6 +74,73 @@ library_foobar_ListOf_Locale_get_value_nullable(FfiOpaqueHandle handle)
     );
 }
 FfiOpaqueHandle
+library_foobar_MapOf_Locale_to_String_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>());
+}
+void
+library_foobar_MapOf_Locale_to_String_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>*>(handle);
+}
+void
+library_foobar_MapOf_Locale_to_String_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, FfiOpaqueHandle value) {
+    reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>*>(handle)->emplace(
+        gluecodium::ffi::Conversion<gluecodium::Locale>::toCpp(key),
+        gluecodium::ffi::Conversion<std::string>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Locale_to_String_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>::iterator(
+        reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>*>(handle)->begin()
+    ));
+}
+void
+library_foobar_MapOf_Locale_to_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle);
+}
+bool
+library_foobar_MapOf_Locale_to_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>*>(handle)->end();
+}
+void
+library_foobar_MapOf_Locale_to_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Locale_to_String_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<gluecodium::Locale>::toFfi(
+        (*reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle))->first
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Locale_to_String_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        (*reinterpret_cast<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle))->second
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Locale_to_String_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>>(
+            gluecodium::ffi::Conversion<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>>::toCpp(value)
+        )
+    );
+}
+void
+library_foobar_MapOf_Locale_to_String_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>>*>(handle);
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Locale_to_String_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_map<gluecodium::Locale, std::string, gluecodium::hash<gluecodium::Locale>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
 library_foobar_MapOf_String_to_Locale_create_handle() {
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, gluecodium::Locale>());
 }
@@ -136,6 +205,66 @@ library_foobar_MapOf_String_to_Locale_get_value_nullable(FfiOpaqueHandle handle)
 {
     return gluecodium::ffi::Conversion<std::unordered_map<std::string, gluecodium::Locale>>::toFfi(
         **reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, gluecodium::Locale>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Locale_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>());
+}
+void
+library_foobar_SetOf_Locale_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>*>(handle);
+}
+void
+library_foobar_SetOf_Locale_insert(FfiOpaqueHandle handle, FfiOpaqueHandle value) {
+    reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>*>(handle)->insert(
+        gluecodium::ffi::Conversion<gluecodium::Locale>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Locale_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>::iterator(
+        reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>*>(handle)->begin()
+    ));
+}
+void
+library_foobar_SetOf_Locale_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle);
+}
+bool
+library_foobar_SetOf_Locale_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>*>(handle)->end();
+}
+void
+library_foobar_SetOf_Locale_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Locale_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<gluecodium::Locale>::toFfi(
+        **reinterpret_cast<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Locale_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>>(
+            gluecodium::ffi::Conversion<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>>::toCpp(value)
+        )
+    );
+}
+void
+library_foobar_SetOf_Locale_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>>*>(handle);
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Locale_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>>*>(handle)
     );
 }
 #ifdef __cplusplus

--- a/gluecodium/src/test/resources/smoke/locales/output/lime/smoke/Locales.lime
+++ b/gluecodium/src/test/resources/smoke/locales/output/lime/smoke/Locales.lime
@@ -1,17 +1,15 @@
 package smoke
-
 class Locales {
     typealias LocaleTypeDef = Locale
     typealias LocaleArray = List<Locale>
     typealias LocaleMap = Map<String, Locale>
-
+    typealias LocaleSet = Set<Locale>
+    typealias LocaleKeyMap = Map<Locale, String>
     struct LocaleStruct {
         localeField: Locale
     }
-
     fun localeMethod(
         input: Locale
     ): Locale
-
     property localeProperty: Locale
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
+++ b/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/Locales.swift
@@ -5,6 +5,8 @@ public class Locales {
     public typealias LocaleTypeDef = Locale
     public typealias LocaleArray = [Locale]
     public typealias LocaleMap = [String: Locale]
+    public typealias LocaleSet = Set<Locale>
+    public typealias LocaleKeyMap = [Locale: String]
     public var localeProperty: Locale {
         get {
             let c_result_handle = smoke_Locales_localeProperty_get(self.c_instance)

--- a/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cbridge/src/smoke/cbridge_OuterStruct.cpp
@@ -111,7 +111,7 @@ void smoke_OuterStruct_InnerClass_remove_swift_object_from_wrapper_cache(_baseRe
     ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::OuterStruct::InnerClass >>(handle)->get());
 }
 _baseRef smoke_OuterStruct_InnerClass_fooBar(_baseRef _instance) {
-    return Conversion<::std::unordered_set< ::gluecodium::Locale >>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::OuterStruct::InnerClass >>(_instance)->get()->foo_bar());
+    return Conversion<::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::OuterStruct::InnerClass >>(_instance)->get()->foo_bar());
 }
 void smoke_OuterStruct_InnerInterface_release_handle(_baseRef handle) {
     delete get_pointer<::std::shared_ptr< ::smoke::OuterStruct::InnerInterface >>(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
@@ -35,7 +35,7 @@ struct _GLUECODIUM_CPP_EXPORT OuterStruct {
         InnerClass();
         virtual ~InnerClass() = 0;
     public:
-        virtual ::std::unordered_set< ::gluecodium::Locale > foo_bar(  ) = 0;
+        virtual ::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > > foo_bar(  ) = 0;
     };
     class _GLUECODIUM_CPP_EXPORT Builder {
     public:

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/ffi/ffi_smoke_OuterStruct.cpp
@@ -103,7 +103,7 @@ library_smoke_OuterStruct_InnerStruct_doSomething(FfiOpaqueHandle _self, int32_t
 FfiOpaqueHandle
 library_smoke_OuterStruct_InnerClass_fooBar(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
-    return gluecodium::ffi::Conversion<std::unordered_set<gluecodium::Locale>>::toFfi(
+    return gluecodium::ffi::Conversion<std::unordered_set<gluecodium::Locale, gluecodium::hash<gluecodium::Locale>>>::toFfi(
         (*gluecodium::ffi::Conversion<std::shared_ptr<::smoke::OuterStruct::InnerClass>>::toCpp(_self)).foo_bar()
     );
 }


### PR DESCRIPTION
Inverted the internal condition in `CppLibraryIncludes.hasStdHash()` predicate so that it lists types for the `true`
result explicitly and returns false otherwise.

The list of `true` types for this predicate is not expected to change. However, each new "basic" type added to LIME
model has to return `false` from this predicate. The new inverted condition accomplishes this automatically. This also
fixes the predicate erroneously returning `true` for the `Locale` type.

Added/updated smoke and functional tests to cover the usages of `Locale` hash function in C++.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>