### PR TITLE
Add support for in-platform tag-skipping in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for tag-based platform-specific skip attribute in IDL (e.g. `@Java(Skip="Tag1")`, similarly for Swift
+    and Dart). Elements marked with such attribute will be omitted in only in that platform's generated code and only
+    if these specific used-defined tags are present.
+
 ## 9.3.0
 Release date: 2021-07-05
 ### Features:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -347,7 +347,7 @@ custom constructors, field default values.
 * **Note:** the way of specifying the name of the external type to use varies slightly between
 output languages. For C++ and Java it needs to be a fully-qualified name and it is specified through
 `cpp name "..."` and `java name "..."` values of the external descriptor. For Swift and Dart a
-regular short name is enough so it can be specified through `@Swift("...")` and `@Dart("...")`
+regular short name is enough, so it can be specified through `@Swift("...")` and `@Dart("...")`
 attributes (or omitted if the name is the name of the type in IDL declaration).
 * **Note:** due to specifics of external type naming mentioned just above, the intermediate internal
 type which is generated when a converter is specified has an additional `_internal` suffix to its
@@ -510,8 +510,9 @@ element is skipped ((not generated). Custom tags are case-insensitive.
   This is the default specification for this attribute.
   * **FunctionName** **=** **"**_FunctionName_**"**: marks a lambda type to have a specific function
   name in the generated functional interface in Java (instead of a default name).
-  * **Skip**: marks an element to be skipped (not generated) in Java. Can be applied to any element except for struct
-  fields. `@Java(Skip)` is equivalent `@Skip(Java)` (see `@Skip` above).
+  * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Java. Can be applied to
+  any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
+  was defined (see `@Skip` above).
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Java
   generated code. _Annotation_ does not need to be prepended with `@`. _Annotation_ can contain parameters, e.g.
   `@Java(Attribute="Deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing
@@ -530,8 +531,9 @@ element is skipped ((not generated). Custom tags are case-insensitive.
   use case for this is adding nested types into a pre-existing Swift type (i.e. non-generated).
   Extending a generated type is also possible, but requires usage of `Name` attribute to avoid name
   clashes on other platforms.
-  * **Skip**: marks an element to be skipped (not generated) in Swift. Can be applied to any element except for struct
-  fields. `@Swift(Skip)` is equivalent `@Skip(Swift)` (see `@Skip` above).
+  * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Swift. Can be applied to
+  any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
+  was defined (see `@Skip` above).
   * **Weak**: marks a property in an interface as `weak` in Swift. Property should have a nullable type. Please note
   that `weak` properties are still represented with "strong" pointers on C++ side. Due to this limitation, if an
   interface type is used for such property, that interface can only have methods that return nullable values or `void`.
@@ -543,8 +545,9 @@ element is skipped ((not generated). Custom tags are case-insensitive.
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart.
   This is the default specification for this attribute.
   * **Default**: marks a constructor as a "default" (nameless) in Dart.
-  * **Skip**: marks an element to be skipped (not generated) in Dart. Can be applied to any element except for struct
-  fields. `@Dart(Skip)` is equivalent `@Skip(Dart)` (see `@Skip` above).
+  * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Dart. Can be applied to
+  any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
+  was defined (see `@Skip` above).
   * **PositionalDefaults**: marks a struct to have a constructor with optional positional parameters in Dart. Can only
   be applied to a struct that has at least one field with a default value.
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Dart

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -57,7 +57,7 @@ import "test/Properties_test.dart" as PropertiesTests;
 import "test/RefEquality_test.dart" as RefEqualityTests;
 import "test/Sets_test.dart" as SetsTests;
 import "test/SimpleEquality_test.dart" as SimpleEqualityTests;
-import "test/SkipEnumerator_test.dart" as SkipEnumeratorTests;
+import "test/SkipElement_test.dart" as SkipElementTests;
 import "test/StaticBooleanMethods_test.dart" as StaticBooleanMethodsTests;
 import "test/StaticFloatDoubleMethods_test.dart" as StaticFloatDoubleMethodsTests;
 import "test/StaticIntMethods_test.dart" as StaticIntMethodsTests;
@@ -101,7 +101,7 @@ final _allTests = [
   RefEqualityTests.main,
   SetsTests.main,
   SimpleEqualityTests.main,
-  SkipEnumeratorTests.main,
+  SkipElementTests.main,
   StaticBooleanMethodsTests.main,
   StaticFloatDoubleMethodsTests.main,
   StaticIntMethodsTests.main,

--- a/functional-tests/functional/dart/test/SkipElement_test.dart
+++ b/functional-tests/functional/dart/test/SkipElement_test.dart
@@ -22,7 +22,16 @@ import "package:test/test.dart";
 import "package:functional/test.dart";
 import "../test_suite.dart";
 
-final _testSuite = TestSuite("SkipEnumerator");
+final _testSuite = TestSuite("SkipElement");
+
+// Compile-time check that SkipTagsInDart contains exactly one method.
+class SkipTagsInDartImpl implements SkipTagsInDart {
+  @override
+  void dontSkipTagged() {}
+
+  @override
+  void release() {}
+}
 
 void main() {
   _testSuite.test("AutoTagRoundTrip", () {

--- a/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
+++ b/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
@@ -36,3 +36,13 @@ interface SkipTagsInSwift {
     @Swift(Skip = ["Lite", "Pro"])
     fun skipTaggedList()
 }
+
+@Skip(Java, Swift)
+interface SkipTagsInDart {
+    @Dart(Skip = "Lite")
+    fun skipTagged()
+    @Dart(Skip = "Pro")
+    fun dontSkipTagged()
+    @Dart(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}

--- a/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
@@ -50,10 +50,10 @@ _GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_release_handle(FfiOp
 {{#each interfaces lambdas}}
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_create_proxy({{!!
 }}uint64_t token, int32_t isolate_id, Dart_Handle dart_handle{{!!
-}}{{#each inheritedFunctions functions}}{{#unless attributes.dart.skip isStatic logic="and"}}{{!!
-}}, FfiOpaqueHandle f{{iter.position}}{{/unless}}{{/each}}{{!!
-}}{{#each inheritedProperties properties}}{{#unless attributes.dart.skip isStatic logic="and"}}, FfiOpaqueHandle p{{iter.position}}g{{!!
-}}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{/unless}}{{/each}});
+}}{{#each inheritedFunctions functions}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}{{!!
+}}, FfiOpaqueHandle f{{iter.position}}{{/ifPredicate}}{{/unless}}{{/each}}{{!!
+}}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}, FfiOpaqueHandle p{{iter.position}}g{{!!
+}}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{/ifPredicate}}{{/unless}}{{/each}});
 {{/each}}
 
 {{#each nonExternalStructs externalStructs}}
@@ -95,19 +95,19 @@ _GLUECODIUM_FFI_EXPORT bool {{libraryName}}_{{resolveName}}_are_equal(FfiOpaqueH
 {{/ffiEqualityFunctionDeclaration}}{{!!
 
 }}{{+ffiClassHeader}}
-{{#functions}}{{#unless attributes.dart.skip}}
+{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>ffiFunctionDeclaration}}
-{{/unless}}{{/functions}}
-{{#properties}}{{#unless attributes.dart.skip}}{{#getter}}
+{{/ifPredicate}}{{/functions}}
+{{#properties}}{{#ifPredicate "shouldRetain"}}{{#getter}}
 {{>ffiFunctionDeclaration}}
 {{/getter}}{{#setter}}
 {{>ffiFunctionDeclaration}}
 {{/setter}}
-{{/unless}}{{/properties}}
+{{/ifPredicate}}{{/properties}}
 {{#structs}}
-{{#functions}}{{#unless attributes.dart.skip}}
+{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>ffiFunctionDeclaration}}
-{{/unless}}{{/functions}}
+{{/ifPredicate}}{{/functions}}
 {{/structs}}
 {{#this.lambdas}}{{#asFunction}}
 {{>ffiFunctionDeclaration}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -93,10 +93,10 @@ void
 {{#interfaces}}
 FfiOpaqueHandle
 {{libraryName}}_{{resolveName}}_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle{{!!
-}}{{#each inheritedFunctions functions}}{{#unless attributes.dart.skip isStatic logic="and"}}{{!!
-}}, FfiOpaqueHandle f{{iter.position}}{{/unless}}{{/each}}{{!!
-}}{{#each inheritedProperties properties}}{{#unless attributes.dart.skip isStatic logic="and"}}, FfiOpaqueHandle p{{iter.position}}g{{!!
-}}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{/unless}}{{/each}}) {
+}}{{#each inheritedFunctions functions}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}{{!!
+}}, FfiOpaqueHandle f{{iter.position}}{{/ifPredicate}}{{/unless}}{{/each}}{{!!
+}}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}, FfiOpaqueHandle p{{iter.position}}g{{!!
+}}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{/ifPredicate}}{{/unless}}{{/each}}) {
     auto cached_proxy = {{>ffi/FfiInternal}}::get_cached_proxy<{{resolveName}}_Proxy>(token, isolate_id, "{{resolveName}}");
     std::shared_ptr<{{resolveName}}_Proxy>* proxy_ptr;
     if (cached_proxy) {
@@ -104,10 +104,10 @@ FfiOpaqueHandle
     } else {
         proxy_ptr = new (std::nothrow) std::shared_ptr<{{resolveName}}_Proxy>(
             new (std::nothrow) {{resolveName}}_Proxy(token, isolate_id, dart_handle{{!!
-            }}{{#each inheritedFunctions functions}}{{#unless attributes.dart.skip isStatic logic="and"}}{{!!
-            }}, f{{iter.position}}{{/unless}}{{/each}}{{!!
-            }}{{#each inheritedProperties properties}}{{#unless attributes.dart.skip isStatic logic="and"}}, p{{iter.position}}g{{!!
-            }}{{#if setter}}, p{{iter.position}}s{{/if}}{{/unless}}{{/each}})
+            }}{{#each inheritedFunctions functions}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}{{!!
+            }}, f{{iter.position}}{{/ifPredicate}}{{/unless}}{{/each}}{{!!
+            }}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}, p{{iter.position}}g{{!!
+            }}{{#if setter}}, p{{iter.position}}s{{/if}}{{/ifPredicate}}{{/unless}}{{/each}})
         );
         {{>ffi/FfiInternal}}::cache_proxy(token, isolate_id, "{{resolveName}}", *proxy_ptr);
     }
@@ -318,19 +318,19 @@ bool
 {{/ffiEqualityFunction}}{{!!
 
 }}{{+ffiClassImpl}}
-{{#set parent=this}}{{#functions}}{{#unless attributes.dart.skip}}
+{{#set parent=this}}{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>ffiFunction}}
-{{/unless}}{{/functions}}
-{{#properties}}{{#unless attributes.dart.skip}}{{#getter}}
+{{/ifPredicate}}{{/functions}}
+{{#properties}}{{#ifPredicate "shouldRetain"}}{{#getter}}
 {{>ffiFunction}}
 {{/getter}}{{#setter}}
 {{>ffiFunction}}
 {{/setter}}
-{{/unless}}{{/properties}}{{/set}}
+{{/ifPredicate}}{{/properties}}{{/set}}
 {{#structs}}
-{{#set parent=this}}{{#functions}}{{#unless attributes.dart.skip}}
+{{#set parent=this}}{{#functions}}{{#ifPredicate "shouldRetain"}}
 {{>ffiFunction}}
-{{/unless}}{{/functions}}{{/set}}
+{{/ifPredicate}}{{/functions}}{{/set}}
 {{/structs}}
 {{#this.lambdas}}{{#set parent=this}}{{#asFunction}}
 {{>ffiFunction}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyDeclaration.mustache
@@ -21,15 +21,15 @@
 class {{resolveName}}_Proxy{{#unless isLambda}} : public {{resolveName "C++"}}{{/unless}} {
 public:
     {{resolveName}}_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle{{!!
-    }}{{#each inheritedFunctions functions}}{{#unless attributes.dart.skip isStatic logic="and"}}{{!!
-    }}, FfiOpaqueHandle f{{iter.position}}{{/unless}}{{/each}}{{!!
-    }}{{#each inheritedProperties properties}}{{#unless attributes.dart.skip isStatic logic="and"}}, FfiOpaqueHandle p{{iter.position}}g{{!!
-    }}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{/unless}}{{/each}})
+    }}{{#each inheritedFunctions functions}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}{{!!
+    }}, FfiOpaqueHandle f{{iter.position}}{{/ifPredicate}}{{/unless}}{{/each}}{{!!
+    }}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}, FfiOpaqueHandle p{{iter.position}}g{{!!
+    }}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{/ifPredicate}}{{/unless}}{{/each}})
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)){{!!
-        }}{{#each inheritedFunctions functions}}{{#unless attributes.dart.skip isStatic logic="and"}}{{!!
-        }}, f{{iter.position}}(f{{iter.position}}){{/unless}}{{/each}}{{!!
-        }}{{#each inheritedProperties properties}}{{#unless attributes.dart.skip isStatic logic="and"}}, p{{iter.position}}g(p{{iter.position}}g){{!!
-        }}{{#if setter}}, p{{iter.position}}s(p{{iter.position}}s){{/if}}{{/unless}}{{/each}} {
+        }}{{#each inheritedFunctions functions}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}{{!!
+        }}, f{{iter.position}}(f{{iter.position}}){{/ifPredicate}}{{/unless}}{{/each}}{{!!
+        }}{{#each inheritedProperties properties}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}, p{{iter.position}}g(p{{iter.position}}g){{!!
+        }}{{#if setter}}, p{{iter.position}}s(p{{iter.position}}s){{/if}}{{/ifPredicate}}{{/unless}}{{/each}} {
 {{#unless isLambda}}
         {{libraryName}}_cache_dart_handle_by_raw_pointer(this, isolate_id, dart_handle);
 {{/unless}}
@@ -64,9 +64,9 @@ public:
     {{resolveName "C++ return type"}}
     {{resolveName "C++"}}({{#parameters}}const {{resolveName typeRef "C++ parameter"}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
     }}{{#if attributes.cpp.const}} const{{/if}}{{#unless isLambda}} override{{/unless}} {
-{{#if attributes.dart.skip}}
+{{#unlessPredicate "shouldRetain"}}
 {{#unless returnType.isVoid}}         return {};{{/unless}}
-{{/if}}{{#unless attributes.dart.skip}}
+{{/unlessPredicate}}{{#ifPredicate "shouldRetain"}}
         {{#unless returnType.isVoid}}{{resolveName returnType.typeRef}} _result_handle;{{/unless}}
         {{#if thrownType}}{{resolveName  exception.errorType}} _error_handle;
         bool _error_flag;{{/if}}
@@ -89,52 +89,52 @@ public:
         }{{/unless}}{{/if}}{{!!
         }}{{#unless thrownType}}{{#unless returnType.isVoid}}
 {{prefixPartial "proxyReturnResult" "        "}}{{/unless}}{{/unless}}
-{{/unless}}
+{{/ifPredicate}}
     }
 
 {{/unless}}{{/each}}
 
-{{#each inheritedProperties properties}}{{#unless isStatic}}{{#set isSkipped=attributes.dart.skip}}
+{{#each inheritedProperties properties}}{{#unless isStatic}}
 {{#getter}}
     {{resolveName returnType.typeRef "C++"}}
     {{resolveName "C++"}}() const override {
-{{#if isSkipped}}
+{{#unlessPredicate "shouldRetain"}}
         return {};
-{{/if}}{{#unless isSkipped}}
+{{/unlessPredicate}}{{#ifPredicate "shouldRetain"}}
         {{resolveName returnType.typeRef}} _result_handle;
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, {{resolveName returnType.typeRef}}*)>{{!!
         }}(p{{iter.position}}g))(Dart_HandleFromPersistent_DL(dart_persistent_handle), &_result_handle); });
         auto _result = {{>ffi/FfiInternal}}::Conversion<{{resolveName returnType.typeRef "C++"}}>::toCpp(_result_handle);
         {{#set typeRef=returnType.typeRef handle="_result_handle"}}{{>ffiReleaseHandle}}{{/set}};
         return _result;
-{{/unless}}
+{{/ifPredicate}}
     }
 {{/getter}}
 {{#setter}}
     void
     {{resolveName "C++"}}(const {{resolveName typeRef "C++ parameter"}} value) override {
-{{#unless isSkipped}}
+{{#ifPredicate "shouldRetain"}}
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, {{resolveName typeRef}})>(p{{iter.position}}s))(
             Dart_HandleFromPersistent_DL(dart_persistent_handle),
             {{>ffi/FfiInternal}}::Conversion<{{resolveName typeRef "C++"}}>::toFfi(value)
         ); });
-{{/unless}}
+{{/ifPredicate}}
     }
 {{/setter}}
-{{/set}}{{/unless}}{{/each}}
+{{/unless}}{{/each}}
 
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
-{{#each inheritedFunctions functions}}{{#unless attributes.dart.skip isStatic logic="and"}}
+{{#each inheritedFunctions functions}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}
     const FfiOpaqueHandle f{{iter.position}};
-{{/unless}}{{/each}}
-{{#each inheritedProperties properties}}{{#unless attributes.dart.skip isStatic logic="and"}}
+{{/ifPredicate}}{{/unless}}{{/each}}
+{{#each inheritedProperties properties}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}
     const FfiOpaqueHandle p{{iter.position}}g;{{#if setter}}
     const FfiOpaqueHandle p{{iter.position}}s;
 {{/if}}
-{{/unless}}{{/each}}
+{{/ifPredicate}}{{/unless}}{{/each}}
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
 
     inline void dispatch(std::function<void()>&& callback) const

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
@@ -36,3 +36,13 @@ interface SkipTagsInSwift {
     @Swift(Skip = ["Lite", "Pro"])
     fun skipTaggedList()
 }
+
+@Skip(Java, Swift)
+interface SkipTagsInDart {
+    @Dart(Skip = "Lite")
+    fun skipTagged()
+    @Dart(Skip = "Pro")
+    fun dontSkipTagged()
+    @Dart(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTagsInDart.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipTagsInDart.cpp
@@ -1,0 +1,112 @@
+#include "ffi_smoke_SkipTagsInDart.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "CallbacksQueue.h"
+#include "IsolateContext.h"
+#include "ProxyCache.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/SkipTagsInDart.h"
+#include <memory>
+#include <memory>
+#include <new>
+class smoke_SkipTagsInDart_Proxy : public smoke::SkipTagsInDart {
+public:
+    smoke_SkipTagsInDart_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f1)
+        : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f1(f1) {
+        library_cache_dart_handle_by_raw_pointer(this, isolate_id, dart_handle);
+    }
+    ~smoke_SkipTagsInDart_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_SkipTagsInDart");
+        auto raw_pointer_local = this;
+        auto isolate_id_local = isolate_id;
+        auto dart_persistent_handle_local = dart_persistent_handle;
+        auto deleter = [raw_pointer_local, isolate_id_local, dart_persistent_handle_local]() {
+            library_uncache_dart_handle_by_raw_pointer(raw_pointer_local, isolate_id_local);
+            Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
+        };
+        if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
+            deleter();
+        } else {
+            gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
+        }
+    }
+    smoke_SkipTagsInDart_Proxy(const smoke_SkipTagsInDart_Proxy&) = delete;
+    smoke_SkipTagsInDart_Proxy& operator=(const smoke_SkipTagsInDart_Proxy&) = delete;
+    void
+    skip_tagged() override {
+    }
+    void
+    dont_skip_tagged() override {
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f1))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
+        ); });
+    }
+    void
+    skip_tagged_list() override {
+    }
+private:
+    const uint64_t token;
+    const int32_t isolate_id;
+    const Dart_PersistentHandle dart_persistent_handle;
+    const FfiOpaqueHandle f1;
+    inline void dispatch(std::function<void()>&& callback) const
+    {
+        gluecodium::ffi::IsolateContext::is_current(isolate_id)
+            ? callback()
+            : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
+    }
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+library_smoke_SkipTagsInDart_dontSkipTagged(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SkipTagsInDart>>::toCpp(_self)).dont_skip_tagged();
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_SkipTagsInDart_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::SkipTagsInDart>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_SkipTagsInDart_release_handle(handle);
+}
+void
+library_smoke_SkipTagsInDart_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_SkipTagsInDart_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_SkipTagsInDart_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::SkipTagsInDart>(
+            *reinterpret_cast<std::shared_ptr<smoke::SkipTagsInDart>*>(handle)
+        )
+    );
+}
+void
+library_smoke_SkipTagsInDart_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::SkipTagsInDart>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_SkipTagsInDart_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f1) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_SkipTagsInDart_Proxy>(token, isolate_id, "smoke_SkipTagsInDart");
+    std::shared_ptr<smoke_SkipTagsInDart_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SkipTagsInDart_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SkipTagsInDart_Proxy>(
+            new (std::nothrow) smoke_SkipTagsInDart_Proxy(token, isolate_id, dart_handle, f1)
+        );
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_SkipTagsInDart", *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
+}
+FfiOpaqueHandle
+library_smoke_SkipTagsInDart_get_type_id(FfiOpaqueHandle handle) {
+    const auto& type_id = ::gluecodium::get_type_repository().get_id(reinterpret_cast<std::shared_ptr<smoke::SkipTagsInDart>*>(handle)->get());
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::string(type_id));
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
@@ -1,0 +1,101 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+abstract class SkipTagsInDart {
+  factory SkipTagsInDart(
+    void Function() dontSkipTaggedLambda,
+  ) => SkipTagsInDart$Lambdas(
+    dontSkipTaggedLambda,
+  );
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
+  void dontSkipTagged();
+}
+// SkipTagsInDart "private" section, not exported.
+final _smokeSkiptagsindartRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_SkipTagsInDart_register_finalizer'));
+final _smokeSkiptagsindartCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SkipTagsInDart_copy_handle'));
+final _smokeSkiptagsindartReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SkipTagsInDart_release_handle'));
+final _smokeSkiptagsindartCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer)
+  >('library_smoke_SkipTagsInDart_create_proxy'));
+final _smokeSkiptagsindartGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SkipTagsInDart_get_type_id'));
+class SkipTagsInDart$Lambdas implements SkipTagsInDart {
+  void Function() dontSkipTaggedLambda;
+  SkipTagsInDart$Lambdas(
+    this.dontSkipTaggedLambda,
+  );
+  @override
+  void release() {}
+  @override
+  void dontSkipTagged() =>
+    dontSkipTaggedLambda();
+}
+class SkipTagsInDart$Impl extends __lib.NativeBase implements SkipTagsInDart {
+  SkipTagsInDart$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  void dontSkipTagged() {
+    final _dontSkipTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SkipTagsInDart_dontSkipTagged'));
+    final _handle = this.handle;
+    _dontSkipTaggedFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+}
+int _smokeSkiptagsindartdontSkipTaggedStatic(Object _obj) {
+  try {
+    (_obj as SkipTagsInDart).dontSkipTagged();
+  } finally {
+  }
+  return 0;
+}
+Pointer<Void> smokeSkiptagsindartToFfi(SkipTagsInDart value) {
+  if (value is __lib.NativeBase) return _smokeSkiptagsindartCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeSkiptagsindartCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Uint8 Function(Handle)>(_smokeSkiptagsindartdontSkipTaggedStatic, __lib.unknownError)
+  );
+  return result;
+}
+SkipTagsInDart smokeSkiptagsindartFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is SkipTagsInDart) return instance as SkipTagsInDart;
+  final _typeIdHandle = _smokeSkiptagsindartGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeSkiptagsindartCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : SkipTagsInDart$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeSkiptagsindartRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeSkiptagsindartReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeSkiptagsindartReleaseHandle(handle);
+Pointer<Void> smokeSkiptagsindartToFfiNullable(SkipTagsInDart? value) =>
+  value != null ? smokeSkiptagsindartToFfi(value) : Pointer<Void>.fromAddress(0);
+SkipTagsInDart? smokeSkiptagsindartFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeSkiptagsindartFromFfi(handle) : null;
+void smokeSkiptagsindartReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeSkiptagsindartReleaseHandle(handle);
+// End of SkipTagsInDart "private" section.


### PR DESCRIPTION
Updated Dart generator and FFI templates to check for skipped functions based on the predicate from
LimeModelSkipPredicates, to support `@Dart(Skip = "CustomTag")` syntax.

Added smoke and functional tests.

Resolves: #980
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>