### PR TITLE
Add support for in-platform tag-skipping in Swift

### DIFF
--- a/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
+++ b/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
@@ -26,3 +26,13 @@ interface SkipTagsInJava {
     @Java(Skip = ["Lite", "Pro"])
     fun skipTaggedList()
 }
+
+@Skip(Java, Dart)
+interface SkipTagsInSwift {
+    @Swift(Skip = "Lite")
+    fun skipTagged()
+    @Swift(Skip = "Pro")
+    fun dontSkipTagged()
+    @Swift(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}

--- a/functional-tests/functional/swift/Tests/SkipElementTests.swift
+++ b/functional-tests/functional/swift/Tests/SkipElementTests.swift
@@ -21,7 +21,12 @@
 import XCTest
 import functional
 
-class SkipEnumeratorTests: XCTestCase {
+class SkipElementTests: XCTestCase {
+    // Compile-time check that SkipTagsInSwift contains exactly one method.
+    class SkipTagsInSwiftImpl: SkipTagsInSwift {
+        func dontSkipTagged() {}
+    }
+
     func testAutoTagRoundTrip() {
         let value = SkipEnumeratorAutoTag.three
 

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -71,7 +71,7 @@ func getAllTests() -> [XCTestCaseEntry] {
         testCase(SerializationTests.allTests),
         testCase(SetTypeTests.allTests),
         testCase(SimpleEqualityTests.allTests),
-        testCase(SkipEnumeratorTests.allTests),
+        testCase(SkipElementTests.allTests),
         testCase(StaticBooleanMethodsTests.allTests),
         testCase(StaticByteArrayMethodsTests.allTests),
         testCase(StaticFloatDoubleMethodsTests.allTests),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -60,7 +60,8 @@ internal class CBridgeGenerator(
     nameCache: CppNameCache,
     private val internalNamespace: List<String>,
     cppNameRules: CppNameRules,
-    private val nameResolver: CBridgeNameResolver
+    private val nameResolver: CBridgeNameResolver,
+    activeTags: Set<String>
 ) {
     val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache, forceFollowThrough = true)
     private val cppRefNameResolver =
@@ -82,7 +83,7 @@ internal class CBridgeGenerator(
             collectOwnImports = true,
             parentTypeFilter = { it is LimeInterface }
         )
-    private val predicates = CBridgeGeneratorPredicates(cppNameResolver).predicates
+    private val predicates = CBridgeGeneratorPredicates(cppNameResolver, limeReferenceMap, activeTags).predicates
     val genericTypesCollector = GenericTypesCollector(nameResolver)
 
     fun generate(rootElement: LimeNamedElement): List<GeneratedFile> {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGeneratorPredicates.kt
@@ -19,19 +19,27 @@
 
 package com.here.gluecodium.generator.cbridge
 
+import com.here.gluecodium.common.LimeModelSkipPredicates
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.cpp.CppNameResolver
+import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.BOOLEAN
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.VOID
+import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 /**
  * List of predicates used by `ifPredicate`/`unlessPredicate` template helpers in CBridge generator.
  */
-internal class CBridgeGeneratorPredicates(private val cppNameResolver: CppNameResolver) {
+internal class CBridgeGeneratorPredicates(
+    cppNameResolver: CppNameResolver,
+    limeReferenceMap: Map<String, LimeElement>,
+    activeTags: Set<String>
+) {
     val predicates = mapOf(
         "hasCppGetter" to { limeField: Any ->
             limeField is LimeField && cppNameResolver.resolveGetterName(limeField) != null
@@ -54,6 +62,10 @@ internal class CBridgeGeneratorPredicates(private val cppNameResolver: CppNameRe
                     !(limeType.typeId.isNumericType || limeType.typeId == BOOLEAN || limeType.typeId == VOID)
                 else -> true
             }
+        },
+        "shouldRetain" to { limeElement: Any ->
+            limeElement is LimeNamedElement &&
+                LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, SWIFT, limeReferenceMap)
         }
     )
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -117,7 +117,8 @@ internal class SwiftGenerator : Generator {
             nameCache = CppNameCache(rootNamespace, cbridgeFilteredModel.referenceMap, cppNameRules),
             internalNamespace = internalNamespace,
             cppNameRules = cppNameRules,
-            nameResolver = cbridgeNameResolver
+            nameResolver = cbridgeNameResolver,
+            activeTags = activeTags
         )
 
         val swiftNameResolver = SwiftNameResolver(limeModel.referenceMap, nameRules, limeLogger, commentsProcessor)

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeClassHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeClassHeader.mustache
@@ -22,8 +22,8 @@
 {{>cbridge/CBridgeEnumeration}}
 {{/enumerations}}
 
-{{#functions}}{{#unless attributes.swift.skip}}{{#if thrownType}}{{>cbridge/ThrowingFunctionReturnType}}
-{{/if}}{{/unless}}{{/functions}}
+{{#functions}}{{#ifPredicate "shouldRetain"}}{{#if thrownType}}{{>cbridge/ThrowingFunctionReturnType}}
+{{/if}}{{/ifPredicate}}{{/functions}}
 
 {{#structs}}
 {{>cbridge/CBridgeStructHeader}}
@@ -49,17 +49,17 @@ _GLUECODIUM_C_EXPORT _baseRef {{resolveName}}_create_proxy({{resolveName}}_Funct
 _GLUECODIUM_C_EXPORT const void* {{resolveName}}_get_swift_object_from_cache(_baseRef handle);
 {{/instanceOf}}
 
-{{#functions}}{{#unless attributes.swift.skip}}
+{{#functions}}{{#ifPredicate "shouldRetain"}}
 _GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
-{{/unless}}{{/functions}}
-{{#properties}}{{#unless attributes.swift.skip}}
+{{/ifPredicate}}{{/functions}}
+{{#properties}}{{#ifPredicate "shouldRetain"}}
 {{#getter}}
 _GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
 {{/getter}}
 {{#setter}}
 _GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
 {{/setter}}
-{{/unless}}{{/properties}}
+{{/ifPredicate}}{{/properties}}
 
 {{#each classes interfaces}}
 {{>cbridge/CBridgeClassHeader}}

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeClassImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeClassImpl.mustache
@@ -88,17 +88,17 @@ uint64_t {{resolveName}}_hash(_baseRef handle) {
 {{/if}}
 
 {{#set selfType=this}}
-{{#functions}}{{#unless attributes.swift.skip}}
+{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>cbridge/CBridgeFunctionDefinition}}
-{{/unless}}{{/functions}}
-{{#properties}}{{#unless attributes.swift.skip}}
+{{/ifPredicate}}{{/functions}}
+{{#properties}}{{#ifPredicate "shouldRetain"}}
 {{#getter}}
 {{>cbridge/CBridgeFunctionDefinition}}
 {{/getter}}
 {{#setter}}
 {{>cbridge/CBridgeFunctionDefinition}}
 {{/setter}}
-{{/unless}}{{/properties}}
+{{/ifPredicate}}{{/properties}}
 {{/set}}
 
 {{#instanceOf this "LimeInterface"}}

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeCppProxy.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeCppProxy.mustache
@@ -36,9 +36,9 @@ public:
 {{#each this.inheritedFunctions this.functions}}{{#unless isStatic}}
     {{>cpp/CppReturnType}} {{resolveName "C++"}}({{joinPartial parameters "cppParameter" ", "}}){{!!
     }}{{#if attributes.cpp.const}} const{{/if}}{{#unless isLambda}} override{{/unless}} {
-{{#if attributes.swift.skip}}
+{{#unlessPredicate "shouldRetain"}}
         {{#if returnType.isVoid error}}return {};{{/if}}{{#unless returnType.isVoid}}return {};{{/unless}}
-{{/if}}{{#unless attributes.swift.skip}}{{#if thrownType}}
+{{/unlessPredicate}}{{#ifPredicate "shouldRetain"}}{{#if thrownType}}
         auto _result_with_error = {{>swiftDelegateCall}};
         if (!_result_with_error.has_value)
         {
@@ -49,24 +49,24 @@ public:
         {{/if}}{{#unless thrownType}}
         {{#unless returnType.isVoid}}auto _call_result = {{/unless}}{{>swiftDelegateCall}};
         {{/unless}}
-        {{#unless returnType.isVoid}}{{>returnConversion}}{{/unless}}{{/unless}}
+        {{#unless returnType.isVoid}}{{>returnConversion}}{{/unless}}{{/ifPredicate}}
     }
 {{/unless}}{{/each}}
 {{#each this.inheritedProperties this.properties}}{{#unless isStatic}}
     {{resolveName typeRef "C++"}} {{resolveName this "C++" "getter"}}() const override {
-{{#if attributes.swift.skip}}
+{{#unlessPredicate "shouldRetain"}}
         return {};
-{{/if}}{{#unless attributes.swift.skip}}
+{{/unlessPredicate}}{{#ifPredicate "shouldRetain"}}
         auto _call_result = mFunctions.{{resolveName getter}}(mFunctions.swift_pointer);
         {{#set returnType=getter.returnType}}{{>returnConversion}}{{/set}}
-{{/unless}}
+{{/ifPredicate}}
     }
 {{#if setter}}
     void {{resolveName this "C++" "setter"}}({{#setter.parameters.0}}{{>cppParameter}}{{/setter.parameters.0}}) override {
-{{#unless attributes.swift.skip}}
+{{#ifPredicate "shouldRetain"}}
         mFunctions.{{resolveName setter}}({{!!
         }}mFunctions.swift_pointer, {{#setter.parameters.0}}{{>swiftParameter}}{{/setter.parameters.0}});
-{{/unless}}
+{{/ifPredicate}}
     }
 {{/if}}
 {{/unless}}{{/each}}

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeStructHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeStructHeader.mustache
@@ -50,7 +50,7 @@ _GLUECODIUM_C_EXPORT {{resolveName typeRef}} {{structName}}_{{resolveName}}_get(
 {{#functions}}{{#if thrownType}}{{>cbridge/ThrowingFunctionReturnType}}
 {{/if}}{{/functions}}
 
-{{#functions}}{{#unless attributes.swift.skip}}
+{{#functions}}{{#ifPredicate "shouldRetain"}}
 _GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
-{{/unless}}{{/functions}}
+{{/ifPredicate}}{{/functions}}
 {{/if}}

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeStructImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeStructImpl.mustache
@@ -91,9 +91,9 @@ void {{resolveName}}_release_optional_handle(_baseRef handle) {
 {{>cbridge/CBridgeClassImpl}}
 {{/each}}
 
-{{#set selfType=this}}{{#functions}}{{#unless attributes.swift.skip}}
+{{#set selfType=this}}{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>cbridge/CBridgeFunctionDefinition}}
-{{/unless}}{{/functions}}{{/set}}{{!!
+{{/ifPredicate}}{{/functions}}{{/set}}{{!!
 
 }}{{+getCppFieldValue}}struct_pointer->{{#ifPredicate field "hasCppGetter"}}{{resolveName field "C++" "getter"}}(){{/ifPredicate}}{{!!
 }}{{#unlessPredicate field "hasCppGetter"}}{{resolveName field "C++"}}{{/unlessPredicate}}{{/getCppFieldValue}}{{!!

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
@@ -26,3 +26,13 @@ interface SkipTagsInJava {
     @Java(Skip = ["Lite", "Pro"])
     fun skipTaggedList()
 }
+
+@Skip(Java, Dart)
+interface SkipTagsInSwift {
+    @Swift(Skip = "Lite")
+    fun skipTagged()
+    @Swift(Skip = "Pro")
+    fun dontSkipTagged()
+    @Swift(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipTagsInSwift.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipTagsInSwift.cpp
@@ -1,0 +1,78 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_SkipTagsInSwift.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/CachedProxyBase.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/SkipTagsInSwift.h"
+#include <memory>
+#include <new>
+void smoke_SkipTagsInSwift_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(handle);
+}
+_baseRef smoke_SkipTagsInSwift_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(handle)))
+        : 0;
+}
+const void* smoke_SkipTagsInSwift_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(handle)->get())
+        : nullptr;
+}
+void smoke_SkipTagsInSwift_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(handle)->get(), swift_pointer);
+}
+void smoke_SkipTagsInSwift_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(handle)->get());
+}
+extern "C" {
+extern void* _CBridgeInitsmoke_SkipTagsInSwift(_baseRef handle);
+}
+namespace {
+struct smoke_SkipTagsInSwiftRegisterInit {
+    smoke_SkipTagsInSwiftRegisterInit() {
+        get_init_repository().add_init("smoke_SkipTagsInSwift", &_CBridgeInitsmoke_SkipTagsInSwift);
+    }
+} s_smoke_SkipTagsInSwift_register_init;
+}
+void* smoke_SkipTagsInSwift_get_typed(_baseRef handle) {
+    const auto& real_type_id = ::gluecodium::get_type_repository().get_id(get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(handle)->get());
+    auto init_function = get_init_repository().get_init(real_type_id);
+    return init_function ? init_function(handle) : _CBridgeInitsmoke_SkipTagsInSwift(handle);
+}
+void smoke_SkipTagsInSwift_dontSkipTagged(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(_instance)->get()->dont_skip_tagged();
+}
+class smoke_SkipTagsInSwiftProxy : public ::smoke::SkipTagsInSwift, public CachedProxyBase<smoke_SkipTagsInSwiftProxy> {
+public:
+    smoke_SkipTagsInSwiftProxy(smoke_SkipTagsInSwift_FunctionTable&& functions)
+     : mFunctions(::std::move(functions))
+    {
+    }
+    virtual ~smoke_SkipTagsInSwiftProxy() {
+        mFunctions.release(mFunctions.swift_pointer);
+    }
+    smoke_SkipTagsInSwiftProxy(const smoke_SkipTagsInSwiftProxy&) = delete;
+    smoke_SkipTagsInSwiftProxy& operator=(const smoke_SkipTagsInSwiftProxy&) = delete;
+    void skip_tagged() override {
+    }
+    void dont_skip_tagged() override {
+        mFunctions.smoke_SkipTagsInSwift_dontSkipTagged(mFunctions.swift_pointer);
+    }
+    void skip_tagged_list() override {
+    }
+private:
+    smoke_SkipTagsInSwift_FunctionTable mFunctions;
+};
+_baseRef smoke_SkipTagsInSwift_create_proxy(smoke_SkipTagsInSwift_FunctionTable functionTable) {
+    auto proxy = smoke_SkipTagsInSwiftProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr< ::smoke::SkipTagsInSwift >(proxy)) : 0;
+}
+const void* smoke_SkipTagsInSwift_get_swift_object_from_cache(_baseRef handle) {
+    return handle ? smoke_SkipTagsInSwiftProxy::get_swift_object(get_pointer<::std::shared_ptr< ::smoke::SkipTagsInSwift >>(handle)->get()) : nullptr;
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTagsInSwift.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTagsInSwift.swift
@@ -1,0 +1,113 @@
+//
+//
+import Foundation
+public protocol SkipTagsInSwift : AnyObject {
+    func dontSkipTagged() -> Void
+}
+internal class _SkipTagsInSwift: SkipTagsInSwift {
+    let c_instance : _baseRef
+    init(cSkipTagsInSwift: _baseRef) {
+        guard cSkipTagsInSwift != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cSkipTagsInSwift
+    }
+    deinit {
+        smoke_SkipTagsInSwift_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_SkipTagsInSwift_release_handle(c_instance)
+    }
+    public func dontSkipTagged() -> Void {
+        smoke_SkipTagsInSwift_dontSkipTagged(self.c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_SkipTagsInSwift")
+internal func _CBridgeInitsmoke_SkipTagsInSwift(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _SkipTagsInSwift(cSkipTagsInSwift: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: SkipTagsInSwift?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_SkipTagsInSwift_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_SkipTagsInSwift_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_SkipTagsInSwift_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_SkipTagsInSwift_dontSkipTagged = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipTagsInSwift
+        swift_class.dontSkipTagged()
+    }
+    let proxy = smoke_SkipTagsInSwift_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_SkipTagsInSwift_release_handle) : RefHolder(proxy)
+}
+extension _SkipTagsInSwift: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+internal func SkipTagsInSwift_copyFromCType(_ handle: _baseRef) -> SkipTagsInSwift {
+    if let swift_pointer = smoke_SkipTagsInSwift_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTagsInSwift {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipTagsInSwift_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTagsInSwift {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipTagsInSwift_get_typed(smoke_SkipTagsInSwift_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? SkipTagsInSwift {
+        smoke_SkipTagsInSwift_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func SkipTagsInSwift_moveFromCType(_ handle: _baseRef) -> SkipTagsInSwift {
+    if let swift_pointer = smoke_SkipTagsInSwift_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTagsInSwift {
+        smoke_SkipTagsInSwift_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipTagsInSwift_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTagsInSwift {
+        smoke_SkipTagsInSwift_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_SkipTagsInSwift_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? SkipTagsInSwift {
+        smoke_SkipTagsInSwift_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func SkipTagsInSwift_copyFromCType(_ handle: _baseRef) -> SkipTagsInSwift? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SkipTagsInSwift_moveFromCType(handle) as SkipTagsInSwift
+}
+internal func SkipTagsInSwift_moveFromCType(_ handle: _baseRef) -> SkipTagsInSwift? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SkipTagsInSwift_moveFromCType(handle) as SkipTagsInSwift
+}
+internal func copyToCType(_ swiftClass: SkipTagsInSwift) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SkipTagsInSwift) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: SkipTagsInSwift?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SkipTagsInSwift?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Updated CBridge generator and templates to check for skipped functions based on the predicate from
LimeModelSkipPredicates, to support `@Swift(Skip = "CustomTag")` syntax.

Added smoke and functional tests.

See: #980
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>