### PR TITLE
Fix CBridge warning about C99 feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   * Fixed `Locale` hash usage for maps and sets in C++.
   * Fixed compilation issues for `@Optimized` Lists as struct fields in Java.
   * Fixed compilation issue for Java when compiled on a Mac.
+  * Fixed CBridge compilation warning about a C99 extension syntax being used.
 
 ## 9.1.1
 Release date: 2021-06-02

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeFunctionDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeFunctionDefinition.mustache
@@ -26,9 +26,9 @@
 {{/if}}{{#unless returnType.isVoid}}
     auto&& RESULT = {{>callBaseApi}};
     if (RESULT.has_value()) {
-        return {true, .returned_value = {{#set delegateToCall="unsafe_value"}}{{>returnConversion}}{{/set}}};
+        return {.has_value = true, .returned_value = {{#set delegateToCall="unsafe_value"}}{{>returnConversion}}{{/set}}};
     } else {
-        return {false, .error_value = static_cast< {{resolveName errorType}} >(RESULT.error().value())};
+        return {.has_value = false, .error_value = static_cast< {{resolveName errorType}} >(RESULT.error().value())};
     }
 {{/unless}}{{/ifPredicate}}{{!!
 }}{{#unlessPredicate errorType "isNonNullableEnum"}}
@@ -37,10 +37,10 @@
 {{#if returnType.isVoid}}
         return {true, 0};
 {{/if}}{{#unless returnType.isVoid}}
-        return {true, .returned_value = {{#set delegateToCall="unsafe_value"}}{{>returnConversion}}{{/set}}};
+        return {.has_value = true, .returned_value = {{#set delegateToCall="unsafe_value"}}{{>returnConversion}}{{/set}}};
 {{/unless}}
     } else {
-        return {false, .error_value = {{>errorConversion}}};
+        return {.has_value = false, .error_value = {{>errorConversion}}};
     }
 {{/unlessPredicate}}{{!!
 }}{{/set}}{{/if}}{{!!

--- a/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/cbridge/src/smoke/cbridge_Constructors.cpp
@@ -61,9 +61,9 @@ _baseRef smoke_Constructors_create_String_ULong(_baseRef foo, uint64_t bar) {
 smoke_Constructors_create_String_result smoke_Constructors_create_String(_baseRef input) {
     auto&& RESULT = ::smoke::Constructors::create(Conversion<::std::string>::toCpp(input));
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<::std::shared_ptr< ::smoke::Constructors >>::toBaseRef(RESULT.unsafe_value())};
+        return {.has_value = true, .returned_value = Conversion<::std::shared_ptr< ::smoke::Constructors >>::toBaseRef(RESULT.unsafe_value())};
     } else {
-        return {false, .error_value = static_cast< smoke_Constructors_ErrorEnum >(RESULT.error().value())};
+        return {.has_value = false, .error_value = static_cast< smoke_Constructors_ErrorEnum >(RESULT.error().value())};
     }
 }
 _baseRef smoke_Constructors_create__3Double_4(_baseRef input) {

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_Errors.cpp
@@ -43,9 +43,9 @@ smoke_Errors_methodWithExternalErrors_result smoke_Errors_methodWithExternalErro
 smoke_Errors_methodWithErrorsAndReturnValue_result smoke_Errors_methodWithErrorsAndReturnValue() {
     auto&& RESULT = ::smoke::Errors::method_with_errors_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {.has_value = true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
-        return {false, .error_value = static_cast< smoke_Errors_InternalErrorCode >(RESULT.error().value())};
+        return {.has_value = false, .error_value = static_cast< smoke_Errors_InternalErrorCode >(RESULT.error().value())};
     }
 }
 smoke_Errors_methodWithPayloadError_result smoke_Errors_methodWithPayloadError() {
@@ -53,14 +53,14 @@ smoke_Errors_methodWithPayloadError_result smoke_Errors_methodWithPayloadError()
     if (RESULT.has_value()) {
         return {true, 0};
     } else {
-        return {false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
+        return {.has_value = false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
     }
 }
 smoke_Errors_methodWithPayloadErrorAndReturnValue_result smoke_Errors_methodWithPayloadErrorAndReturnValue() {
     auto&& RESULT = ::smoke::Errors::method_with_payload_error_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {.has_value = true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
-        return {false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
+        return {.has_value = false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
     }
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/cbridge/src/smoke/cbridge_ErrorsInterface.cpp
@@ -59,9 +59,9 @@ smoke_ErrorsInterface_methodWithExternalErrors_result smoke_ErrorsInterface_meth
 smoke_ErrorsInterface_methodWithErrorsAndReturnValue_result smoke_ErrorsInterface_methodWithErrorsAndReturnValue(_baseRef _instance) {
     auto&& RESULT = get_pointer<::std::shared_ptr< ::smoke::ErrorsInterface >>(_instance)->get()->method_with_errors_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {.has_value = true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
-        return {false, .error_value = static_cast< smoke_ErrorsInterface_InternalError >(RESULT.error().value())};
+        return {.has_value = false, .error_value = static_cast< smoke_ErrorsInterface_InternalError >(RESULT.error().value())};
     }
 }
 smoke_ErrorsInterface_methodWithPayloadError_result smoke_ErrorsInterface_methodWithPayloadError() {
@@ -69,15 +69,15 @@ smoke_ErrorsInterface_methodWithPayloadError_result smoke_ErrorsInterface_method
     if (RESULT.has_value()) {
         return {true, 0};
     } else {
-        return {false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
+        return {.has_value = false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
     }
 }
 smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_result smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue() {
     auto&& RESULT = ::smoke::ErrorsInterface::method_with_payload_error_and_return_value();
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
+        return {.has_value = true, .returned_value = Conversion<::std::string>::toBaseRef(RESULT.unsafe_value())};
     } else {
-        return {false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
+        return {.has_value = false, .error_value = Conversion<::smoke::Payload>::toBaseRef(RESULT.error())};
     }
 }
 class smoke_ErrorsInterfaceProxy : public ::smoke::ErrorsInterface, public CachedProxyBase<smoke_ErrorsInterfaceProxy> {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cbridge/src/namerules/cbridge_NameRules.cpp
@@ -38,9 +38,9 @@ _baseRef namerules_INameRules_create() {
 namerules_INameRules_someMethod_result namerules_INameRules_someMethod(_baseRef _instance, _baseRef someArgument) {
     auto&& RESULT = get_pointer<::std::shared_ptr< ::namerules::NameRules >>(_instance)->get()->someMethod(Conversion<::namerules::NameRules::ExampleStruct>::toCpp(someArgument));
     if (RESULT.has_value()) {
-        return {true, .returned_value = RESULT.unsafe_value()};
+        return {.has_value = true, .returned_value = RESULT.unsafe_value()};
     } else {
-        return {false, .error_value = static_cast< namerules_INameRules_IExampleErrorCode >(RESULT.error().value())};
+        return {.has_value = false, .error_value = static_cast< namerules_INameRules_IExampleErrorCode >(RESULT.error().value())};
     }
 }
 uint32_t namerules_INameRules_intPropertyPod_get(_baseRef _instance) {

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethods.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethods.cpp
@@ -59,8 +59,8 @@ _baseRef smoke_StructsWithMethods_Vector_create_Double_Double(double x, double y
 smoke_StructsWithMethods_Vector_create_Vector_result smoke_StructsWithMethods_Vector_create_Vector(_baseRef other) {
     auto&& RESULT = ::smoke::Vector::create(Conversion<::smoke::Vector>::toCpp(other));
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<::smoke::Vector>::toBaseRef(RESULT.unsafe_value())};
+        return {.has_value = true, .returned_value = Conversion<::smoke::Vector>::toBaseRef(RESULT.unsafe_value())};
     } else {
-        return {false, .error_value = static_cast< smoke_ValidationUtils_ValidationErrorCode >(RESULT.error().value())};
+        return {.has_value = false, .error_value = static_cast< smoke_ValidationUtils_ValidationErrorCode >(RESULT.error().value())};
     }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/cbridge/src/smoke/cbridge_StructsWithMethodsInterface.cpp
@@ -90,9 +90,9 @@ _baseRef smoke_StructsWithMethodsInterface_Vector3_create_String(_baseRef input)
 smoke_StructsWithMethodsInterface_Vector3_create_Vector3_result smoke_StructsWithMethodsInterface_Vector3_create_Vector3(_baseRef other) {
     auto&& RESULT = ::smoke::StructsWithMethodsInterface::Vector3::create(Conversion<::smoke::StructsWithMethodsInterface::Vector3>::toCpp(other));
     if (RESULT.has_value()) {
-        return {true, .returned_value = Conversion<::smoke::StructsWithMethodsInterface::Vector3>::toBaseRef(RESULT.unsafe_value())};
+        return {.has_value = true, .returned_value = Conversion<::smoke::StructsWithMethodsInterface::Vector3>::toBaseRef(RESULT.unsafe_value())};
     } else {
-        return {false, .error_value = static_cast< smoke_ValidationUtils_ValidationErrorCode >(RESULT.error().value())};
+        return {.has_value = false, .error_value = static_cast< smoke_ValidationUtils_ValidationErrorCode >(RESULT.error().value())};
     }
 }
 void smoke_StructsWithMethodsInterface_StructWithStaticMethodsOnly_doStuff() {


### PR DESCRIPTION
Updated "CBridgeFunctionDefinition" template to use explicit field name for both fields when initializing "return value
with error" struct. Using an explicit name for value/error field is required as it is a union. Mixing nameless and named
fields in initialization is a non-standard C99 feature, which produced a compiler warning. The updated template fixes
the warning.

Updated smoke tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
