### PR TITLE
Add `Duration` types support for Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Release date: 2021-06-25
 Release date: 2021-06-22
 ### Features:
   * Added automatic finalization for lambdas in Dart.
+  * Added support for system `Duration` types in all generators.
 ### Bug fixes:
   * Fixed `Locale` hash usage for maps and sets in C++.
   * Fixed compilation issues for `@Optimized` Lists as struct fields in Java.

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -361,7 +361,7 @@ feature(Dates cpp android swift dart SOURCES
     input/lime/Dates.lime
 )
 
-feature(Durations cpp android swift SOURCES
+feature(Durations cpp android swift dart SOURCES
     input/src/cpp/Durations.cpp
 
     input/lime/Durations.lime

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -28,6 +28,7 @@ import "test/Constants_test.dart" as ConstantsTests;
 import "test/CppConstMethods_test.dart" as CppConstMethodsTests;
 import "test/Dates_test.dart" as DatesTests;
 import "test/Defaults_test.dart" as DefaultsTests;
+import "test/Durations_test.dart" as DurationsTests;
 import "test/EquatableClasses_test.dart" as EquatableClassesTests;
 import "test/EquatableStructs_test.dart" as EquatableStructsTests;
 import "test/Enums_test.dart" as EnumsTests;
@@ -71,6 +72,7 @@ final _allTests = [
   CppConstMethodsTests.main,
   DatesTests.main,
   DefaultsTests.main,
+  DurationsTests.main,
   EquatableClassesTests.main,
   EquatableStructsTests.main,
   EnumsTests.main,

--- a/functional-tests/functional/dart/test/Durations_test.dart
+++ b/functional-tests/functional/dart/test/Durations_test.dart
@@ -1,0 +1,109 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Durations");
+
+void main() {
+  _testSuite.test("Duration<Seconds> round trip", () {
+    final duration = Duration(seconds: 42);
+
+    final result = DurationSeconds.increaseDuration(duration);
+
+    expect(result.inMicroseconds, 43000000);
+  });
+  _testSuite.test("Duration<Seconds> round trip rounded down", () {
+    final duration = Duration(seconds: 42, milliseconds: 42);
+
+    final result = DurationSeconds.increaseDuration(duration);
+
+    expect(result.inMicroseconds, 43000000);
+  });
+  _testSuite.test("Duration<Seconds> round trip rounded up", () {
+    final duration = Duration(seconds: 42, milliseconds: 840);
+
+    final result = DurationSeconds.increaseDuration(duration);
+
+    expect(result.inMicroseconds, 44000000);
+  });
+  _testSuite.test("Duration<Seconds> nullable round trip", () {
+    final duration = Duration(seconds: 42);
+
+    final result = DurationSeconds.increaseDurationMaybe(duration);
+
+    expect(result?.inMicroseconds, 43000000);
+  });
+  _testSuite.test("Duration<Seconds> nullable round trip null", () {
+    final result = DurationSeconds.increaseDurationMaybe(null);
+
+    expect(result, isNull);
+  });
+  _testSuite.test("Duration<Seconds> struct round trip", () {
+    final duration = DurationSecondsDurationStruct(Duration(seconds: 42));
+
+    final result = DurationSeconds.durationStructRoundTrip(duration);
+
+    expect(result.durationField.inMicroseconds, 42000000);
+  });
+  _testSuite.test("Duration<Milliseconds> round trip", () {
+    final duration = Duration(seconds: 42, milliseconds: 42);
+
+    final result = DurationMilliseconds.increaseDuration(duration);
+
+    expect(result.inMicroseconds, 43042000);
+  });
+  _testSuite.test("Duration<Milliseconds> round trip rounded down", () {
+    final duration = Duration(seconds: 42, milliseconds: 42, microseconds: 71);
+
+    final result = DurationMilliseconds.increaseDuration(duration);
+
+    expect(result.inMicroseconds, 43042000);
+  });
+  _testSuite.test("Duration<Milliseconds> round trip rounded up", () {
+    final duration = Duration(seconds: 42, milliseconds: 42, microseconds: 710);
+
+    final result = DurationMilliseconds.increaseDuration(duration);
+
+    expect(result.inMicroseconds, 43043000);
+  });
+  _testSuite.test("Duration<Milliseconds> nullable round trip", () {
+    final duration = Duration(seconds: 42, milliseconds: 42);
+
+    final result = DurationMilliseconds.increaseDurationMaybe(duration);
+
+    expect(result?.inMicroseconds, 43042000);
+  });
+  _testSuite.test("Duration<Milliseconds> nullable round trip null", () {
+    final result = DurationMilliseconds.increaseDurationMaybe(null);
+
+    expect(result, isNull);
+  });
+  _testSuite.test("Duration<Milliseconds> struct round trip", () {
+    final duration =
+        DurationMillisecondsDurationStruct(Duration(seconds: 42, milliseconds: 42));
+
+    final result = DurationMilliseconds.durationStructRoundTrip(duration);
+
+    expect(result.durationField.inMicroseconds, 42042000);
+  });
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CamelCaseNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CamelCaseNameResolver.kt
@@ -23,9 +23,5 @@ internal class CamelCaseNameResolver(private val mainResolver: NameResolver, upp
 
     val camelCase = if (upper) NameHelper::toUpperCamelCase else NameHelper::toLowerCamelCase
 
-    override fun resolveName(element: Any): String =
-        when (element) {
-            is String -> camelCase(element)
-            else -> camelCase(mainResolver.resolveName(element))
-        }
+    override fun resolveName(element: Any) = camelCase(mainResolver.resolveName(element))
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -103,8 +103,8 @@ internal class DartNameResolver(
             TypeId.STRING -> "String"
             TypeId.BLOB -> "Uint8List"
             TypeId.DATE -> "DateTime"
+            TypeId.DURATION -> "Duration"
             TypeId.LOCALE -> "Locale"
-            else -> "" // TODO: #911 Duration types
         }
 
     private fun resolveValue(limeValue: LimeValue): String =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiApiTypeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiApiTypeNameResolver.kt
@@ -67,11 +67,8 @@ internal class FfiApiTypeNameResolver : NameResolver {
             TypeId.BOOLEAN -> "Uint8"
             TypeId.FLOAT -> "Float"
             TypeId.DOUBLE -> "Double"
-            TypeId.STRING -> OPAQUE_HANDLE_TYPE
-            TypeId.BLOB -> OPAQUE_HANDLE_TYPE
-            TypeId.DATE -> "Uint64"
-            TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
-            else -> "" // TODO: #911 Duration types
+            TypeId.DATE, TypeId.DURATION -> "Uint64"
+            TypeId.STRING, TypeId.BLOB, TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
         }
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiDartTypeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/FfiDartTypeNameResolver.kt
@@ -67,11 +67,8 @@ internal class FfiDartTypeNameResolver : NameResolver {
             TypeId.BOOLEAN -> "int"
             TypeId.FLOAT -> "double"
             TypeId.DOUBLE -> "double"
-            TypeId.STRING -> OPAQUE_HANDLE_TYPE
-            TypeId.BLOB -> OPAQUE_HANDLE_TYPE
-            TypeId.DATE -> "int"
-            TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
-            else -> "" // TODO: #911 Duration types
+            TypeId.DATE, TypeId.DURATION -> "int"
+            TypeId.STRING, TypeId.BLOB, TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
         }
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
@@ -98,14 +98,14 @@ internal class FfiCppIncludeResolver(
         when (limeType.typeId) {
             TypeId.VOID, TypeId.BOOLEAN, TypeId.FLOAT, TypeId.DOUBLE -> emptyList()
             TypeId.STRING -> listOf(CppLibraryIncludes.STRING)
-            TypeId.BLOB -> listOf(
-                CppLibraryIncludes.MEMORY,
-                CppLibraryIncludes.VECTOR,
-                CppLibraryIncludes.INT_TYPES
-            )
+            TypeId.BLOB -> listOf(CppLibraryIncludes.MEMORY, CppLibraryIncludes.VECTOR, CppLibraryIncludes.INT_TYPES)
             TypeId.DATE -> listOf(
                 CppLibraryIncludes.CHRONO,
                 cppIncludesCache.createInternalNamespaceInclude("TimePointHash.h")
+            )
+            TypeId.DURATION -> listOf(
+                CppLibraryIncludes.CHRONO,
+                cppIncludesCache.createInternalNamespaceInclude("DurationHash.h")
             )
             TypeId.LOCALE -> listOf(cppIncludesCache.createInternalNamespaceInclude("Locale.h"))
             else -> listOf(CppLibraryIncludes.INT_TYPES)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
@@ -108,11 +108,8 @@ internal class FfiNameResolver(
             TypeId.BOOLEAN -> "bool"
             TypeId.FLOAT -> "float"
             TypeId.DOUBLE -> "double"
-            TypeId.STRING -> OPAQUE_HANDLE_TYPE
-            TypeId.BLOB -> OPAQUE_HANDLE_TYPE
-            TypeId.DATE -> "uint64_t"
-            TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
-            else -> "" // TODO: #911 Duration types
+            TypeId.DATE, TypeId.DURATION -> "uint64_t"
+            TypeId.STRING, TypeId.BLOB, TypeId.LOCALE -> OPAQUE_HANDLE_TYPE
         }
 
     private fun getListName(elementType: LimeTypeRef) =

--- a/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartBuiltInTypesConversion.mustache
@@ -73,6 +73,14 @@ DateTime dateFromFfi(int us) => DateTime.fromMicrosecondsSinceEpoch(us, isUtc: t
 
 void dateReleaseFfiHandle(int handle) {}
 
+// Duration
+
+int durationToFfi(Duration value) => value.inMicroseconds;
+
+Duration durationFromFfi(int us) => Duration(microseconds: us);
+
+void durationReleaseFfiHandle(int handle) {}
+
 // String
 
 final _stringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -215,3 +223,17 @@ DateTime? dateFromFfiNullable(Pointer<Void> handle) {
 }
 
 void dateReleaseFfiHandleNullable(Pointer<Void> handle) => _longReleaseHandleNullable(handle);
+
+// Nullable Duration
+
+Pointer<Void> durationToFfiNullable(Duration? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  return _longCreateHandleNullable(durationToFfi(value));
+}
+
+Duration? durationFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  return durationFromFfi(_longGetValueNullable(handle));
+}
+
+void durationReleaseFfiHandleNullable(Pointer<Void> handle) => _longReleaseHandleNullable(handle);

--- a/gluecodium/src/main/resources/templates/ffi/FfiConversionBase.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiConversionBase.mustache
@@ -25,6 +25,7 @@
 #include "OpaqueHandle.h"
 #include "{{>common/InternalInclude}}Optional.h"
 #include <chrono>
+#include <cstdlib>
 #include <functional>
 #include <memory>
 #include <new>
@@ -173,6 +174,61 @@ struct Conversion<
                     **reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<uint64_t>*>(handle)
                 )
             ) : {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<std::chrono::time_point<Clock, Duration>>{};
+    }
+};
+
+template<class Rep, class Period>
+struct Conversion<std::chrono::duration<Rep, Period>, typename std::enable_if<std::is_class<std::chrono::duration<Rep, Period>>::value>::type> {
+    static uint64_t
+    toFfi(const std::chrono::duration<Rep, Period>& t) {
+        return std::chrono::duration_cast<std::chrono::microseconds>(t).count();
+    }
+
+    static uint64_t
+    toFfi(std::chrono::duration<Rep, Period>&& t) {
+        return std::chrono::duration_cast<std::chrono::microseconds>(t).count();
+    }
+
+    static std::chrono::duration<Rep, Period>
+    toCpp(uint64_t microseconds_value) {
+        using namespace std::chrono;
+        auto num = Period::den * microseconds::period::num;
+        auto den = Period::num * microseconds::period::den;
+        auto micro_division = std::lldiv(microseconds_value * num, den);
+        auto result_value = micro_division.quot;
+
+        // Rounding
+        if (2 * micro_division.rem >= den) {
+            result_value += 1;
+        }
+
+        return std::chrono::duration<Rep, Period>(result_value);
+    }
+};
+
+template<class Rep, class Period>
+struct Conversion<
+    {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<std::chrono::duration<Rep, Period>>,
+    typename std::enable_if<std::is_class<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<std::chrono::duration<Rep, Period>>>::value>::type
+> {
+    static FfiOpaqueHandle
+    toFfi({{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<std::chrono::duration<Rep, Period>> t) {
+        return t
+            ? reinterpret_cast<FfiOpaqueHandle>(
+                new (std::nothrow) {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<uint64_t>(
+                    Conversion<std::chrono::duration<Rep, Period>>::toFfi(*t)
+                )
+            ) : 0;
+    }
+
+    static {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<std::chrono::duration<Rep, Period>>
+    toCpp(const FfiOpaqueHandle& handle) {
+        return handle
+            ? {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<std::chrono::duration<Rep, Period>>(
+                Conversion<std::chrono::duration<Rep, Period>>::toCpp(
+                    **reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<uint64_t>*>(handle)
+                )
+            ) : {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<std::chrono::duration<Rep, Period>>{};
     }
 };
 

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/builtin_types__conversion.dart
@@ -36,6 +36,10 @@ void booleanReleaseFfiHandle(int handle) {}
 int dateToFfi(DateTime value) => value.microsecondsSinceEpoch;
 DateTime dateFromFfi(int us) => DateTime.fromMicrosecondsSinceEpoch(us, isUtc: true);
 void dateReleaseFfiHandle(int handle) {}
+// Duration
+int durationToFfi(Duration value) => value.inMicroseconds;
+Duration durationFromFfi(int us) => Duration(microseconds: us);
+void durationReleaseFfiHandle(int handle) {}
 // String
 final _stringCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Utf8>),
@@ -509,3 +513,13 @@ DateTime? dateFromFfiNullable(Pointer<Void> handle) {
   return dateFromFfi(_longGetValueNullable(handle));
 }
 void dateReleaseFfiHandleNullable(Pointer<Void> handle) => _longReleaseHandleNullable(handle);
+// Nullable Duration
+Pointer<Void> durationToFfiNullable(Duration? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  return _longCreateHandleNullable(durationToFfi(value));
+}
+Duration? durationFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  return durationFromFfi(_longGetValueNullable(handle));
+}
+void durationReleaseFfiHandleNullable(Pointer<Void> handle) => _longReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationMilliseconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationMilliseconds.cpp
@@ -1,0 +1,110 @@
+#include "ffi_smoke_DurationMilliseconds.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "gluecodium/DurationHash.h"
+#include "gluecodium/Optional.h"
+#include "smoke/DurationMilliseconds.h"
+#include <chrono>
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+uint64_t
+library_smoke_DurationMilliseconds_durationFunction__Duration(FfiOpaqueHandle _self, int32_t _isolate_id, uint64_t input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::chrono::milliseconds>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationMilliseconds>>::toCpp(_self)).duration_function(
+            gluecodium::ffi::Conversion<std::chrono::milliseconds>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+library_smoke_DurationMilliseconds_nullableDurationFunction__Duration(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::milliseconds>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationMilliseconds>>::toCpp(_self)).nullable_duration_function(
+            gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::milliseconds>>::toCpp(input)
+        )
+    );
+}
+uint64_t
+library_smoke_DurationMilliseconds_durationProperty_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::chrono::milliseconds>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationMilliseconds>>::toCpp(_self)).get_duration_property()
+    );
+}
+void
+library_smoke_DurationMilliseconds_durationProperty_set__Duration(FfiOpaqueHandle _self, int32_t _isolate_id, uint64_t value) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationMilliseconds>>::toCpp(_self)).set_duration_property(
+            gluecodium::ffi::Conversion<std::chrono::milliseconds>::toCpp(value)
+        );
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_DurationMilliseconds_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::DurationMilliseconds>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_DurationMilliseconds_release_handle(handle);
+}
+void
+library_smoke_DurationMilliseconds_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_DurationMilliseconds_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_DurationMilliseconds_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::DurationMilliseconds>(
+            *reinterpret_cast<std::shared_ptr<smoke::DurationMilliseconds>*>(handle)
+        )
+    );
+}
+void
+library_smoke_DurationMilliseconds_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::DurationMilliseconds>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DurationMilliseconds_DurationStruct_create_handle(uint64_t durationField) {
+    auto _result = new (std::nothrow) smoke::DurationMilliseconds::DurationStruct(gluecodium::ffi::Conversion<std::chrono::milliseconds>::toCpp(durationField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_DurationMilliseconds_DurationStruct_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<smoke::DurationMilliseconds::DurationStruct*>(handle);
+}
+uint64_t
+library_smoke_DurationMilliseconds_DurationStruct_get_field_durationField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::chrono::milliseconds>::toFfi(
+        reinterpret_cast<smoke::DurationMilliseconds::DurationStruct*>(handle)->duration_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_DurationMilliseconds_DurationStruct_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<smoke::DurationMilliseconds::DurationStruct>(
+            gluecodium::ffi::Conversion<smoke::DurationMilliseconds::DurationStruct>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_DurationMilliseconds_DurationStruct_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<smoke::DurationMilliseconds::DurationStruct>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DurationMilliseconds_DurationStruct_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<smoke::DurationMilliseconds::DurationStruct>::toFfi(
+        **reinterpret_cast<gluecodium::optional<smoke::DurationMilliseconds::DurationStruct>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationSeconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationSeconds.cpp
@@ -1,0 +1,110 @@
+#include "ffi_smoke_DurationSeconds.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "gluecodium/DurationHash.h"
+#include "gluecodium/Optional.h"
+#include "smoke/DurationSeconds.h"
+#include <chrono>
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+uint64_t
+library_smoke_DurationSeconds_durationFunction__Duration(FfiOpaqueHandle _self, int32_t _isolate_id, uint64_t input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::chrono::seconds>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationSeconds>>::toCpp(_self)).duration_function(
+            gluecodium::ffi::Conversion<std::chrono::seconds>::toCpp(input)
+        )
+    );
+}
+FfiOpaqueHandle
+library_smoke_DurationSeconds_nullableDurationFunction__Duration(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::seconds>>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationSeconds>>::toCpp(_self)).nullable_duration_function(
+            gluecodium::ffi::Conversion<gluecodium::optional<std::chrono::seconds>>::toCpp(input)
+        )
+    );
+}
+uint64_t
+library_smoke_DurationSeconds_durationProperty_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::chrono::seconds>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationSeconds>>::toCpp(_self)).get_duration_property()
+    );
+}
+void
+library_smoke_DurationSeconds_durationProperty_set__Duration(FfiOpaqueHandle _self, int32_t _isolate_id, uint64_t value) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationSeconds>>::toCpp(_self)).set_duration_property(
+            gluecodium::ffi::Conversion<std::chrono::seconds>::toCpp(value)
+        );
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_DurationSeconds_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::DurationSeconds>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_DurationSeconds_release_handle(handle);
+}
+void
+library_smoke_DurationSeconds_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_DurationSeconds_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_DurationSeconds_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::DurationSeconds>(
+            *reinterpret_cast<std::shared_ptr<smoke::DurationSeconds>*>(handle)
+        )
+    );
+}
+void
+library_smoke_DurationSeconds_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::DurationSeconds>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DurationSeconds_DurationStruct_create_handle(uint64_t durationField) {
+    auto _result = new (std::nothrow) smoke::DurationSeconds::DurationStruct(gluecodium::ffi::Conversion<std::chrono::seconds>::toCpp(durationField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_DurationSeconds_DurationStruct_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<smoke::DurationSeconds::DurationStruct*>(handle);
+}
+uint64_t
+library_smoke_DurationSeconds_DurationStruct_get_field_durationField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::chrono::seconds>::toFfi(
+        reinterpret_cast<smoke::DurationSeconds::DurationStruct*>(handle)->duration_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_DurationSeconds_DurationStruct_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<smoke::DurationSeconds::DurationStruct>(
+            gluecodium::ffi::Conversion<smoke::DurationSeconds::DurationStruct>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_DurationSeconds_DurationStruct_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<smoke::DurationSeconds::DurationStruct>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DurationSeconds_DurationStruct_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<smoke::DurationSeconds::DurationStruct>::toFfi(
+        **reinterpret_cast<gluecodium::optional<smoke::DurationSeconds::DurationStruct>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
@@ -1,0 +1,161 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+abstract class DurationMilliseconds {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
+  Duration durationFunction(Duration input);
+  Duration? nullableDurationFunction(Duration? input);
+  Duration get durationProperty;
+  set durationProperty(Duration value);
+}
+class DurationMilliseconds_DurationStruct {
+  Duration durationField;
+  DurationMilliseconds_DurationStruct(this.durationField);
+}
+// DurationMilliseconds_DurationStruct "private" section, not exported.
+final _smokeDurationmillisecondsDurationstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64),
+    Pointer<Void> Function(int)
+  >('library_smoke_DurationMilliseconds_DurationStruct_create_handle'));
+final _smokeDurationmillisecondsDurationstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DurationMilliseconds_DurationStruct_release_handle'));
+final _smokeDurationmillisecondsDurationstructGetFielddurationField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DurationMilliseconds_DurationStruct_get_field_durationField'));
+Pointer<Void> smokeDurationmillisecondsDurationstructToFfi(DurationMilliseconds_DurationStruct value) {
+  final _durationFieldHandle = durationToFfi(value.durationField);
+  final _result = _smokeDurationmillisecondsDurationstructCreateHandle(_durationFieldHandle);
+  durationReleaseFfiHandle(_durationFieldHandle);
+  return _result;
+}
+DurationMilliseconds_DurationStruct smokeDurationmillisecondsDurationstructFromFfi(Pointer<Void> handle) {
+  final _durationFieldHandle = _smokeDurationmillisecondsDurationstructGetFielddurationField(handle);
+  try {
+    return DurationMilliseconds_DurationStruct(
+      durationFromFfi(_durationFieldHandle)
+    );
+  } finally {
+    durationReleaseFfiHandle(_durationFieldHandle);
+  }
+}
+void smokeDurationmillisecondsDurationstructReleaseFfiHandle(Pointer<Void> handle) => _smokeDurationmillisecondsDurationstructReleaseHandle(handle);
+// Nullable DurationMilliseconds_DurationStruct
+final _smokeDurationmillisecondsDurationstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DurationMilliseconds_DurationStruct_create_handle_nullable'));
+final _smokeDurationmillisecondsDurationstructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DurationMilliseconds_DurationStruct_release_handle_nullable'));
+final _smokeDurationmillisecondsDurationstructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DurationMilliseconds_DurationStruct_get_value_nullable'));
+Pointer<Void> smokeDurationmillisecondsDurationstructToFfiNullable(DurationMilliseconds_DurationStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDurationmillisecondsDurationstructToFfi(value);
+  final result = _smokeDurationmillisecondsDurationstructCreateHandleNullable(_handle);
+  smokeDurationmillisecondsDurationstructReleaseFfiHandle(_handle);
+  return result;
+}
+DurationMilliseconds_DurationStruct? smokeDurationmillisecondsDurationstructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDurationmillisecondsDurationstructGetValueNullable(handle);
+  final result = smokeDurationmillisecondsDurationstructFromFfi(_handle);
+  smokeDurationmillisecondsDurationstructReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDurationmillisecondsDurationstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDurationmillisecondsDurationstructReleaseHandleNullable(handle);
+// End of DurationMilliseconds_DurationStruct "private" section.
+// DurationMilliseconds "private" section, not exported.
+final _smokeDurationmillisecondsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_DurationMilliseconds_register_finalizer'));
+final _smokeDurationmillisecondsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DurationMilliseconds_copy_handle'));
+final _smokeDurationmillisecondsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DurationMilliseconds_release_handle'));
+class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMilliseconds {
+  DurationMilliseconds$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  Duration durationFunction(Duration input) {
+    final _durationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DurationMilliseconds_durationFunction__Duration'));
+    final _inputHandle = durationToFfi(input);
+    final _handle = this.handle;
+    final __resultHandle = _durationFunctionFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    durationReleaseFfiHandle(_inputHandle);
+    try {
+      return durationFromFfi(__resultHandle);
+    } finally {
+      durationReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  Duration? nullableDurationFunction(Duration? input) {
+    final _nullableDurationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DurationMilliseconds_nullableDurationFunction__Duration'));
+    final _inputHandle = durationToFfiNullable(input);
+    final _handle = this.handle;
+    final __resultHandle = _nullableDurationFunctionFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    durationReleaseFfiHandleNullable(_inputHandle);
+    try {
+      return durationFromFfiNullable(__resultHandle);
+    } finally {
+      durationReleaseFfiHandleNullable(__resultHandle);
+    }
+  }
+  @override
+  Duration get durationProperty {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DurationMilliseconds_durationProperty_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return durationFromFfi(__resultHandle);
+    } finally {
+      durationReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  set durationProperty(Duration value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_DurationMilliseconds_durationProperty_set__Duration'));
+    final _valueHandle = durationToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    durationReleaseFfiHandle(_valueHandle);
+  }
+}
+Pointer<Void> smokeDurationmillisecondsToFfi(DurationMilliseconds value) =>
+  _smokeDurationmillisecondsCopyHandle((value as __lib.NativeBase).handle);
+DurationMilliseconds smokeDurationmillisecondsFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is DurationMilliseconds) return instance as DurationMilliseconds;
+  final _copiedHandle = _smokeDurationmillisecondsCopyHandle(handle);
+  final result = DurationMilliseconds$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeDurationmillisecondsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeDurationmillisecondsReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeDurationmillisecondsReleaseHandle(handle);
+Pointer<Void> smokeDurationmillisecondsToFfiNullable(DurationMilliseconds? value) =>
+  value != null ? smokeDurationmillisecondsToFfi(value) : Pointer<Void>.fromAddress(0);
+DurationMilliseconds? smokeDurationmillisecondsFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeDurationmillisecondsFromFfi(handle) : null;
+void smokeDurationmillisecondsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDurationmillisecondsReleaseHandle(handle);
+// End of DurationMilliseconds "private" section.

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
@@ -1,0 +1,161 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+abstract class DurationSeconds {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
+  Duration durationFunction(Duration input);
+  Duration? nullableDurationFunction(Duration? input);
+  Duration get durationProperty;
+  set durationProperty(Duration value);
+}
+class DurationSeconds_DurationStruct {
+  Duration durationField;
+  DurationSeconds_DurationStruct(this.durationField);
+}
+// DurationSeconds_DurationStruct "private" section, not exported.
+final _smokeDurationsecondsDurationstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64),
+    Pointer<Void> Function(int)
+  >('library_smoke_DurationSeconds_DurationStruct_create_handle'));
+final _smokeDurationsecondsDurationstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DurationSeconds_DurationStruct_release_handle'));
+final _smokeDurationsecondsDurationstructGetFielddurationField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DurationSeconds_DurationStruct_get_field_durationField'));
+Pointer<Void> smokeDurationsecondsDurationstructToFfi(DurationSeconds_DurationStruct value) {
+  final _durationFieldHandle = durationToFfi(value.durationField);
+  final _result = _smokeDurationsecondsDurationstructCreateHandle(_durationFieldHandle);
+  durationReleaseFfiHandle(_durationFieldHandle);
+  return _result;
+}
+DurationSeconds_DurationStruct smokeDurationsecondsDurationstructFromFfi(Pointer<Void> handle) {
+  final _durationFieldHandle = _smokeDurationsecondsDurationstructGetFielddurationField(handle);
+  try {
+    return DurationSeconds_DurationStruct(
+      durationFromFfi(_durationFieldHandle)
+    );
+  } finally {
+    durationReleaseFfiHandle(_durationFieldHandle);
+  }
+}
+void smokeDurationsecondsDurationstructReleaseFfiHandle(Pointer<Void> handle) => _smokeDurationsecondsDurationstructReleaseHandle(handle);
+// Nullable DurationSeconds_DurationStruct
+final _smokeDurationsecondsDurationstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DurationSeconds_DurationStruct_create_handle_nullable'));
+final _smokeDurationsecondsDurationstructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DurationSeconds_DurationStruct_release_handle_nullable'));
+final _smokeDurationsecondsDurationstructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DurationSeconds_DurationStruct_get_value_nullable'));
+Pointer<Void> smokeDurationsecondsDurationstructToFfiNullable(DurationSeconds_DurationStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDurationsecondsDurationstructToFfi(value);
+  final result = _smokeDurationsecondsDurationstructCreateHandleNullable(_handle);
+  smokeDurationsecondsDurationstructReleaseFfiHandle(_handle);
+  return result;
+}
+DurationSeconds_DurationStruct? smokeDurationsecondsDurationstructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDurationsecondsDurationstructGetValueNullable(handle);
+  final result = smokeDurationsecondsDurationstructFromFfi(_handle);
+  smokeDurationsecondsDurationstructReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDurationsecondsDurationstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDurationsecondsDurationstructReleaseHandleNullable(handle);
+// End of DurationSeconds_DurationStruct "private" section.
+// DurationSeconds "private" section, not exported.
+final _smokeDurationsecondsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_DurationSeconds_register_finalizer'));
+final _smokeDurationsecondsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DurationSeconds_copy_handle'));
+final _smokeDurationsecondsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DurationSeconds_release_handle'));
+class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
+  DurationSeconds$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  Duration durationFunction(Duration input) {
+    final _durationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DurationSeconds_durationFunction__Duration'));
+    final _inputHandle = durationToFfi(input);
+    final _handle = this.handle;
+    final __resultHandle = _durationFunctionFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    durationReleaseFfiHandle(_inputHandle);
+    try {
+      return durationFromFfi(__resultHandle);
+    } finally {
+      durationReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  Duration? nullableDurationFunction(Duration? input) {
+    final _nullableDurationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DurationSeconds_nullableDurationFunction__Duration'));
+    final _inputHandle = durationToFfiNullable(input);
+    final _handle = this.handle;
+    final __resultHandle = _nullableDurationFunctionFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    durationReleaseFfiHandleNullable(_inputHandle);
+    try {
+      return durationFromFfiNullable(__resultHandle);
+    } finally {
+      durationReleaseFfiHandleNullable(__resultHandle);
+    }
+  }
+  @override
+  Duration get durationProperty {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DurationSeconds_durationProperty_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return durationFromFfi(__resultHandle);
+    } finally {
+      durationReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  set durationProperty(Duration value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_DurationSeconds_durationProperty_set__Duration'));
+    final _valueHandle = durationToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    durationReleaseFfiHandle(_valueHandle);
+  }
+}
+Pointer<Void> smokeDurationsecondsToFfi(DurationSeconds value) =>
+  _smokeDurationsecondsCopyHandle((value as __lib.NativeBase).handle);
+DurationSeconds smokeDurationsecondsFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is DurationSeconds) return instance as DurationSeconds;
+  final _copiedHandle = _smokeDurationsecondsCopyHandle(handle);
+  final result = DurationSeconds$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeDurationsecondsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeDurationsecondsReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeDurationsecondsReleaseHandle(handle);
+Pointer<Void> smokeDurationsecondsToFfiNullable(DurationSeconds? value) =>
+  value != null ? smokeDurationsecondsToFfi(value) : Pointer<Void>.fromAddress(0);
+DurationSeconds? smokeDurationsecondsFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeDurationsecondsFromFfi(handle) : null;
+void smokeDurationsecondsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDurationsecondsReleaseHandle(handle);
+// End of DurationSeconds "private" section.


### PR DESCRIPTION
Updated Dart name resolvers to map `Duration` type to Dart `Duration` class. Added conversion functions for these types
to the appropriate templates.

Added/updated smoke and functional tests.

Resolves: #911
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>