### PR TITLE
Make `Date` type "hashable"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     analyze" warning.
   * Fixed Gluecodium crash caused by a documentation comment on a function parameter when another overload of this
     function is skipped.
+  * Fixed validation issue that prevented usage of `Date` type in `Set<Date>` and `Map<Date, SomeType>` collections.
 
 ## 9.2.0
 Release date: 2021-06-22

--- a/functional-tests/functional/input/lime/Dates.lime
+++ b/functional-tests/functional/input/lime/Dates.lime
@@ -35,4 +35,5 @@ class Dates {
         input: Date?
     ): Date?
     static property dateAttribute: Date
+    static property dateSet: Set<Date>
 }

--- a/functional-tests/functional/input/src/cpp/Dates.cpp
+++ b/functional-tests/functional/input/src/cpp/Dates.cpp
@@ -25,6 +25,7 @@ namespace test
 using namespace std::chrono;
 
 system_clock::time_point s_date;
+std::unordered_set<system_clock::time_point, lorem_ipsum::test::hash<system_clock::time_point>> s_date_set;
 
 system_clock::time_point
 Dates::increase_date( const system_clock::time_point& input )
@@ -49,4 +50,15 @@ Dates::set_date_attribute( const system_clock::time_point& value )
 {
     s_date = value;
 }
-}  // namespace test
+
+std::unordered_set<system_clock::time_point, lorem_ipsum::test::hash<system_clock::time_point>>
+Dates::get_date_set() {
+    return s_date_set;
+}
+
+void
+Dates::set_date_set(const std::unordered_set<system_clock::time_point, lorem_ipsum::test::hash<system_clock::time_point>>& value) {
+    s_date_set = value;
+}
+
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeGenericTypesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeGenericTypesValidator.kt
@@ -71,9 +71,7 @@ internal class LimeGenericTypesValidator(private val logger: LimeLogger) :
             actualType is LimeEnumeration -> true
             actualType.attributes.have(LimeAttributeType.EQUATABLE) -> true
             actualType is LimeContainerWithInheritance -> true
-            actualType is LimeBasicType ->
-                actualType.typeId != LimeBasicType.TypeId.BLOB &&
-                    actualType.typeId != LimeBasicType.TypeId.DATE
+            actualType is LimeBasicType -> actualType.typeId != LimeBasicType.TypeId.BLOB
             actualType is LimeTypeAlias -> isHashable(actualType.typeRef)
             actualType is LimeList -> isHashable(actualType.elementType)
             actualType is LimeSet -> isHashable(actualType.elementType)

--- a/gluecodium/src/main/resources/templates/cbridge/common/BaseHandleImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/common/BaseHandleImpl.mustache
@@ -243,7 +243,7 @@ struct Conversion<std::chrono::time_point<Clock, Duration>> {
     }
 
     static double
-    referenceBaseRef(std::chrono::time_point<Clock, Duration>& timestamp) {
+    referenceBaseRef(const std::chrono::time_point<Clock, Duration>& timestamp) {
         return time_point_to_seconds_since_epoch( timestamp );
     }
 

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeGenericTypesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeGenericTypesValidatorTest.kt
@@ -77,7 +77,7 @@ class LimeGenericTypesValidatorTest(
         fun testData() = listOf(
             arrayOf(LimeBasicType(LimeBasicType.TypeId.FLOAT), true),
             arrayOf(LimeBasicType(LimeBasicType.TypeId.BLOB), false),
-            arrayOf(LimeBasicType(LimeBasicType.TypeId.DATE), false),
+            arrayOf(LimeBasicType(LimeBasicType.TypeId.DATE), true),
             arrayOf(LimeEnumeration(EMPTY_PATH), true),
             arrayOf(LimeList(LimeBasicTypeRef.INT), true),
             arrayOf(LimeSet(LimeBasicTypeRef.INT), true),

--- a/gluecodium/src/test/resources/smoke/dates/input/Dates.lime
+++ b/gluecodium/src/test/resources/smoke/dates/input/Dates.lime
@@ -31,4 +31,5 @@ class Dates {
     fun nullableDateMethod(input: Date?): Date?
 
     property dateProperty: Date
+    property dateSet: Set<Date>
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/Dates.java
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/Dates.java
@@ -6,6 +6,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.example.NativeBase;
 import java.util.Date;
+import java.util.Set;
 public final class Dates extends NativeBase {
     public static final class DateStruct {
         @NonNull
@@ -37,4 +38,7 @@ public final class Dates extends NativeBase {
     @NonNull
     public native Date getDateProperty();
     public native void setDateProperty(@NonNull final Date value);
+    @NonNull
+    public native Set<Date> getDateSet();
+    public native void setDateSet(@NonNull final Set<Date> value);
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
@@ -64,6 +64,32 @@ Java_com_example_smoke_Dates_setDateProperty(JNIEnv* _jenv, jobject _jinstance, 
             (int64_t*)nullptr));
     (*pInstanceSharedPointer)->set_date_property(value);
 }
+jobject
+Java_com_example_smoke_Dates_getDateSet(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_date_set();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+void
+Java_com_example_smoke_Dates_setDateSet(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+{
+    ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > > value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            (::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_date_set(value);
+}
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Dates_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/include/smoke/cbridge_Dates.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/include/smoke/cbridge_Dates.h
@@ -4,8 +4,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include "cbridge\include\BaseHandle.h"
-#include "cbridge\include\Export.h"
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
 _GLUECODIUM_C_EXPORT _baseRef smoke_Dates_DateStruct_create_handle(double dateField, _baseRef nullableDateField);
 _GLUECODIUM_C_EXPORT void smoke_Dates_DateStruct_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_Dates_DateStruct_create_optional_handle(double dateField, _baseRef nullableDateField);
@@ -22,6 +22,8 @@ _GLUECODIUM_C_EXPORT double smoke_Dates_dateMethod(_baseRef _instance, double in
 _GLUECODIUM_C_EXPORT _baseRef smoke_Dates_nullableDateMethod(_baseRef _instance, _baseRef input);
 _GLUECODIUM_C_EXPORT double smoke_Dates_dateProperty_get(_baseRef _instance);
 _GLUECODIUM_C_EXPORT void smoke_Dates_dateProperty_set(_baseRef _instance, double value);
+_GLUECODIUM_C_EXPORT _baseRef smoke_Dates_dateSet_get(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_Dates_dateSet_set(_baseRef _instance, _baseRef value);
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_Dates.cpp
@@ -6,10 +6,12 @@
 #include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TimePointHash.h"
+#include "gluecodium/UnorderedSetHash.h"
 #include "smoke/Dates.h"
 #include <chrono>
 #include <memory>
 #include <new>
+#include <unordered_set>
 void smoke_Dates_release_handle(_baseRef handle) {
     delete get_pointer<::std::shared_ptr< ::smoke::Dates >>(handle);
 }
@@ -42,6 +44,12 @@ double smoke_Dates_dateProperty_get(_baseRef _instance) {
 }
 void smoke_Dates_dateProperty_set(_baseRef _instance, double value) {
     return get_pointer<::std::shared_ptr< ::smoke::Dates >>(_instance)->get()->set_date_property(Conversion<::std::chrono::system_clock::time_point>::toCpp(value));
+}
+_baseRef smoke_Dates_dateSet_get(_baseRef _instance) {
+    return Conversion<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::Dates >>(_instance)->get()->get_date_set());
+}
+void smoke_Dates_dateSet_set(_baseRef _instance, _baseRef value) {
+    return get_pointer<::std::shared_ptr< ::smoke::Dates >>(_instance)->get()->set_date_set(Conversion<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>::toCpp(value));
 }
 _baseRef
 smoke_Dates_DateStruct_create_handle( double dateField, _baseRef nullableDateField )

--- a/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/Dates.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/Dates.h
@@ -7,10 +7,12 @@
 #include "gluecodium/Optional.h"
 #include "gluecodium/TimePointHash.h"
 #include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
 #include "gluecodium/VectorHash.h"
 #include <chrono>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Dates {
@@ -32,5 +34,7 @@ public:
     virtual ::gluecodium::optional< ::std::chrono::system_clock::time_point > nullable_date_method( const ::gluecodium::optional< ::std::chrono::system_clock::time_point >& input ) = 0;
     virtual ::std::chrono::system_clock::time_point get_date_property(  ) const = 0;
     virtual void set_date_property( const ::std::chrono::system_clock::time_point& value ) = 0;
+    virtual ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > > get_date_set(  ) const = 0;
+    virtual void set_date_set( const ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >& value ) = 0;
 };
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_Dates.cpp
@@ -5,9 +5,11 @@
 #include "IsolateContext.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TimePointHash.h"
+#include "gluecodium/UnorderedSetHash.h"
 #include "smoke/Dates.h"
 #include <chrono>
 #include <memory>
+#include <unordered_set>
 #include <memory>
 #include <new>
 #ifdef __cplusplus
@@ -43,6 +45,20 @@ library_smoke_Dates_dateProperty_set__Date(FfiOpaqueHandle _self, int32_t _isola
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
             (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Dates>>::toCpp(_self)).set_date_property(
             gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toCpp(value)
+        );
+}
+FfiOpaqueHandle
+library_smoke_Dates_dateSet_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Dates>>::toCpp(_self)).get_date_set()
+    );
+}
+void
+library_smoke_Dates_dateSet_set__SetOf_1Date(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle value) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::Dates>>::toCpp(_self)).set_date_set(
+            gluecodium::ffi::Conversion<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>>::toCpp(value)
         );
 }
 // "Private" finalizer, not exposed to be callable from Dart.

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -3,6 +3,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 abstract class Dates {
   /// @nodoc
   @Deprecated("Does nothing")
@@ -11,6 +12,8 @@ abstract class Dates {
   DateTime? nullableDateMethod(DateTime? input);
   DateTime get dateProperty;
   set dateProperty(DateTime value);
+  Set<DateTime> get dateSet;
+  set dateSet(Set<DateTime> value);
 }
 class Dates_DateStruct {
   DateTime dateField;
@@ -147,6 +150,25 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     dateReleaseFfiHandle(_valueHandle);
+  }
+  @override
+  Set<DateTime> get dateSet {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Dates_dateSet_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return foobarSetofDateFromFfi(__resultHandle);
+    } finally {
+      foobarSetofDateReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  set dateSet(Set<DateTime> value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Dates_dateSet_set__SetOf_1Date'));
+    final _valueHandle = foobarSetofDateToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    foobarSetofDateReleaseFfiHandle(_valueHandle);
   }
 }
 Pointer<Void> smokeDatesToFfi(Dates value) =>

--- a/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/Dates.lime
+++ b/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/Dates.lime
@@ -14,4 +14,5 @@ class Dates {
         input: Date?
     ): Date?
     property dateProperty: Date
+    property dateSet: Set<Date>
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/Dates.swift
@@ -15,6 +15,16 @@ public class Dates {
             smoke_Dates_dateProperty_set(self.c_instance, c_value.ref)
         }
     }
+    public var dateSet: Set<Date> {
+        get {
+            let c_result_handle = smoke_Dates_dateSet_get(self.c_instance)
+            return foobar_moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = foobar_moveToCType(newValue)
+            smoke_Dates_dateSet_set(self.c_instance, c_value.ref)
+        }
+    }
     let c_instance : _baseRef
     init(cDates: _baseRef) {
         guard cDates != 0 else {


### PR DESCRIPTION
Updated LimeGenericTypesValidator to accept `Date` type as a "hashable" type, thus enabling its usage in `Set<Date>` and
`Map<Date, SomeType>` containers. It was erroneously not marked as "hashable" before, despite having a hash function
generated in C++.

Added smoke test and compilation functional test.

Also fixed a typo in CBridge conversion functions for `Date` that was revealed by the added tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>