### PR TITLE
Fix `List<@Cpp(Type)Date>` usage in Swift

### DIFF
--- a/functional-tests/functional/input/lime/Dates.lime
+++ b/functional-tests/functional/input/lime/Dates.lime
@@ -51,4 +51,5 @@ class DatesSteady {
 
     static fun increaseDate(input: MonotonicDate): MonotonicDate
     static fun increaseDateMaybe(input: MonotonicDate?): MonotonicDate?
+    static fun dateListMethod(input: DateList): DateList
 }

--- a/functional-tests/functional/input/src/cpp/Dates.cpp
+++ b/functional-tests/functional/input/src/cpp/Dates.cpp
@@ -73,4 +73,9 @@ DatesSteady::increase_date_maybe(const lorem_ipsum::test::optional<steady_clock:
     return input ? *input + hours(24) + hours(1) + minutes(1) + seconds(1) : input;
 }
 
+std::vector<steady_clock::time_point>
+DatesSteady::date_list_method(const std::vector<steady_clock::time_point>& input) {
+    return input;
+}
+
 }

--- a/gluecodium/src/main/resources/templates/swift/ConversionPrefixFrom.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ConversionPrefixFrom.mustache
@@ -20,6 +20,7 @@
   !}}
 {{#typeRef.type.actualType}}{{#instanceOf this "LimeInterface"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeClass"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
+}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "hasCppTypeAttribute"}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeSet"}}{{internalPrefix}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeMap"}}{{internalPrefix}}{{/instanceOf}}{{/typeRef.type.actualType}}
+}}{{#instanceOf this "LimeMap"}}{{internalPrefix}}{{/instanceOf}}{{/unlessPredicate}}{{/typeRef.type.actualType}}

--- a/gluecodium/src/main/resources/templates/swift/ConversionPrefixTo.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ConversionPrefixTo.mustache
@@ -18,6 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#typeRef.type.actualType}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
+{{#typeRef.type.actualType}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "hasCppTypeAttribute"}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeSet"}}{{internalPrefix}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeMap"}}{{internalPrefix}}{{/instanceOf}}{{/typeRef.type.actualType}}
+}}{{#instanceOf this "LimeMap"}}{{internalPrefix}}{{/instanceOf}}{{/unlessPredicate}}{{/typeRef.type.actualType}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftLists.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftLists.mustache
@@ -28,7 +28,7 @@ import {{this}}
 {{/imports}}
 
 {{#collections}}
-internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}} {
+internal func {{>functionPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}} {
     var result: {{resolveName}} = []
     let count = {{resolveName "CBridge"}}_count(handle)
     for idx in 0..<count {
@@ -37,14 +37,14 @@ internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveNa
     return result
 }
 
-internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}} {
+internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}} {
     defer {
         {{resolveName "CBridge"}}_release_handle(handle)
     }
-    return {{internalPrefix}}copyFromCType(handle)
+    return {{>functionPrefix}}copyFromCType(handle)
 }
 
-internal func {{internalPrefix}}copyToCType(_ swiftArray: {{resolveName}}) -> RefHolder {
+internal func {{>functionPrefix}}copyToCType(_ swiftArray: {{resolveName}}) -> RefHolder {
     let handle = {{resolveName "CBridge"}}_create_handle()
     for item in swiftArray {
         let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
@@ -53,14 +53,14 @@ internal func {{internalPrefix}}copyToCType(_ swiftArray: {{resolveName}}) -> Re
     return RefHolder(handle)
 }
 
-internal func {{internalPrefix}}moveToCType(_ swiftArray: {{resolveName}}) -> RefHolder {
-    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftArray).ref, release: {{resolveName "CBridge"}}_release_handle)
+internal func {{>functionPrefix}}moveToCType(_ swiftArray: {{resolveName}}) -> RefHolder {
+    return RefHolder(ref: {{>functionPrefix}}copyToCType(swiftArray).ref, release: {{resolveName "CBridge"}}_release_handle)
 }
 
 {{!!
 Optionals
 }}
-internal func {{internalPrefix}}copyToCType(_ swiftArray: {{resolveName}}?) -> RefHolder {
+internal func {{>functionPrefix}}copyToCType(_ swiftArray: {{resolveName}}?) -> RefHolder {
     guard let swiftArray = swiftArray else {
         return RefHolder(0)
     }
@@ -73,23 +73,26 @@ internal func {{internalPrefix}}copyToCType(_ swiftArray: {{resolveName}}?) -> R
     return RefHolder(optionalHandle)
 }
 
-internal func {{internalPrefix}}moveToCType(_ swiftType: {{resolveName}}?) -> RefHolder {
-    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
+internal func {{>functionPrefix}}moveToCType(_ swiftType: {{resolveName}}?) -> RefHolder {
+    return RefHolder(ref: {{>functionPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
 }
 
-internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}}? {
+internal func {{>functionPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}}? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = {{resolveName "CBridge"}}_unwrap_optional_handle(handle)
-    return {{internalPrefix}}copyFromCType(unwrappedHandle) as {{resolveName}}
+    return {{>functionPrefix}}copyFromCType(unwrappedHandle) as {{resolveName}}
 }
 
-internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}}? {
+internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}}? {
     defer {
         {{resolveName "CBridge"}}_release_optional_handle(handle)
     }
-    return {{internalPrefix}}copyFromCType(handle)
+    return {{>functionPrefix}}copyFromCType(handle)
 }
 
-{{/collections}}
+{{/collections}}{{!!
+
+}}{{+functionPrefix}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "hasCppTypeAttribute"}}{{internalPrefix}}{{/unlessPredicate}}{{/functionPrefix}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftMaps.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftMaps.mustache
@@ -24,7 +24,7 @@ import {{this}}
 {{/imports}}
 
 {{#collections}}
-internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}} {
+internal func {{>functionPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}} {
     var swiftDict: {{resolveName}} = [:]
     let iterator_handle = {{resolveName "CBridge"}}_iterator(handle)
     while {{resolveName "CBridge"}}_iterator_is_valid(handle, iterator_handle) {
@@ -39,14 +39,14 @@ internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveNa
     return swiftDict
 }
 
-internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}} {
+internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}} {
     defer {
         {{resolveName "CBridge"}}_release_handle(handle)
     }
-    return {{internalPrefix}}copyFromCType(handle)
+    return {{>functionPrefix}}copyFromCType(handle)
 }
 
-internal func {{internalPrefix}}copyToCType(_ swiftDict: {{resolveName}}) -> RefHolder {
+internal func {{>functionPrefix}}copyToCType(_ swiftDict: {{resolveName}}) -> RefHolder {
     let c_handle = {{resolveName "CBridge"}}_create_handle()
     for (key, value) in swiftDict {
         let c_key = {{#set typeRef=keyType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(key)
@@ -56,29 +56,29 @@ internal func {{internalPrefix}}copyToCType(_ swiftDict: {{resolveName}}) -> Ref
     return RefHolder(c_handle)
 }
 
-internal func {{internalPrefix}}moveToCType(_ swiftDict: {{resolveName}}) -> RefHolder {
-    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftDict).ref, release: {{resolveName "CBridge"}}_release_handle)
+internal func {{>functionPrefix}}moveToCType(_ swiftDict: {{resolveName}}) -> RefHolder {
+    return RefHolder(ref: {{>functionPrefix}}copyToCType(swiftDict).ref, release: {{resolveName "CBridge"}}_release_handle)
 }
 
 {{!!
 Optionals
 }}
-internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}}? {
+internal func {{>functionPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}}? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = {{resolveName "CBridge"}}_unwrap_optional_handle(handle)
-    return {{internalPrefix}}copyFromCType(unwrappedHandle) as {{resolveName}}
+    return {{>functionPrefix}}copyFromCType(unwrappedHandle) as {{resolveName}}
 }
 
-internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}}? {
+internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}}? {
     defer {
         {{resolveName "CBridge"}}_release_optional_handle(handle)
     }
-    return {{internalPrefix}}copyFromCType(handle)
+    return {{>functionPrefix}}copyFromCType(handle)
 }
 
-internal func {{internalPrefix}}copyToCType(_ swiftDict: {{resolveName}}?) -> RefHolder {
+internal func {{>functionPrefix}}copyToCType(_ swiftDict: {{resolveName}}?) -> RefHolder {
     guard let swiftDict = swiftDict else {
         return RefHolder(0)
     }
@@ -92,8 +92,11 @@ internal func {{internalPrefix}}copyToCType(_ swiftDict: {{resolveName}}?) -> Re
     return RefHolder(optionalHandle)
 }
 
-internal func {{internalPrefix}}moveToCType(_ swiftType: {{resolveName}}?) -> RefHolder {
-    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
+internal func {{>functionPrefix}}moveToCType(_ swiftType: {{resolveName}}?) -> RefHolder {
+    return RefHolder(ref: {{>functionPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
 }
 
-{{/collections}}
+{{/collections}}{{!!
+
+}}{{+functionPrefix}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "hasCppTypeAttribute"}}{{internalPrefix}}{{/unlessPredicate}}{{/functionPrefix}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftSets.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftSets.mustache
@@ -28,7 +28,7 @@ import {{this}}
 {{/imports}}
 
 {{#collections}}
-internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}} {
+internal func {{>functionPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}} {
     var result: {{resolveName}} = []
     let iterator_handle = {{resolveName "CBridge"}}_iterator(handle)
     while {{resolveName "CBridge"}}_iterator_is_valid(handle, iterator_handle) {
@@ -39,14 +39,14 @@ internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveNa
     return result
 }
 
-internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}} {
+internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}} {
     defer {
         {{resolveName "CBridge"}}_release_handle(handle)
     }
-    return {{internalPrefix}}copyFromCType(handle)
+    return {{>functionPrefix}}copyFromCType(handle)
 }
 
-internal func {{internalPrefix}}copyToCType(_ swiftSet: {{resolveName}}) -> RefHolder {
+internal func {{>functionPrefix}}copyToCType(_ swiftSet: {{resolveName}}) -> RefHolder {
     let handle = {{resolveName "CBridge"}}_create_handle()
     for item in swiftSet {
         let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
@@ -55,14 +55,14 @@ internal func {{internalPrefix}}copyToCType(_ swiftSet: {{resolveName}}) -> RefH
     return RefHolder(handle)
 }
 
-internal func {{internalPrefix}}moveToCType(_ swiftSet: {{resolveName}}) -> RefHolder {
-    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftSet).ref, release: {{resolveName "CBridge"}}_release_handle)
+internal func {{>functionPrefix}}moveToCType(_ swiftSet: {{resolveName}}) -> RefHolder {
+    return RefHolder(ref: {{>functionPrefix}}copyToCType(swiftSet).ref, release: {{resolveName "CBridge"}}_release_handle)
 }
 
 {{!!
 Optionals
 }}
-internal func {{internalPrefix}}copyToCType(_ swiftSet: {{resolveName}}?) -> RefHolder {
+internal func {{>functionPrefix}}copyToCType(_ swiftSet: {{resolveName}}?) -> RefHolder {
     guard let swiftSet = swiftSet else {
         return RefHolder(0)
     }
@@ -75,23 +75,26 @@ internal func {{internalPrefix}}copyToCType(_ swiftSet: {{resolveName}}?) -> Ref
     return RefHolder(optionalHandle)
 }
 
-internal func {{internalPrefix}}moveToCType(_ swiftType: {{resolveName}}?) -> RefHolder {
-    return RefHolder(ref: {{internalPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
+internal func {{>functionPrefix}}moveToCType(_ swiftType: {{resolveName}}?) -> RefHolder {
+    return RefHolder(ref: {{>functionPrefix}}copyToCType(swiftType).ref, release: {{resolveName "CBridge"}}_release_optional_handle)
 }
 
-internal func {{internalPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}}? {
+internal func {{>functionPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}}? {
     guard handle != 0 else {
         return nil
     }
     let unwrappedHandle = {{resolveName "CBridge"}}_unwrap_optional_handle(handle)
-    return {{internalPrefix}}copyFromCType(unwrappedHandle) as {{resolveName}}
+    return {{>functionPrefix}}copyFromCType(unwrappedHandle) as {{resolveName}}
 }
 
-internal func {{internalPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}}? {
+internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveName}}? {
     defer {
         {{resolveName "CBridge"}}_release_optional_handle(handle)
     }
-    return {{internalPrefix}}copyFromCType(handle)
+    return {{>functionPrefix}}copyFromCType(handle)
 }
 
-{{/collections}}
+{{/collections}}{{!!
+
+}}{{+functionPrefix}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "hasCppTypeAttribute"}}{{internalPrefix}}{{/unlessPredicate}}{{/functionPrefix}}

--- a/gluecodium/src/test/resources/smoke/dates/input/Dates.lime
+++ b/gluecodium/src/test/resources/smoke/dates/input/Dates.lime
@@ -47,4 +47,5 @@ class DatesSteady {
 
     fun dateMethod(input: MonotonicDate): MonotonicDate
     fun nullableDateMethod(input: MonotonicDate?): MonotonicDate?
+    fun dateListMethod(input: DateList): DateList
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
@@ -38,6 +38,21 @@ Java_com_example_smoke_DatesSteady_nullableDateMethod(JNIEnv* _jenv, jobject _ji
     auto result = (*pInstanceSharedPointer)->nullable_date_method(input);
     return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
 }
+jobject
+Java_com_example_smoke_DatesSteady_dateListMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::smoke::DatesSteady::DateList input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::smoke::DatesSteady::DateList*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->date_list_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
 JNIEXPORT void JNICALL
 Java_com_example_smoke_DatesSteady_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
 {

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/GenericCollections.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/GenericCollections.cpp
@@ -1,0 +1,183 @@
+//
+//
+#include "cbridge/include/GenericCollections.h"
+#include "cbridge/include/StringHandle.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "gluecodium/Optional.h"
+#include "gluecodium/TimePointHash.h"
+#include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
+#include "gluecodium/VectorHash.h"
+#include "smoke/DatesSteady.h"
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <new>
+_baseRef foobar_ArrayOf__Date_create_handle() {
+    return reinterpret_cast<_baseRef>( new ::std::vector< ::std::chrono::system_clock::time_point >( ) );
+}
+_baseRef foobar_ArrayOf__Date_copy_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ::std::vector< ::std::chrono::system_clock::time_point >( *reinterpret_cast<::std::vector< ::std::chrono::system_clock::time_point >*>( handle ) ) );
+}
+void foobar_ArrayOf__Date_release_handle(_baseRef handle) {
+    delete reinterpret_cast<::std::vector< ::std::chrono::system_clock::time_point >*>( handle );
+}
+uint64_t foobar_ArrayOf__Date_count(_baseRef handle) {
+    return Conversion<::std::vector< ::std::chrono::system_clock::time_point >>::toCpp( handle ).size( );
+}
+double foobar_ArrayOf__Date_get( _baseRef handle, uint64_t index ) {
+    return Conversion<::std::chrono::system_clock::time_point>::referenceBaseRef(Conversion<::std::vector< ::std::chrono::system_clock::time_point >>::toCpp( handle )[index]);
+}
+void foobar_ArrayOf__Date_append( _baseRef handle, double item )
+{
+    Conversion<::std::vector< ::std::chrono::system_clock::time_point >>::toCpp(handle).push_back(Conversion<::std::chrono::system_clock::time_point>::toCpp(item));
+}
+_baseRef foobar_ArrayOf__Date_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector< ::std::chrono::system_clock::time_point >>( ::std::vector< ::std::chrono::system_clock::time_point >( ) ) );
+}
+void foobar_ArrayOf__Date_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::std::vector< ::std::chrono::system_clock::time_point >>*>( handle );
+}
+_baseRef foobar_ArrayOf__Date_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector< ::std::chrono::system_clock::time_point >>*>( handle ) );
+}
+_baseRef foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_create_handle() {
+    return reinterpret_cast<_baseRef>( new ::std::vector< std::chrono::steady_clock::time_point >( ) );
+}
+_baseRef foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_copy_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ::std::vector< std::chrono::steady_clock::time_point >( *reinterpret_cast<::std::vector< std::chrono::steady_clock::time_point >*>( handle ) ) );
+}
+void foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_release_handle(_baseRef handle) {
+    delete reinterpret_cast<::std::vector< std::chrono::steady_clock::time_point >*>( handle );
+}
+uint64_t foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_count(_baseRef handle) {
+    return Conversion<::std::vector< std::chrono::steady_clock::time_point >>::toCpp( handle ).size( );
+}
+double foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_get( _baseRef handle, uint64_t index ) {
+    return Conversion<std::chrono::steady_clock::time_point>::referenceBaseRef(Conversion<::std::vector< std::chrono::steady_clock::time_point >>::toCpp( handle )[index]);
+}
+void foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_append( _baseRef handle, double item )
+{
+    Conversion<::std::vector< std::chrono::steady_clock::time_point >>::toCpp(handle).push_back(Conversion<std::chrono::steady_clock::time_point>::toCpp(item));
+}
+_baseRef foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::vector< std::chrono::steady_clock::time_point >>( ::std::vector< std::chrono::steady_clock::time_point >( ) ) );
+}
+void foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::std::vector< std::chrono::steady_clock::time_point >>*>( handle );
+}
+_baseRef foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::vector< std::chrono::steady_clock::time_point >>*>( handle ) );
+}
+_baseRef foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_create_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >() );
+}
+void foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_release_handle(_baseRef handle) {
+    delete get_pointer<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >>(handle);
+}
+_baseRef foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_iterator(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >::iterator( get_pointer<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >>(handle)->begin() ) );
+}
+void foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_iterator_release_handle(_baseRef iterator_handle) {
+    delete reinterpret_cast<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >::iterator*>( iterator_handle );
+}
+void foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_put(_baseRef handle, double key, _baseRef value) {
+    (*get_pointer<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >>(handle)).emplace(Conversion<std::chrono::steady_clock::time_point>::toCpp(key), Conversion<::std::string>::toCpp(value));
+}
+bool foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
+    return *reinterpret_cast<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >>(handle)->end();
+}
+void foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_iterator_increment(_baseRef iterator_handle) {
+    ++*reinterpret_cast<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >::iterator*>( iterator_handle );
+}
+double foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_iterator_key(_baseRef iterator_handle) {
+    auto& key = (*reinterpret_cast<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >::iterator*>( iterator_handle ))->first;
+    return Conversion<std::chrono::steady_clock::time_point>::toBaseRef(key);
+}
+_baseRef foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_iterator_value(_baseRef iterator_handle) {
+    auto& value = (*reinterpret_cast<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::string>::toBaseRef(value);
+}
+_baseRef foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >>( ::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >( ) ) );
+}
+void foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >>*>( handle );
+}
+_baseRef foobar_MapOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_To__String_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map< std::chrono::steady_clock::time_point, ::std::string, ::gluecodium::hash< std::chrono::steady_clock::time_point > >>*>( handle ) );
+}
+_baseRef foobar_MapOf__String_To__Date_create_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >() );
+}
+void foobar_MapOf__String_To__Date_release_handle(_baseRef handle) {
+    delete get_pointer<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >>(handle);
+}
+_baseRef foobar_MapOf__String_To__Date_iterator(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >::iterator( get_pointer<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >>(handle)->begin() ) );
+}
+void foobar_MapOf__String_To__Date_iterator_release_handle(_baseRef iterator_handle) {
+    delete reinterpret_cast<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >::iterator*>( iterator_handle );
+}
+void foobar_MapOf__String_To__Date_put(_baseRef handle, _baseRef key, double value) {
+    (*get_pointer<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >>(handle)).emplace(Conversion<::std::string>::toCpp(key), Conversion<::std::chrono::system_clock::time_point>::toCpp(value));
+}
+bool foobar_MapOf__String_To__Date_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
+    return *reinterpret_cast<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >::iterator*>( iterator_handle ) != get_pointer<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >>(handle)->end();
+}
+void foobar_MapOf__String_To__Date_iterator_increment(_baseRef iterator_handle) {
+    ++*reinterpret_cast<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >::iterator*>( iterator_handle );
+}
+_baseRef foobar_MapOf__String_To__Date_iterator_key(_baseRef iterator_handle) {
+    auto& key = (*reinterpret_cast<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >::iterator*>( iterator_handle ))->first;
+    return Conversion<::std::string>::toBaseRef(key);
+}
+double foobar_MapOf__String_To__Date_iterator_value(_baseRef iterator_handle) {
+    auto& value = (*reinterpret_cast<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >::iterator*>( iterator_handle ))->second;
+    return Conversion<::std::chrono::system_clock::time_point>::toBaseRef(value);
+}
+_baseRef foobar_MapOf__String_To__Date_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >>( ::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >( ) ) );
+}
+void foobar_MapOf__String_To__Date_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >>*>( handle );
+}
+_baseRef foobar_MapOf__String_To__Date_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >>*>( handle ) );
+}
+_baseRef foobar_SetOf__Date_create_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >() );
+}
+void foobar_SetOf__Date_release_handle(_baseRef handle) {
+    delete get_pointer<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>(handle);
+}
+void foobar_SetOf__Date_insert(_baseRef handle, double value) {
+    (*get_pointer<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>(handle)).insert(::std::move(Conversion<::std::chrono::system_clock::time_point>::toCpp(value)));
+}
+_baseRef foobar_SetOf__Date_iterator(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >::iterator( get_pointer<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>(handle)->begin() ) );
+}
+void foobar_SetOf__Date_iterator_release_handle(_baseRef iterator_handle) {
+    delete reinterpret_cast<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >::iterator*>( iterator_handle );
+}
+bool foobar_SetOf__Date_iterator_is_valid(_baseRef handle, _baseRef iterator_handle) {
+    return *reinterpret_cast<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >::iterator*>( iterator_handle ) != get_pointer<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>(handle)->end();
+}
+void foobar_SetOf__Date_iterator_increment(_baseRef iterator_handle) {
+    ++*reinterpret_cast<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >::iterator*>( iterator_handle );
+}
+double foobar_SetOf__Date_iterator_get(_baseRef iterator_handle) {
+    auto& value = **reinterpret_cast<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >::iterator*>( iterator_handle );
+    return Conversion<::std::chrono::system_clock::time_point>::referenceBaseRef(value);
+}
+_baseRef foobar_SetOf__Date_create_optional_handle() {
+    return reinterpret_cast<_baseRef>( new ( ::std::nothrow ) ::gluecodium::optional<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>( ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >( ) ) );
+}
+void foobar_SetOf__Date_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>*>( handle );
+}
+_baseRef foobar_SetOf__Date_unwrap_optional_handle(_baseRef handle) {
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>*>( handle ) );
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/cbridge/src/smoke/cbridge_DatesSteady.cpp
@@ -5,9 +5,11 @@
 #include "cbridge_internal/include/TypeInitRepository.h"
 #include "cbridge_internal/include/WrapperCache.h"
 #include "gluecodium/Optional.h"
+#include "gluecodium/VectorHash.h"
 #include "smoke/DatesSteady.h"
 #include <memory>
 #include <new>
+#include <vector>
 void smoke_DatesSteady_release_handle(_baseRef handle) {
     delete get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(handle);
 }
@@ -34,6 +36,9 @@ double smoke_DatesSteady_dateMethod(_baseRef _instance, double input) {
 }
 _baseRef smoke_DatesSteady_nullableDateMethod(_baseRef _instance, _baseRef input) {
     return Conversion<::gluecodium::optional< std::chrono::steady_clock::time_point >>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(_instance)->get()->nullable_date_method(Conversion<::gluecodium::optional< std::chrono::steady_clock::time_point >>::toCpp(input)));
+}
+_baseRef smoke_DatesSteady_dateListMethod(_baseRef _instance, _baseRef input) {
+    return Conversion<::std::vector< std::chrono::steady_clock::time_point >>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::DatesSteady >>(_instance)->get()->date_list_method(Conversion<::std::vector< std::chrono::steady_clock::time_point >>::toCpp(input)));
 }
 _baseRef
 smoke_DatesSteady_DateStruct_create_handle( double dateField, _baseRef nullableDateField )

--- a/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DatesSteady.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DatesSteady.h
@@ -30,5 +30,6 @@ public:
 public:
     virtual ::smoke::DatesSteady::MonotonicDate date_method( const ::smoke::DatesSteady::MonotonicDate& input ) = 0;
     virtual ::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate > nullable_date_method( const ::gluecodium::optional< ::smoke::DatesSteady::MonotonicDate >& input ) = 0;
+    virtual ::smoke::DatesSteady::DateList date_list_method( const ::smoke::DatesSteady::DateList& input ) = 0;
 };
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/GenericTypesConversion.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/GenericTypesConversion.cpp
@@ -1,0 +1,273 @@
+#include "GenericTypesConversion.h"
+#include "ConversionBase.h"
+#include "gluecodium/TimePointHash.h"
+#include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
+#include "gluecodium/VectorHash.h"
+#include <chrono>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_foobar_ListOf_Date_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::chrono::system_clock::time_point>());
+}
+void
+library_foobar_ListOf_Date_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::vector<std::chrono::system_clock::time_point>*>(handle);
+}
+void
+library_foobar_ListOf_Date_insert(FfiOpaqueHandle handle, uint64_t value) {
+    reinterpret_cast<std::vector<std::chrono::system_clock::time_point>*>(handle)->push_back(
+        gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_foobar_ListOf_Date_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::vector<std::chrono::system_clock::time_point>::iterator(
+        reinterpret_cast<std::vector<std::chrono::system_clock::time_point>*>(handle)->begin()
+    ));
+}
+void
+library_foobar_ListOf_Date_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::vector<std::chrono::system_clock::time_point>::iterator*>(iterator_handle);
+}
+bool
+library_foobar_ListOf_Date_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::vector<std::chrono::system_clock::time_point>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::vector<std::chrono::system_clock::time_point>*>(handle)->end();
+}
+void
+library_foobar_ListOf_Date_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::vector<std::chrono::system_clock::time_point>::iterator*>(iterator_handle);
+}
+uint64_t
+library_foobar_ListOf_Date_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toFfi(
+        **reinterpret_cast<std::vector<std::chrono::system_clock::time_point>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_ListOf_Date_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::vector<std::chrono::system_clock::time_point>>(
+            gluecodium::ffi::Conversion<std::vector<std::chrono::system_clock::time_point>>::toCpp(value)
+        )
+    );
+}
+void
+library_foobar_ListOf_Date_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::vector<std::chrono::system_clock::time_point>>*>(handle);
+}
+FfiOpaqueHandle
+library_foobar_ListOf_Date_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::vector<std::chrono::system_clock::time_point>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::vector<std::chrono::system_clock::time_point>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Date_to_String_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>());
+}
+void
+library_foobar_MapOf_Date_to_String_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>*>(handle);
+}
+void
+library_foobar_MapOf_Date_to_String_put(FfiOpaqueHandle handle, uint64_t key, FfiOpaqueHandle value) {
+    reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>*>(handle)->emplace(
+        gluecodium::ffi::Conversion<std::chrono::steady_clock::time_point>::toCpp(key),
+        gluecodium::ffi::Conversion<std::string>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Date_to_String_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>::iterator(
+        reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>*>(handle)->begin()
+    ));
+}
+void
+library_foobar_MapOf_Date_to_String_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>::iterator*>(iterator_handle);
+}
+bool
+library_foobar_MapOf_Date_to_String_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>*>(handle)->end();
+}
+void
+library_foobar_MapOf_Date_to_String_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>::iterator*>(iterator_handle);
+}
+uint64_t
+library_foobar_MapOf_Date_to_String_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::chrono::steady_clock::time_point>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>::iterator*>(iterator_handle))->first
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Date_to_String_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>::iterator*>(iterator_handle))->second
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Date_to_String_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>>(
+            gluecodium::ffi::Conversion<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>>::toCpp(value)
+        )
+    );
+}
+void
+library_foobar_MapOf_Date_to_String_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>>*>(handle);
+}
+FfiOpaqueHandle
+library_foobar_MapOf_Date_to_String_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::chrono::steady_clock::time_point, std::string, gluecodium::hash<std::chrono::steady_clock::time_point>>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_String_to_Date_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, std::chrono::system_clock::time_point>());
+}
+void
+library_foobar_MapOf_String_to_Date_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>*>(handle);
+}
+void
+library_foobar_MapOf_String_to_Date_put(FfiOpaqueHandle handle, FfiOpaqueHandle key, uint64_t value) {
+    reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>*>(handle)->emplace(
+        gluecodium::ffi::Conversion<std::string>::toCpp(key),
+        gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_String_to_Date_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_map<std::string, std::chrono::system_clock::time_point>::iterator(
+        reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>*>(handle)->begin()
+    ));
+}
+void
+library_foobar_MapOf_String_to_Date_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>::iterator*>(iterator_handle);
+}
+bool
+library_foobar_MapOf_String_to_Date_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>*>(handle)->end();
+}
+void
+library_foobar_MapOf_String_to_Date_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>::iterator*>(iterator_handle);
+}
+FfiOpaqueHandle
+library_foobar_MapOf_String_to_Date_iterator_get_key(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>::iterator*>(iterator_handle))->first
+    );
+}
+uint64_t
+library_foobar_MapOf_String_to_Date_iterator_get_value(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toFfi(
+        (*reinterpret_cast<std::unordered_map<std::string, std::chrono::system_clock::time_point>::iterator*>(iterator_handle))->second
+    );
+}
+FfiOpaqueHandle
+library_foobar_MapOf_String_to_Date_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_map<std::string, std::chrono::system_clock::time_point>>(
+            gluecodium::ffi::Conversion<std::unordered_map<std::string, std::chrono::system_clock::time_point>>::toCpp(value)
+        )
+    );
+}
+void
+library_foobar_MapOf_String_to_Date_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, std::chrono::system_clock::time_point>>*>(handle);
+}
+FfiOpaqueHandle
+library_foobar_MapOf_String_to_Date_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_map<std::string, std::chrono::system_clock::time_point>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_map<std::string, std::chrono::system_clock::time_point>>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Date_create_handle() {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>());
+}
+void
+library_foobar_SetOf_Date_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>*>(handle);
+}
+void
+library_foobar_SetOf_Date_insert(FfiOpaqueHandle handle, uint64_t value) {
+    reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>*>(handle)->insert(
+        gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toCpp(value)
+    );
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Date_iterator(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>::iterator(
+        reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>*>(handle)->begin()
+    ));
+}
+void
+library_foobar_SetOf_Date_iterator_release_handle(FfiOpaqueHandle iterator_handle) {
+    delete reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>::iterator*>(iterator_handle);
+}
+bool
+library_foobar_SetOf_Date_iterator_is_valid(FfiOpaqueHandle handle, FfiOpaqueHandle iterator_handle) {
+    return *reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>::iterator*>(iterator_handle) !=
+        reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>*>(handle)->end();
+}
+void
+library_foobar_SetOf_Date_iterator_increment(FfiOpaqueHandle iterator_handle) {
+    ++*reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>::iterator*>(iterator_handle);
+}
+uint64_t
+library_foobar_SetOf_Date_iterator_get(FfiOpaqueHandle iterator_handle) {
+    return gluecodium::ffi::Conversion<std::chrono::system_clock::time_point>::toFfi(
+        **reinterpret_cast<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>::iterator*>(iterator_handle)
+    );
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Date_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>>(
+            gluecodium::ffi::Conversion<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>>::toCpp(value)
+        )
+    );
+}
+void
+library_foobar_SetOf_Date_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>>*>(handle);
+}
+FfiOpaqueHandle
+library_foobar_SetOf_Date_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>>::toFfi(
+        **reinterpret_cast<gluecodium::optional<std::unordered_set<std::chrono::system_clock::time_point, gluecodium::hash<std::chrono::system_clock::time_point>>>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/ffi/ffi_smoke_DatesSteady.cpp
@@ -5,9 +5,11 @@
 #include "IsolateContext.h"
 #include "gluecodium/Optional.h"
 #include "gluecodium/TimePointHash.h"
+#include "gluecodium/VectorHash.h"
 #include "smoke/DatesSteady.h"
 #include <chrono>
 #include <memory>
+#include <vector>
 #include <memory>
 #include <new>
 #ifdef __cplusplus
@@ -28,6 +30,15 @@ library_smoke_DatesSteady_nullableDateMethod__Date(FfiOpaqueHandle _self, int32_
     return gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::steady_clock::time_point>>::toFfi(
         (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DatesSteady>>::toCpp(_self)).nullable_date_method(
             gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::steady_clock::time_point>>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+library_smoke_DatesSteady_dateListMethod__ListOf_1Date(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::vector<std::chrono::steady_clock::time_point>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DatesSteady>>::toCpp(_self)).date_list_method(
+            gluecodium::ffi::Conversion<std::vector<std::chrono::steady_clock::time_point>>::toCpp(input)
         )
     );
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/generic_types__conversion.dart
@@ -1,0 +1,361 @@
+import 'package:library/src/builtin_types__conversion.dart';
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+final _foobarListofDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_foobar_ListOf_Date_create_handle'));
+final _foobarListofDateReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_ListOf_Date_release_handle'));
+final _foobarListofDateInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint64),
+    void Function(Pointer<Void>, int)
+  >('library_foobar_ListOf_Date_insert'));
+final _foobarListofDateIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_ListOf_Date_iterator'));
+final _foobarListofDateIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_ListOf_Date_iterator_release_handle'));
+final _foobarListofDateIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_foobar_ListOf_Date_iterator_is_valid'));
+final _foobarListofDateIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_ListOf_Date_iterator_increment'));
+final _foobarListofDateIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_foobar_ListOf_Date_iterator_get'));
+Pointer<Void> foobarListofDateToFfi(List<DateTime> value) {
+  final _result = _foobarListofDateCreateHandle();
+  for (final element in value) {
+    final _elementHandle = dateToFfi(element);
+    _foobarListofDateInsert(_result, _elementHandle);
+    dateReleaseFfiHandle(_elementHandle);
+  }
+  return _result;
+}
+List<DateTime> foobarListofDateFromFfi(Pointer<Void> handle) {
+  final result = List<DateTime>.empty(growable: true);
+  final _iteratorHandle = _foobarListofDateIterator(handle);
+  while (_foobarListofDateIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofDateIteratorGet(_iteratorHandle);
+    try {
+      result.add(dateFromFfi(_elementHandle));
+    } finally {
+      dateReleaseFfiHandle(_elementHandle);
+    }
+    _foobarListofDateIteratorIncrement(_iteratorHandle);
+  }
+  _foobarListofDateIteratorReleaseHandle(_iteratorHandle);
+  return result;
+}
+void foobarListofDateReleaseFfiHandle(Pointer<Void> handle) => _foobarListofDateReleaseHandle(handle);
+final _foobarListofDateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_ListOf_Date_create_handle_nullable'));
+final _foobarListofDateReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_ListOf_Date_release_handle_nullable'));
+final _foobarListofDateGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_ListOf_Date_get_value_nullable'));
+Pointer<Void> foobarListofDateToFfiNullable(List<DateTime>? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = foobarListofDateToFfi(value);
+  final result = _foobarListofDateCreateHandleNullable(_handle);
+  foobarListofDateReleaseFfiHandle(_handle);
+  return result;
+}
+List<DateTime>? foobarListofDateFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _foobarListofDateGetValueNullable(handle);
+  final result = foobarListofDateFromFfi(_handle);
+  foobarListofDateReleaseFfiHandle(_handle);
+  return result;
+}
+void foobarListofDateReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _foobarListofDateReleaseHandleNullable(handle);
+final _foobarMapofDateToStringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_foobar_MapOf_Date_to_String_create_handle'));
+final _foobarMapofDateToStringReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_MapOf_Date_to_String_release_handle'));
+final _foobarMapofDateToStringPut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint64, Pointer<Void>),
+    void Function(Pointer<Void>, int, Pointer<Void>)
+  >('library_foobar_MapOf_Date_to_String_put'));
+final _foobarMapofDateToStringIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_MapOf_Date_to_String_iterator'));
+final _foobarMapofDateToStringIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_MapOf_Date_to_String_iterator_release_handle'));
+final _foobarMapofDateToStringIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_foobar_MapOf_Date_to_String_iterator_is_valid'));
+final _foobarMapofDateToStringIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_MapOf_Date_to_String_iterator_increment'));
+final _foobarMapofDateToStringIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_foobar_MapOf_Date_to_String_iterator_get_key'));
+final _foobarMapofDateToStringIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_MapOf_Date_to_String_iterator_get_value'));
+Pointer<Void> foobarMapofDateToStringToFfi(Map<DateTime, String> value) {
+  final _result = _foobarMapofDateToStringCreateHandle();
+  for (final entry in value.entries) {
+    final _keyHandle = dateToFfi(entry.key);
+    final _valueHandle = stringToFfi(entry.value);
+    _foobarMapofDateToStringPut(_result, _keyHandle, _valueHandle);
+    dateReleaseFfiHandle(_keyHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+  return _result;
+}
+Map<DateTime, String> foobarMapofDateToStringFromFfi(Pointer<Void> handle) {
+  final result = Map<DateTime, String>();
+  final _iteratorHandle = _foobarMapofDateToStringIterator(handle);
+  while (_foobarMapofDateToStringIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofDateToStringIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofDateToStringIteratorGetValue(_iteratorHandle);
+    try {
+      result[dateFromFfi(_keyHandle)] =
+        stringFromFfi(_valueHandle);
+    } finally {
+      dateReleaseFfiHandle(_keyHandle);
+      stringReleaseFfiHandle(_valueHandle);
+    }
+    _foobarMapofDateToStringIteratorIncrement(_iteratorHandle);
+  }
+  _foobarMapofDateToStringIteratorReleaseHandle(_iteratorHandle);
+  return result;
+}
+void foobarMapofDateToStringReleaseFfiHandle(Pointer<Void> handle) => _foobarMapofDateToStringReleaseHandle(handle);
+final _foobarMapofDateToStringCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_MapOf_Date_to_String_create_handle_nullable'));
+final _foobarMapofDateToStringReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_MapOf_Date_to_String_release_handle_nullable'));
+final _foobarMapofDateToStringGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_MapOf_Date_to_String_get_value_nullable'));
+Pointer<Void> foobarMapofDateToStringToFfiNullable(Map<DateTime, String>? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = foobarMapofDateToStringToFfi(value);
+  final result = _foobarMapofDateToStringCreateHandleNullable(_handle);
+  foobarMapofDateToStringReleaseFfiHandle(_handle);
+  return result;
+}
+Map<DateTime, String>? foobarMapofDateToStringFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _foobarMapofDateToStringGetValueNullable(handle);
+  final result = foobarMapofDateToStringFromFfi(_handle);
+  foobarMapofDateToStringReleaseFfiHandle(_handle);
+  return result;
+}
+void foobarMapofDateToStringReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _foobarMapofDateToStringReleaseHandleNullable(handle);
+final _foobarMapofStringToDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_foobar_MapOf_String_to_Date_create_handle'));
+final _foobarMapofStringToDateReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_MapOf_String_to_Date_release_handle'));
+final _foobarMapofStringToDatePut = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>, Uint64),
+    void Function(Pointer<Void>, Pointer<Void>, int)
+  >('library_foobar_MapOf_String_to_Date_put'));
+final _foobarMapofStringToDateIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_MapOf_String_to_Date_iterator'));
+final _foobarMapofStringToDateIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_MapOf_String_to_Date_iterator_release_handle'));
+final _foobarMapofStringToDateIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_foobar_MapOf_String_to_Date_iterator_is_valid'));
+final _foobarMapofStringToDateIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_MapOf_String_to_Date_iterator_increment'));
+final _foobarMapofStringToDateIteratorGetKey = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_MapOf_String_to_Date_iterator_get_key'));
+final _foobarMapofStringToDateIteratorGetValue = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_foobar_MapOf_String_to_Date_iterator_get_value'));
+Pointer<Void> foobarMapofStringToDateToFfi(Map<String, DateTime> value) {
+  final _result = _foobarMapofStringToDateCreateHandle();
+  for (final entry in value.entries) {
+    final _keyHandle = stringToFfi(entry.key);
+    final _valueHandle = dateToFfi(entry.value);
+    _foobarMapofStringToDatePut(_result, _keyHandle, _valueHandle);
+    stringReleaseFfiHandle(_keyHandle);
+    dateReleaseFfiHandle(_valueHandle);
+  }
+  return _result;
+}
+Map<String, DateTime> foobarMapofStringToDateFromFfi(Pointer<Void> handle) {
+  final result = Map<String, DateTime>();
+  final _iteratorHandle = _foobarMapofStringToDateIterator(handle);
+  while (_foobarMapofStringToDateIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _keyHandle = _foobarMapofStringToDateIteratorGetKey(_iteratorHandle);
+    final _valueHandle = _foobarMapofStringToDateIteratorGetValue(_iteratorHandle);
+    try {
+      result[stringFromFfi(_keyHandle)] =
+        dateFromFfi(_valueHandle);
+    } finally {
+      stringReleaseFfiHandle(_keyHandle);
+      dateReleaseFfiHandle(_valueHandle);
+    }
+    _foobarMapofStringToDateIteratorIncrement(_iteratorHandle);
+  }
+  _foobarMapofStringToDateIteratorReleaseHandle(_iteratorHandle);
+  return result;
+}
+void foobarMapofStringToDateReleaseFfiHandle(Pointer<Void> handle) => _foobarMapofStringToDateReleaseHandle(handle);
+final _foobarMapofStringToDateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_MapOf_String_to_Date_create_handle_nullable'));
+final _foobarMapofStringToDateReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_MapOf_String_to_Date_release_handle_nullable'));
+final _foobarMapofStringToDateGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_MapOf_String_to_Date_get_value_nullable'));
+Pointer<Void> foobarMapofStringToDateToFfiNullable(Map<String, DateTime>? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = foobarMapofStringToDateToFfi(value);
+  final result = _foobarMapofStringToDateCreateHandleNullable(_handle);
+  foobarMapofStringToDateReleaseFfiHandle(_handle);
+  return result;
+}
+Map<String, DateTime>? foobarMapofStringToDateFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _foobarMapofStringToDateGetValueNullable(handle);
+  final result = foobarMapofStringToDateFromFfi(_handle);
+  foobarMapofStringToDateReleaseFfiHandle(_handle);
+  return result;
+}
+void foobarMapofStringToDateReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _foobarMapofStringToDateReleaseHandleNullable(handle);
+final _foobarSetofDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_foobar_SetOf_Date_create_handle'));
+final _foobarSetofDateReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_SetOf_Date_release_handle'));
+final _foobarSetofDateInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint64),
+    void Function(Pointer<Void>, int)
+  >('library_foobar_SetOf_Date_insert'));
+final _foobarSetofDateIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_SetOf_Date_iterator'));
+final _foobarSetofDateIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_SetOf_Date_iterator_release_handle'));
+final _foobarSetofDateIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_foobar_SetOf_Date_iterator_is_valid'));
+final _foobarSetofDateIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_SetOf_Date_iterator_increment'));
+final _foobarSetofDateIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_foobar_SetOf_Date_iterator_get'));
+Pointer<Void> foobarSetofDateToFfi(Set<DateTime> value) {
+  final _result = _foobarSetofDateCreateHandle();
+  for (final element in value) {
+    final _elementHandle = dateToFfi(element);
+    _foobarSetofDateInsert(_result, _elementHandle);
+    dateReleaseFfiHandle(_elementHandle);
+  }
+  return _result;
+}
+Set<DateTime> foobarSetofDateFromFfi(Pointer<Void> handle) {
+  final result = Set<DateTime>();
+  final _iteratorHandle = _foobarSetofDateIterator(handle);
+  while (_foobarSetofDateIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarSetofDateIteratorGet(_iteratorHandle);
+    try {
+      result.add(dateFromFfi(_elementHandle));
+    } finally {
+      dateReleaseFfiHandle(_elementHandle);
+    }
+    _foobarSetofDateIteratorIncrement(_iteratorHandle);
+  }
+  _foobarSetofDateIteratorReleaseHandle(_iteratorHandle);
+  return result;
+}
+void foobarSetofDateReleaseFfiHandle(Pointer<Void> handle) => _foobarSetofDateReleaseHandle(handle);
+final _foobarSetofDateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_SetOf_Date_create_handle_nullable'));
+final _foobarSetofDateReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_SetOf_Date_release_handle_nullable'));
+final _foobarSetofDateGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_SetOf_Date_get_value_nullable'));
+Pointer<Void> foobarSetofDateToFfiNullable(Set<DateTime>? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = foobarSetofDateToFfi(value);
+  final result = _foobarSetofDateCreateHandleNullable(_handle);
+  foobarSetofDateReleaseFfiHandle(_handle);
+  return result;
+}
+Set<DateTime>? foobarSetofDateFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _foobarSetofDateGetValueNullable(handle);
+  final result = foobarSetofDateFromFfi(_handle);
+  foobarSetofDateReleaseFfiHandle(_handle);
+  return result;
+}
+void foobarSetofDateReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _foobarSetofDateReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
@@ -1,0 +1,165 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
+abstract class DatesSteady {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
+  DateTime dateMethod(DateTime input);
+  DateTime? nullableDateMethod(DateTime? input);
+  List<DateTime> dateListMethod(List<DateTime> input);
+}
+class DatesSteady_DateStruct {
+  DateTime dateField;
+  DateTime? nullableDateField;
+  DatesSteady_DateStruct(this.dateField, this.nullableDateField);
+}
+// DatesSteady_DateStruct "private" section, not exported.
+final _smokeDatessteadyDatestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Pointer<Void>),
+    Pointer<Void> Function(int, Pointer<Void>)
+  >('library_smoke_DatesSteady_DateStruct_create_handle'));
+final _smokeDatessteadyDatestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_DateStruct_release_handle'));
+final _smokeDatessteadyDatestructGetFielddateField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_DateStruct_get_field_dateField'));
+final _smokeDatessteadyDatestructGetFieldnullableDateField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_DateStruct_get_field_nullableDateField'));
+Pointer<Void> smokeDatessteadyDatestructToFfi(DatesSteady_DateStruct value) {
+  final _dateFieldHandle = dateToFfi(value.dateField);
+  final _nullableDateFieldHandle = dateToFfiNullable(value.nullableDateField);
+  final _result = _smokeDatessteadyDatestructCreateHandle(_dateFieldHandle, _nullableDateFieldHandle);
+  dateReleaseFfiHandle(_dateFieldHandle);
+  dateReleaseFfiHandleNullable(_nullableDateFieldHandle);
+  return _result;
+}
+DatesSteady_DateStruct smokeDatessteadyDatestructFromFfi(Pointer<Void> handle) {
+  final _dateFieldHandle = _smokeDatessteadyDatestructGetFielddateField(handle);
+  final _nullableDateFieldHandle = _smokeDatessteadyDatestructGetFieldnullableDateField(handle);
+  try {
+    return DatesSteady_DateStruct(
+      dateFromFfi(_dateFieldHandle),
+      dateFromFfiNullable(_nullableDateFieldHandle)
+    );
+  } finally {
+    dateReleaseFfiHandle(_dateFieldHandle);
+    dateReleaseFfiHandleNullable(_nullableDateFieldHandle);
+  }
+}
+void smokeDatessteadyDatestructReleaseFfiHandle(Pointer<Void> handle) => _smokeDatessteadyDatestructReleaseHandle(handle);
+// Nullable DatesSteady_DateStruct
+final _smokeDatessteadyDatestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_DateStruct_create_handle_nullable'));
+final _smokeDatessteadyDatestructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_DateStruct_release_handle_nullable'));
+final _smokeDatessteadyDatestructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_DateStruct_get_value_nullable'));
+Pointer<Void> smokeDatessteadyDatestructToFfiNullable(DatesSteady_DateStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDatessteadyDatestructToFfi(value);
+  final result = _smokeDatessteadyDatestructCreateHandleNullable(_handle);
+  smokeDatessteadyDatestructReleaseFfiHandle(_handle);
+  return result;
+}
+DatesSteady_DateStruct? smokeDatessteadyDatestructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDatessteadyDatestructGetValueNullable(handle);
+  final result = smokeDatessteadyDatestructFromFfi(_handle);
+  smokeDatessteadyDatestructReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDatessteadyDatestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDatessteadyDatestructReleaseHandleNullable(handle);
+// End of DatesSteady_DateStruct "private" section.
+// DatesSteady "private" section, not exported.
+final _smokeDatessteadyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_DatesSteady_register_finalizer'));
+final _smokeDatessteadyCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_copy_handle'));
+final _smokeDatessteadyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DatesSteady_release_handle'));
+class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
+  DatesSteady$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  DateTime dateMethod(DateTime input) {
+    final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DatesSteady_dateMethod__Date'));
+    final _inputHandle = dateToFfi(input);
+    final _handle = this.handle;
+    final __resultHandle = _dateMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    dateReleaseFfiHandle(_inputHandle);
+    try {
+      return dateFromFfi(__resultHandle);
+    } finally {
+      dateReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  DateTime? nullableDateMethod(DateTime? input) {
+    final _nullableDateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_nullableDateMethod__Date'));
+    final _inputHandle = dateToFfiNullable(input);
+    final _handle = this.handle;
+    final __resultHandle = _nullableDateMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    dateReleaseFfiHandleNullable(_inputHandle);
+    try {
+      return dateFromFfiNullable(__resultHandle);
+    } finally {
+      dateReleaseFfiHandleNullable(__resultHandle);
+    }
+  }
+  @override
+  List<DateTime> dateListMethod(List<DateTime> input) {
+    final _dateListMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_dateListMethod__ListOf_1Date'));
+    final _inputHandle = foobarListofDateToFfi(input);
+    final _handle = this.handle;
+    final __resultHandle = _dateListMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    foobarListofDateReleaseFfiHandle(_inputHandle);
+    try {
+      return foobarListofDateFromFfi(__resultHandle);
+    } finally {
+      foobarListofDateReleaseFfiHandle(__resultHandle);
+    }
+  }
+}
+Pointer<Void> smokeDatessteadyToFfi(DatesSteady value) =>
+  _smokeDatessteadyCopyHandle((value as __lib.NativeBase).handle);
+DatesSteady smokeDatessteadyFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is DatesSteady) return instance as DatesSteady;
+  final _copiedHandle = _smokeDatessteadyCopyHandle(handle);
+  final result = DatesSteady$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeDatessteadyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeDatessteadyReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeDatessteadyReleaseHandle(handle);
+Pointer<Void> smokeDatessteadyToFfiNullable(DatesSteady? value) =>
+  value != null ? smokeDatessteadyToFfi(value) : Pointer<Void>.fromAddress(0);
+DatesSteady? smokeDatessteadyFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeDatessteadyFromFfi(handle) : null;
+void smokeDatessteadyReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDatessteadyReleaseHandle(handle);
+// End of DatesSteady "private" section.

--- a/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DatesSteady.lime
+++ b/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DatesSteady.lime
@@ -13,4 +13,7 @@ class DatesSteady {
     fun nullableDateMethod(
         input: MonotonicDate?
     ): MonotonicDate?
+    fun dateListMethod(
+        input: DateList
+    ): DateList
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/Collections.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/Collections.swift
@@ -1,0 +1,109 @@
+//
+//
+import Foundation
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [Date] {
+    var result: [Date] = []
+    let count = foobar_ArrayOf__Date_count(handle)
+    for idx in 0..<count {
+        result.append(copyFromCType(foobar_ArrayOf__Date_get(handle, idx)))
+    }
+    return result
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [Date] {
+    defer {
+        foobar_ArrayOf__Date_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftArray: [Date]) -> RefHolder {
+    let handle = foobar_ArrayOf__Date_create_handle()
+    for item in swiftArray {
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Date_append(handle, _item.ref)
+    }
+    return RefHolder(handle)
+}
+internal func foobar_moveToCType(_ swiftArray: [Date]) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftArray).ref, release: foobar_ArrayOf__Date_release_handle)
+}
+internal func foobar_copyToCType(_ swiftArray: [Date]?) -> RefHolder {
+    guard let swiftArray = swiftArray else {
+        return RefHolder(0)
+    }
+    let optionalHandle = foobar_ArrayOf__Date_create_optional_handle()
+    let handle = foobar_ArrayOf__Date_unwrap_optional_handle(optionalHandle)
+    for item in swiftArray {
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Date_append(handle, _item.ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func foobar_moveToCType(_ swiftType: [Date]?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_ArrayOf__Date_release_optional_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> [Date]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = foobar_ArrayOf__Date_unwrap_optional_handle(handle)
+    return foobar_copyFromCType(unwrappedHandle) as [Date]
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> [Date]? {
+    defer {
+        foobar_ArrayOf__Date_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyFromCType(_ handle: _baseRef) -> [DatesSteady.MonotonicDate] {
+    var result: [DatesSteady.MonotonicDate] = []
+    let count = foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_count(handle)
+    for idx in 0..<count {
+        result.append(copyFromCType(foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_get(handle, idx)))
+    }
+    return result
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointmoveFromCType(_ handle: _baseRef) -> [DatesSteady.MonotonicDate] {
+    defer {
+        foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_release_handle(handle)
+    }
+    return foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyFromCType(handle)
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyToCType(_ swiftArray: [DatesSteady.MonotonicDate]) -> RefHolder {
+    let handle = foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_create_handle()
+    for item in swiftArray {
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_append(handle, _item.ref)
+    }
+    return RefHolder(handle)
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointmoveToCType(_ swiftArray: [DatesSteady.MonotonicDate]) -> RefHolder {
+    return RefHolder(ref: foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyToCType(swiftArray).ref, release: foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_release_handle)
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyToCType(_ swiftArray: [DatesSteady.MonotonicDate]?) -> RefHolder {
+    guard let swiftArray = swiftArray else {
+        return RefHolder(0)
+    }
+    let optionalHandle = foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_create_optional_handle()
+    let handle = foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_unwrap_optional_handle(optionalHandle)
+    for item in swiftArray {
+        let _item = moveToCType(item)
+        foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_append(handle, _item.ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointmoveToCType(_ swiftType: [DatesSteady.MonotonicDate]?) -> RefHolder {
+    return RefHolder(ref: foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyToCType(swiftType).ref, release: foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_release_optional_handle)
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyFromCType(_ handle: _baseRef) -> [DatesSteady.MonotonicDate]? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_unwrap_optional_handle(handle)
+    return foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyFromCType(unwrappedHandle) as [DatesSteady.MonotonicDate]
+}
+internal func foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointmoveFromCType(_ handle: _baseRef) -> [DatesSteady.MonotonicDate]? {
+    defer {
+        foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1point_release_optional_handle(handle)
+    }
+    return foobar_ArrayOf__Date_std_2_2chrono_2_2steady_1clock_2_2time_1pointcopyFromCType(handle)
+}


### PR DESCRIPTION
Updated Swift templates and CBridge name resolver to uniquely distinguish between `List<Date>` (and other collection
types) with and without `@Cpp(Type)` attribute.

Similar fix for Dart will be done in a separate commit.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
