### PR TITLE
Add support for specifying C++ type for `Date` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for `@Cpp(Type)` attribute. This attribute can only be applied to a `Date` type reference, and it
+    specifies which `timepoint<>` type to use in C++ generated code to represent this single type reference.
+
 ## 9.2.1
 Release date: 2021-06-25
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -563,6 +563,9 @@ element is skipped ((not generated). Custom tags are case-insensitive.
   generated code. _Attribute_ does not need to be enclosed in `[[]]`. _Attribute_ can contain parameters, e.g.
   `@Cpp(Attribute="deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing
   quotes need to be backslash-escaped, as in the example.
+  * **Type** **=** **"**_TypeName_**"**: marks a `Date` type reference to use an alternative type in C++ generated code.
+  For example, `@Cpp(Type="std::chrono::steady_clock::time_point")` will use monotonic clock time point type, instead of
+  the system clock time point type which is used by default.    
   * ~~**ExternalType** **=** **"**_HeaderPaths_**"**~~: legacy attribute, superseded by `cpp
   include` in the `External Descriptor` (see above).
   * ~~**ExternalName** **=** **"**_FullyQualifiedName_**"**~~: legacy attribute, superseded by `cpp

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/DatesTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/DatesTest.java
@@ -87,4 +87,47 @@ public class DatesTest {
     assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE));
     assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND));
   }
+
+  @Test
+  public void steadyDateMethodRoundTrip() {
+    Date date = new Date(1, 3, 5, 7, 9, 11);
+    Calendar dateCalendar = new GregorianCalendar();
+    dateCalendar.setTime(date);
+
+    Date result = DatesSteady.increaseDate(date);
+
+    Calendar resultCalendar = new GregorianCalendar();
+    resultCalendar.setTime(result);
+    assertEquals(dateCalendar.get(Calendar.YEAR), resultCalendar.get(Calendar.YEAR));
+    assertEquals(dateCalendar.get(Calendar.MONTH), resultCalendar.get(Calendar.MONTH));
+    assertEquals(dateCalendar.get(Calendar.DATE) + 1, resultCalendar.get(Calendar.DATE));
+    assertEquals(dateCalendar.get(Calendar.HOUR) + 1, resultCalendar.get(Calendar.HOUR));
+    assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE));
+    assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND));
+  }
+
+  @Test
+  public void steadyDateMethodNullableNullRoundTrip() {
+    Date result = DatesSteady.increaseDateMaybe(null);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void steadyDateMethodNullableRoundTrip() {
+    Date date = new Date(1, 3, 5, 7, 9, 11);
+    Calendar dateCalendar = new GregorianCalendar();
+    dateCalendar.setTime(date);
+
+    Date result = DatesSteady.increaseDateMaybe(date);
+
+    Calendar resultCalendar = new GregorianCalendar();
+    resultCalendar.setTime(result);
+    assertEquals(dateCalendar.get(Calendar.YEAR), resultCalendar.get(Calendar.YEAR));
+    assertEquals(dateCalendar.get(Calendar.MONTH), resultCalendar.get(Calendar.MONTH));
+    assertEquals(dateCalendar.get(Calendar.DATE) + 1, resultCalendar.get(Calendar.DATE));
+    assertEquals(dateCalendar.get(Calendar.HOUR) + 1, resultCalendar.get(Calendar.HOUR));
+    assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE));
+    assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND));
+  }
 }

--- a/functional-tests/functional/dart/test/Dates_test.dart
+++ b/functional-tests/functional/dart/test/Dates_test.dart
@@ -62,4 +62,33 @@ void main() {
     expect(result?.minute, 10);
     expect(result?.second, 12);
   });
+  _testSuite.test("Date steady method round trip", () {
+    final input = DateTime.utc(1971, 3, 5, 7, 9, 11);
+
+    final result = DatesSteady.increaseDate(input);
+
+    expect(result.year, 1971);
+    expect(result.month, 3);
+    expect(result.day, 6);
+    expect(result.hour, 8);
+    expect(result.minute, 10);
+    expect(result.second, 12);
+  });
+  _testSuite.test("Nullable Date steady null round trip", () {
+    final result = DatesSteady.increaseDateMaybe(null);
+
+    expect(result, isNull);
+  });
+  _testSuite.test("Nullable Date steady non-null round trip", () {
+    final input = DateTime.utc(1971, 3, 5, 7, 9, 11);
+
+    final result = DatesSteady.increaseDateMaybe(input);
+
+    expect(result?.year, 1971);
+    expect(result?.month, 3);
+    expect(result?.day, 6);
+    expect(result?.hour, 8);
+    expect(result?.minute, 10);
+    expect(result?.second, 12);
+  });
 }

--- a/functional-tests/functional/input/lime/Dates.lime
+++ b/functional-tests/functional/input/lime/Dates.lime
@@ -37,3 +37,18 @@ class Dates {
     static property dateAttribute: Date
     static property dateSet: Set<Date>
 }
+
+class DatesSteady {
+    typealias MonotonicDate = @Cpp(Type = "std::chrono::steady_clock::time_point") Date
+
+    struct DateStruct {
+        dateField: MonotonicDate
+        nullableDateField: MonotonicDate?
+    }
+
+    typealias DateList = List<MonotonicDate>
+    typealias DateMap = Map<MonotonicDate, String>
+
+    static fun increaseDate(input: MonotonicDate): MonotonicDate
+    static fun increaseDateMaybe(input: MonotonicDate?): MonotonicDate?
+}

--- a/functional-tests/functional/input/src/cpp/Dates.cpp
+++ b/functional-tests/functional/input/src/cpp/Dates.cpp
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/Dates.h"
+#include "test/DatesSteady.h"
 
 namespace test
 {
@@ -59,6 +60,17 @@ Dates::get_date_set() {
 void
 Dates::set_date_set(const std::unordered_set<system_clock::time_point, lorem_ipsum::test::hash<system_clock::time_point>>& value) {
     s_date_set = value;
+}
+
+
+steady_clock::time_point
+DatesSteady::increase_date(const steady_clock::time_point& input) {
+    return input + hours(24) + hours(1) + minutes(1) + seconds(1);
+}
+
+lorem_ipsum::test::optional<steady_clock::time_point>
+DatesSteady::increase_date_maybe(const lorem_ipsum::test::optional<steady_clock::time_point>& input) {
+    return input ? *input + hours(24) + hours(1) + minutes(1) + seconds(1) : input;
 }
 
 }

--- a/functional-tests/functional/swift/Tests/DatesTests.swift
+++ b/functional-tests/functional/swift/Tests/DatesTests.swift
@@ -80,11 +80,54 @@ class DatesTests: XCTestCase {
         XCTAssertEqual(calendar.component(.second, from: result!), dateComponents.second! + 1)
     }
 
+    func testDatesSteadyMethodRoundTrip() {
+        let calendar = Calendar.current
+        let dateComponents = DateComponents(calendar: calendar,
+                                            year: 1971, month: 3, day: 5,
+                                            hour: 7, minute: 9, second: 11)
+
+        let result = DatesSteady.increaseDate(input: dateComponents.date!)
+
+        XCTAssertEqual(calendar.component(.year, from: result), dateComponents.year!)
+        XCTAssertEqual(calendar.component(.month, from: result), dateComponents.month!)
+        XCTAssertEqual(calendar.component(.day, from: result), dateComponents.day! + 1)
+        XCTAssertEqual(calendar.component(.hour, from: result), dateComponents.hour! + 1)
+        XCTAssertEqual(calendar.component(.minute, from: result), dateComponents.minute! + 1)
+        XCTAssertEqual(calendar.component(.second, from: result), dateComponents.second! + 1)
+    }
+
+    func testDatesSteadyMethodNullableNullRoundTrip() {
+        let result = DatesSteady.increaseDateMaybe(input: nil)
+
+        XCTAssertNil(result)
+    }
+
+    func testDatesSteadyMethodNullableRoundTrip() {
+        let calendar = Calendar.current
+        let dateComponents = DateComponents(calendar: calendar,
+                                            year: 1971, month: 3, day: 5,
+                                            hour: 7, minute: 9, second: 11)
+
+        let result = DatesSteady.increaseDateMaybe(input: dateComponents.date)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(calendar.component(.year, from: result!), dateComponents.year!)
+        XCTAssertEqual(calendar.component(.month, from: result!), dateComponents.month!)
+        XCTAssertEqual(calendar.component(.day, from: result!), dateComponents.day! + 1)
+        XCTAssertEqual(calendar.component(.hour, from: result!), dateComponents.hour! + 1)
+        XCTAssertEqual(calendar.component(.minute, from: result!), dateComponents.minute! + 1)
+        XCTAssertEqual(calendar.component(.second, from: result!), dateComponents.second! + 1)
+    }
+
+
     static var allTests = [
         ("testDateAttributeRoundTrip", testDateAttributeRoundTrip),
         ("testDateAttributeRoundTripRounding", testDateAttributeRoundTripRounding),
         ("testDateMethodRoundTrip", testDateMethodRoundTrip),
         ("testMethodNullableNullRoundTrip", testMethodNullableNullRoundTrip),
-        ("testMethodNullableRoundTrip", testMethodNullableRoundTrip)
+        ("testMethodNullableRoundTrip", testMethodNullableRoundTrip),
+        ("testDatesSteadyMethodRoundTrip", testDatesSteadyMethodRoundTrip),
+        ("testDatesSteadyMethodNullableNullRoundTrip", testDatesSteadyMethodNullableNullRoundTrip),
+        ("testDatesSteadyMethodNullableRoundTrip", testDatesSteadyMethodNullableRoundTrip)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeCppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeCppNameResolver.kt
@@ -41,8 +41,7 @@ internal class CBridgeCppNameResolver(
 
     override fun resolveName(element: Any): String =
         when (element) {
-            is LimeTypeRef -> resolveTypeRefName(element)
-            is LimeBasicType, is LimeGenericType -> cppShortNameResolver.resolveName(element)
+            is LimeTypeRef, is LimeBasicType, is LimeGenericType -> cppShortNameResolver.resolveName(element)
             is LimeType -> cppFullNameResolver.resolveName(element)
             is LimeFunction -> resolveFunctionName(element)
             else -> cppShortNameResolver.resolveName(element)
@@ -53,28 +52,19 @@ internal class CBridgeCppNameResolver(
         return when {
             parentElement is LimeLambda -> "operator()"
             parentElement !is LimeProperty -> cppShortNameResolver.resolveName(limeFunction)
-            limeFunction === parentElement.setter -> cppShortNameResolver.resolveSetterName(parentElement)
-            else -> cppShortNameResolver.resolveGetterName(parentElement)
-        }!!
+            limeFunction === parentElement.setter -> cppShortNameResolver.resolveSetterName(parentElement)!!
+            else -> cppShortNameResolver.resolveGetterName(parentElement)!!
+        }
     }
 
     override fun resolveGetterName(element: Any) = cppShortNameResolver.resolveGetterName(element)
 
     override fun resolveSetterName(element: Any) = cppShortNameResolver.resolveSetterName(element)
 
-    override fun resolveReferenceName(element: Any) =
+    override fun resolveReferenceName(element: Any): String? =
         when (element) {
-            is LimeType -> cppShortNameResolver.resolveName(LimeDirectTypeRef(element))
-            is LimeTypeRef -> resolveTypeRefName(element)
+            is LimeType -> resolveReferenceName(LimeDirectTypeRef(element))
+            is LimeTypeRef -> cppShortNameResolver.resolveName(element)
             else -> null
         }
-
-    private fun resolveTypeRefName(limeTypeRef: LimeTypeRef) =
-        cppShortNameResolver.resolveName(
-            LimeDirectTypeRef(
-                limeTypeRef.type.actualType,
-                isNullable = limeTypeRef.isNullable,
-                attributes = limeTypeRef.attributes
-            )
-        )
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -62,7 +62,7 @@ internal class CBridgeGenerator(
     cppNameRules: CppNameRules,
     private val nameResolver: CBridgeNameResolver
 ) {
-    val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
+    val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache, forceFollowThrough = true)
     private val cppRefNameResolver =
         CBridgeCppNameResolver(limeReferenceMap, CppFullNameResolver(nameCache), cppNameResolver)
     private val cppIncludeResolver = CppIncludeResolver(limeReferenceMap, cppNameRules, internalNamespace)

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
@@ -43,6 +43,11 @@ namespace jni
 
 // -------------------- JNI object field getters --------------------------------------------------
 
+JNIEXPORT JniReference< jobject > get_object_field_value( JNIEnv* env,
+                                       const JniReference<jobject>& object,
+                                       const char* fieldName,
+                                       const char* fieldSignature );
+
 JNIEXPORT bool get_field_value(
     JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, bool* );
 JNIEXPORT int8_t get_field_value(
@@ -128,16 +133,28 @@ JNIEXPORT {{>common/InternalNamespace}}optional< ::std::shared_ptr< ::std::vecto
     const char* fieldName,
     {{>common/InternalNamespace}}optional< ::std::shared_ptr< ::std::vector< uint8_t > > >* );
 
-JNIEXPORT ::std::chrono::system_clock::time_point get_field_value(
-    JNIEnv* env,
-    const JniReference< jobject >& object,
-    const char* fieldName,
-    ::std::chrono::system_clock::time_point* );
-JNIEXPORT {{>common/InternalNamespace}}optional< ::std::chrono::system_clock::time_point > get_field_value(
-    JNIEnv* env,
-    const JniReference< jobject >& object,
-    const char* fieldName,
-    {{>common/InternalNamespace}}optional< ::std::chrono::system_clock::time_point >* );
+template<class Clock, class Duration>
+std::chrono::time_point<Clock, Duration>
+get_field_value(
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, std::chrono::time_point<Clock, Duration>*
+) {
+    auto fieldValue = get_object_field_value(env, object, fieldName, "Ljava/util/Date;");
+
+    return {{>common/InternalNamespace}}jni::convert_from_jni(env, fieldValue, (std::chrono::time_point<Clock, Duration>*)nullptr);
+}
+
+template<class Clock, class Duration>
+{{>common/InternalNamespace}}optional<std::chrono::time_point<Clock, Duration>>
+get_field_value(
+    JNIEnv* env, const JniReference<jobject >& object, const char* fieldName,
+    {{>common/InternalNamespace}}optional<std::chrono::time_point<Clock, Duration>>*
+) {
+    auto fieldValue = get_object_field_value(env, object, fieldName, "Ljava/util/Date;");
+
+    return {{>common/InternalNamespace}}jni::convert_from_jni(
+        env, fieldValue, ({{>common/InternalNamespace}}optional<std::chrono::time_point<Clock, Duration>>*)nullptr
+    );
+}
 
 JNIEXPORT {{>common/InternalNamespace}}Locale get_field_value(
     JNIEnv* env,
@@ -150,12 +167,13 @@ JNIEXPORT {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Lo
     const char* fieldName,
     {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale >* );
 
-JNIEXPORT JniReference< jobject > get_object_field_value( JNIEnv* env,
-                                       const JniReference<jobject>& object,
-                                       const char* fieldName,
-                                       const char* fieldSignature );
-
 // -------------------- JNI object field setters --------------------------------------------------
+
+JNIEXPORT void set_object_field_value( JNIEnv* env,
+                             const JniReference<jobject>& object,
+                             const char* fieldName,
+                             const char* fieldSignature,
+                             const JniReference<jobject>& fieldValue );
 
 JNIEXPORT void set_field_value(
     JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, bool value );
@@ -242,14 +260,26 @@ JNIEXPORT void set_field_value( JNIEnv* env,
                       const char* fieldName,
                       {{>common/InternalNamespace}}optional< std::shared_ptr< ::std::vector< uint8_t > > > fieldValue );
 
-JNIEXPORT void set_field_value( JNIEnv* env,
-                      const JniReference<jobject>& object,
-                      const char* fieldName,
-                      const ::std::chrono::system_clock::time_point& fieldValue );
-JNIEXPORT void set_field_value( JNIEnv* env,
-                      const JniReference<jobject>& object,
-                      const char* fieldName,
-                      {{>common/InternalNamespace}}optional< ::std::chrono::system_clock::time_point > fieldValue );
+template<class Clock, class Duration>
+void
+set_field_value(
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, const std::chrono::time_point<Clock, Duration>& fieldValue
+) {
+    auto fieldId = env->GetFieldID(get_object_class(env, object).get(), fieldName, "Ljava/util/Date;");
+    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni(env, fieldValue);
+    env->SetObjectField(object.get(), fieldId, jValue.get());
+}
+
+template<class Clock, class Duration>
+void
+set_field_value(
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName,
+    const {{>common/InternalNamespace}}optional<std::chrono::time_point<Clock, Duration>>& fieldValue
+) {
+    auto fieldId = env->GetFieldID(get_object_class(env, object).get(), fieldName, "Ljava/util/Date;");
+    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni(env, fieldValue);
+    env->SetObjectField(object.get(), fieldId, jValue.get());
+}
 
 JNIEXPORT void set_field_value( JNIEnv* env,
                       const JniReference<jobject>& object,
@@ -259,12 +289,6 @@ JNIEXPORT void set_field_value( JNIEnv* env,
                       const JniReference<jobject>& object,
                       const char* fieldName,
                       {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale > fieldValue );
-
-JNIEXPORT void set_object_field_value( JNIEnv* env,
-                             const JniReference<jobject>& object,
-                             const char* fieldName,
-                             const char* fieldSignature,
-                             const JniReference<jobject>& fieldValue );
 
 }
 {{#internalNamespace}}

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsImplementation.mustache
@@ -321,30 +321,6 @@ get_field_value( JNIEnv* env,
     return convert_from_jni( env, fieldValue, ({{>common/InternalNamespace}}optional<std::shared_ptr<std::vector<uint8_t>>>*)nullptr );
 }
 
-std::chrono::system_clock::time_point
-get_field_value( JNIEnv* env,
-                 const JniReference<jobject>& object,
-                 const char* fieldName,
-                 std::chrono::system_clock::time_point* )
-{
-    auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/util/Date;" );
-
-    return {{>common/InternalNamespace}}jni::convert_from_jni(
-        env, fieldValue, (std::chrono::system_clock::time_point*)nullptr );
-}
-
-{{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point >
-get_field_value( JNIEnv* env,
-                 const JniReference<jobject>& object,
-                 const char* fieldName,
-                 {{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point >* )
-{
-    auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/util/Date;" );
-
-    return {{>common/InternalNamespace}}jni::convert_from_jni(
-        env, fieldValue, ({{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point >*)nullptr );
-}
-
 {{>common/InternalNamespace}}Locale
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
@@ -654,28 +630,6 @@ set_field_value( JNIEnv* env,
                  {{>common/InternalNamespace}}optional<std::shared_ptr<std::vector<uint8_t>>> fieldValue )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "[B" );
-    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni( env, fieldValue );
-    env->SetObjectField( object.get(), fieldId, jValue.get() );
-}
-
-void
-set_field_value( JNIEnv* env,
-                 const JniReference<jobject>& object,
-                 const char* fieldName,
-                 const std::chrono::system_clock::time_point& fieldValue )
-{
-    auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "Ljava/util/Date;" );
-    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni( env, fieldValue );
-    env->SetObjectField( object.get(), fieldId, jValue.get() );
-}
-
-void
-set_field_value( JNIEnv* env,
-                 const JniReference<jobject>& object,
-                 const char* fieldName,
-                 {{>common/InternalNamespace}}optional< std::chrono::system_clock::time_point > fieldValue )
-{
-    auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "Ljava/util/Date;" );
     auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni( env, fieldValue );
     env->SetObjectField( object.get(), fieldId, jValue.get() );
 }

--- a/gluecodium/src/test/resources/smoke/dates/input/Dates.lime
+++ b/gluecodium/src/test/resources/smoke/dates/input/Dates.lime
@@ -33,3 +33,18 @@ class Dates {
     property dateProperty: Date
     property dateSet: Set<Date>
 }
+
+class DatesSteady {
+    typealias MonotonicDate = @Cpp(Type = "std::chrono::steady_clock::time_point") Date
+
+    struct DateStruct {
+        dateField: MonotonicDate
+        nullableDateField: MonotonicDate?
+    }
+
+    typealias DateList = List<MonotonicDate>
+    typealias DateMap = Map<MonotonicDate, String>
+
+    fun dateMethod(input: MonotonicDate): MonotonicDate
+    fun nullableDateMethod(input: MonotonicDate?): MonotonicDate?
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
@@ -1,0 +1,48 @@
+/*
+ *
+ */
+#include "com_example_smoke_DatesSteady.h"
+#include "com_example_smoke_DatesSteady__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jobject
+Java_com_example_smoke_DatesSteady_dateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::smoke::DatesSteady::MonotonicDate input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::smoke::DatesSteady::MonotonicDate*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->date_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_DatesSteady_nullableDateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate >*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->nullable_date_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_DatesSteady_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_DatesSteady.cpp
@@ -1,0 +1,74 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_DatesSteady.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/Optional.h"
+#include "smoke/DatesSteady.h"
+#include <memory>
+#include <new>
+void smoke_DatesSteady_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(handle);
+}
+_baseRef smoke_DatesSteady_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(handle)))
+        : 0;
+}
+const void* smoke_DatesSteady_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(handle)->get())
+        : nullptr;
+}
+void smoke_DatesSteady_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(handle)->get(), swift_pointer);
+}
+void smoke_DatesSteady_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(handle)->get());
+}
+double smoke_DatesSteady_dateMethod(_baseRef _instance, double input) {
+    return Conversion<std::chrono::steady_clock::time_point>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(_instance)->get()->date_method(Conversion<std::chrono::steady_clock::time_point>::toCpp(input)));
+}
+_baseRef smoke_DatesSteady_nullableDateMethod(_baseRef _instance, _baseRef input) {
+    return Conversion<::gluecodium::optional< std::chrono::steady_clock::time_point >>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(_instance)->get()->nullable_date_method(Conversion<::gluecodium::optional< std::chrono::steady_clock::time_point >>::toCpp(input)));
+}
+_baseRef
+smoke_DatesSteady_DateStruct_create_handle( double dateField, _baseRef nullableDateField )
+{
+    ::smoke::DatesSteady::DateStruct* _struct = new ( ::std::nothrow ) ::smoke::DatesSteady::DateStruct();
+    _struct->date_field = Conversion<std::chrono::steady_clock::time_point>::toCpp( dateField );
+    _struct->nullable_date_field = Conversion<::gluecodium::optional< std::chrono::steady_clock::time_point >>::toCpp( nullableDateField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_DatesSteady_DateStruct_release_handle( _baseRef handle )
+{
+    delete get_pointer<::smoke::DatesSteady::DateStruct>( handle );
+}
+_baseRef
+smoke_DatesSteady_DateStruct_create_optional_handle(double dateField, _baseRef nullableDateField)
+{
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::DatesSteady::DateStruct>( ::smoke::DatesSteady::DateStruct( ) );
+    (*_struct)->date_field = Conversion<std::chrono::steady_clock::time_point>::toCpp( dateField );
+    (*_struct)->nullable_date_field = Conversion<::gluecodium::optional< std::chrono::steady_clock::time_point >>::toCpp( nullableDateField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_DatesSteady_DateStruct_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::smoke::DatesSteady::DateStruct>*>( handle ) );
+}
+void smoke_DatesSteady_DateStruct_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::smoke::DatesSteady::DateStruct>*>( handle );
+}
+double smoke_DatesSteady_DateStruct_dateField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::DatesSteady::DateStruct>(handle);
+    return Conversion<std::chrono::steady_clock::time_point>::toBaseRef(struct_pointer->date_field);
+}
+_baseRef smoke_DatesSteady_DateStruct_nullableDateField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::DatesSteady::DateStruct>(handle);
+    return Conversion<::gluecodium::optional< std::chrono::steady_clock::time_point >>::toBaseRef(struct_pointer->nullable_date_field);
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DatesSteady.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DatesSteady.h
@@ -1,0 +1,34 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/Optional.h"
+#include "gluecodium/TimePointHash.h"
+#include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/VectorHash.h"
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <vector>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT DatesSteady {
+public:
+    DatesSteady();
+    virtual ~DatesSteady() = 0;
+public:
+    using MonotonicDate = std::chrono::steady_clock::time_point;
+    using DateList = ::std::vector< ::smoke::DatesSteady::MonotonicDate >;
+    using DateMap = ::std::unordered_map< ::smoke::DatesSteady::MonotonicDate, ::std::string, ::gluecodium::hash< ::smoke::DatesSteady::MonotonicDate > >;
+    struct _GLUECODIUM_CPP_EXPORT DateStruct {
+        ::smoke::DatesSteady::MonotonicDate date_field;
+        ::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate > nullable_date_field;
+        DateStruct( );
+        DateStruct( ::smoke::DatesSteady::MonotonicDate date_field, ::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate > nullable_date_field );
+    };
+public:
+    virtual ::smoke::DatesSteady::MonotonicDate date_method( const ::smoke::DatesSteady::MonotonicDate& input ) = 0;
+    virtual ::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate > nullable_date_method( const ::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate >& input ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_DatesSteady.cpp
@@ -1,0 +1,102 @@
+#include "ffi_smoke_DatesSteady.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "gluecodium/Optional.h"
+#include "gluecodium/TimePointHash.h"
+#include "smoke/DatesSteady.h"
+#include <chrono>
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+uint64_t
+library_smoke_DatesSteady_dateMethod__Date(FfiOpaqueHandle _self, int32_t _isolate_id, uint64_t input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::chrono::steady_clock::time_point>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DatesSteady>>::toCpp(_self)).date_method(
+            gluecodium::ffi::Conversion<std::chrono::steady_clock::time_point>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+library_smoke_DatesSteady_nullableDateMethod__Date(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::steady_clock::time_point>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DatesSteady>>::toCpp(_self)).nullable_date_method(
+            gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::steady_clock::time_point>>::toCpp(input)
+        )
+    );
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_DatesSteady_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::DatesSteady>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_DatesSteady_release_handle(handle);
+}
+void
+library_smoke_DatesSteady_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_DatesSteady_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_DatesSteady_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::DatesSteady>(
+            *reinterpret_cast<std::shared_ptr<smoke::DatesSteady>*>(handle)
+        )
+    );
+}
+void
+library_smoke_DatesSteady_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::DatesSteady>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DatesSteady_DateStruct_create_handle(uint64_t dateField, FfiOpaqueHandle nullableDateField) {
+    auto _result = new (std::nothrow) smoke::DatesSteady::DateStruct(gluecodium::ffi::Conversion<std::chrono::steady_clock::time_point>::toCpp(dateField), gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::steady_clock::time_point>>::toCpp(nullableDateField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_DatesSteady_DateStruct_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<smoke::DatesSteady::DateStruct*>(handle);
+}
+uint64_t
+library_smoke_DatesSteady_DateStruct_get_field_dateField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::chrono::steady_clock::time_point>::toFfi(
+        reinterpret_cast<smoke::DatesSteady::DateStruct*>(handle)->date_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_DatesSteady_DateStruct_get_field_nullableDateField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::steady_clock::time_point>>::toFfi(
+        reinterpret_cast<smoke::DatesSteady::DateStruct*>(handle)->nullable_date_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_DatesSteady_DateStruct_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<smoke::DatesSteady::DateStruct>(
+            gluecodium::ffi::Conversion<smoke::DatesSteady::DateStruct>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_DatesSteady_DateStruct_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<smoke::DatesSteady::DateStruct>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DatesSteady_DateStruct_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<smoke::DatesSteady::DateStruct>::toFfi(
+        **reinterpret_cast<gluecodium::optional<smoke::DatesSteady::DateStruct>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DatesSteady.lime
+++ b/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DatesSteady.lime
@@ -1,0 +1,16 @@
+package smoke
+class DatesSteady {
+    typealias MonotonicDate = @Cpp(Type = "std::chrono::steady_clock::time_point") Date
+    typealias DateList = List<MonotonicDate>
+    typealias DateMap = Map<MonotonicDate, String>
+    struct DateStruct {
+        dateField: MonotonicDate
+        nullableDateField: MonotonicDate?
+    }
+    fun dateMethod(
+        input: MonotonicDate
+    ): MonotonicDate
+    fun nullableDateMethod(
+        input: MonotonicDate?
+    ): MonotonicDate?
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -197,6 +197,7 @@ internal object AntlrLimeConverter {
             "Ref" -> LimeAttributeValueType.REF
             "Skip" -> LimeAttributeValueType.SKIP
             "Tag" -> LimeAttributeValueType.TAG
+            "Type" -> LimeAttributeValueType.TYPE
             "Weak" -> LimeAttributeValueType.WEAK
             "ExternalType", "ExternalName", "ExternalGetter", "ExternalSetter" -> null
             else -> throw LimeLoadingException("Unsupported attribute value: '$id'")

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -35,6 +35,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     REF("Ref"),
     SKIP("Skip"),
     TAG("Tag"),
+    TYPE("Type"),
     WEAK("Weak");
 
     override fun toString() = tag


### PR DESCRIPTION
Added support for `@Cpp(Type)` attribute that can be applied to any type reference of `Date` type in IDL to specify an
`std::chrono::timepoint<>` type to be used. If this attribute is not added, `std::chrono::system_clock::timepoint` is
still used as before. If this attribute is added, an alternative `timepoint<>` type is used in generated C++ code with
no visible changes to public API in other output languages.

Added smoke and functional tests. The tests are based on the proposed use case of using monotonic clock time point
`std::chrono::steady_clock::timepoint`.

Resolves: #965
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
