### PR TITLE
Move function skipping from templates to generators

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
@@ -87,7 +87,7 @@ internal class CppGenerator : Generator {
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val filteredModel =
-            LimeModelFilter.filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, null, activeTags) }
+            LimeModelFilter.filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags) }
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
         val overloadsValidator =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
 import com.here.gluecodium.common.LimeModelSkipPredicates
-import com.here.gluecodium.common.LimeModelSkipPredicates.isSkippedByTags
 import com.here.gluecodium.common.LimeTypeRefsVisitor
 import com.here.gluecodium.generator.common.CamelCaseNameResolver
 import com.here.gluecodium.generator.common.CommentsProcessor
@@ -110,10 +109,10 @@ internal class DartGenerator : Generator {
         val dartNameResolver = DartNameResolver(limeModel.referenceMap, nameRules, limeLogger, commentsProcessor)
         val ffiNameResolver = FfiNameResolver(limeModel.referenceMap, nameRules, internalPrefix)
 
-        val ffiFilteredModel =
-            LimeModelFilter.filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, DART, activeTags) }
+        val ffiFilteredModel = LimeModelFilter
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, DART, retainFunctions = true) }
         val dartFilteredElements = LimeModelFilter
-            .filter(limeModel) { !isSkippedByTags(it, activeTags) && !it.attributes.have(DART, SKIP) }
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, DART, retainFunctions = false) }
             .topElements
         val validationResult = DartOverloadsValidator(dartNameResolver, limeLogger, overloadsWerror)
             .validate(dartFilteredElements)

--- a/gluecodium/src/main/resources/templates/java/JavaClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaClass.mustache
@@ -27,14 +27,14 @@
 {{#constants}}{{prefixPartial "java/JavaConstant" "    "}}
 {{/constants}}
 {{>java/JavaContainerContents}}
-{{#set classElement=this}}{{#constructors}}{{#unless attributes.java.skip}}
+{{#set classElement=this}}{{#constructors}}
 {{prefixPartial "java/JavaMethodComment" "    "}}
     {{resolveName visibility}}{{resolveName classElement}}({{joinPartial parameters "java/JavaParameter" ", "}}){{!!
     }}{{#thrownType}} throws {{resolveName typeRef}}{{/thrownType}} {
         this({{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}), (Object)null);
         cacheThisInstance();
     }
-{{/unless}}{{/constructors}}{{/set}}
+{{/constructors}}{{/set}}
 {{#unless visibility.isInternal}}
     /**
      * For internal use only.
@@ -63,30 +63,30 @@
 
 {{/if}}
 
-{{#set isClass=true}}{{#functions}}{{#unless attributes.java.skip}}
+{{#set isClass=true}}{{#functions}}
 {{prefixPartial "java/JavaFunction" "    "}}
-{{/unless}}{{/functions}}{{/set}}
-{{#properties}}{{#unless attributes.java.skip}}{{#set isCached=attributes.cached property=this}}
+{{/functions}}{{/set}}
+{{#properties}}{{#set isCached=attributes.cached property=this}}
 {{#set isGetter=true}}{{#getter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/getter}}{{/set}}
 {{#setter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/setter}}{{/set}}
-{{/unless}}{{/properties}}
+{{/properties}}
 
 {{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}{{#set override=true classElement=this}}
-{{#set isClass=true}}{{#classElement.inheritedFunctions}}{{#unless attributes.java.skip}}
+{{#set isClass=true}}{{#classElement.inheritedFunctions}}
 {{prefixPartial "java/JavaFunction" "    "}}
-{{/unless}}{{/classElement.inheritedFunctions}}{{/set}}
-{{#classElement.inheritedProperties}}{{#unless attributes.java.skip}}{{#set isCached=attributes.cached property=this}}
+{{/classElement.inheritedFunctions}}{{/set}}
+{{#classElement.inheritedProperties}}{{#set isCached=attributes.cached property=this}}
 {{#set isGetter=true}}{{#getter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/getter}}{{/set}}
 {{#setter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/setter}}{{/set}}
-{{/unless}}{{/classElement.inheritedProperties}}
+{{/classElement.inheritedProperties}}
 {{/set}}{{/instanceOf}}{{/if}}
 
 {{#eval "optimizedLists" path}}{{#this}}

--- a/gluecodium/src/main/resources/templates/java/JavaFunction.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaFunction.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unless attributes.java.skip}}{{#if isCached}}
+{{#if isCached}}
 private {{#if isStatic}}static {{/if}}{{resolveName returnType}} cache_{{resolveName}};
 private {{#if isStatic}}static {{/if}}boolean is_cached_{{resolveName}} = false;
 
@@ -36,4 +36,4 @@ private {{#if isStatic}}static {{/if}}boolean is_cached_{{resolveName}} = false;
 private {{#if isStatic}}static {{/if}}native {{resolveName returnType}} {{resolveName}}_private({{!!
 }}{{joinPartial parameters "java/JavaParameter" ", "}});
 {{/if}}{{!!
-}}{{#unless isCached}}{{>java/JavaMethodSignature}};{{/unless}}{{/unless}}
+}}{{#unless isCached}}{{>java/JavaMethodSignature}};{{/unless}}

--- a/gluecodium/src/main/resources/templates/java/JavaImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaImplClass.mustache
@@ -43,29 +43,29 @@ static {{/if}}class {{resolveName}}Impl extends NativeBase implements {{resolveN
 
 {{/if}}
 
-{{#set isImpl=true interface=this}}{{#functions}}{{#unless attributes.java.skip}}
+{{#set isImpl=true interface=this}}{{#functions}}
 {{prefixPartial "java/JavaFunction" "    "}}
-{{/unless}}{{/functions}}
-{{#interface.properties}}{{#unless attributes.java.skip}}{{#set isCached=attributes.cached}}
+{{/functions}}
+{{#interface.properties}}{{#set isCached=attributes.cached}}
 {{#getter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/getter}}
 {{#setter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/setter}}
-{{/set}}{{/unless}}{{/interface.properties}}
+{{/set}}{{/interface.properties}}
 
 {{#if parent}}{{#set override=true}}
-{{#interface.inheritedFunctions}}{{#unless attributes.java.skip}}
+{{#interface.inheritedFunctions}}
 {{prefixPartial "java/JavaFunction" "    "}}
-{{/unless}}{{/interface.inheritedFunctions}}
-{{#interface.inheritedProperties}}{{#unless attributes.java.skip}}{{#set isCached=attributes.cached}}
+{{/interface.inheritedFunctions}}
+{{#interface.inheritedProperties}}{{#set isCached=attributes.cached}}
 {{#getter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/getter}}
 {{#setter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/setter}}
-{{/set}}{{/unless}}{{/interface.inheritedProperties}}
+{{/set}}{{/interface.inheritedProperties}}
 {{/set}}{{/if}}{{/set}}
 }

--- a/gluecodium/src/main/resources/templates/java/JavaInterface.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaInterface.mustache
@@ -24,10 +24,10 @@
 {{/constants}}
 {{>java/JavaContainerContents}}
 {{#set isInterface=true}}
-{{#functions}}{{#unless attributes.java.skip isStatic logic="and"}}
+{{#functions}}{{#unless isStatic}}
 {{prefixPartial "java/JavaMethodSignature" "    "}};
 {{/unless}}{{/functions}}
-{{#properties}}{{#unless attributes.java.skip isStatic logic="and"}}{{#set property=this}}
+{{#properties}}{{#unless isStatic}}{{#set property=this}}
 {{#set isGetter=true}}{{#getter}}
 {{prefixPartial "java/JavaMethodSignature" "    "}};
 {{/getter}}{{/set}}
@@ -39,17 +39,17 @@
 
 }}{{#ifPredicate "hasStaticFunctions"}}
 {{#set isInterface=true interface=this}}
-{{#functions}}{{#if isStatic}}{{#unless attributes.java.skip}}
+{{#functions}}{{#if isStatic}}
 {{prefixPartial "java/JavaMethodSignature" "    "}}{{prefixPartial "redirectToImpl" "    " skipFirstLine=true}}
-{{/unless}}{{/if}}{{/functions}}
-{{#properties}}{{#if isStatic}}{{#unless attributes.java.skip}}{{#set property=this}}
+{{/if}}{{/functions}}
+{{#properties}}{{#if isStatic}}{{#set property=this}}
 {{#set isGetter=true}}{{#getter}}
 {{prefixPartial "java/JavaMethodSignature" "    "}}{{prefixPartial "redirectToImpl" "    " skipFirstLine=true}}
 {{/getter}}{{/set}}
 {{#setter}}
 {{prefixPartial "java/JavaMethodSignature" "    "}}{{prefixPartial "redirectToImpl" "    " skipFirstLine=true}}
 {{/setter}}
-{{/set}}{{/unless}}{{/if}}{{/properties}}
+{{/set}}{{/if}}{{/properties}}
 {{/set}}
 {{/ifPredicate}}
 }{{!!

--- a/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
@@ -29,7 +29,7 @@
 {{#set isImmutable=attributes.immutable}}{{#fields}}{{prefixPartial "java/JavaField" "    "}}
 {{/fields}}{{/set}}
 {{>java/JavaContainerContents}}
-{{#set classElement=this}}{{#constructors}}{{#unless attributes.java.skip}}
+{{#set classElement=this}}{{#constructors}}
 {{prefixPartial "java/JavaMethodComment" "    "}}
     {{>structVisibility}}{{resolveName classElement}}({{#set noAttributes=true}}{{joinPartial parameters "java/JavaParameter" ", "}}{{/set}}){{!!
     }}{{#thrownType}} throws {{resolveName typeRef}}{{/thrownType}} {
@@ -37,7 +37,7 @@
 {{#fields}}        this.{{resolveName}} = _other.{{resolveName}};
 {{/fields}}
     }
-{{/unless}}{{/constructors}}{{/set}}
+{{/constructors}}{{/set}}
 {{#if fields}}{{#unless constructors}}
 
 {{#unless constructorComment.isEmpty}}
@@ -109,9 +109,9 @@
 
 {{/unless}}{{/if}}{{/unless}}
 
-{{#functions}}{{#unless attributes.java.skip}}
+{{#functions}}
 {{prefixPartial "java/JavaFunction" "    "}}
-{{/unless}}{{/functions}}
+{{/functions}}
 
 {{#eval "optimizedLists" path}}{{#this}}
 {{#elementType}}{{prefixPartial "java/LazyNativeList" "    "}}{{/elementType}}

--- a/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
+++ b/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
@@ -22,13 +22,13 @@
 {{>swift/SwiftConstant}}
 {{/constants}}
 {{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
-{{#inheritedProperties}}{{#unless attributes.swift.skip}}
+{{#inheritedProperties}}
 {{>swift/SwiftProperty}}
-{{/unless}}{{/inheritedProperties}}
+{{/inheritedProperties}}
 {{/instanceOf}}{{/if}}
-{{#set container=this}}{{#properties}}{{#unless attributes.swift.skip}}
+{{#set container=this}}{{#properties}}
 {{>swift/SwiftProperty}}
-{{/unless}}{{/properties}}{{/set}}{{!!
+{{/properties}}{{/set}}{{!!
 
 }}
 {{#unlessPredicate "parentIsClass"}}let c_instance : _baseRef
@@ -62,11 +62,11 @@ deinit {
 {{/structs}}{{/unless}}{{!!
 
 }}{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
-{{#inheritedFunctions}}{{#unless attributes.swift.skip}}
+{{#inheritedFunctions}}
 {{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}
-{{/unless}}{{/inheritedFunctions}}
+{{/inheritedFunctions}}
 {{/instanceOf}}{{/if}}{{!!
 
-}}{{#set container=this}}{{#functions}}{{#unless attributes.swift.skip}}
+}}{{#set container=this}}{{#functions}}
 {{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}
-{{/unless}}{{/functions}}{{/set}}
+{{/functions}}{{/set}}

--- a/gluecodium/src/main/resources/templates/swift/GetReference.mustache
+++ b/gluecodium/src/main/resources/templates/swift/GetReference.mustache
@@ -56,10 +56,10 @@
     }
 
 {{#set class=this}}{{#class}}
-{{#each inheritedFunctions functions}}{{#unless attributes.swift.skip isStatic logic="and"}}
+{{#each inheritedFunctions functions}}{{#unless isStatic}}
 {{#set delegateToCall="delegateCall2" function=this}}{{>functionTableEntry}}{{/set}}
 {{/unless}}{{/each}}
-{{#each inheritedProperties properties}}{{#unless attributes.swift.skip isStatic logic="and"}}
+{{#each inheritedProperties properties}}{{#unless isStatic}}
 {{#set property=this}}{{#getter}}{{#set delegateToCall="callPropertyGetter" function=this}}{{>functionTableEntry}}{{/set}}{{/getter}}
 {{#setter}}{{#set delegateToCall="callPropertySetter" function=this}}{{>functionTableEntry}}{{/set}}{{/setter}}{{/set}}
 {{/unless}}{{/each}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -28,7 +28,7 @@
 {{#lambdas}}
 {{prefixPartial "swift/SwiftLambdaDefinition" "    "}}
 {{/lambdas}}
-{{#set class=this}}{{#constructors}}{{#unless attributes.swift.skip}}
+{{#set class=this}}{{#constructors}}
 {{prefixPartial "swift/SwiftFunctionComment" "    "}}
     {{resolveName visibility}} {{#ifPredicate "isOverriding"}}override {{/ifPredicate}}{{!!
     }}init({{>swift/SwiftFunctionParameters}}){{#if thrownType}} throws{{/if}} {
@@ -44,7 +44,7 @@
         {{resolveName class "CBridge"}}_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
 
-{{/unless}}{{/constructors}}{{/set}}
+{{/constructors}}{{/set}}
 
 {{prefixPartial "swift/CommonClassParts" "    "}}
 }

--- a/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
@@ -27,15 +27,15 @@
 {{#lambdas}}
 {{prefixPartial "swift/SwiftLambdaDefinition" "    "}}
 {{/lambdas}}{{/set}}
-{{#each inheritedProperties properties}}{{#unless attributes.swift.skip}}
+{{#each inheritedProperties properties}}
 {{prefixPartial "swift/SwiftComment" "    "}}{{prefixPartial "swift/SwiftAttributes" "    "}}
     {{#if isStatic}}static {{/if}}var {{resolveName}}: {{resolveName typeRef}} { get {{#if setter}}set {{/if}}}
-{{/unless}}{{/each}}
-{{#each inheritedFunctions functions}}{{#unless attributes.swift.skip}}
+{{/each}}
+{{#each inheritedFunctions functions}}
 {{prefixPartial "swift/SwiftFunctionComment" "    "}}{{prefixPartial "swift/SwiftAttributes" "    "}}
     {{#if isStatic}}static {{/if}}func {{resolveName}}({{>swift/SwiftFunctionParameters}}){{!!
     }}{{#if thrownType}} throws{{/if}} -> {{resolveName returnType}}
-{{/unless}}{{/each}}
+{{/each}}
 }
 
 internal class _{{resolveName}}: {{resolveName}} {

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
@@ -81,7 +81,7 @@
 {{/fields}}{{/set}}
     }
 {{/if}}{{!!
-}}{{#set struct=this}}{{#constructors}}{{#unless attributes.swift.skip}}
+}}{{#set struct=this}}{{#constructors}}
 {{prefixPartial "swift/SwiftFunctionComment" "    "}}
     {{resolveName visibility}} {{#if overriding}}override {{/if}}init({{>swift/SwiftFunctionParameters}}){{#if thrownType}} throws{{/if}} {
         let _result_handle = {{#if thrownType}}try {{/if}}{{resolveName struct "" "ref"}}.{{resolveName}}({{#parameters}}{{!!
@@ -97,7 +97,7 @@
 {{/fields}}
     }
 
-{{/unless}}{{/constructors}}{{/set}}
+{{/constructors}}{{/set}}
 {{#enumerations}}
 {{prefixPartial "swift/SwiftEnumDefinition" "    "}}
 {{/enumerations}}
@@ -132,9 +132,9 @@
 {{/ifPredicate}}{{!!
 }}{{#if functions}}
 
-{{#set selfIsStruct=true}}{{#functions}}{{#unless attributes.swift.skip}}
+{{#set selfIsStruct=true}}{{#functions}}
 {{prefixPartial "swift/SwiftFunctionSignature" "    "}} {{prefixPartial "swift/SwiftFunctionBody" "    " skipFirstLine=true}}
-{{/unless}}{{/functions}}{{/set}}{{/if}}
+{{/functions}}{{/set}}{{/if}}
 }
 
 {{#interfaces}}

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
@@ -29,18 +29,19 @@ import com.here.gluecodium.model.lime.LimeProperty
 object LimeModelSkipPredicates {
     fun shouldRetainElement(
         limeElement: LimeNamedElement,
-        platformAttribute: LimeAttributeType?,
-        activeTags: Set<String>
+        activeTags: Set<String>,
+        platformAttribute: LimeAttributeType? = null,
+        retainFunctions: Boolean = false
     ) =
         when {
             isSkippedByTags(limeElement, activeTags) -> false
-            platformAttribute == null -> true
-            limeElement is LimeFunction || limeElement is LimeProperty -> true
-            limeElement.attributes.have(platformAttribute, LimeAttributeValueType.SKIP) -> false
+            retainFunctions && (limeElement is LimeFunction || limeElement is LimeProperty) -> true
+            platformAttribute != null &&
+                limeElement.attributes.have(platformAttribute, LimeAttributeValueType.SKIP) -> false
             else -> true
         }
 
-    fun isSkippedByTags(limeElement: LimeNamedElement, activeTags: Set<String>): Boolean {
+    private fun isSkippedByTags(limeElement: LimeNamedElement, activeTags: Set<String>): Boolean {
         val isEnabled = hasTagsMatch(limeElement, LimeAttributeType.ENABLE_IF, activeTags)
         if (isEnabled == false) return true
 


### PR DESCRIPTION
Functions and properties need to be handled in the bindings even if they are platform-skipped, to produce valid
C++-facing proxy objects. In Java and Swift generators this was handled by skipping them through templates. In Dart
generator, however, this was done by applying model filtering separately: once for Dart, once for FFI, with different
predicates.

Updated Java and Swift generators to apply separate model filtering, similar to Dart. This eliminates skipping checks in Java and Swift templates, and concentrates most skipping logic in one single place (LimeModelSkipPredicates).

See: #980
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>