### PR TITLE
Add support for in-platform tag-skipping in Java

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -421,6 +421,7 @@ feature(Visibility dart SOURCES
 feature(SkipAttribute cpp android swift dart SOURCES
     input/lime/Skip.lime
     input/lime/SkipTags.lime
+    input/lime/SkipTagsInPlatform.lime
     input/lime/SkipEnumerator.lime
     input/lime/EnableIfEnabled.lime
     input/lime/EnableIfSkipped.lime

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/SkipElementTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/SkipElementTest.java
@@ -29,7 +29,14 @@ import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = Build.VERSION_CODES.M, application = RobolectricApplication.class)
-public final class SkipEnumeratorTest {
+public final class SkipElementTest {
+
+  // Compile-time check that SkipTagsInJava contains exactly one method.
+  private static class SkipTagsInJavaImpl implements SkipTagsInJava {
+    @Override
+    public void dontSkipTagged() {}
+  }
+
   @Test
   public void autoTagRoundTrip() {
     SkipEnumeratorAutoTag value = SkipEnumeratorAutoTag.THREE;

--- a/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
+++ b/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Skip(Swift, Dart)
+interface SkipTagsInJava {
+    @Java(Skip = "Lite")
+    fun skipTagged()
+    @Java(Skip = "Pro")
+    fun dontSkipTagged()
+    @Java(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -136,7 +136,8 @@ internal class JavaGenerator : Generator {
             internalNamespace = internalNamespace,
             cppNameRules = cppNameRules,
             generatorName = GENERATOR_NAME,
-            nameCache = cachingNameResolver
+            nameCache = cachingNameResolver,
+            activeTags = activeTags
         )
         for (fileName in UTILS_FILES) {
             resultFiles += jniTemplates.generateConversionUtilsHeaderFile(fileName)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -19,10 +19,12 @@
 
 package com.here.gluecodium.generator.jni
 
+import com.here.gluecodium.common.LimeModelSkipPredicates
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.generator.java.JavaSignatureResolver
+import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.BOOLEAN
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.VOID
@@ -43,7 +45,8 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 internal class JniGeneratorPredicates(
     limeReferenceMap: Map<String, LimeElement>,
     javaNameRules: JavaNameRules,
-    private val cppNameResolver: CppNameResolver
+    cppNameResolver: CppNameResolver,
+    activeTags: Set<String>
 ) {
     private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules)
 
@@ -82,6 +85,10 @@ internal class JniGeneratorPredicates(
         "returnsOpaqueHandle" to { limeFunction: Any ->
             limeFunction is LimeFunction && limeFunction.isConstructor &&
                 limeFunction.returnType.typeRef.type is LimeClass
+        },
+        "shouldRetain" to { limeElement: Any ->
+            limeElement is LimeNamedElement &&
+                LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, JAVA, limeReferenceMap)
         }
     )
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -52,7 +52,8 @@ internal class JniTemplates(
     private val internalNamespace: List<String>,
     cppNameRules: CppNameRules,
     generatorName: String,
-    nameCache: CppNameCache
+    nameCache: CppNameCache,
+    activeTags: Set<String>
 ) {
     private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, javaNameRules)
     private val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
@@ -64,7 +65,7 @@ internal class JniTemplates(
         "C++" to cppNameResolver,
         "C++ FQN" to CppFullNameResolver(nameCache)
     )
-    private val predicates = JniGeneratorPredicates(limeReferenceMap, javaNameRules, cppNameResolver).predicates
+    private val predicates = JniGeneratorPredicates(limeReferenceMap, javaNameRules, cppNameResolver, activeTags).predicates
 
     private val cppIncludeResolver = CppIncludeResolver(limeReferenceMap, cppNameRules, internalNamespace)
     private val jniIncludeResolver = JniIncludeResolver(fileNameRules)

--- a/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
@@ -63,9 +63,9 @@ namespace jni
 }}{{#notInstanceOf container "LimeLambda"}}{{resolveName "C++"}}{{/notInstanceOf}}{{/unless}}( {{!!
 }}{{joinPartial parameters "jni/CppProxyMethodParameter" ", "}} {{!!
 }}){{#if attributes.cpp.const isConst logic="or"}} const{{/if}} {
-{{#if attributes.java.skip isSkipped logic="or"}}
+{{#unlessPredicate "shouldRetain"}}
     {{#unless returnType.isVoid}}return {};{{/unless}}
-{{/if}}{{#unless attributes.java.skip isSkipped logic="and"}}
+{{/unlessPredicate}}{{#ifPredicate "shouldRetain"}}
     JNIEnv* jniEnv = getJniEnvironment( );{{!!
 }}{{#parameters}}{{!!
 }}{{#unlessPredicate typeRef "isJniPrimitive"}}
@@ -123,17 +123,17 @@ namespace jni
 {{/notInstanceOf}}{{/if}}
     }
 {{/if}}
-{{/unless}}
+{{/ifPredicate}}
 }
 {{/proxyMethodImpl}}{{!!
 
 }}{{+proxyPropertyImpl}}{{!!
-}}{{#if getter}}{{#set property=this function=getter isConst=true isSkipped=attributes.java.skip}}{{!!
+}}{{#if getter}}{{#set property=this function=getter isConst=true}}{{!!
 }}{{#resolveName property "C++" "getter"}}{{#set cppName=this}}{{!!
 }}{{#resolveName property "" "getter"}}{{#set javaName=this}}{{#function}}
 {{>proxyMethodImpl}}
 {{/function}}{{/set}}{{/resolveName}}{{/set}}{{/resolveName}}{{/set}}{{/if}}{{!!
-}}{{#if setter}}{{#set property=this function=setter isSkipped=attributes.java.skip}}{{!!
+}}{{#if setter}}{{#set property=this function=setter}}{{!!
 }}{{#resolveName property "C++" "setter"}}{{#set cppName=this}}{{!!
 }}{{#resolveName property "" "setter"}}{{#set javaName=this}}{{#function}}
 {{>proxyMethodImpl}}

--- a/gluecodium/src/main/resources/templates/jni/Header.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Header.mustache
@@ -28,24 +28,24 @@
 extern "C" {
 #endif
 
-{{#container}}{{#functions}}{{#unless attributes.java.skip}}
+{{#container}}{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>jniFunctionHeader}}
 
-{{/unless}}{{/functions}}
-{{#properties}}{{#unless attributes.java.skip}}
+{{/ifPredicate}}{{/functions}}
+{{#properties}}{{#ifPredicate "shouldRetain"}}
 {{>jniPropertyHeader}}
 
-{{/unless}}{{/properties}}
+{{/ifPredicate}}{{/properties}}
 
 {{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
-{{#inheritedFunctions}}{{#unless attributes.java.skip}}
+{{#inheritedFunctions}}{{#ifPredicate "shouldRetain"}}
 {{>jniFunctionHeader}}
 
-{{/unless}}{{/inheritedFunctions}}
-{{#inheritedProperties}}{{#unless attributes.java.skip}}
+{{/ifPredicate}}{{/inheritedFunctions}}
+{{#inheritedProperties}}{{#ifPredicate "shouldRetain"}}
 {{>jniPropertyHeader}}
 
-{{/unless}}{{/inheritedProperties}}
+{{/ifPredicate}}{{/inheritedProperties}}
 {{/instanceOf}}{{/if}}
 
 {{#if attributes.equatable attributes.pointerEquatable logic="or"}}

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -30,22 +30,22 @@
 
 extern "C" {
 
-{{#container}}{{#functions}}{{#unless attributes.java.skip}}
+{{#container}}{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>jniMethodImpl}}
 
-{{/unless}}{{/functions}}
-{{#properties}}{{#unless attributes.java.skip}}
+{{/ifPredicate}}{{/functions}}
+{{#properties}}{{#ifPredicate "shouldRetain"}}
 {{>jniPropertyImpl}}
-{{/unless}}{{/properties}}
+{{/ifPredicate}}{{/properties}}
 
 {{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
-{{#inheritedFunctions}}{{#unless attributes.java.skip}}
+{{#inheritedFunctions}}{{#ifPredicate "shouldRetain"}}
 {{>jniMethodImpl}}
 
-{{/unless}}{{/inheritedFunctions}}
-{{#inheritedProperties}}{{#unless attributes.java.skip}}
+{{/ifPredicate}}{{/inheritedFunctions}}
+{{#inheritedProperties}}{{#ifPredicate "shouldRetain"}}
 {{>jniPropertyImpl}}
-{{/unless}}{{/inheritedProperties}}
+{{/ifPredicate}}{{/inheritedProperties}}
 {{/instanceOf}}{{/if}}
 
 {{#notInstanceOf container "LimeStruct"}}

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Skip(Swift, Dart)
+interface SkipTagsInJava {
+    @Java(Skip = "Lite")
+    fun skipTagged()
+    @Java(Skip = "Pro")
+    fun dontSkipTagged()
+    @Java(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTagsInJava.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTagsInJava.java
@@ -1,0 +1,7 @@
+/*
+ *
+ */
+package com.example.smoke;
+public interface SkipTagsInJava {
+    void dontSkipTagged();
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipTagsInJavaImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipTagsInJavaImplCppProxy.cpp
@@ -1,0 +1,34 @@
+/*
+ *
+ */
+#include "com_example_smoke_SkipTagsInJavaImplCppProxy.h"
+#include "com_example_smoke_SkipTagsInJava__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+namespace gluecodium
+{
+namespace jni
+{
+com_example_smoke_SkipTagsInJava_CppProxy::com_example_smoke_SkipTagsInJava_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode )
+    : CppProxyBase( _jenv, std::move( globalRef ), _jHashCode, "com_example_smoke_SkipTagsInJava" ) {
+}
+void
+com_example_smoke_SkipTagsInJava_CppProxy::skip_tagged(  ) {
+}
+void
+com_example_smoke_SkipTagsInJava_CppProxy::dont_skip_tagged(  ) {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    callJavaMethod<void>( "dontSkipTagged", "()V", jniEnv  );
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+}
+void
+com_example_smoke_SkipTagsInJava_CppProxy::skip_tagged_list(  ) {
+}
+}
+}


### PR DESCRIPTION
Updated LimeModelSkipPredicates to add support for `@Java(Skip = "CustomTag")` syntax (also for other platforms).

Updated JNI generator and templates to check for skipped functions based on the predicate from LimeModelSkipPredicates,
to support this syntax.

Added smoke and functional tests.

See: #980
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>