### PR TITLE
Improve smoke tests to use snippets as reference

### DIFF
--- a/gluecodium/build.gradle
+++ b/gluecodium/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
     testImplementation 'io.mockk:mockk:1.10.0'
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
 }
 
 apply plugin: 'application'

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/com/example/smoke/BasicTypes.java
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/com/example/smoke/BasicTypes.java
@@ -1,23 +1,3 @@
-/*
- *
- */
-package com.example.smoke;
-import android.support.annotation.NonNull;
-import com.example.NativeBase;
-public final class BasicTypes extends NativeBase {
-    /**
-     * For internal use only.
-     * @exclude
-     */
-    protected BasicTypes(final long nativeHandle, final Object dummy) {
-        super(nativeHandle, new Disposer() {
-            @Override
-            public void disposeNative(long handle) {
-                disposeNativeHandle(handle);
-            }
-        });
-    }
-    private static native void disposeNativeHandle(long nativeHandle);
     @NonNull
     public static native String stringFunction(@NonNull final String input);
     public static native boolean boolFunction(final boolean input);
@@ -31,4 +11,3 @@ public final class BasicTypes extends NativeBase {
     public static native int ushortFunction(final int input);
     public static native long uintFunction(final long input);
     public static native long ulongFunction(final long input);
-}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
@@ -1,13 +1,3 @@
-/*
- *
- */
-#include "com_example_smoke_BasicTypes.h"
-#include "com_example_smoke_BasicTypes__Conversion.h"
-#include "ArrayConversionUtils.h"
-#include "JniClassCache.h"
-#include "JniReference.h"
-#include "JniWrapperCache.h"
-extern "C" {
 jstring
 Java_com_example_smoke_BasicTypes_stringFunction(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
 {
@@ -93,12 +83,4 @@ Java_com_example_smoke_BasicTypes_ulongFunction(JNIEnv* _jenv, jobject _jinstanc
     uint64_t input = jinput;
     auto result = ::smoke::BasicTypes::ulong_function(input);
     return result;
-}
-JNIEXPORT void JNICALL
-Java_com_example_smoke_BasicTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
-{
-    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::BasicTypes>*>(_jpointerRef);
-    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
-    delete p_nobj;
-}
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.h
@@ -1,7 +1,3 @@
-/*
- *
- */
-#pragma once
 #include <jni.h>
 #ifdef __cplusplus
 extern "C" {

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/include/smoke/cbridge_BasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/include/smoke/cbridge_BasicTypes.h
@@ -1,6 +1,3 @@
-//
-//
-#pragma once
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -8,11 +5,9 @@ extern "C" {
 #include "cbridge/include/Export.h"
 #include <stdbool.h>
 #include <stdint.h>
-_GLUECODIUM_C_EXPORT void smoke_BasicTypes_release_handle(_baseRef handle);
-_GLUECODIUM_C_EXPORT _baseRef smoke_BasicTypes_copy_handle(_baseRef handle);
-_GLUECODIUM_C_EXPORT const void* smoke_BasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle);
-_GLUECODIUM_C_EXPORT void smoke_BasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
-_GLUECODIUM_C_EXPORT void smoke_BasicTypes_remove_swift_object_from_wrapper_cache(_baseRef handle);
+
+{{SKIP}}
+
 _GLUECODIUM_C_EXPORT _baseRef smoke_BasicTypes_stringFunction(_baseRef input);
 _GLUECODIUM_C_EXPORT bool smoke_BasicTypes_boolFunction(bool input);
 _GLUECODIUM_C_EXPORT float smoke_BasicTypes_floatFunction(float input);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cbridge/src/smoke/cbridge_BasicTypes.cpp
@@ -1,7 +1,5 @@
-//
-//
 #include "cbridge/include/smoke/cbridge_BasicTypes.h"
-#include "cbridge\include\StringHandle.h"
+#include "cbridge/include/StringHandle.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
 #include "cbridge_internal/include/TypeInitRepository.h"
 #include "cbridge_internal/include/WrapperCache.h"
@@ -10,27 +8,9 @@
 #include <memory>
 #include <new>
 #include <string>
-void smoke_BasicTypes_release_handle(_baseRef handle) {
-    delete get_pointer<::std::shared_ptr< ::smoke::BasicTypes >>(handle);
-}
-_baseRef smoke_BasicTypes_copy_handle(_baseRef handle) {
-    return handle
-        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::BasicTypes >>(handle)))
-        : 0;
-}
-const void* smoke_BasicTypes_get_swift_object_from_wrapper_cache(_baseRef handle) {
-    return handle
-        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::BasicTypes >>(handle)->get())
-        : nullptr;
-}
-void smoke_BasicTypes_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
-    if (!handle) return;
-    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::BasicTypes >>(handle)->get(), swift_pointer);
-}
-void smoke_BasicTypes_remove_swift_object_from_wrapper_cache(_baseRef handle) {
-    if (!::gluecodium::WrapperCache::is_alive) return;
-    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::BasicTypes >>(handle)->get());
-}
+
+{{SKIP}}
+
 _baseRef smoke_BasicTypes_stringFunction(_baseRef input) {
     return Conversion<::std::string>::toBaseRef(::smoke::BasicTypes::string_function(Conversion<::std::string>::toCpp(input)));
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/BasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/BasicTypes.h
@@ -1,17 +1,8 @@
-// -------------------------------------------------------------------------------------------------
-//
-//
-// -------------------------------------------------------------------------------------------------
-#pragma once
-#include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <string>
-namespace smoke {
-class _GLUECODIUM_CPP_EXPORT BasicTypes {
-public:
-    BasicTypes();
-    virtual ~BasicTypes() = 0;
-public:
+
+{{SKIP}}
+
     static ::std::string string_function( const ::std::string& input );
     static bool bool_function( const bool input );
     static float float_function( const float input );
@@ -24,5 +15,3 @@ public:
     static uint16_t ushort_function( const uint16_t input );
     static uint32_t uint_function( const uint32_t input );
     static uint64_t ulong_function( const uint64_t input );
-};
-}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
@@ -1,34 +1,3 @@
-// -------------------------------------------------------------------------------------------------
-//
-//
-// -------------------------------------------------------------------------------------------------
-#pragma once
-#include "gluecodium/ExportGluecodiumCpp.h"
-#include "gluecodium/Optional.h"
-#include "gluecodium/Return.h"
-#include <cstdint>
-#include <memory>
-#include <string>
-#include <system_error>
-namespace smoke {
-    class CppRefReturnType;
-}
-namespace smoke {
-class _GLUECODIUM_CPP_EXPORT CppRefReturnType {
-public:
-    CppRefReturnType();
-    virtual ~CppRefReturnType() = 0;
-public:
-    enum class InternalError {
-        FOO,
-        BAR
-    };
-    struct _GLUECODIUM_CPP_EXPORT SomeStruct {
-        ::std::string field;
-        SomeStruct( );
-        SomeStruct( ::std::string field );
-    };
-public:
     static void void_ref(  );
     static const bool& bool_ref(  );
     static const ::std::string& string_ref(  );
@@ -44,11 +13,3 @@ public:
     static ::gluecodium::Return< void, ::smoke::CppRefReturnType::SomeStruct > throwing_struct_with_void(  );
     static ::gluecodium::Return< const ::std::string&, ::smoke::CppRefReturnType::SomeStruct > throwing_struct_with_string(  );
     static const ::std::string& get_string_property(  );
-};
-_GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::CppRefReturnType::InternalError value ) noexcept;
-}
-namespace std
-{
-template <>
-struct is_error_code_enum< ::smoke::CppRefReturnType::InternalError > : public std::true_type { };
-}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnTypeStruct.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnTypeStruct.h
@@ -1,12 +1,3 @@
-// -------------------------------------------------------------------------------------------------
-//
-//
-// -------------------------------------------------------------------------------------------------
-#pragma once
-#include "gluecodium/ExportGluecodiumCpp.h"
-#include <string>
-namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT CppRefReturnTypeStruct {
     static const ::std::string& string_ref(  );
 };
-}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/StringsWithCstring.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/StringsWithCstring.h
@@ -1,16 +1,3 @@
-// -------------------------------------------------------------------------------------------------
-//
-//
-// -------------------------------------------------------------------------------------------------
-#pragma once
-#include "gluecodium/ExportGluecodiumCpp.h"
-#include <string>
-namespace smoke {
-class _GLUECODIUM_CPP_EXPORT StringsWithCstring {
-public:
-    StringsWithCstring();
-    virtual ~StringsWithCstring() = 0;
-public:
     /**
      * Method that takes a C string as input and returns an std::string it as output.
      * \param[in] input_string
@@ -23,5 +10,3 @@ public:
      * \return
      */
     static ::std::string return_input_string( const ::std::string& input_string );
-};
-}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/ffi/ffi_smoke_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/ffi/ffi_smoke_BasicTypes.cpp
@@ -120,30 +120,3 @@ library_smoke_BasicTypes_ulongFunction__ULong(int32_t _isolate_id, uint64_t inpu
         )
     );
 }
-// "Private" finalizer, not exposed to be callable from Dart.
-void
-library_smoke_BasicTypes_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
-    auto ptr_ptr = reinterpret_cast<std::shared_ptr<::smoke::BasicTypes>*>(handle);
-    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
-    library_smoke_BasicTypes_release_handle(handle);
-}
-void
-library_smoke_BasicTypes_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
-    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_BasicTypes_finalizer};
-    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
-}
-FfiOpaqueHandle
-library_smoke_BasicTypes_copy_handle(FfiOpaqueHandle handle) {
-    return reinterpret_cast<FfiOpaqueHandle>(
-        new (std::nothrow) std::shared_ptr<::smoke::BasicTypes>(
-            *reinterpret_cast<std::shared_ptr<::smoke::BasicTypes>*>(handle)
-        )
-    );
-}
-void
-library_smoke_BasicTypes_release_handle(FfiOpaqueHandle handle) {
-    delete reinterpret_cast<std::shared_ptr<::smoke::BasicTypes>*>(handle);
-}
-#ifdef __cplusplus
-}
-#endif

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/ffi/ffi_smoke_BasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/ffi/ffi_smoke_BasicTypes.h
@@ -1,7 +1,3 @@
-#pragma once
-#include "Export.h"
-#include "OpaqueHandle.h"
-#include "dart_api_dl.h"
 #include <stdint.h>
 #ifdef __cplusplus
 extern "C" {
@@ -18,10 +14,3 @@ _GLUECODIUM_FFI_EXPORT uint8_t library_smoke_BasicTypes_ubyteFunction__UByte(int
 _GLUECODIUM_FFI_EXPORT uint16_t library_smoke_BasicTypes_ushortFunction__UShort(int32_t _isolate_id, uint16_t input);
 _GLUECODIUM_FFI_EXPORT uint32_t library_smoke_BasicTypes_uintFunction__UInt(int32_t _isolate_id, uint32_t input);
 _GLUECODIUM_FFI_EXPORT uint64_t library_smoke_BasicTypes_ulongFunction__ULong(int32_t _isolate_id, uint64_t input);
-_GLUECODIUM_FFI_EXPORT void library_smoke_BasicTypes_register_finalizer(
-    FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle);
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_BasicTypes_copy_handle(FfiOpaqueHandle handle);
-_GLUECODIUM_FFI_EXPORT void library_smoke_BasicTypes_release_handle(FfiOpaqueHandle handle);
-#ifdef __cplusplus
-}
-#endif

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -1,42 +1,3 @@
-import 'dart:ffi';
-import 'package:library/src/_library_context.dart' as __lib;
-import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
-abstract class BasicTypes {
-  /// @nodoc
-  @Deprecated("Does nothing")
-  void release();
-  static String stringFunction(String input) => BasicTypes$Impl.stringFunction(input);
-  static bool boolFunction(bool input) => BasicTypes$Impl.boolFunction(input);
-  static double floatFunction(double input) => BasicTypes$Impl.floatFunction(input);
-  static double doubleFunction(double input) => BasicTypes$Impl.doubleFunction(input);
-  static int byteFunction(int input) => BasicTypes$Impl.byteFunction(input);
-  static int shortFunction(int input) => BasicTypes$Impl.shortFunction(input);
-  static int intFunction(int input) => BasicTypes$Impl.intFunction(input);
-  static int longFunction(int input) => BasicTypes$Impl.longFunction(input);
-  static int ubyteFunction(int input) => BasicTypes$Impl.ubyteFunction(input);
-  static int ushortFunction(int input) => BasicTypes$Impl.ushortFunction(input);
-  static int uintFunction(int input) => BasicTypes$Impl.uintFunction(input);
-  static int ulongFunction(int input) => BasicTypes$Impl.ulongFunction(input);
-}
-// BasicTypes "private" section, not exported.
-final _smokeBasictypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>, Int32, Handle),
-    void Function(Pointer<Void>, int, Object)
-  >('library_smoke_BasicTypes_register_finalizer'));
-final _smokeBasictypesCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Pointer<Void>),
-    Pointer<Void> Function(Pointer<Void>)
-  >('library_smoke_BasicTypes_copy_handle'));
-final _smokeBasictypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Void Function(Pointer<Void>),
-    void Function(Pointer<Void>)
-  >('library_smoke_BasicTypes_release_handle'));
-class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
-  BasicTypes$Impl(Pointer<Void> handle) : super(handle);
-  @override
-  void release() {}
   static String stringFunction(String input) {
     final _stringFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String'));
     final _inputHandle = stringToFfi(input);
@@ -149,24 +110,3 @@ class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
     } finally {
     }
   }
-}
-Pointer<Void> smokeBasictypesToFfi(BasicTypes value) =>
-  _smokeBasictypesCopyHandle((value as __lib.NativeBase).handle);
-BasicTypes smokeBasictypesFromFfi(Pointer<Void> handle) {
-  final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is BasicTypes) return instance as BasicTypes;
-  final _copiedHandle = _smokeBasictypesCopyHandle(handle);
-  final result = BasicTypes$Impl(_copiedHandle);
-  __lib.cacheInstance(_copiedHandle, result);
-  _smokeBasictypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
-  return result;
-}
-void smokeBasictypesReleaseFfiHandle(Pointer<Void> handle) =>
-  _smokeBasictypesReleaseHandle(handle);
-Pointer<Void> smokeBasictypesToFfiNullable(BasicTypes? value) =>
-  value != null ? smokeBasictypesToFfi(value) : Pointer<Void>.fromAddress(0);
-BasicTypes? smokeBasictypesFromFfiNullable(Pointer<Void> handle) =>
-  handle.address != 0 ? smokeBasictypesFromFfi(handle) : null;
-void smokeBasictypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
-  _smokeBasictypesReleaseHandle(handle);
-// End of BasicTypes "private" section.

--- a/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/swift/smoke/BasicTypes.swift
@@ -1,18 +1,3 @@
-//
-//
-import Foundation
-public class BasicTypes {
-    let c_instance : _baseRef
-    init(cBasicTypes: _baseRef) {
-        guard cBasicTypes != 0 else {
-            fatalError("Nullptr value is not supported for initializers")
-        }
-        c_instance = cBasicTypes
-    }
-    deinit {
-        smoke_BasicTypes_remove_swift_object_from_wrapper_cache(c_instance)
-        smoke_BasicTypes_release_handle(c_instance)
-    }
     public static func stringFunction(input: String) -> String {
         let c_input = moveToCType(input)
         let c_result_handle = smoke_BasicTypes_stringFunction(c_input.ref)
@@ -73,70 +58,4 @@ public class BasicTypes {
         let c_result_handle = smoke_BasicTypes_ulongFunction(c_input.ref)
         return moveFromCType(c_result_handle)
     }
-}
-internal func getRef(_ ref: BasicTypes?, owning: Bool = true) -> RefHolder {
-    guard let c_handle = ref?.c_instance else {
-        return RefHolder(0)
-    }
-    let handle_copy = smoke_BasicTypes_copy_handle(c_handle)
-    return owning
-        ? RefHolder(ref: handle_copy, release: smoke_BasicTypes_release_handle)
-        : RefHolder(handle_copy)
-}
-extension BasicTypes: NativeBase {
-    /// :nodoc:
-    var c_handle: _baseRef { return c_instance }
-}
-extension BasicTypes: Hashable {
-    /// :nodoc:
-    public static func == (lhs: BasicTypes, rhs: BasicTypes) -> Bool {
-        return lhs.c_handle == rhs.c_handle
-    }
-    /// :nodoc:
-    public func hash(into hasher: inout Hasher) {
-        hasher.combine(c_handle)
-    }
-}
-internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes {
-    if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
-        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {
-        return re_constructed
-    }
-    let result = BasicTypes(cBasicTypes: smoke_BasicTypes_copy_handle(handle))
-    smoke_BasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
-    return result
-}
-internal func BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes {
-    if let swift_pointer = smoke_BasicTypes_get_swift_object_from_wrapper_cache(handle),
-        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? BasicTypes {
-        smoke_BasicTypes_release_handle(handle)
-        return re_constructed
-    }
-    let result = BasicTypes(cBasicTypes: handle)
-    smoke_BasicTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
-    return result
-}
-internal func BasicTypes_copyFromCType(_ handle: _baseRef) -> BasicTypes? {
-    guard handle != 0 else {
-        return nil
-    }
-    return BasicTypes_moveFromCType(handle) as BasicTypes
-}
-internal func BasicTypes_moveFromCType(_ handle: _baseRef) -> BasicTypes? {
-    guard handle != 0 else {
-        return nil
-    }
-    return BasicTypes_moveFromCType(handle) as BasicTypes
-}
-internal func copyToCType(_ swiftClass: BasicTypes) -> RefHolder {
-    return getRef(swiftClass, owning: false)
-}
-internal func moveToCType(_ swiftClass: BasicTypes) -> RefHolder {
-    return getRef(swiftClass, owning: true)
-}
-internal func copyToCType(_ swiftClass: BasicTypes?) -> RefHolder {
-    return getRef(swiftClass, owning: false)
-}
-internal func moveToCType(_ swiftClass: BasicTypes?) -> RefHolder {
-    return getRef(swiftClass, owning: true)
 }


### PR DESCRIPTION
Updated SmokeTest and NiceErrorCollector classes to support comparing generated code against reference code snippets
(partial files) instead of full reference files as before. This approach is backwards-compatible with the old one, as
full files are still valid "snippets".

This allows excluding parts of the reference file that are not relevant to the feature-under-test in each test case.
Which, in turn, reduces maintenance load by reducing the number and the size of reference files affected by each change.

As a demonstration of this approach, updated "basic types" smoke test to use snippets.

See: #953
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
