### PR TITLE
Fix compilation of Java generated code on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Bug fixes:
   * Fixed `Locale` hash usage for maps and sets in C++.
   * Fixed compilation issues for `@Optimized` Lists as struct fields in Java.
+  * Fixed compilation issue for Java when compiled on a Mac.
 
 ## 9.1.1
 Release date: 2021-06-02

--- a/gluecodium/src/main/resources/templates/jni/utils/JniReferenceHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniReferenceHeader.mustache
@@ -179,7 +179,7 @@ create_object( JNIEnv* env, const JniReference<jclass>& javaClass )
     const char* signature = "()V";
     auto theConstructor = env->GetMethodID( javaClass.get(), name, signature );
 
-    return new_object(env, javaClass, theConstructor );
+    return new_object(env, javaClass, theConstructor);
 }
 
 inline JniReference<jobject>
@@ -189,7 +189,8 @@ create_instance_object( JNIEnv* env, const JniReference<jclass>& javaClass, jlon
     const char* signature = "(JLjava/lang/Object;)V";
     auto theConstructor = env->GetMethodID( javaClass.get(), name, signature );
 
-    return new_object(env, javaClass, theConstructor, instancePointer, NULL );
+    // On Mac platform `jlong` and `jobject` are `long long`, but `NULL` is `long`, so need to cast here.
+    return new_object(env, javaClass, theConstructor, instancePointer, static_cast<jobject>(NULL));
 }
 
 inline JniReference<jobject>


### PR DESCRIPTION
Updated JniReferenceHeader template to cast the `NULL` value to the `jobject` type explicitly. This fixes a compilation issue
when compiling on a Mac, where `jlong` and `jobject` are `long long`, but `NULL` is `long`.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>