### PR TITLE
Fix the crash for overloads of a skipped function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   * Fixed "dart analyze" warning about unnecessary cast in the class/interface equality operator.
   * In Dart there is now less dead code generated for functions returning `void`. This also fixes a corresponding "dart
     analyze" warning.
+  * Fixed Gluecodium crash caused by a documentation comment on a function parameter when another overload of this
+    function is skipped.
 
 ## 9.2.0
 Release date: 2021-06-22

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipOverloads.lime
@@ -1,0 +1,30 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct SkipOverloads {
+    dummy: Double
+
+    fun doFoo(
+        // Must have a comment to trigger the bug
+        input: Double
+    )
+
+    @Skip("Lite")
+    fun doFoo()
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
@@ -58,8 +58,14 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
     fun filter(): LimeModel {
         val topElements = limeModel.topElements.filter(predicate).map { filterTopElement(it) }
         val auxiliaryElements = limeModel.auxiliaryElements.filter(predicate).map { filterTopElement(it) }
+
         // Has to be filtered last, when [droppedElements] is already filled.
-        val referenceMap = limeModel.referenceMap.filterValues { refMapPredicate(it) }
+        val referenceMap = limeModel.referenceMap.filterValues { refMapPredicate(it) }.toMutableMap()
+        // Restore ambiguous keys if some of the non-ambiguous entries are still present.
+        referenceMap.entries
+            .filter { it.key.contains(":") }
+            .sortedBy { it.key }
+            .forEach { referenceMap.putIfAbsent(it.key.split(":").first(), it.value) }
 
         return LimeModel(referenceMap, topElements, auxiliaryElements, limeModel.fileNameMap)
     }


### PR DESCRIPTION
Updated LimeModelFilter to restore "ambiguous" keys in the reference map if some of the related non-ambigous keys are
still present in the map after filtering. This fixes the issue where Gluecodium crashes while trying to parse a
documentation comment on a function parameter when another overload of this function is skipped.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>