### PR TITLE
Don't return `void` from functions in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed "dart analyze" warning about unnecessary cast in the class/interface equality operator.
+  * In Dart there is now less dead code generated for functions returning `void`. This also fixes a corresponding "dart
+    analyze" warning.
 
 ## 9.2.0
 Release date: 2021-06-22

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -27,8 +27,9 @@
   final _handle = {{#if isStruct}}{{resolveName parent "Ffi"}}ToFfi(this){{/if}}{{!!
   }}{{#unless isStruct}}this.handle{{/unless}};
 {{/unless}}
-  final __{{#if thrownType}}callResult{{/if}}{{#unless thrownType}}result{{/unless}}Handle = _{{resolveName}}Ffi({{!!
-  }}{{#unless isStatic}}_handle, {{/unless}}__lib.LibraryContext.isolateId{{#if parameters}}, {{/if}}{{!!
+  {{#if thrownType}}final __callResultHandle = {{/if}}{{!!
+  }}{{#unless thrownType returnType.isVoid logic="and"}}final __resultHandle = {{/unless}}{{!!
+  }}_{{resolveName}}Ffi({{#unless isStatic}}_handle, {{/unless}}__lib.LibraryContext.isolateId{{#if parameters}}, {{/if}}{{!!
   }}{{#parameters}}_{{resolveName}}Handle{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{#if isStruct}}{{#unless isStatic}}  {{resolveName parent "Ffi"}}ReleaseFfiHandle(_handle);
 {{/unless}}{{/if}}{{!!
@@ -45,12 +46,14 @@
         {{#set typeRef=exception.errorType varName="__errorHandle"}}{{>dart/DartFfiReleaseHandle}}{{/set}}
       }
   }
+{{#unless returnType.isVoid}}
   final __resultHandle = _{{resolveName}}ReturnGetResult(__callResultHandle);
+{{/unless}}
   _{{resolveName}}ReturnReleaseHandle(__callResultHandle);
 {{/if}}
 {{#if isConstructor}}{{#if isStruct}}{{>ffiReturnConversion}}{{/if}}{{!!
 }}{{#unless isStruct}}  return __resultHandle;{{/unless}}{{/if}}{{!!
-}}{{#unless isConstructor}}{{>ffiReturnConversion}}{{/unless}}
+}}{{#unless isConstructor returnType.isVoid logic="and"}}{{>ffiReturnConversion}}{{/unless}}
 }{{!!
 
 }}{{+ffiApi}}{{#if thrownType}}Pointer<Void>{{/if}}{{#unless thrownType}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
@@ -23,11 +23,12 @@ final _{{resolveName}}ReturnReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_return_release_handle'));
-final _{{resolveName}}ReturnGetResult = {{#unless returnType.isVoid}}__lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+{{#unless returnType.isVoid}}
+final _{{resolveName}}ReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName returnType.typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName returnType.typeRef "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_return_get_result'));{{/unless}}{{!!
-    }}{{#if returnType.isVoid}}(Pointer) {};{{/if}}
+  >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_return_get_result'));
+{{/unless}}
 final _{{resolveName}}ReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName exception.errorType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName exception.errorType "FfiDartTypes"}} Function(Pointer<Void>)

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -39,12 +39,8 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_veryFun__String'));
     final _paramHandle = stringToFfi(param);
     final _handle = this.handle;
-    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
+    _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
     stringReleaseFfiHandle(_paramHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @OnPropertyInClass
   @override
@@ -64,12 +60,8 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_prop_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeAttributesclassToFfi(AttributesClass value) =>

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -77,12 +77,8 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_veryFun__String'));
     final _paramHandle = stringToFfi(param);
     final _handle = this.handle;
-    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
+    _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
     stringReleaseFfiHandle(_paramHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @OnPropertyInInterface
   String get prop {
@@ -100,12 +96,8 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_prop_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeAttributesinterfaceveryFunStatic(Object _obj, Pointer<Void> param) {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -26,11 +26,7 @@ class AttributesLambda$Impl {
   void call() {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesLambda_call'));
     final _handle = this.handle;
-    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _callFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 int _smokeAttributeslambdacallStatic(Object _obj) {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_struct.dart
@@ -13,13 +13,9 @@ class AttributesStruct {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesStruct_veryFun__String'));
     final _paramHandle = stringToFfi(param);
     final _handle = smokeAttributesstructToFfi(this);
-    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
+    _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
     smokeAttributesstructReleaseFfiHandle(_handle);
     stringReleaseFfiHandle(_paramHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 // AttributesStruct "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -110,11 +110,7 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
   void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_veryFun'));
     final _handle = this.handle;
-    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @OnPropertyInClass
   @override
@@ -134,12 +130,8 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithComments_prop_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeAttributeswithcommentsToFfi(AttributesWithComments value) =>

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -109,11 +109,7 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
   void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_veryFun'));
     final _handle = this.handle;
-    final __resultHandle = _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @OnPropertyInClass
   @override
@@ -133,12 +129,8 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesWithDeprecated_prop_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeAttributeswithdeprecatedToFfi(AttributesWithDeprecated value) =>

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -48,51 +48,31 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
   void noLists2() {
     final _noLists2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists2'));
     final _handle = this.handle;
-    final __resultHandle = _noLists2Ffi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _noLists2Ffi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void noLists3() {
     final _noLists3Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists3'));
     final _handle = this.handle;
-    final __resultHandle = _noLists3Ffi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _noLists3Ffi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void listFirst() {
     final _listFirstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listFirst'));
     final _handle = this.handle;
-    final __resultHandle = _listFirstFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _listFirstFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void listSecond() {
     final _listSecondFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listSecond'));
     final _handle = this.handle;
-    final __resultHandle = _listSecondFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _listSecondFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void twoLists() {
     final _twoListsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_twoLists'));
     final _handle = this.handle;
-    final __resultHandle = _twoListsFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _twoListsFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeMultipleattributesdartToFfi(MultipleAttributesDart value) =>

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -32,21 +32,13 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
   void withEscaping() {
     final _withEscapingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withEscaping'));
     final _handle = this.handle;
-    final __resultHandle = _withEscapingFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _withEscapingFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void withLineBreak() {
     final _withLineBreakFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withLineBreak'));
     final _handle = this.handle;
-    final __resultHandle = _withLineBreakFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _withLineBreakFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeSpecialattributesToFfi(SpecialAttributes value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -404,24 +404,16 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void someMethodWithoutReturnTypeWithNoComments(String input) {
     final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
@@ -449,21 +441,13 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
   void someMethodWithNothing() {
     final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing'));
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   String oneParameterCommentOnly(String undocumented, String documented) {
@@ -509,12 +493,8 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeCommentsToFfi(Comments value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -358,24 +358,16 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void someMethodWithoutReturnTypeWithNoComments(String input) {
     final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
@@ -403,21 +395,13 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   void someMethodWithNothing() {
     final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing'));
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
   }
   /// Gets some very useful property.
   bool get isSomeProperty {
@@ -435,12 +419,8 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeCommentsinterfacesomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -192,13 +192,9 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
     final _textHandle = stringToFfi(text);
     final _flagHandle = booleanToFfi(flag);
     final _handle = this.handle;
-    final __resultHandle = _randomMethod2Ffi(_handle, __lib.LibraryContext.isolateId, _textHandle, _flagHandle);
+    _randomMethod2Ffi(_handle, __lib.LibraryContext.isolateId, _textHandle, _flagHandle);
     stringReleaseFfiHandle(_textHandle);
     booleanReleaseFfiHandle(_flagHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeCommentslinksToFfi(CommentsLinks value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -259,12 +259,8 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   /// Gets the property but not accessors.
   @Deprecated("Will be removed in v3.2.1.")
@@ -283,12 +279,8 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_propertyButNotAccessors_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -225,12 +225,8 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -320,11 +320,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   bool get isSomeProperty {
@@ -342,12 +338,8 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedComments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeExcludedcommentsToFfi(ExcludedComments value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -296,11 +296,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
-    final __resultHandle = _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   bool get isSomeProperty {
@@ -318,12 +314,8 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeExcludedcommentsonlyToFfi(ExcludedCommentsOnly value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -34,11 +34,7 @@ class InternalClassWithComments$Impl extends __lib.NativeBase implements Interna
   void internal_doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));
     final _handle = this.handle;
-    final __resultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeInternalclasswithcommentsToFfi(InternalClassWithComments value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -36,12 +36,8 @@ class MapScene_LoadSceneCallback$Impl {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MapScene_LoadSceneCallback_call__String'));
     final _p0Handle = stringToFfiNullable(p0);
     final _handle = this.handle;
-    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     stringReleaseFfiHandleNullable(_p0Handle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeMapsceneLoadscenecallbackcallStatic(Object _obj, Pointer<Void> p0) {
@@ -121,12 +117,8 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     final _mapSchemeHandle = (mapScheme);
     final _callbackHandle = smokeMapsceneLoadscenecallbackToFfiNullable(callback);
     final _handle = this.handle;
-    final __resultHandle = _loadSceneWithIntFfi(_handle, __lib.LibraryContext.isolateId, _mapSchemeHandle, _callbackHandle);
+    _loadSceneWithIntFfi(_handle, __lib.LibraryContext.isolateId, _mapSchemeHandle, _callbackHandle);
     smokeMapsceneLoadscenecallbackReleaseFfiHandleNullable(_callbackHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback) {
@@ -134,13 +126,9 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     final _configurationFileHandle = stringToFfi(configurationFile);
     final _callbackHandle = smokeMapsceneLoadscenecallbackToFfiNullable(callback);
     final _handle = this.handle;
-    final __resultHandle = _loadSceneWithStringFfi(_handle, __lib.LibraryContext.isolateId, _configurationFileHandle, _callbackHandle);
+    _loadSceneWithStringFfi(_handle, __lib.LibraryContext.isolateId, _configurationFileHandle, _callbackHandle);
     stringReleaseFfiHandle(_configurationFileHandle);
     smokeMapsceneLoadscenecallbackReleaseFfiHandleNullable(_callbackHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeMapsceneToFfi(MapScene value) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -191,21 +191,13 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
   void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));
     final _handle = this.handle;
-    final __resultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void doMagic() {
     final _doMagicFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic'));
     final _handle = this.handle;
-    final __resultHandle = _doMagicFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _doMagicFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   bool someMethodWithAllComments(String input) {
@@ -235,11 +227,7 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
   void someDeprecatedMethod() {
     final _someDeprecatedMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod'));
     final _handle = this.handle;
-    final __resultHandle = _someDeprecatedMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someDeprecatedMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokePlatformcommentsToFfi(PlatformComments value) =>

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -145,12 +145,8 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateProperty_set__Date'));
     final _valueHandle = dateToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     dateReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeDatesToFfi(Dates value) =>

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -165,7 +165,6 @@ final _methodWithErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __li
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_release_handle'));
-final _methodWithErrorsReturnGetResult = (Pointer) {};
 final _methodWithErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
@@ -178,7 +177,6 @@ final _methodWithExternalErrorsReturnReleaseHandle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_release_handle'));
-final _methodWithExternalErrorsReturnGetResult = (Pointer) {};
 final _methodWithExternalErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
@@ -207,7 +205,6 @@ final _methodWithPayloadErrorReturnReleaseHandle = __lib.catchArgumentError(() =
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_release_handle'));
-final _methodWithPayloadErrorReturnGetResult = (Pointer) {};
 final _methodWithPayloadErrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -248,12 +245,7 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
           smokeErrorsInternalerrorcodeReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithErrorsReturnGetResult(__callResultHandle);
     _methodWithErrorsReturnReleaseHandle(__callResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   static void methodWithExternalErrors() {
     final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors'));
@@ -267,12 +259,7 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
           smokeErrorsExternalerrorsReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithExternalErrorsReturnGetResult(__callResultHandle);
     _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   static String methodWithErrorsAndReturnValue() {
     final _methodWithErrorsAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue'));
@@ -306,12 +293,7 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
           smokePayloadReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithPayloadErrorReturnGetResult(__callResultHandle);
     _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   static String methodWithPayloadErrorAndReturnValue() {
     final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue'));

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -184,7 +184,6 @@ final _methodWithErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __li
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_release_handle'));
-final _methodWithErrorsReturnGetResult = (Pointer) {};
 final _methodWithErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
@@ -197,7 +196,6 @@ final _methodWithExternalErrorsReturnReleaseHandle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_release_handle'));
-final _methodWithExternalErrorsReturnGetResult = (Pointer) {};
 final _methodWithExternalErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
@@ -226,7 +224,6 @@ final _methodWithPayloadErrorReturnReleaseHandle = __lib.catchArgumentError(() =
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_release_handle'));
-final _methodWithPayloadErrorReturnGetResult = (Pointer) {};
 final _methodWithPayloadErrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -290,12 +287,7 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
           smokeErrorsinterfaceInternalerrorReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithErrorsReturnGetResult(__callResultHandle);
     _methodWithErrorsReturnReleaseHandle(__callResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void methodWithExternalErrors() {
@@ -311,12 +303,7 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
           smokeErrorsinterfaceExternalerrorsReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithExternalErrorsReturnGetResult(__callResultHandle);
     _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   String methodWithErrorsAndReturnValue() {
@@ -353,12 +340,7 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
           smokePayloadReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithPayloadErrorReturnGetResult(__callResultHandle);
     _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   static String methodWithPayloadErrorAndReturnValue() {

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -102,12 +102,8 @@ class Class$Impl extends __lib.NativeBase implements Class {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_package_Class_property_set__enum'));
     final _valueHandle = packageTypesEnumToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     packageTypesEnumReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> packageClassToFfi(Class value) =>

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -146,12 +146,8 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
   static void methodWithExternalEnum(Enums_ExternalEnum input) {
     final _methodWithExternalEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_1Enum'));
     final _inputHandle = smokeEnumsExternalenumToFfi(input);
-    final __resultHandle = _methodWithExternalEnumFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    _methodWithExternalEnumFfi(__lib.LibraryContext.isolateId, _inputHandle);
     smokeEnumsExternalenumReleaseFfiHandle(_inputHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeEnumsToFfi(Enums value) =>

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -148,11 +148,7 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
     final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalClass_someMethod__Byte'));
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;
-    final __resultHandle = _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
   }
   @override
   String get someProperty {

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -180,11 +180,7 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
     final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalInterface_someMethod__Byte'));
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;
-    final __resultHandle = _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
   }
   String get someProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someProperty_get'));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -216,12 +216,8 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_1Float'));
     final _valueHandle = foobarListofFloatToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofFloatReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   Map<double, double> get mapProperty {
@@ -239,12 +235,8 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_1Float_1to_1Double'));
     final _valueHandle = foobarMapofFloatToDoubleToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarMapofFloatToDoubleReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   Set<double> get setProperty {
@@ -262,12 +254,8 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_1Float'));
     final _valueHandle = foobarSetofFloatToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarSetofFloatReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeGenerictypeswithbasictypesToFfi(GenericTypesWithBasicTypes value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -36,11 +36,7 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
   void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod'));
     final _handle = this.handle;
-    final __resultHandle = _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeChildclassfromclassToFfi(ChildClassFromClass value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -36,21 +36,13 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
   void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));
     final _handle = this.handle;
-    final __resultHandle = _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
-    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   String get rootProperty {
@@ -68,12 +60,8 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeChildclassfrominterfaceToFfi(ChildClassFromInterface value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -76,21 +76,13 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
-    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void childMethod() {
     final _childMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod'));
     final _handle = this.handle;
-    final __resultHandle = _childMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _childMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
   String get rootProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
@@ -106,12 +98,8 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeChildinterfacerootMethodStatic(Object _obj) {

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -60,12 +60,8 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentWithClassReferences_classProperty_set__ParentClass'));
     final _valueHandle = smokeParentclassToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeParentclassReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeChildwithparentclassreferencesToFfi(ChildWithParentClassReferences value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -37,11 +37,7 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod'));
     final _handle = this.handle;
-    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   String get rootProperty {
@@ -59,12 +55,8 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentClass_rootProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeParentclassToFfi(ParentClass value) =>

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -70,11 +70,7 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
-    final __resultHandle = _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
   String get rootProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
@@ -90,12 +86,8 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeParentinterfacerootMethodStatic(Object _obj) {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -214,12 +214,8 @@ class Lambdas_Consumer$Impl {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String'));
     final _p0Handle = stringToFfi(p0);
     final _handle = this.handle;
-    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     stringReleaseFfiHandle(_p0Handle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeLambdasConsumercallStatic(Object _obj, Pointer<Void> p0) {

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -36,12 +36,8 @@ class LambdasWithStructuredTypes_ClassCallback$Impl {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface'));
     final _p0Handle = smokeLambdasinterfaceToFfi(p0);
     final _handle = this.handle;
-    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     smokeLambdasinterfaceReleaseFfiHandle(_p0Handle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeLambdaswithstructuredtypesClasscallbackcallStatic(Object _obj, Pointer<Void> p0) {
@@ -123,12 +119,8 @@ class LambdasWithStructuredTypes_StructCallback$Impl {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct'));
     final _p0Handle = smokeLambdasdeclarationorderSomestructToFfi(p0);
     final _handle = this.handle;
-    final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+    _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     smokeLambdasdeclarationorderSomestructReleaseFfiHandle(_p0Handle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeLambdaswithstructuredtypesStructcallbackcallStatic(Object _obj, Pointer<Void> p0) {
@@ -207,24 +199,16 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
     final _doClassStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback'));
     final _callbackHandle = smokeLambdaswithstructuredtypesClasscallbackToFfi(callback);
     final _handle = this.handle;
-    final __resultHandle = _doClassStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
+    _doClassStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
     smokeLambdaswithstructuredtypesClasscallbackReleaseFfiHandle(_callbackHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
     final _doStructStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback'));
     final _callbackHandle = smokeLambdaswithstructuredtypesStructcallbackToFfi(callback);
     final _handle = this.handle;
-    final __resultHandle = _doStructStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
+    _doStructStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
     smokeLambdaswithstructuredtypesStructcallbackReleaseFfiHandle(_callbackHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeLambdaswithstructuredtypesToFfi(LambdasWithStructuredTypes value) =>

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -161,70 +161,46 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _onCalculationResultFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResult__Double'));
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
-    final __resultHandle = _onCalculationResultFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _onCalculationResultFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
   }
   @override
   void onCalculationResultConst(double calculationResult) {
     final _onCalculationResultConstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double'));
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
-    final __resultHandle = _onCalculationResultConstFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _onCalculationResultConstFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
   }
   @override
   void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
     final _onCalculationResultStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct'));
     final _calculationResultHandle = smokeCalculatorlistenerResultstructToFfi(calculationResult);
     final _handle = this.handle;
-    final __resultHandle = _onCalculationResultStructFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    _onCalculationResultStructFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
     smokeCalculatorlistenerResultstructReleaseFfiHandle(_calculationResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void onCalculationResultArray(List<double> calculationResult) {
     final _onCalculationResultArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_1Double'));
     final _calculationResultHandle = foobarListofDoubleToFfi(calculationResult);
     final _handle = this.handle;
-    final __resultHandle = _onCalculationResultArrayFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    _onCalculationResultArrayFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
     foobarListofDoubleReleaseFfiHandle(_calculationResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void onCalculationResultMap(Map<String, double> calculationResults) {
     final _onCalculationResultMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_1String_1to_1Double'));
     final _calculationResultsHandle = foobarMapofStringToDoubleToFfi(calculationResults);
     final _handle = this.handle;
-    final __resultHandle = _onCalculationResultMapFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultsHandle);
+    _onCalculationResultMapFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultsHandle);
     foobarMapofStringToDoubleReleaseFfiHandle(_calculationResultsHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   void onCalculationResultInstance(CalculationResult calculationResult) {
     final _onCalculationResultInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult'));
     final _calculationResultHandle = smokeCalculationresultToFfi(calculationResult);
     final _handle = this.handle;
-    final __resultHandle = _onCalculationResultInstanceFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+    _onCalculationResultInstanceFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
     smokeCalculationresultReleaseFfiHandle(_calculationResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeCalculatorlisteneronCalculationResultStatic(Object _obj, double calculationResult) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -104,12 +104,8 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_regularProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   static String get staticProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticProperty_get'));
@@ -123,12 +119,8 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
   static set staticProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_staticProperty_set__String'));
     final _valueHandle = stringToFfi(value);
-    final __resultHandle = _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeInterfacewithstaticregularFunctionStatic(Object _obj, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -280,12 +280,8 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   CalculationResult get packedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_packedMessage_get'));
@@ -301,12 +297,8 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult'));
     final _valueHandle = smokeCalculationresultToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeCalculationresultReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   ListenerWithProperties_ResultStruct get structuredMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_structuredMessage_get'));
@@ -322,12 +314,8 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct'));
     final _valueHandle = smokeListenerwithpropertiesResultstructToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeListenerwithpropertiesResultstructReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   ListenerWithProperties_ResultEnum get enumeratedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_get'));
@@ -343,12 +331,8 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum'));
     final _valueHandle = smokeListenerwithpropertiesResultenumToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeListenerwithpropertiesResultenumReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   List<String> get arrayedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_arrayedMessage_get'));
@@ -364,12 +348,8 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_1String'));
     final _valueHandle = foobarListofStringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   Map<String, double> get mappedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get'));
@@ -385,12 +365,8 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_1String_1to_1Double'));
     final _valueHandle = foobarMapofStringToDoubleToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarMapofStringToDoubleReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   Uint8List get bufferedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_bufferedMessage_get'));
@@ -406,12 +382,8 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob'));
     final _valueHandle = blobToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     blobReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeListenerwithpropertiesmessageGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -122,12 +122,8 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeProperty_set__Locale'));
     final _valueHandle = localeToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     localeReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeLocalesToFfi(Locales value) =>

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -32,41 +32,25 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
   void create() {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create'));
     final _handle = this.handle;
-    final __resultHandle = _createFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _createFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void reallyRelease() {
     final _reallyReleaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release'));
     final _handle = this.handle;
-    final __resultHandle = _reallyReleaseFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _reallyReleaseFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void createProxy() {
     final _createProxyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy'));
     final _handle = this.handle;
-    final __resultHandle = _createProxyFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _createProxyFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   void Uppercase() {
     final _UppercaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase'));
     final _handle = this.handle;
-    final __resultHandle = _UppercaseFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _UppercaseFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeSpecialnamesToFfi(SpecialNames value) =>

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -12,7 +12,6 @@ final _doNothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_release_handle'));
-final _doNothingReturnGetResult = (Pointer) {};
 final _doNothingReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
@@ -38,12 +37,7 @@ class OuterStruct {
           smokeOuterstructInnerenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _doNothingReturnGetResult(__callResultHandle);
     _doNothingReturnReleaseHandle(__callResultHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 enum OuterStruct_InnerEnum {
@@ -115,12 +109,8 @@ class OuterStruct_InnerStruct {
   void doSomething() {
     final _doSomethingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerStruct_doSomething'));
     final _handle = smokeOuterstructInnerstructToFfi(this);
-    final __resultHandle = _doSomethingFfi(_handle, __lib.LibraryContext.isolateId);
+    _doSomethingFfi(_handle, __lib.LibraryContext.isolateId);
     smokeOuterstructInnerstructReleaseFfiHandle(_handle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 // OuterStruct_InnerStruct "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -604,12 +604,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String'));
     final _valueHandle = stringToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   bool? get isBoolProperty {
@@ -627,12 +623,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean'));
     final _valueHandle = booleanToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   double? get doubleProperty {
@@ -650,12 +642,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double'));
     final _valueHandle = doubleToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     doubleReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   int? get intProperty {
@@ -673,12 +661,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long'));
     final _valueHandle = longToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     longReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   Nullable_SomeStruct? get structProperty {
@@ -696,12 +680,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct'));
     final _valueHandle = smokeNullableSomestructToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeNullableSomestructReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   Nullable_SomeEnum? get enumProperty {
@@ -719,12 +699,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum'));
     final _valueHandle = smokeNullableSomeenumToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeNullableSomeenumReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   List<String>? get arrayProperty {
@@ -742,12 +718,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_1String'));
     final _valueHandle = foobarListofStringToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   List<String>? get inlineArrayProperty {
@@ -765,12 +737,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_1String'));
     final _valueHandle = foobarListofStringToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   Map<int, String>? get mapProperty {
@@ -788,12 +756,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_1Long_1to_1String'));
     final _valueHandle = foobarMapofLongToStringToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarMapofLongToStringReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   SomeInterface? get instanceProperty {
@@ -811,12 +775,8 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface'));
     final _valueHandle = smokeSomeinterfaceToFfiNullable(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeSomeinterfaceReleaseFfiHandleNullable(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeNullableToFfi(Nullable value) =>

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -69,11 +69,7 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_PlatformNamesInterface_basicProperty_set__UInt'));
     final _valueHandle = (value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
   }
 }
 Pointer<Void> smokePlatformnamesinterfaceToFfi(weeInterface value) =>

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -57,12 +57,8 @@ class weeListener$Impl extends __lib.NativeBase implements weeListener {
     final _WeeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String'));
     final _WeeParameterHandle = stringToFfi(WeeParameter);
     final _handle = this.handle;
-    final __resultHandle = _WeeMethodFfi(_handle, __lib.LibraryContext.isolateId, _WeeParameterHandle);
+    _WeeMethodFfi(_handle, __lib.LibraryContext.isolateId, _WeeParameterHandle);
     stringReleaseFfiHandle(_WeeParameterHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokePlatformnameslistenerWeeMethodStatic(Object _obj, Pointer<Void> WeeParameter) {

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -182,11 +182,7 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt'));
     final _valueHandle = (value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
   }
   @override
   double get readonlyProperty {
@@ -214,12 +210,8 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct'));
     final _valueHandle = smokePropertiesExamplestructToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesExamplestructReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   List<String> get arrayProperty {
@@ -237,12 +229,8 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_1String'));
     final _valueHandle = foobarListofStringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   Properties_InternalErrorCode get complexTypeProperty {
@@ -260,12 +248,8 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode'));
     final _valueHandle = smokePropertiesInternalerrorcodeToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesInternalerrorcodeReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   Uint8List get byteBufferProperty {
@@ -283,12 +267,8 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob'));
     final _valueHandle = blobToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     blobReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   PropertiesInterface get instanceProperty {
@@ -306,12 +286,8 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface'));
     final _valueHandle = smokePropertiesinterfaceToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesinterfaceReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   bool get isBooleanProperty {
@@ -329,12 +305,8 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   static String get staticProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticProperty_get'));
@@ -348,12 +320,8 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
   static set staticProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String'));
     final _valueHandle = stringToFfi(value);
-    final __resultHandle = _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   static Properties_ExampleStruct get staticReadonlyProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticReadonlyProperty_get'));

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -134,12 +134,8 @@ class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInt
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct'));
     final _valueHandle = smokePropertiesinterfaceExamplestructToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesinterfaceExamplestructReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokePropertiesinterfacestructPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -33,59 +33,31 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
   void release() {}
   static void enableIfUnquoted() {
     final _enableIfUnquotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquoted'));
-    final __resultHandle = _enableIfUnquotedFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _enableIfUnquotedFfi(__lib.LibraryContext.isolateId);
   }
   static void enableIfUnquotedList() {
     final _enableIfUnquotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquotedList'));
-    final __resultHandle = _enableIfUnquotedListFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _enableIfUnquotedListFfi(__lib.LibraryContext.isolateId);
   }
   static void enableIfQuoted() {
     final _enableIfQuotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuoted'));
-    final __resultHandle = _enableIfQuotedFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _enableIfQuotedFfi(__lib.LibraryContext.isolateId);
   }
   static void enableIfQuotedList() {
     final _enableIfQuotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuotedList'));
-    final __resultHandle = _enableIfQuotedListFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _enableIfQuotedListFfi(__lib.LibraryContext.isolateId);
   }
   static void enableIfTagged() {
     final _enableIfTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTagged'));
-    final __resultHandle = _enableIfTaggedFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _enableIfTaggedFfi(__lib.LibraryContext.isolateId);
   }
   static void enableIfTaggedList() {
     final _enableIfTaggedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTaggedList'));
-    final __resultHandle = _enableIfTaggedListFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _enableIfTaggedListFfi(__lib.LibraryContext.isolateId);
   }
   static void enableIfMixedList() {
     final _enableIfMixedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfMixedList'));
-    final __resultHandle = _enableIfMixedListFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _enableIfMixedListFfi(__lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeEnableifenabledToFfi(EnableIfEnabled value) =>

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -123,12 +123,8 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   bool get isSkippedInSwift {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
@@ -144,12 +140,8 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeInheritfromskippednotInJavaStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -128,12 +128,8 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   bool get isSkippedInSwift {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
@@ -149,12 +145,8 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 int _smokeSkipproxynotInJavaStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -48,11 +48,7 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
   void voidFunction() {
     final _voidFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SomeClass_voidFunction'));
     final _handle = this.handle;
-    final __resultHandle = _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   bool boolFunction() {
@@ -99,11 +95,7 @@ class SomeClass$Impl extends __lib.NativeBase implements SomeClass {
   }
   void staticFunction() {
     final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_SomeClass_staticFunction'));
-    final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _staticFunctionFfi(__lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeSomeclassToFfi(SomeClass value) =>

--- a/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_structs/output/dart/lib/src/smoke/struct_with_methods.dart
@@ -18,12 +18,8 @@ class StructWithMethods$Impl {
   void voidFunction() {
     final _voidFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_voidFunction'));
     final _handle = smokeStructwithmethodsToFfi(this);
-    final __resultHandle = _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+    _voidFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     smokeStructwithmethodsReleaseFfiHandle(_handle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   bool boolFunction() {
     final _boolFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_StructWithMethods_boolFunction'));
@@ -70,11 +66,7 @@ class StructWithMethods$Impl {
   }
   void staticFunction() {
     final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_StructWithMethods_staticFunction'));
-    final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _staticFunctionFfi(__lib.LibraryContext.isolateId);
   }
 }
 // StructWithMethods "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -239,12 +239,8 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_1Double'));
     final _valueHandle = foobarListofDoubleToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofDoubleReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeTypedefsToFfi(TypeDefs value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -31,11 +31,7 @@ class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
   void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));
     final _handle = this.handle;
-    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 Pointer<Void> smokeInternalclassToFfi(InternalClass value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -44,11 +44,7 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
   void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar'));
     final _handle = this.handle;
-    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
   }
   static Pointer<Void> _make() {
     final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithFunctions_make'));

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -42,12 +42,8 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
   static set internal_fooBar(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String'));
     final _valueHandle = stringToFfi(value);
-    final __resultHandle = _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokeInternalclasswithstaticpropertyToFfi(InternalClassWithStaticProperty value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -58,11 +58,7 @@ class InternalInterface$Impl extends __lib.NativeBase implements InternalInterfa
   void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));
     final _handle = this.handle;
-    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
+    _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
   }
 }
 int _smokeInternalinterfacefooBarStatic(Object _obj) {

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -329,12 +329,8 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct'));
     final _valueHandle = smokePublicclassInternalstructToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePublicclassInternalstructReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
   @override
   String get internalSetterProperty {
@@ -352,12 +348,8 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
-    final __resultHandle = _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 Pointer<Void> smokePublicclassToFfi(PublicClass value) =>

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -10,12 +10,8 @@ class InternalStruct {
   void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PublicTypeCollection_InternalStruct_fooBar'));
     final _handle = smokePublictypecollectionInternalstructToFfi(this);
-    final __resultHandle = _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
+    _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
     smokePublictypecollectionInternalstructReleaseFfiHandle(_handle);
-    try {
-      return (__resultHandle);
-    } finally {
-    }
   }
 }
 // InternalStruct "private" section, not exported.


### PR DESCRIPTION
Updated Dart templates to avoid returning `void` explicitly from functions. While Dart syntax allows such return
statements, they don't do anything useful and are just dead code.

Updated smoke tests.

See: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>