### PR TITLE
Fix Dart FFI missing include for top-level lambdas

### DIFF
--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -25,6 +25,8 @@
 #include "ConversionBase.h"
 {{#if classes}}
 #include "InstanceCache.h"
+{{/if}}
+{{#if classes lambdas logic="or"}}
 #include "FinalizerData.h"
 {{/if}}
 {{#includes}}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/ffi/ffi_smoke_StandaloneProducer.cpp
@@ -1,5 +1,6 @@
 #include "ffi_smoke_StandaloneProducer.h"
 #include "ConversionBase.h"
+#include "FinalizerData.h"
 #include "CallbacksQueue.h"
 #include "IsolateContext.h"
 #include "ProxyCache.h"


### PR DESCRIPTION
Updated Dart "FfiImplementation" template to have "FinalizerData.h" include when lambdas are present. This fixes a
compilation issue where this include is missing if there are no classes or interfaces present, only lambdas.

The issue was introduced with "automatic finalizers for lmabdas" feature, which is not released yet, so no separate
changelog entry is added for the fix itself.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>