### PR TITLE
Use new Gradle dependency syntax to avoid deprecation warnings

### DIFF
--- a/gluecodium-gradle/build.gradle
+++ b/gluecodium-gradle/build.gradle
@@ -7,16 +7,17 @@ repositories {
 }
 
 dependencies {
-    compile project(":gluecodium")
+    implementation project(":gluecodium")
 
-    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
-    compile('com.android.tools.build:gradle:4.1.2') {
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
+    implementation('com.android.tools.build:gradle:4.1.2') {
         exclude group: 'net.sf.proguard', module: 'proguard-gradle'
     }
+    implementation 'com.natpryce:konfig:1.6.10.0'
 
-    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testCompile 'io.mockk:mockk:1.10.0'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testImplementation 'io.mockk:mockk:1.10.0'
+    testImplementation 'junit:junit:4.12'
 }
 
 gradlePlugin {

--- a/gluecodium/build.gradle
+++ b/gluecodium/build.gradle
@@ -21,27 +21,27 @@ plugins {
     id "com.lazan.dependency-export" version "0.5"
 }
 dependencies {
-    compile project(":lime-runtime")
-    compile project(":lime-loader")
+    api project(":lime-runtime")
+    implementation project(":lime-loader")
 
-    compile 'com.android.tools:annotations:25.3.0'
-    compile 'com.google.guava:guava:29.0-jre'
-    compile 'com.natpryce:konfig:1.6.10.0'
-    compile 'com.vladsch.flexmark:flexmark-util:0.62.2'
-    compile 'com.vladsch.flexmark:flexmark:0.62.2'
-    compile 'commons-cli:commons-cli:1.4'
-    compile 'org.apache.logging.log4j:log4j-core:2.14.1'
-    compile 'org.jetbrains.kotlin:kotlin-reflect:1.4.32'
-    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
-    compile 'org.jetbrains:annotations:13.0'
-    compile 'org.slf4j:slf4j-api:1.7.31'
-    compile 'org.slf4j:slf4j-log4j12:1.7.31'
-    compile 'org.trimou:trimou-core:2.5.0.Final'
+    compileOnly 'com.android.tools:annotations:25.3.0'
+    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.natpryce:konfig:1.6.10.0'
+    implementation 'com.vladsch.flexmark:flexmark-util:0.62.2'
+    implementation 'com.vladsch.flexmark:flexmark:0.62.2'
+    implementation 'commons-cli:commons-cli:1.4'
+    implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.4.32'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
+    implementation 'org.jetbrains:annotations:13.0'
+    implementation 'org.slf4j:slf4j-api:1.7.31'
+    implementation 'org.slf4j:slf4j-log4j12:1.7.31'
+    implementation 'org.trimou:trimou-core:2.5.0.Final'
 
-    testCompile files({ project(":lime-runtime").sourceSets.test.output })
-    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testCompile 'io.mockk:mockk:1.10.0'
-    testCompile 'junit:junit:4.12'
+    testImplementation files({ project(":lime-runtime").sourceSets.test.output })
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testImplementation 'io.mockk:mockk:1.10.0'
+    testImplementation 'junit:junit:4.12'
 }
 
 apply plugin: 'application'
@@ -50,7 +50,7 @@ mainClassName = 'com.here.gluecodium.Gluecodium'
 jar {
     manifest {
         attributes('Main-Class': 'com.here.gluecodium.Gluecodium',
-                   'Class-Path': configurations.runtime.files.collect { it.getName() }.join(' '))
+                   'Class-Path': configurations.runtimeClasspath.files.collect { it.getName() }.join(' '))
     }
 }
 

--- a/lime-loader/build.gradle
+++ b/lime-loader/build.gradle
@@ -4,14 +4,14 @@ plugins {
 
 dependencies {
     antlr "org.antlr:antlr4:4.9.1"
-    compile project(":lime-runtime")
-    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
-    compile "org.antlr:antlr4-runtime:4.9.1"
+    api project(":lime-runtime")
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
+    implementation "org.antlr:antlr4-runtime:4.9.1"
 
-    testCompile files({ project(":lime-runtime").sourceSets.test.output })
-    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testCompile 'io.mockk:mockk:1.10.0'
-    testCompile 'junit:junit:4.12'
+    testImplementation files({ project(":lime-runtime").sourceSets.test.output })
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testImplementation 'io.mockk:mockk:1.10.0'
+    testImplementation 'junit:junit:4.12'
 }
 
 generateGrammarSource {

--- a/lime-runtime/build.gradle
+++ b/lime-runtime/build.gradle
@@ -18,12 +18,12 @@
  */
 
 dependencies {
-    compile 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
-    compile 'org.jetbrains:annotations:13.0'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
+    compileOnly 'org.jetbrains:annotations:13.0'
 
-    testCompile 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testCompile 'io.mockk:mockk:1.10.0'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
+    testImplementation 'io.mockk:mockk:1.10.0'
+    testImplementation 'junit:junit:4.12'
 }
 
 javadoc.enabled = false


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>