### PR TITLE
Move tag-filtering to generators

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
@@ -24,7 +24,6 @@ data class GluecodiumOptions(
     var auxiliaryIdlSources: List<String> = emptyList(),
     var outputDir: String = "",
     var commonOutputDir: String = "",
-    var tags: Set<String> = emptySet(),
     var generators: Set<String> = setOf(),
     var isValidatingOnly: Boolean = false,
     var isEnableCaching: Boolean = false

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -182,7 +182,6 @@ object OptionReader {
         gluecodiumOptions.generators = getStringListValue("generators")?.toSet() ?: emptySet()
         gluecodiumOptions.isValidatingOnly = getFlagValue("validate")
         gluecodiumOptions.isEnableCaching = getFlagValue("output") && getFlagValue("cache")
-        getStringListValue("tag")?.let { gluecodiumOptions.tags = CaseInsensitiveSet(it) }
 
         val generatorOptions = GeneratorOptions()
 
@@ -212,6 +211,7 @@ object OptionReader {
             readConfigFile(getStringValue("dartnamerules"), generatorOptions.dartNameRules)
 
         generatorOptions.copyrightHeaderContents = getStringValue("copyright")?.let { File(it).readText() }
+        getStringListValue("tag")?.let { generatorOptions.tags = CaseInsensitiveSet(it) }
 
         return Pair(gluecodiumOptions, generatorOptions)
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/Generator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/Generator.kt
@@ -31,10 +31,6 @@ interface Generator {
     /** Short name of the generator. */
     val shortName: String
 
-    /** Whether the generator expects an unfiltered model as an input. */
-    val needsUnfilteredModel: Boolean
-        get() = false
-
     /** Initialize the generator with given options. */
     fun initialize(options: GeneratorOptions) {}
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
@@ -55,7 +55,8 @@ data class GeneratorOptions(
     var dartNameRules: Configuration = ConfigurationProperties.fromResource(
         Gluecodium::class.java,
         "/namerules/dart.properties"
-    )
+    ),
+    var tags: Set<String> = emptySet()
 ) {
     companion object {
         const val WARNING_DOC_LINKS = "DocLinks"

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
@@ -39,8 +39,6 @@ internal class LimeGenerator : Generator {
 
     override val shortName = "lime"
 
-    override val needsUnfilteredModel = true
-
     override fun generate(limeModel: LimeModel) = limeModel.topElements.map { generate(it) }
 
     private fun generate(rootElement: LimeNamedElement): GeneratedFile {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.generator.swift
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
+import com.here.gluecodium.common.LimeModelSkipPredicates
 import com.here.gluecodium.generator.cbridge.CBridgeGenerator
 import com.here.gluecodium.generator.cbridge.CBridgeGenerator.Companion.getAllParentTypes
 import com.here.gluecodium.generator.cbridge.CBridgeNameResolver
@@ -36,12 +37,10 @@ import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.CppNameCache
 import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
-import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeException
-import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
@@ -49,7 +48,6 @@ import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
-import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeAlias
@@ -69,7 +67,9 @@ internal class SwiftGenerator : Generator {
     private lateinit var cppNameRules: CppNameRules
     private lateinit var nameRules: SwiftNameRules
     private lateinit var conversionVisibility: String
+    private lateinit var activeTags: Set<String>
     private var internalPrefix: String? = null
+
     private val importsCollector =
         GenericImportsCollector(
             SwiftImportsResolver(),
@@ -90,11 +90,14 @@ internal class SwiftGenerator : Generator {
         internalPrefix = options.internalPrefix
         conversionVisibility =
             if (options.swiftExposeInternals) CONVERSION_VISIBILITY_PUBLIC else CONVERSION_VISIBILITY_INTERNAL
+        activeTags = options.tags
     }
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val limeReferenceMap = limeModel.referenceMap
-        val filteredElements = LimeModelFilter.filter(limeModel) { shouldRetainElement(it) }.topElements
+        val filteredElements = LimeModelFilter
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, SWIFT, activeTags) }
+            .topElements
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
         val overloadsValidator = LimeOverloadsValidator(limeModel.referenceMap, SWIFT, nameRules, limeLogger)
@@ -258,13 +261,6 @@ internal class SwiftGenerator : Generator {
             is LimeInterface -> "swift/SwiftClassConversion"
             is LimeTypesCollection -> null
             else -> null
-        }
-
-    private fun shouldRetainElement(limeElement: LimeNamedElement) =
-        when {
-            limeElement is LimeFunction || limeElement is LimeProperty -> true
-            limeElement.attributes.have(SWIFT, SKIP) -> false
-            else -> true
         }
 
     companion object {

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -99,14 +99,7 @@ class SmokeTest(
 
         val limeModel = LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()))
         assertTrue(gluecodium.validateModel(limeModel))
-        assertTrue(
-            gluecodium.executeGenerator(
-                generatorName = generatorName,
-                filteredModel = gluecodium.filterModel(limeModel),
-                unfilteredModel = limeModel,
-                fileNamesCache = HashMap()
-            )
-        )
+        assertTrue(gluecodium.executeGenerator(generatorName, limeModel, HashMap()))
 
         val generatedContents = results.associateBy({ it.targetFile.path }, { it.content })
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.common
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.TAG
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeProperty
+
+object LimeModelSkipPredicates {
+    fun shouldRetainElement(
+        limeElement: LimeNamedElement,
+        platformAttribute: LimeAttributeType?,
+        activeTags: Set<String>
+    ) =
+        when {
+            isSkippedByTags(limeElement, activeTags) -> false
+            platformAttribute == null -> true
+            limeElement is LimeFunction || limeElement is LimeProperty -> true
+            limeElement.attributes.have(platformAttribute, LimeAttributeValueType.SKIP) -> false
+            else -> true
+        }
+
+    fun isSkippedByTags(limeElement: LimeNamedElement, activeTags: Set<String>): Boolean {
+        val isEnabled = hasTagsMatch(limeElement, LimeAttributeType.ENABLE_IF, activeTags)
+        if (isEnabled == false) return true
+
+        val isSkipped = hasTagsMatch(limeElement, LimeAttributeType.SKIP, activeTags)
+        return isSkipped ?: false
+    }
+
+    private fun hasTagsMatch(
+        limeElement: LimeNamedElement,
+        attributeType: LimeAttributeType,
+        activeTags: Set<String>
+    ): Boolean? =
+        when (val attributeTags = limeElement.attributes.get(attributeType, TAG, Any::class.java)) {
+            is String -> activeTags.contains(attributeTags)
+            is List<*> -> attributeTags.filterIsInstance<String>().intersect(activeTags).isNotEmpty()
+            else -> null
+        }
+}


### PR DESCRIPTION
Updated the filtering of the LIME model to be done in one step (in the generators), instead of two steps (also in
Gluecodium.kt class) as before. The "old" approach separated tag-filtering and platform-filtering, the new approach
combines them in one place (predicates extracted to LimeModelSkipPredicates). This is needed for implementing additional
logic that can depend on both types of filtering at the same time.

See: #980
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
