### PR TITLE
Normalize FFI names for nullable basic types

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -393,9 +393,8 @@ internal class DartGenerator : Generator {
         )
     }
 
-    private fun generateFfiCommonFiles(
-        nameResolvers: Map<String, NameResolver>
-    ): List<GeneratedFile> {
+    private fun generateFfiCommonFiles(nameResolvers: Map<String, NameResolver>): List<GeneratedFile> {
+
         val headerOnly = listOf("ConversionBase", "Export", "OpaqueHandle")
         val headerAndImpl = listOf(
             "BlobHandle",

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
@@ -46,6 +46,7 @@ internal class FfiNameResolver(
 
     override fun resolveName(element: Any): String =
         when (element) {
+            is String -> mangleName(element)
             is TypeId -> getBasicTypeName(element)
             is LimeTypeRef -> getTypeRefName(element)
             is LimeFunction -> getMangledFullName(element)

--- a/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
@@ -171,15 +171,15 @@ void localeReleaseFfiHandle(Pointer<Void> handle) => _localeReleaseHandle(handle
 final _{{resolveName toString "Ffi"}}CreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function({{resolveName "FfiApiTypes"}}),
     Pointer<Void> Function({{resolveName "FfiDartTypes"}})
-  >('{{libraryName}}_{{this}}_create_handle_nullable'));
+  >('{{libraryName}}_{{resolveName toString "FfiSnakeCase"}}_create_handle_nullable'));
 final _{{resolveName toString "Ffi"}}ReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{this}}_release_handle_nullable'));
+  >('{{libraryName}}_{{resolveName toString "FfiSnakeCase"}}_release_handle_nullable'));
 final _{{resolveName toString "Ffi"}}GetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{this}}_get_value_nullable'));
+  >('{{libraryName}}_{{resolveName toString "FfiSnakeCase"}}_get_value_nullable'));
 
 Pointer<Void> {{resolveName toString "Ffi"}}ToFfiNullable({{resolveName}}? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);

--- a/gluecodium/src/main/resources/templates/ffi/FfiNullableHandlesHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiNullableHandlesHeader.mustache
@@ -31,9 +31,9 @@ extern "C" {
 #endif
 
 {{#builtInTypes}}
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{this}}_create_handle_nullable({{resolveName}} value);
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{this}}_release_handle_nullable(FfiOpaqueHandle handle);
-_GLUECODIUM_FFI_EXPORT {{resolveName}} {{libraryName}}_{{this}}_get_value_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName toString ""}}_create_handle_nullable({{resolveName}} value);
+_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName toString ""}}_release_handle_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT {{resolveName}} {{libraryName}}_{{resolveName toString ""}}_get_value_nullable(FfiOpaqueHandle handle);
 {{/builtInTypes}}
 
 #ifdef __cplusplus

--- a/gluecodium/src/main/resources/templates/ffi/FfiNullableHandlesImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiNullableHandlesImpl.mustache
@@ -37,7 +37,7 @@ extern "C" {
 
 {{#builtInTypes}}
 FfiOpaqueHandle
-{{libraryName}}_{{this}}_create_handle_nullable({{resolveName}} value)
+{{libraryName}}_{{resolveName toString ""}}_create_handle_nullable({{resolveName}} value)
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName "C++"}}>(
@@ -48,13 +48,13 @@ FfiOpaqueHandle
 }
 
 void
-{{libraryName}}_{{this}}_release_handle_nullable(FfiOpaqueHandle handle)
+{{libraryName}}_{{resolveName toString ""}}_release_handle_nullable(FfiOpaqueHandle handle)
 {
     delete reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName "C++"}}>*>(handle);
 }
 
 {{resolveName}}
-{{libraryName}}_{{this}}_get_value_nullable(FfiOpaqueHandle handle)
+{{libraryName}}_{{resolveName toString ""}}_get_value_nullable(FfiOpaqueHandle handle)
 {
     return {{#unless isNumericType}}{{#isNotEq toString "Boolean"}}{{!!
     }}{{>ffi/FfiInternal}}::Conversion<{{resolveName "C++"}}>::toFfi{{/isNotEq}}{{/unless}}(


### PR DESCRIPTION
Updated Dart and FFI templates to pass the names of basic types through the FFI name resolver when using these names in
function names, instead of using these names verbatim as before. This allowes for correct syntax when the name of a
basic type contains non-alphanumeric characters (e.g. the upcoming `Duration<>` basic types).

See: #911