### PR TITLE
Fix @Optimized lists as fields in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Added automatic finalization for lambdas in Dart.
 ### Bug fixes:
   * Fixed `Locale` hash usage for maps and sets in C++.
+  * Fixed compilation issues for `@Optimized` Lists as struct fields in Java.
 
 ## 9.1.1
 Release date: 2021-06-02

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/BlobsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/BlobsTest.java
@@ -20,6 +20,7 @@ package com.here.android.test;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 
 import android.os.Build;
 import com.here.android.RobolectricApplication;

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerRoundtripTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerRoundtripTest.java
@@ -54,7 +54,7 @@ public class ListenerRoundtripTest {
 
   @Test
   public void convolutedRoundTrip() {
-    final SomeLifecycleListener listener = new SomeIndicator();
+    final SomeIndicator listener = new SomeIndicator();
     final SomeBase base = new RealBase();
 
     base.addLifecycleListener(listener);

--- a/functional-tests/scripts/build-android-functional
+++ b/functional-tests/scripts/build-android-functional
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2016-2018 HERE Europe B.V.
 #

--- a/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
@@ -59,7 +59,7 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
 {{#if typeRef.attributes.optimized}}
     auto j_{{resolveName "C++"}} = get_object_field_value(_jenv, _jinput, "{{resolveName}}", "L{{resolveName typeRef.type.actualType}};");
     auto {{resolveName "C++"}}_handle = get_field_value(_jenv, j_{{resolveName "C++"}}, "nativeHandle", (int64_t*)nullptr);
-    auto& n_{{resolveName "C++"}} = *reinterpret_cast<std::shared_ptr<{{resolveName typeRef "C++"}}>*>({{resolveName "C++"}}_handle);
+    auto& n_{{resolveName "C++"}} = **reinterpret_cast<std::shared_ptr<{{resolveName typeRef "C++"}}>*>({{resolveName "C++"}}_handle);
 {{/if}}{{#unless typeRef.attributes.optimized}}
     {{resolveName typeRef "C++"}} n_{{resolveName "C++"}} = convert_from_jni(
         _jenv,
@@ -108,7 +108,7 @@ convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput)
 {{/ifPredicate}}{{/if}}{{!!
 }}{{#unless external.java.setterName}}{{#notInstanceOf typeRef.type.actualType "LimeBasicType"}}
     auto j{{resolveName "C++"}} = {{#if typeRef.attributes.optimized}}{{!!
-}}convert_to_jni_optimized(_jenv, result, "{{resolveName struct "" "ref"}}${{resolveName typeRef "" "ref"}}"){{/if}}{{!!
+}}convert_to_jni_optimized(_jenv, {{>getCppFieldValue}}, "{{resolveName struct "" "ref"}}${{resolveName typeRef "" "ref"}}"){{/if}}{{!!
 }}{{#unless typeRef.attributes.optimized}}convert_to_jni(_jenv, {{>getCppFieldValue}}){{/unless}};
     {{>common/InternalNamespace}}jni::set_object_field_value({{!!
     }}_jenv, _jresult, "{{resolveName}}", "L{{resolveName typeRef.type.actualType}};", j{{resolveName "C++"}});

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_UseOptimizedListStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_UseOptimizedListStruct__Conversion.cpp
@@ -15,10 +15,10 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::U
 {
     auto j_structs = get_object_field_value(_jenv, _jinput, "structs", "Ljava/util/List;");
     auto structs_handle = get_field_value(_jenv, j_structs, "nativeHandle", (int64_t*)nullptr);
-    auto& n_structs = *reinterpret_cast<std::shared_ptr<::std::vector< ::std::shared_ptr< ::smoke::VeryBigStruct > >>*>(structs_handle);
+    auto& n_structs = **reinterpret_cast<std::shared_ptr<::std::vector< ::std::shared_ptr< ::smoke::VeryBigStruct > >>*>(structs_handle);
     auto j_classes = get_object_field_value(_jenv, _jinput, "classes", "Ljava/util/List;");
     auto classes_handle = get_field_value(_jenv, j_classes, "nativeHandle", (int64_t*)nullptr);
-    auto& n_classes = *reinterpret_cast<std::shared_ptr<::std::vector< ::std::shared_ptr< ::smoke::UnreasonablyLazyClass > >>*>(classes_handle);
+    auto& n_classes = **reinterpret_cast<std::shared_ptr<::std::vector< ::std::shared_ptr< ::smoke::UnreasonablyLazyClass > >>*>(classes_handle);
     return ::smoke::UseOptimizedListStruct(std::move(n_structs), std::move(n_classes));
 }
 ::gluecodium::optional<::smoke::UseOptimizedListStruct>
@@ -34,9 +34,9 @@ convert_to_jni(JNIEnv* _jenv, const ::smoke::UseOptimizedListStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::UseOptimizedListStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
-    auto jstructs = convert_to_jni_optimized(_jenv, result, "com/example/smoke/UseOptimizedListStruct$VeryBigStructLazyNativeList");
+    auto jstructs = convert_to_jni_optimized(_jenv, _ninput.structs, "com/example/smoke/UseOptimizedListStruct$VeryBigStructLazyNativeList");
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "structs", "Ljava/util/List;", jstructs);
-    auto jclasses = convert_to_jni_optimized(_jenv, result, "com/example/smoke/UseOptimizedListStruct$UnreasonablyLazyClassLazyNativeList");
+    auto jclasses = convert_to_jni_optimized(_jenv, _ninput.classes, "com/example/smoke/UseOptimizedListStruct$UnreasonablyLazyClassLazyNativeList");
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "classes", "Ljava/util/List;", jclasses);
     return _jresult;
 }


### PR DESCRIPTION
Fixed a typo in JNI struct conversion template that resulted in compilation error for `@Optimized` List used as struct
field type. Fixed the build script that masked this error on CI.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>