### PR TITLE
Add `Duration` types support for Java

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -361,7 +361,7 @@ feature(Dates cpp android swift dart SOURCES
     input/lime/Dates.lime
 )
 
-feature(Durations cpp SOURCES
+feature(Durations cpp android SOURCES
     input/src/cpp/Durations.cpp
 
     input/lime/Durations.lime

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/DurationsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/DurationsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNull;
+
+import android.os.Build;
+import com.here.android.RobolectricApplication;
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.M, application = RobolectricApplication.class)
+public class DurationsTest {
+
+  @Test
+  public void durationSecondsRoundTrip() {
+    Duration duration = Duration.ofSeconds(42);
+
+    Duration result = DurationSeconds.increaseDuration(duration);
+
+    assertEquals(43, result.getSeconds());
+    assertEquals(0, result.getNano());
+  }
+
+  @Test
+  public void durationSecondsRoundTripRoundedDown() {
+    Duration duration = Duration.ofMillis(42042);
+
+    Duration result = DurationSeconds.increaseDuration(duration);
+
+    assertEquals(43, result.getSeconds());
+    assertEquals(0, result.getNano());
+  }
+
+  @Test
+  public void durationSecondsRoundTripRoundedUp() {
+    Duration duration = Duration.ofMillis(42840);
+
+    Duration result = DurationSeconds.increaseDuration(duration);
+
+    assertEquals(44, result.getSeconds());
+    assertEquals(0, result.getNano());
+  }
+
+  @Test
+  public void nullableDurationSecondsRoundTrip() {
+    Duration duration = Duration.ofSeconds(42);
+
+    Duration result = DurationSeconds.increaseDurationMaybe(duration);
+
+    assertEquals(43, result.getSeconds());
+    assertEquals(0, result.getNano());
+  }
+
+  @Test
+  public void nullableDurationSecondsRoundTripNull() {
+    Duration result = DurationSeconds.increaseDurationMaybe(null);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void durationSecondsStructRoundTrip() {
+    DurationSeconds.DurationStruct struct =
+        new DurationSeconds.DurationStruct(Duration.ofSeconds(42));
+
+    DurationSeconds.DurationStruct result = DurationSeconds.durationStructRoundTrip(struct);
+
+    assertEquals(42, result.durationField.getSeconds());
+    assertEquals(0, result.durationField.getNano());
+  }
+
+  @Test
+  public void durationMillisecondsRoundTrip() {
+    Duration duration = Duration.ofMillis(42042);
+
+    Duration result = DurationMilliseconds.increaseDuration(duration);
+
+    assertEquals(43, result.getSeconds());
+    assertEquals(42000000, result.getNano());
+  }
+
+  @Test
+  public void durationMillisecondsRoundTripRoundedDown() {
+    Duration duration = Duration.ofNanos(42042071000L);
+
+    Duration result = DurationMilliseconds.increaseDuration(duration);
+
+    assertEquals(43, result.getSeconds());
+    assertEquals(42000000, result.getNano());
+  }
+
+  @Test
+  public void durationMillisecondsRoundTripRoundedUp() {
+    Duration duration = Duration.ofNanos(42042710000L);
+
+    Duration result = DurationMilliseconds.increaseDuration(duration);
+
+    assertEquals(43, result.getSeconds());
+    assertEquals(43000000, result.getNano());
+  }
+
+  @Test
+  public void nullableDurationMillisecondsRoundTrip() {
+    Duration duration = Duration.ofMillis(42042);
+
+    Duration result = DurationMilliseconds.increaseDurationMaybe(duration);
+
+    assertEquals(43, result.getSeconds());
+    assertEquals(42000000, result.getNano());
+  }
+
+  @Test
+  public void nullableDurationMillisecondsRoundTripNull() {
+    Duration result = DurationMilliseconds.increaseDurationMaybe(null);
+
+    assertNull(result);
+  }
+
+  @Test
+  public void durationMillisecondsStructRoundTrip() {
+    DurationMilliseconds.DurationStruct struct =
+        new DurationMilliseconds.DurationStruct(Duration.ofMillis(42042));
+
+    DurationMilliseconds.DurationStruct result =
+        DurationMilliseconds.durationStructRoundTrip(struct);
+
+    assertEquals(42, result.durationField.getSeconds());
+    assertEquals(42000000, result.durationField.getNano());
+  }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportResolver.kt
@@ -163,6 +163,7 @@ internal class JavaImportResolver(
     private fun resolveBasicTypeImport(typeId: TypeId) =
         when (typeId) {
             TypeId.DATE -> JavaImport(javaUtilPackage, "Date")
+            TypeId.DURATION -> JavaImport(listOf("java", "time"), "Duration")
             TypeId.LOCALE -> JavaImport(javaUtilPackage, "Locale")
             else -> null
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -181,8 +181,8 @@ internal class JavaNameResolver(
             TypeId.STRING -> "String"
             TypeId.BLOB -> "byte[]"
             TypeId.DATE -> "Date"
+            TypeId.DURATION -> "Duration"
             TypeId.LOCALE -> "Locale"
-            else -> "" // TODO: #911 Duration types
         }
 
     private fun buildPathMap(): Map<String, String> {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
@@ -149,7 +149,6 @@ internal class JniNameResolver(
             TypeId.DOUBLE -> "jdouble"
             TypeId.STRING -> "jstring"
             TypeId.BLOB -> "jbyteArray"
-            TypeId.DATE, TypeId.LOCALE -> "jobject"
-            else -> "" // TODO: #911 Duration types
+            TypeId.DATE, TypeId.DURATION, TypeId.LOCALE -> "jobject"
         }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTypeSignatureNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTypeSignatureNameResolver.kt
@@ -64,8 +64,8 @@ internal class JniTypeSignatureNameResolver(private val baseNameResolver: JniNam
             TypeId.STRING -> "Ljava/lang/String;"
             TypeId.BLOB -> "[B"
             TypeId.DATE -> "Ljava/util/Date;"
+            TypeId.DURATION -> "Ljava/time/Duration;"
             TypeId.LOCALE -> "Ljava/util/Locale;"
-            else -> "" // TODO: #911 Duration types
         }
 
     private fun resolveNullableBasicTypeSignature(typeId: TypeId) =

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
@@ -290,6 +290,63 @@ JNIEXPORT void set_field_value( JNIEnv* env,
                       const char* fieldName,
                       {{>common/InternalNamespace}}optional< {{>common/InternalNamespace}}Locale > fieldValue );
 
+JNIEXPORT void set_object_field_value( JNIEnv* env,
+                             const JniReference<jobject>& object,
+                             const char* fieldName,
+                             const char* fieldSignature,
+                             const JniReference<jobject>& fieldValue );
+
+// -------------------- Templated JNI field accessors for Duration types --------------------------
+
+template<class Rep, class Period>
+JNIEXPORT ::std::chrono::duration<Rep, Period> get_field_value(
+    JNIEnv* env,
+    const JniReference<jobject>& object,
+    const char* fieldName,
+    ::std::chrono::duration<Rep, Period>* ) {
+
+    auto fieldValue = get_object_field_value(env, object, fieldName, "Ljava/time/Duration;");
+
+    return {{>common/InternalNamespace}}jni::convert_from_jni(env, fieldValue, (::std::chrono::duration<Rep, Period>*)nullptr);
+}
+
+template<class Rep, class Period>
+JNIEXPORT {{>common/InternalNamespace}}optional<::std::chrono::duration<Rep, Period>> get_field_value(
+    JNIEnv* env,
+    const JniReference<jobject>& object,
+    const char* fieldName,
+    {{>common/InternalNamespace}}optional<::std::chrono::duration<Rep, Period>>* ) {
+
+    auto fieldValue = get_object_field_value(env, object, fieldName, "Ljava/time/Duration;");
+
+    return {{>common/InternalNamespace}}jni::convert_from_jni(
+        env, fieldValue, ({{>common/InternalNamespace}}optional<::std::chrono::duration<Rep, Period>>*)nullptr);
+}
+
+template<class Rep, class Period>
+JNIEXPORT void set_field_value(
+    JNIEnv* env,
+    const JniReference<jobject>& object,
+    const char* fieldName,
+    const ::std::chrono::duration<Rep, Period>& fieldValue ) {
+
+    auto fieldId = env->GetFieldID(get_object_class(env, object).get(), fieldName, "Ljava/time/Duration;");
+    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni(env, fieldValue);
+    env->SetObjectField(object.get(), fieldId, jValue.get());
+}
+
+template<class Rep, class Period>
+JNIEXPORT void set_field_value(
+    JNIEnv* env,
+    const JniReference<jobject>& object,
+    const char* fieldName,
+    {{>common/InternalNamespace}}optional<::std::chrono::duration<Rep, Period>> fieldValue ) {
+
+    auto fieldId = env->GetFieldID(get_object_class(env, object).get(), fieldName, "Ljava/time/Duration;");
+    auto jValue = {{>common/InternalNamespace}}jni::convert_to_jni(env, fieldValue);
+    env->SetObjectField(object.get(), fieldId, jValue.get());
+}
+
 }
 {{#internalNamespace}}
 }

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
@@ -28,9 +28,11 @@
 #include "JniReference.h"
 #include "{{>common/InternalInclude}}Locale.h"
 #include "{{>common/InternalInclude}}Optional.h"
+#include "JniCallJavaMethod.h"
 
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <string>
@@ -100,6 +102,55 @@ convert_from_jni(
 }
 
 /**
+ * Converts a Java Duration object to an std::chrono::duration<>.
+ */
+template<class Rep, class Period>
+std::chrono::duration<Rep, Period>
+convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, std::chrono::duration<Rep, Period>*) {
+    if (!jvalue) {
+        auto exceptionClass = {{>common/InternalNamespace}}jni::find_class(env, "java/lang/NullPointerException");
+        env->ThrowNew(exceptionClass.get(), "");
+        return {};
+    }
+
+    auto javaDurationClass = find_class(env, "java/time/Duration");
+    auto getSecondsMethodId = env->GetMethodID(javaDurationClass.get(), "getSeconds", "()J");
+    jlong seconds_value = call_java_method<jlong>(env, jvalue, getSecondsMethodId);
+    auto getNanoMethodId = env->GetMethodID(javaDurationClass.get(), "getNano", "()I");
+    jint nano_value = call_java_method<jint>(env, jvalue, getNanoMethodId);
+
+    using namespace std::chrono;
+
+    auto seconds_division = std::lldiv(seconds_value * Period::den, Period::num);
+    auto combined_nano_value =
+        duration_cast<nanoseconds>(seconds(seconds_division.rem)).count() + nano_value;
+    auto num = Period::den * nanoseconds::period::num;
+    auto den = Period::num * nanoseconds::period::den;
+    auto nano_division = std::lldiv(combined_nano_value * num, den);
+    auto result_value = seconds_division.quot + nano_division.quot;
+
+    // Rounding
+    if (2 * nano_division.rem >= den) {
+        result_value += 1;
+    }
+
+    return duration<Rep, Period>(result_value);
+}
+
+template<class Rep, class Period>
+{{>common/InternalNamespace}}optional<std::chrono::duration<Rep, Period>>
+convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue,
+    {{>common/InternalNamespace}}optional<std::chrono::duration<Rep, Period>>*
+) {
+
+    return jvalue
+        ? {{>common/InternalNamespace}}optional<std::chrono::duration<Rep, Period>>(
+            convert_from_jni( env, jvalue, (std::chrono::duration<Rep, Period>*)nullptr))
+        : {{>common/InternalNamespace}}optional<std::chrono::duration<Rep, Period>>{};
+}
+
+/**
  * Converts a Java Locale object to {{>common/InternalNamespace}}Locale.
  */
 JNIEXPORT {{>common/InternalNamespace}}Locale convert_from_jni(
@@ -143,11 +194,35 @@ convert_to_jni(JNIEnv* env, const {{>common/InternalNamespace}}optional<std::chr
 }
 
 /**
- * Converts {{>common/InternalNamespace}}Locale to a Java Date object.
+ * Converts an std::chrono::duration<> to a Java Duration object.
+ */
+template<class Rep, class Period>
+JniReference<jobject>
+convert_to_jni(JNIEnv* env, const std::chrono::duration<Rep, Period>& nvalue) {
+    auto javaDurationClass = find_class(env, "java/time/Duration");
+    auto factoryMethodId = env->GetStaticMethodID(javaDurationClass.get(), "ofSeconds", "(JJ)Ljava/time/Duration;");
+
+    using namespace std::chrono;
+    auto seconds_duration = duration_cast<seconds>(nvalue);
+    auto seconds_value = duration_cast<seconds>(nvalue).count();
+    auto nanos_adjustment = duration_cast<nanoseconds>(nvalue - seconds_duration).count();
+    return make_local_ref(env, env->CallStaticObjectMethod(javaDurationClass.get(), factoryMethodId, seconds_value, nanos_adjustment));
+}
+
+/**
+ * Converts {{>common/InternalNamespace}}Locale to a Java Locale object.
  */
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* env, const {{>common/InternalNamespace}}Locale& nvalue);
 JNIEXPORT JniReference<jobject> convert_to_jni(
     JNIEnv* env, const {{>common/InternalNamespace}}optional<{{>common/InternalNamespace}}Locale>& nvalue);
+
+template<class Rep, class Period>
+JNIEXPORT JniReference<jobject> convert_to_jni(
+    JNIEnv* env, const {{>common/InternalNamespace}}optional<std::chrono::duration<Rep, Period>>& nvalue ) {
+
+    return nvalue ? convert_to_jni(env, *nvalue) : JniReference<jobject>{};
+}
+
 
 // -------------------- optional<std::function<>> conversion functions -----------------------------
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android/com/example/smoke/DurationMilliseconds.java
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/com/example/smoke/DurationMilliseconds.java
@@ -1,0 +1,37 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.example.NativeBase;
+import java.time.Duration;
+public final class DurationMilliseconds extends NativeBase {
+    public static final class DurationStruct {
+        @NonNull
+        public Duration durationField;
+        public DurationStruct(@NonNull final Duration durationField) {
+            this.durationField = durationField;
+        }
+    }
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected DurationMilliseconds(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    @NonNull
+    public native Duration durationFunction(@NonNull final Duration input);
+    @Nullable
+    public native Duration nullableDurationFunction(@Nullable final Duration input);
+    @NonNull
+    public native Duration getDurationProperty();
+    public native void setDurationProperty(@NonNull final Duration value);
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/android/com/example/smoke/DurationSeconds.java
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/com/example/smoke/DurationSeconds.java
@@ -1,0 +1,37 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.example.NativeBase;
+import java.time.Duration;
+public final class DurationSeconds extends NativeBase {
+    public static final class DurationStruct {
+        @NonNull
+        public Duration durationField;
+        public DurationStruct(@NonNull final Duration durationField) {
+            this.durationField = durationField;
+        }
+    }
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected DurationSeconds(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    @NonNull
+    public native Duration durationFunction(@NonNull final Duration input);
+    @Nullable
+    public native Duration nullableDurationFunction(@Nullable final Duration input);
+    @NonNull
+    public native Duration getDurationProperty();
+    public native void setDurationProperty(@NonNull final Duration value);
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationMilliseconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationMilliseconds.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ */
+#include "com_example_smoke_DurationMilliseconds.h"
+#include "com_example_smoke_DurationMilliseconds__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jobject
+Java_com_example_smoke_DurationMilliseconds_durationFunction(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    std::chrono::milliseconds input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (std::chrono::milliseconds*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationMilliseconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_DurationMilliseconds_nullableDurationFunction(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::gluecodium::optional< std::chrono::milliseconds > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::gluecodium::optional< std::chrono::milliseconds >*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationMilliseconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->nullable_duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_DurationMilliseconds_getDurationProperty(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationMilliseconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_duration_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+void
+Java_com_example_smoke_DurationMilliseconds_setDurationProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+{
+    std::chrono::milliseconds value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            (std::chrono::milliseconds*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationMilliseconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_duration_property(value);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_DurationMilliseconds_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::DurationMilliseconds>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationSeconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationSeconds.cpp
@@ -1,0 +1,74 @@
+/*
+ *
+ */
+#include "com_example_smoke_DurationSeconds.h"
+#include "com_example_smoke_DurationSeconds__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jobject
+Java_com_example_smoke_DurationSeconds_durationFunction(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::std::chrono::seconds input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::std::chrono::seconds*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationSeconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_DurationSeconds_nullableDurationFunction(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+{
+    ::gluecodium::optional< ::std::chrono::seconds > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            (::gluecodium::optional< ::std::chrono::seconds >*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationSeconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->nullable_duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+jobject
+Java_com_example_smoke_DurationSeconds_getDurationProperty(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationSeconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->get_duration_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+void
+Java_com_example_smoke_DurationSeconds_setDurationProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+{
+    ::std::chrono::seconds value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            (::std::chrono::seconds*)nullptr);
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DurationSeconds>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->set_duration_property(value);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_DurationSeconds_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::DurationSeconds>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}


### PR DESCRIPTION
Updated Java name resolvers to map `Duration` types to
`java.time.Duration`. Added conversion functions for these types
to the appropriate templates.

Added smoke and functional tests.

See: #911
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>