### PR TITLE
Fix even more Dart warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed more "dart analyze" warnings.
+
 ## 9.3.1
 Release date: 2021-07-14
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -53,7 +53,7 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
         return when {
             limeElement is LimeLambda -> listOf(tokenCacheImport)
             limeElement is LimeStruct && limeElement.external?.dart == null -> resolveStructImports(limeElement)
-            limeElement is LimeInterface -> classInterfaceImports + metaPackageImport
+            limeElement is LimeInterface -> classInterfaceImports
             limeElement is LimeClass && (limeElement.parent != null || limeElement.visibility.isOpen) ->
                 classInterfaceImports
             limeElement is LimeClass -> listOf(tokenCacheImport, nativeBaseImport)

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -130,7 +130,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
 
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is {{resolveName}}) return instance as {{resolveName}};
+  if (instance != null && instance is {{resolveName}}) return instance;
 
 {{#if this.parent visibility.isOpen logic="or"}}
   final _typeIdHandle = _{{resolveName "Ffi"}}GetTypeId(handle);

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -37,7 +37,6 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
 {{#set parent=this}}{{#enumerators}}
   case {{resolveName parent "" "ref"}}{{#if external.dart.converter}}Internal{{/if}}.{{resolveName}}:
     return {{value}};
-  break;
 {{/enumerators}}{{/set}}
   default:
     throw StateError("Invalid enum value $value for {{resolveName}} enum.");
@@ -53,7 +52,6 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
 {{/if}}{{#unless external.dart.converter}}
     return {{resolveName parent "" "ref"}}.{{resolveName}};
 {{/unless}}
-  break;
 {{/enumerators}}{{/set}}
   default:
     throw StateError("Invalid numeric value $handle for {{resolveName}} enum.");

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -234,7 +234,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
 
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is {{resolveName}}) return instance as {{resolveName}};
+  if (instance != null && instance is {{resolveName}}) return instance;
 
   final _typeIdHandle = _{{resolveName "Ffi"}}GetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];

--- a/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNativeBase.mustache
@@ -23,10 +23,15 @@
 import 'dart:ffi';
 import 'package:meta/meta.dart';
 
+/// For internal use only.
 /// @nodoc
 class NativeBase {
-  @protected
+  /// For internal use only.
+  /// @nodoc
   Pointer<Void> handle = Pointer<Void>.fromAddress(0);
 
+  /// For internal use only.
+  /// @nodoc
+  @protected
   NativeBase(this.handle);
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -68,7 +68,7 @@ Pointer<Void> smokeAttributesclassToFfi(AttributesClass value) =>
   _smokeAttributesclassCopyHandle((value as __lib.NativeBase).handle);
 AttributesClass smokeAttributesclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is AttributesClass) return instance as AttributesClass;
+  if (instance != null && instance is AttributesClass) return instance;
   final _copiedHandle = _smokeAttributesclassCopyHandle(handle);
   final result = AttributesClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
@@ -10,7 +10,6 @@ int smokeAttributesenumToFfi(AttributesEnum value) {
   switch (value) {
   case AttributesEnum.nope:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for AttributesEnum enum.");
   }
@@ -19,7 +18,6 @@ AttributesEnum smokeAttributesenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return AttributesEnum.nope;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for AttributesEnum enum.");
   }

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 @OnInterface
 abstract class AttributesInterface {
   factory AttributesInterface(
@@ -135,7 +134,7 @@ Pointer<Void> smokeAttributesinterfaceToFfi(AttributesInterface value) {
 }
 AttributesInterface smokeAttributesinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is AttributesInterface) return instance as AttributesInterface;
+  if (instance != null && instance is AttributesInterface) return instance;
   final _typeIdHandle = _smokeAttributesinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -138,7 +138,7 @@ Pointer<Void> smokeAttributeswithcommentsToFfi(AttributesWithComments value) =>
   _smokeAttributeswithcommentsCopyHandle((value as __lib.NativeBase).handle);
 AttributesWithComments smokeAttributeswithcommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is AttributesWithComments) return instance as AttributesWithComments;
+  if (instance != null && instance is AttributesWithComments) return instance;
   final _copiedHandle = _smokeAttributeswithcommentsCopyHandle(handle);
   final result = AttributesWithComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -137,7 +137,7 @@ Pointer<Void> smokeAttributeswithdeprecatedToFfi(AttributesWithDeprecated value)
   _smokeAttributeswithdeprecatedCopyHandle((value as __lib.NativeBase).handle);
 AttributesWithDeprecated smokeAttributeswithdeprecatedFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is AttributesWithDeprecated) return instance as AttributesWithDeprecated;
+  if (instance != null && instance is AttributesWithDeprecated) return instance;
   final _copiedHandle = _smokeAttributeswithdeprecatedCopyHandle(handle);
   final result = AttributesWithDeprecated$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -79,7 +79,7 @@ Pointer<Void> smokeMultipleattributesdartToFfi(MultipleAttributesDart value) =>
   _smokeMultipleattributesdartCopyHandle((value as __lib.NativeBase).handle);
 MultipleAttributesDart smokeMultipleattributesdartFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is MultipleAttributesDart) return instance as MultipleAttributesDart;
+  if (instance != null && instance is MultipleAttributesDart) return instance;
   final _copiedHandle = _smokeMultipleattributesdartCopyHandle(handle);
   final result = MultipleAttributesDart$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -45,7 +45,7 @@ Pointer<Void> smokeSpecialattributesToFfi(SpecialAttributes value) =>
   _smokeSpecialattributesCopyHandle((value as __lib.NativeBase).handle);
 SpecialAttributes smokeSpecialattributesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SpecialAttributes) return instance as SpecialAttributes;
+  if (instance != null && instance is SpecialAttributes) return instance;
   final _copiedHandle = _smokeSpecialattributesCopyHandle(handle);
   final result = SpecialAttributes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -154,7 +154,7 @@ Pointer<Void> smokeBasictypesToFfi(BasicTypes value) =>
   _smokeBasictypesCopyHandle((value as __lib.NativeBase).handle);
 BasicTypes smokeBasictypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is BasicTypes) return instance as BasicTypes;
+  if (instance != null && instance is BasicTypes) return instance;
   final _copiedHandle = _smokeBasictypesCopyHandle(handle);
   final result = BasicTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -75,10 +75,8 @@ int smokeCommentsSomeenumToFfi(Comments_SomeEnum value) {
   switch (value) {
   case Comments_SomeEnum.useless:
     return 0;
-  break;
   case Comments_SomeEnum.useful:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Comments_SomeEnum enum.");
   }
@@ -87,10 +85,8 @@ Comments_SomeEnum smokeCommentsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Comments_SomeEnum.useless;
-  break;
   case 1:
     return Comments_SomeEnum.useful;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Comments_SomeEnum enum.");
   }
@@ -501,7 +497,7 @@ Pointer<Void> smokeCommentsToFfi(Comments value) =>
   _smokeCommentsCopyHandle((value as __lib.NativeBase).handle);
 Comments smokeCommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Comments) return instance as Comments;
+  if (instance != null && instance is Comments) return instance;
   final _copiedHandle = _smokeCommentsCopyHandle(handle);
   final result = Comments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 /// This is some very useful interface.
 abstract class CommentsInterface {
   factory CommentsInterface(
@@ -96,10 +95,8 @@ int smokeCommentsinterfaceSomeenumToFfi(CommentsInterface_SomeEnum value) {
   switch (value) {
   case CommentsInterface_SomeEnum.useless:
     return 0;
-  break;
   case CommentsInterface_SomeEnum.useful:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for CommentsInterface_SomeEnum enum.");
   }
@@ -108,10 +105,8 @@ CommentsInterface_SomeEnum smokeCommentsinterfaceSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return CommentsInterface_SomeEnum.useless;
-  break;
   case 1:
     return CommentsInterface_SomeEnum.useful;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for CommentsInterface_SomeEnum enum.");
   }
@@ -547,7 +542,7 @@ Pointer<Void> smokeCommentsinterfaceToFfi(CommentsInterface value) {
 }
 CommentsInterface smokeCommentsinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is CommentsInterface) return instance as CommentsInterface;
+  if (instance != null && instance is CommentsInterface) return instance;
   final _typeIdHandle = _smokeCommentsinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -201,7 +201,7 @@ Pointer<Void> smokeCommentslinksToFfi(CommentsLinks value) =>
   _smokeCommentslinksCopyHandle((value as __lib.NativeBase).handle);
 CommentsLinks smokeCommentslinksFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is CommentsLinks) return instance as CommentsLinks;
+  if (instance != null && instance is CommentsLinks) return instance;
   final _copiedHandle = _smokeCommentslinksCopyHandle(handle);
   final result = CommentsLinks$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
@@ -54,7 +54,7 @@ Pointer<Void> smokeCommentsmarkdownToFfi(CommentsMarkdown value) =>
   _smokeCommentsmarkdownCopyHandle((value as __lib.NativeBase).handle);
 CommentsMarkdown smokeCommentsmarkdownFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is CommentsMarkdown) return instance as CommentsMarkdown;
+  if (instance != null && instance is CommentsMarkdown) return instance;
   final _copiedHandle = _smokeCommentsmarkdownCopyHandle(handle);
   final result = CommentsMarkdown$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 abstract class DeprecationComments {
@@ -59,7 +58,6 @@ int smokeDeprecationcommentsSomeenumToFfi(DeprecationComments_SomeEnum value) {
   switch (value) {
   case DeprecationComments_SomeEnum.useless:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for DeprecationComments_SomeEnum enum.");
   }
@@ -68,7 +66,6 @@ DeprecationComments_SomeEnum smokeDeprecationcommentsSomeenumFromFfi(int handle)
   switch (handle) {
   case 0:
     return DeprecationComments_SomeEnum.useless;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for DeprecationComments_SomeEnum enum.");
   }
@@ -335,7 +332,7 @@ Pointer<Void> smokeDeprecationcommentsToFfi(DeprecationComments value) {
 }
 DeprecationComments smokeDeprecationcommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is DeprecationComments) return instance as DeprecationComments;
+  if (instance != null && instance is DeprecationComments) return instance;
   final _typeIdHandle = _smokeDeprecationcommentsGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 @Deprecated("Unfortunately, this interface is deprecated.")
 abstract class DeprecationCommentsOnly {
   factory DeprecationCommentsOnly(
@@ -42,7 +41,6 @@ int smokeDeprecationcommentsonlySomeenumToFfi(DeprecationCommentsOnly_SomeEnum v
   switch (value) {
   case DeprecationCommentsOnly_SomeEnum.useless:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for DeprecationCommentsOnly_SomeEnum enum.");
   }
@@ -51,7 +49,6 @@ DeprecationCommentsOnly_SomeEnum smokeDeprecationcommentsonlySomeenumFromFfi(int
   switch (handle) {
   case 0:
     return DeprecationCommentsOnly_SomeEnum.useless;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for DeprecationCommentsOnly_SomeEnum enum.");
   }
@@ -266,7 +263,7 @@ Pointer<Void> smokeDeprecationcommentsonlyToFfi(DeprecationCommentsOnly value) {
 }
 DeprecationCommentsOnly smokeDeprecationcommentsonlyFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is DeprecationCommentsOnly) return instance as DeprecationCommentsOnly;
+  if (instance != null && instance is DeprecationCommentsOnly) return instance;
   final _typeIdHandle = _smokeDeprecationcommentsonlyGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -45,7 +45,6 @@ int smokeExcludedcommentsSomeenumToFfi(ExcludedComments_SomeEnum value) {
   switch (value) {
   case ExcludedComments_SomeEnum.useless:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for ExcludedComments_SomeEnum enum.");
   }
@@ -54,7 +53,6 @@ ExcludedComments_SomeEnum smokeExcludedcommentsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return ExcludedComments_SomeEnum.useless;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ExcludedComments_SomeEnum enum.");
   }
@@ -346,7 +344,7 @@ Pointer<Void> smokeExcludedcommentsToFfi(ExcludedComments value) =>
   _smokeExcludedcommentsCopyHandle((value as __lib.NativeBase).handle);
 ExcludedComments smokeExcludedcommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ExcludedComments) return instance as ExcludedComments;
+  if (instance != null && instance is ExcludedComments) return instance;
   final _copiedHandle = _smokeExcludedcommentsCopyHandle(handle);
   final result = ExcludedComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 /// This is some very useful interface.
 /// @nodoc
 abstract class ExcludedCommentsInterface {
@@ -49,7 +48,7 @@ Pointer<Void> smokeExcludedcommentsinterfaceToFfi(ExcludedCommentsInterface valu
 }
 ExcludedCommentsInterface smokeExcludedcommentsinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ExcludedCommentsInterface) return instance as ExcludedCommentsInterface;
+  if (instance != null && instance is ExcludedCommentsInterface) return instance;
   final _typeIdHandle = _smokeExcludedcommentsinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -29,7 +29,6 @@ int smokeExcludedcommentsonlySomeenumToFfi(ExcludedCommentsOnly_SomeEnum value) 
   switch (value) {
   case ExcludedCommentsOnly_SomeEnum.useless:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for ExcludedCommentsOnly_SomeEnum enum.");
   }
@@ -38,7 +37,6 @@ ExcludedCommentsOnly_SomeEnum smokeExcludedcommentsonlySomeenumFromFfi(int handl
   switch (handle) {
   case 0:
     return ExcludedCommentsOnly_SomeEnum.useless;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ExcludedCommentsOnly_SomeEnum enum.");
   }
@@ -322,7 +320,7 @@ Pointer<Void> smokeExcludedcommentsonlyToFfi(ExcludedCommentsOnly value) =>
   _smokeExcludedcommentsonlyCopyHandle((value as __lib.NativeBase).handle);
 ExcludedCommentsOnly smokeExcludedcommentsonlyFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ExcludedCommentsOnly) return instance as ExcludedCommentsOnly;
+  if (instance != null && instance is ExcludedCommentsOnly) return instance;
   final _copiedHandle = _smokeExcludedcommentsonlyCopyHandle(handle);
   final result = ExcludedCommentsOnly$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -41,7 +41,7 @@ Pointer<Void> smokeInternalclasswithcommentsToFfi(InternalClassWithComments valu
   _smokeInternalclasswithcommentsCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithComments smokeInternalclasswithcommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is InternalClassWithComments) return instance as InternalClassWithComments;
+  if (instance != null && instance is InternalClassWithComments) return instance;
   final _copiedHandle = _smokeInternalclasswithcommentsCopyHandle(handle);
   final result = InternalClassWithComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -135,7 +135,7 @@ Pointer<Void> smokeMapsceneToFfi(MapScene value) =>
   _smokeMapsceneCopyHandle((value as __lib.NativeBase).handle);
 MapScene smokeMapsceneFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is MapScene) return instance as MapScene;
+  if (instance != null && instance is MapScene) return instance;
   final _copiedHandle = _smokeMapsceneCopyHandle(handle);
   final result = MapScene$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -76,7 +76,7 @@ Pointer<Void> smokeMultilinecommentsToFfi(MultiLineComments value) =>
   _smokeMultilinecommentsCopyHandle((value as __lib.NativeBase).handle);
 MultiLineComments smokeMultilinecommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is MultiLineComments) return instance as MultiLineComments;
+  if (instance != null && instance is MultiLineComments) return instance;
   final _copiedHandle = _smokeMultilinecommentsCopyHandle(handle);
   final result = MultiLineComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -34,10 +34,8 @@ int smokePlatformcommentsSomeenumToFfi(PlatformComments_SomeEnum value) {
   switch (value) {
   case PlatformComments_SomeEnum.useless:
     return 0;
-  break;
   case PlatformComments_SomeEnum.useful:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for PlatformComments_SomeEnum enum.");
   }
@@ -46,10 +44,8 @@ PlatformComments_SomeEnum smokePlatformcommentsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return PlatformComments_SomeEnum.useless;
-  break;
   case 1:
     return PlatformComments_SomeEnum.useful;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for PlatformComments_SomeEnum enum.");
   }
@@ -234,7 +230,7 @@ Pointer<Void> smokePlatformcommentsToFfi(PlatformComments value) =>
   _smokePlatformcommentsCopyHandle((value as __lib.NativeBase).handle);
 PlatformComments smokePlatformcommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is PlatformComments) return instance as PlatformComments;
+  if (instance != null && instance is PlatformComments) return instance;
   final _copiedHandle = _smokePlatformcommentsCopyHandle(handle);
   final result = PlatformComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -80,7 +80,7 @@ Pointer<Void> smokeUnicodecommentsToFfi(UnicodeComments value) =>
   _smokeUnicodecommentsCopyHandle((value as __lib.NativeBase).handle);
 UnicodeComments smokeUnicodecommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is UnicodeComments) return instance as UnicodeComments;
+  if (instance != null && instance is UnicodeComments) return instance;
   final _copiedHandle = _smokeUnicodecommentsCopyHandle(handle);
   final result = UnicodeComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -33,7 +33,7 @@ Pointer<Void> smokeCollectionconstantsToFfi(CollectionConstants value) =>
   _smokeCollectionconstantsCopyHandle((value as __lib.NativeBase).handle);
 CollectionConstants smokeCollectionconstantsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is CollectionConstants) return instance as CollectionConstants;
+  if (instance != null && instance is CollectionConstants) return instance;
   final _copiedHandle = _smokeCollectionconstantsCopyHandle(handle);
   final result = CollectionConstants$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
@@ -9,10 +9,8 @@ int smokeConstantsStateenumToFfi(StateEnum value) {
   switch (value) {
   case StateEnum.off:
     return 0;
-  break;
   case StateEnum.on:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for StateEnum enum.");
   }
@@ -21,10 +19,8 @@ StateEnum smokeConstantsStateenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return StateEnum.off;
-  break;
   case 1:
     return StateEnum.on;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for StateEnum enum.");
   }

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -23,10 +23,8 @@ int smokeConstantsinterfaceStateenumToFfi(ConstantsInterface_StateEnum value) {
   switch (value) {
   case ConstantsInterface_StateEnum.off:
     return 0;
-  break;
   case ConstantsInterface_StateEnum.on:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for ConstantsInterface_StateEnum enum.");
   }
@@ -35,10 +33,8 @@ ConstantsInterface_StateEnum smokeConstantsinterfaceStateenumFromFfi(int handle)
   switch (handle) {
   case 0:
     return ConstantsInterface_StateEnum.off;
-  break;
   case 1:
     return ConstantsInterface_StateEnum.on;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ConstantsInterface_StateEnum enum.");
   }
@@ -95,7 +91,7 @@ Pointer<Void> smokeConstantsinterfaceToFfi(ConstantsInterface value) =>
   _smokeConstantsinterfaceCopyHandle((value as __lib.NativeBase).handle);
 ConstantsInterface smokeConstantsinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ConstantsInterface) return instance as ConstantsInterface;
+  if (instance != null && instance is ConstantsInterface) return instance;
   final _copiedHandle = _smokeConstantsinterfaceCopyHandle(handle);
   final result = ConstantsInterface$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -168,7 +168,7 @@ Pointer<Void> smokeStructconstantsToFfi(StructConstants value) =>
   _smokeStructconstantsCopyHandle((value as __lib.NativeBase).handle);
 StructConstants smokeStructconstantsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is StructConstants) return instance as StructConstants;
+  if (instance != null && instance is StructConstants) return instance;
   final _copiedHandle = _smokeStructconstantsCopyHandle(handle);
   final result = StructConstants$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -25,10 +25,8 @@ int smokeConstructorsErrorenumToFfi(Constructors_ErrorEnum value) {
   switch (value) {
   case Constructors_ErrorEnum.none:
     return 0;
-  break;
   case Constructors_ErrorEnum.crashed:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Constructors_ErrorEnum enum.");
   }
@@ -37,10 +35,8 @@ Constructors_ErrorEnum smokeConstructorsErrorenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Constructors_ErrorEnum.none;
-  break;
   case 1:
     return Constructors_ErrorEnum.crashed;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Constructors_ErrorEnum enum.");
   }
@@ -196,7 +192,7 @@ Pointer<Void> smokeConstructorsToFfi(Constructors value) =>
   _smokeConstructorsCopyHandle((value as __lib.NativeBase).handle);
 Constructors smokeConstructorsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Constructors) return instance as Constructors;
+  if (instance != null && instance is Constructors) return instance;
   final _typeIdHandle = _smokeConstructorsGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -39,7 +39,7 @@ Pointer<Void> smokeSinglenamedconstructorToFfi(SingleNamedConstructor value) =>
   _smokeSinglenamedconstructorCopyHandle((value as __lib.NativeBase).handle);
 SingleNamedConstructor smokeSinglenamedconstructorFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SingleNamedConstructor) return instance as SingleNamedConstructor;
+  if (instance != null && instance is SingleNamedConstructor) return instance;
   final _copiedHandle = _smokeSinglenamedconstructorCopyHandle(handle);
   final result = SingleNamedConstructor$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -39,7 +39,7 @@ Pointer<Void> smokeSinglenamelessconstructorToFfi(SingleNamelessConstructor valu
   _smokeSinglenamelessconstructorCopyHandle((value as __lib.NativeBase).handle);
 SingleNamelessConstructor smokeSinglenamelessconstructorFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SingleNamelessConstructor) return instance as SingleNamelessConstructor;
+  if (instance != null && instance is SingleNamelessConstructor) return instance;
   final _copiedHandle = _smokeSinglenamelessconstructorCopyHandle(handle);
   final result = SingleNamelessConstructor$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -175,7 +175,7 @@ Pointer<Void> smokeDatesToFfi(Dates value) =>
   _smokeDatesCopyHandle((value as __lib.NativeBase).handle);
 Dates smokeDatesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Dates) return instance as Dates;
+  if (instance != null && instance is Dates) return instance;
   final _copiedHandle = _smokeDatesCopyHandle(handle);
   final result = Dates$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
@@ -147,7 +147,7 @@ Pointer<Void> smokeDatessteadyToFfi(DatesSteady value) =>
   _smokeDatessteadyCopyHandle((value as __lib.NativeBase).handle);
 DatesSteady smokeDatessteadyFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is DatesSteady) return instance as DatesSteady;
+  if (instance != null && instance is DatesSteady) return instance;
   final _copiedHandle = _smokeDatessteadyCopyHandle(handle);
   final result = DatesSteady$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -19,10 +19,8 @@ int smokeDefaultvaluesSomeenumToFfi(DefaultValues_SomeEnum value) {
   switch (value) {
   case DefaultValues_SomeEnum.fooValue:
     return 0;
-  break;
   case DefaultValues_SomeEnum.barValue:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for DefaultValues_SomeEnum enum.");
   }
@@ -31,10 +29,8 @@ DefaultValues_SomeEnum smokeDefaultvaluesSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return DefaultValues_SomeEnum.fooValue;
-  break;
   case 1:
     return DefaultValues_SomeEnum.barValue;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for DefaultValues_SomeEnum enum.");
   }
@@ -78,10 +74,8 @@ int smokeDefaultvaluesExternalenumToFfi(DefaultValues_ExternalEnum value) {
   switch (value) {
   case DefaultValues_ExternalEnum.oneValue:
     return 0;
-  break;
   case DefaultValues_ExternalEnum.anotherValue:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for DefaultValues_ExternalEnum enum.");
   }
@@ -90,10 +84,8 @@ DefaultValues_ExternalEnum smokeDefaultvaluesExternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return DefaultValues_ExternalEnum.oneValue;
-  break;
   case 1:
     return DefaultValues_ExternalEnum.anotherValue;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for DefaultValues_ExternalEnum enum.");
   }
@@ -709,7 +701,7 @@ Pointer<Void> smokeDefaultvaluesToFfi(DefaultValues value) =>
   _smokeDefaultvaluesCopyHandle((value as __lib.NativeBase).handle);
 DefaultValues smokeDefaultvaluesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is DefaultValues) return instance as DefaultValues;
+  if (instance != null && instance is DefaultValues) return instance;
   final _copiedHandle = _smokeDefaultvaluesCopyHandle(handle);
   final result = DefaultValues$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -13,10 +13,8 @@ int smokeTypeswithdefaultsSomeenumToFfi(SomeEnum value) {
   switch (value) {
   case SomeEnum.fooValue:
     return 0;
-  break;
   case SomeEnum.barValue:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for SomeEnum enum.");
   }
@@ -25,10 +23,8 @@ SomeEnum smokeTypeswithdefaultsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return SomeEnum.fooValue;
-  break;
   case 1:
     return SomeEnum.barValue;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for SomeEnum enum.");
   }

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
@@ -143,7 +143,7 @@ Pointer<Void> smokeDurationmillisecondsToFfi(DurationMilliseconds value) =>
   _smokeDurationmillisecondsCopyHandle((value as __lib.NativeBase).handle);
 DurationMilliseconds smokeDurationmillisecondsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is DurationMilliseconds) return instance as DurationMilliseconds;
+  if (instance != null && instance is DurationMilliseconds) return instance;
   final _copiedHandle = _smokeDurationmillisecondsCopyHandle(handle);
   final result = DurationMilliseconds$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
@@ -143,7 +143,7 @@ Pointer<Void> smokeDurationsecondsToFfi(DurationSeconds value) =>
   _smokeDurationsecondsCopyHandle((value as __lib.NativeBase).handle);
 DurationSeconds smokeDurationsecondsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is DurationSeconds) return instance as DurationSeconds;
+  if (instance != null && instance is DurationSeconds) return instance;
   final _copiedHandle = _smokeDurationsecondsCopyHandle(handle);
   final result = DurationSeconds$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
@@ -9,10 +9,8 @@ int smokeEnumstartswithoneToFfi(EnumStartsWithOne value) {
   switch (value) {
   case EnumStartsWithOne.first:
     return 1;
-  break;
   case EnumStartsWithOne.second:
     return 2;
-  break;
   default:
     throw StateError("Invalid enum value $value for EnumStartsWithOne enum.");
   }
@@ -21,10 +19,8 @@ EnumStartsWithOne smokeEnumstartswithoneFromFfi(int handle) {
   switch (handle) {
   case 1:
     return EnumStartsWithOne.first;
-  break;
   case 2:
     return EnumStartsWithOne.second;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for EnumStartsWithOne enum.");
   }

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -21,10 +21,8 @@ int smokeEnumsSimpleenumToFfi(Enums_SimpleEnum value) {
   switch (value) {
   case Enums_SimpleEnum.first:
     return 0;
-  break;
   case Enums_SimpleEnum.second:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Enums_SimpleEnum enum.");
   }
@@ -33,10 +31,8 @@ Enums_SimpleEnum smokeEnumsSimpleenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Enums_SimpleEnum.first;
-  break;
   case 1:
     return Enums_SimpleEnum.second;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Enums_SimpleEnum enum.");
   }
@@ -80,10 +76,8 @@ int smokeEnumsInternalerrorcodeToFfi(Enums_InternalErrorCode value) {
   switch (value) {
   case Enums_InternalErrorCode.errorNone:
     return 0;
-  break;
   case Enums_InternalErrorCode.errorFatal:
     return 999;
-  break;
   default:
     throw StateError("Invalid enum value $value for Enums_InternalErrorCode enum.");
   }
@@ -92,10 +86,8 @@ Enums_InternalErrorCode smokeEnumsInternalerrorcodeFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Enums_InternalErrorCode.errorNone;
-  break;
   case 999:
     return Enums_InternalErrorCode.errorFatal;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Enums_InternalErrorCode enum.");
   }
@@ -272,7 +264,7 @@ Pointer<Void> smokeEnumsToFfi(Enums value) =>
   _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
 Enums smokeEnumsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Enums) return instance as Enums;
+  if (instance != null && instance is Enums) return instance;
   final _copiedHandle = _smokeEnumsCopyHandle(handle);
   final result = Enums$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -13,10 +13,8 @@ int smokeEquatableSomeenumToFfi(SomeEnum value) {
   switch (value) {
   case SomeEnum.foo:
     return 0;
-  break;
   case SomeEnum.bar:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for SomeEnum enum.");
   }
@@ -25,10 +23,8 @@ SomeEnum smokeEquatableSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return SomeEnum.foo;
-  break;
   case 1:
     return SomeEnum.bar;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for SomeEnum enum.");
   }

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class EquatableInterface {
   /// @nodoc
   @Deprecated("Does nothing")
@@ -56,7 +55,7 @@ Pointer<Void> smokeEquatableinterfaceToFfi(EquatableInterface value) {
 }
 EquatableInterface smokeEquatableinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is EquatableInterface) return instance as EquatableInterface;
+  if (instance != null && instance is EquatableInterface) return instance;
   final _typeIdHandle = _smokeEquatableinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -24,10 +24,8 @@ int smokeErrorsInternalerrorcodeToFfi(Errors_InternalErrorCode value) {
   switch (value) {
   case Errors_InternalErrorCode.errorNone:
     return 0;
-  break;
   case Errors_InternalErrorCode.errorFatal:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Errors_InternalErrorCode enum.");
   }
@@ -36,10 +34,8 @@ Errors_InternalErrorCode smokeErrorsInternalerrorcodeFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Errors_InternalErrorCode.errorNone;
-  break;
   case 1:
     return Errors_InternalErrorCode.errorFatal;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Errors_InternalErrorCode enum.");
   }
@@ -84,13 +80,10 @@ int smokeErrorsExternalerrorsToFfi(Errors_ExternalErrors value) {
   switch (value) {
   case Errors_ExternalErrors.none:
     return 0;
-  break;
   case Errors_ExternalErrors.boom:
     return 1;
-  break;
   case Errors_ExternalErrors.bust:
     return 2;
-  break;
   default:
     throw StateError("Invalid enum value $value for Errors_ExternalErrors enum.");
   }
@@ -99,13 +92,10 @@ Errors_ExternalErrors smokeErrorsExternalerrorsFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Errors_ExternalErrors.none;
-  break;
   case 1:
     return Errors_ExternalErrors.boom;
-  break;
   case 2:
     return Errors_ExternalErrors.bust;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Errors_ExternalErrors enum.");
   }
@@ -320,7 +310,7 @@ Pointer<Void> smokeErrorsToFfi(Errors value) =>
   _smokeErrorsCopyHandle((value as __lib.NativeBase).handle);
 Errors smokeErrorsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Errors) return instance as Errors;
+  if (instance != null && instance is Errors) return instance;
   final _copiedHandle = _smokeErrorsCopyHandle(handle);
   final result = Errors$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -6,7 +6,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
-import 'package:meta/meta.dart';
 abstract class ErrorsInterface {
   factory ErrorsInterface(
     void Function() methodWithErrorsLambda,
@@ -35,10 +34,8 @@ int smokeErrorsinterfaceInternalerrorToFfi(ErrorsInterface_InternalError value) 
   switch (value) {
   case ErrorsInterface_InternalError.errorNone:
     return 0;
-  break;
   case ErrorsInterface_InternalError.errorFatal:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for ErrorsInterface_InternalError enum.");
   }
@@ -47,10 +44,8 @@ ErrorsInterface_InternalError smokeErrorsinterfaceInternalerrorFromFfi(int handl
   switch (handle) {
   case 0:
     return ErrorsInterface_InternalError.errorNone;
-  break;
   case 1:
     return ErrorsInterface_InternalError.errorFatal;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ErrorsInterface_InternalError enum.");
   }
@@ -95,13 +90,10 @@ int smokeErrorsinterfaceExternalerrorsToFfi(ErrorsInterface_ExternalErrors value
   switch (value) {
   case ErrorsInterface_ExternalErrors.none:
     return 0;
-  break;
   case ErrorsInterface_ExternalErrors.boom:
     return 1;
-  break;
   case ErrorsInterface_ExternalErrors.bust:
     return 2;
-  break;
   default:
     throw StateError("Invalid enum value $value for ErrorsInterface_ExternalErrors enum.");
   }
@@ -110,13 +102,10 @@ ErrorsInterface_ExternalErrors smokeErrorsinterfaceExternalerrorsFromFfi(int han
   switch (handle) {
   case 0:
     return ErrorsInterface_ExternalErrors.none;
-  break;
   case 1:
     return ErrorsInterface_ExternalErrors.boom;
-  break;
   case 2:
     return ErrorsInterface_ExternalErrors.bust;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ErrorsInterface_ExternalErrors enum.");
   }
@@ -416,7 +405,7 @@ Pointer<Void> smokeErrorsinterfaceToFfi(ErrorsInterface value) {
 }
 ErrorsInterface smokeErrorsinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ErrorsInterface) return instance as ErrorsInterface;
+  if (instance != null && instance is ErrorsInterface) return instance;
   final _typeIdHandle = _smokeErrorsinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -110,7 +110,7 @@ Pointer<Void> packageClassToFfi(Class value) =>
   _packageClassCopyHandle((value as __lib.NativeBase).handle);
 Class packageClassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Class) return instance as Class;
+  if (instance != null && instance is Class) return instance;
   final _typeIdHandle = _packageClassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class Interface {
   /// @nodoc
   @Deprecated("Does nothing")
@@ -47,7 +46,7 @@ Pointer<Void> packageInterfaceToFfi(Interface value) {
 }
 Interface packageInterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Interface) return instance as Interface;
+  if (instance != null && instance is Interface) return instance;
   final _typeIdHandle = _packageInterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -8,7 +8,6 @@ int packageTypesEnumToFfi(Enum value) {
   switch (value) {
   case Enum.naN:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for Enum enum.");
   }
@@ -17,7 +16,6 @@ Enum packageTypesEnumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Enum.naN;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Enum enum.");
   }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -17,10 +17,8 @@ int smokeEnumsExternalenumToFfi(Enums_ExternalEnum value) {
   switch (value) {
   case Enums_ExternalEnum.fooValue:
     return 0;
-  break;
   case Enums_ExternalEnum.barValue:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Enums_ExternalEnum enum.");
   }
@@ -29,10 +27,8 @@ Enums_ExternalEnum smokeEnumsExternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Enums_ExternalEnum.fooValue;
-  break;
   case 1:
     return Enums_ExternalEnum.barValue;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Enums_ExternalEnum enum.");
   }
@@ -76,10 +72,8 @@ int smokeEnumsVeryexternalenumToFfi(Enums_VeryExternalEnum value) {
   switch (value) {
   case Enums_VeryExternalEnum.foo:
     return 0;
-  break;
   case Enums_VeryExternalEnum.bar:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Enums_VeryExternalEnum enum.");
   }
@@ -88,10 +82,8 @@ Enums_VeryExternalEnum smokeEnumsVeryexternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Enums_VeryExternalEnum.foo;
-  break;
   case 1:
     return Enums_VeryExternalEnum.bar;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Enums_VeryExternalEnum enum.");
   }
@@ -154,7 +146,7 @@ Pointer<Void> smokeEnumsToFfi(Enums value) =>
   _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
 Enums smokeEnumsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Enums) return instance as Enums;
+  if (instance != null && instance is Enums) return instance;
   final _copiedHandle = _smokeEnumsCopyHandle(handle);
   final result = Enums$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -18,7 +18,6 @@ int smokeExternalclassSomeenumToFfi(ExternalClass_SomeEnum value) {
   switch (value) {
   case ExternalClass_SomeEnum.someValue:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for ExternalClass_SomeEnum enum.");
   }
@@ -27,7 +26,6 @@ ExternalClass_SomeEnum smokeExternalclassSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return ExternalClass_SomeEnum.someValue;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ExternalClass_SomeEnum enum.");
   }
@@ -166,7 +164,7 @@ Pointer<Void> smokeExternalclassToFfi(ExternalClass value) =>
   _smokeExternalclassCopyHandle((value as __lib.NativeBase).handle);
 ExternalClass smokeExternalclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ExternalClass) return instance as ExternalClass;
+  if (instance != null && instance is ExternalClass) return instance;
   final _copiedHandle = _smokeExternalclassCopyHandle(handle);
   final result = ExternalClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class ExternalInterface {
   factory ExternalInterface(
     void Function(int) someMethodLambda,
@@ -27,7 +26,6 @@ int smokeExternalinterfaceSomeenumToFfi(ExternalInterface_SomeEnum value) {
   switch (value) {
   case ExternalInterface_SomeEnum.someValue:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for ExternalInterface_SomeEnum enum.");
   }
@@ -36,7 +34,6 @@ ExternalInterface_SomeEnum smokeExternalinterfaceSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return ExternalInterface_SomeEnum.someValue;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ExternalInterface_SomeEnum enum.");
   }
@@ -217,7 +214,7 @@ Pointer<Void> smokeExternalinterfaceToFfi(ExternalInterface value) {
 }
 ExternalInterface smokeExternalinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ExternalInterface) return instance as ExternalInterface;
+  if (instance != null && instance is ExternalInterface) return instance;
   final _typeIdHandle = _smokeExternalinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -6,13 +6,10 @@ int smokeCompressionstateToFfi(bar.HttpClientResponseCompressionState value) {
   switch (value) {
   case bar.HttpClientResponseCompressionState.compressed:
     return 0;
-  break;
   case bar.HttpClientResponseCompressionState.decompressed:
     return 1;
-  break;
   case bar.HttpClientResponseCompressionState.notCompressed:
     return 2;
-  break;
   default:
     throw StateError("Invalid enum value $value for HttpClientResponseCompressionState enum.");
   }
@@ -21,13 +18,10 @@ bar.HttpClientResponseCompressionState smokeCompressionstateFromFfi(int handle) 
   switch (handle) {
   case 0:
     return bar.HttpClientResponseCompressionState.compressed;
-  break;
   case 1:
     return bar.HttpClientResponseCompressionState.decompressed;
-  break;
   case 2:
     return bar.HttpClientResponseCompressionState.notCompressed;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for HttpClientResponseCompressionState enum.");
   }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -13,16 +13,12 @@ int smokeDartseasonToFfi(String valueExternal) {
   switch (value) {
   case StringInternal.winter:
     return 0;
-  break;
   case StringInternal.spring:
     return 1;
-  break;
   case StringInternal.summer:
     return 2;
-  break;
   case StringInternal.autumn:
     return 3;
-  break;
   default:
     throw StateError("Invalid enum value $value for String enum.");
   }
@@ -31,16 +27,12 @@ String smokeDartseasonFromFfi(int handle) {
   switch (handle) {
   case 0:
     return SeasonConverter.convertFromInternal(StringInternal.winter);
-  break;
   case 1:
     return SeasonConverter.convertFromInternal(StringInternal.spring);
-  break;
   case 2:
     return SeasonConverter.convertFromInternal(StringInternal.summer);
-  break;
   case 3:
     return SeasonConverter.convertFromInternal(StringInternal.autumn);
-  break;
   default:
     throw StateError("Invalid numeric value $handle for String enum.");
   }

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -207,7 +207,7 @@ Pointer<Void> smokeStructsToFfi(Structs value) =>
   _smokeStructsCopyHandle((value as __lib.NativeBase).handle);
 Structs smokeStructsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Structs) return instance as Structs;
+  if (instance != null && instance is Structs) return instance;
   final _copiedHandle = _smokeStructsCopyHandle(handle);
   final result = Structs$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -83,7 +83,7 @@ Pointer<Void> smokeUsedartexternaltypesToFfi(UseDartExternalTypes value) =>
   _smokeUsedartexternaltypesCopyHandle((value as __lib.NativeBase).handle);
 UseDartExternalTypes smokeUsedartexternaltypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is UseDartExternalTypes) return instance as UseDartExternalTypes;
+  if (instance != null && instance is UseDartExternalTypes) return instance;
   final _copiedHandle = _smokeUsedartexternaltypesCopyHandle(handle);
   final result = UseDartExternalTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -262,7 +262,7 @@ Pointer<Void> smokeGenerictypeswithbasictypesToFfi(GenericTypesWithBasicTypes va
   _smokeGenerictypeswithbasictypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithBasicTypes smokeGenerictypeswithbasictypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is GenericTypesWithBasicTypes) return instance as GenericTypesWithBasicTypes;
+  if (instance != null && instance is GenericTypesWithBasicTypes) return instance;
   final _copiedHandle = _smokeGenerictypeswithbasictypesCopyHandle(handle);
   final result = GenericTypesWithBasicTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -28,10 +28,8 @@ int smokeGenerictypeswithcompoundtypesSomeenumToFfi(GenericTypesWithCompoundType
   switch (value) {
   case GenericTypesWithCompoundTypes_SomeEnum.foo:
     return 0;
-  break;
   case GenericTypesWithCompoundTypes_SomeEnum.bar:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for GenericTypesWithCompoundTypes_SomeEnum enum.");
   }
@@ -40,10 +38,8 @@ GenericTypesWithCompoundTypes_SomeEnum smokeGenerictypeswithcompoundtypesSomeenu
   switch (handle) {
   case 0:
     return GenericTypesWithCompoundTypes_SomeEnum.foo;
-  break;
   case 1:
     return GenericTypesWithCompoundTypes_SomeEnum.bar;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for GenericTypesWithCompoundTypes_SomeEnum enum.");
   }
@@ -87,10 +83,8 @@ int smokeGenerictypeswithcompoundtypesExternalenumToFfi(GenericTypesWithCompound
   switch (value) {
   case GenericTypesWithCompoundTypes_ExternalEnum.on:
     return 0;
-  break;
   case GenericTypesWithCompoundTypes_ExternalEnum.off:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for GenericTypesWithCompoundTypes_ExternalEnum enum.");
   }
@@ -99,10 +93,8 @@ GenericTypesWithCompoundTypes_ExternalEnum smokeGenerictypeswithcompoundtypesExt
   switch (handle) {
   case 0:
     return GenericTypesWithCompoundTypes_ExternalEnum.on;
-  break;
   case 1:
     return GenericTypesWithCompoundTypes_ExternalEnum.off;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for GenericTypesWithCompoundTypes_ExternalEnum enum.");
   }
@@ -389,7 +381,7 @@ Pointer<Void> smokeGenerictypeswithcompoundtypesToFfi(GenericTypesWithCompoundTy
   _smokeGenerictypeswithcompoundtypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithCompoundTypes smokeGenerictypeswithcompoundtypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is GenericTypesWithCompoundTypes) return instance as GenericTypesWithCompoundTypes;
+  if (instance != null && instance is GenericTypesWithCompoundTypes) return instance;
   final _copiedHandle = _smokeGenerictypeswithcompoundtypesCopyHandle(handle);
   final result = GenericTypesWithCompoundTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -129,7 +129,7 @@ Pointer<Void> smokeGenerictypeswithgenerictypesToFfi(GenericTypesWithGenericType
   _smokeGenerictypeswithgenerictypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithGenericTypes smokeGenerictypeswithgenerictypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is GenericTypesWithGenericTypes) return instance as GenericTypesWithGenericTypes;
+  if (instance != null && instance is GenericTypesWithGenericTypes) return instance;
   final _copiedHandle = _smokeGenerictypeswithgenerictypesCopyHandle(handle);
   final result = GenericTypesWithGenericTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -89,7 +89,7 @@ Pointer<Void> smokeUseoptimizedlistToFfi(UseOptimizedList value) =>
   _smokeUseoptimizedlistCopyHandle((value as __lib.NativeBase).handle);
 UseOptimizedList smokeUseoptimizedlistFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is UseOptimizedList) return instance as UseOptimizedList;
+  if (instance != null && instance is UseOptimizedList) return instance;
   final _copiedHandle = _smokeUseoptimizedlistCopyHandle(handle);
   final result = UseOptimizedList$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -43,7 +43,7 @@ Pointer<Void> smokeChildclassfromclassToFfi(ChildClassFromClass value) =>
   _smokeChildclassfromclassCopyHandle((value as __lib.NativeBase).handle);
 ChildClassFromClass smokeChildclassfromclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ChildClassFromClass) return instance as ChildClassFromClass;
+  if (instance != null && instance is ChildClassFromClass) return instance;
   final _typeIdHandle = _smokeChildclassfromclassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -68,7 +68,7 @@ Pointer<Void> smokeChildclassfrominterfaceToFfi(ChildClassFromInterface value) =
   _smokeChildclassfrominterfaceCopyHandle((value as __lib.NativeBase).handle);
 ChildClassFromInterface smokeChildclassfrominterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ChildClassFromInterface) return instance as ChildClassFromInterface;
+  if (instance != null && instance is ChildClassFromInterface) return instance;
   final _typeIdHandle = _smokeChildclassfrominterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -5,7 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
-import 'package:meta/meta.dart';
 abstract class ChildInterface implements ParentInterface {
   factory ChildInterface(
     void Function() rootMethodLambda,
@@ -144,7 +143,7 @@ Pointer<Void> smokeChildinterfaceToFfi(ChildInterface value) {
 }
 ChildInterface smokeChildinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ChildInterface) return instance as ChildInterface;
+  if (instance != null && instance is ChildInterface) return instance;
   final _typeIdHandle = _smokeChildinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -68,7 +68,7 @@ Pointer<Void> smokeChildwithparentclassreferencesToFfi(ChildWithParentClassRefer
   _smokeChildwithparentclassreferencesCopyHandle((value as __lib.NativeBase).handle);
 ChildWithParentClassReferences smokeChildwithparentclassreferencesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ChildWithParentClassReferences) return instance as ChildWithParentClassReferences;
+  if (instance != null && instance is ChildWithParentClassReferences) return instance;
   final _typeIdHandle = _smokeChildwithparentclassreferencesGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -63,7 +63,7 @@ Pointer<Void> smokeParentclassToFfi(ParentClass value) =>
   _smokeParentclassCopyHandle((value as __lib.NativeBase).handle);
 ParentClass smokeParentclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ParentClass) return instance as ParentClass;
+  if (instance != null && instance is ParentClass) return instance;
   final _typeIdHandle = _smokeParentclassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class ParentInterface {
   factory ParentInterface(
     void Function() rootMethodLambda,
@@ -124,7 +123,7 @@ Pointer<Void> smokeParentinterfaceToFfi(ParentInterface value) {
 }
 ParentInterface smokeParentinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ParentInterface) return instance as ParentInterface;
+  if (instance != null && instance is ParentInterface) return instance;
   final _typeIdHandle = _smokeParentinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/_native_base.dart
@@ -1,8 +1,13 @@
 import 'dart:ffi';
 import 'package:meta/meta.dart';
+/// For internal use only.
 /// @nodoc
 class NativeBase {
-  @protected
+  /// For internal use only.
+  /// @nodoc
   Pointer<Void> handle = Pointer<Void>.fromAddress(0);
+  /// For internal use only.
+  /// @nodoc
+  @protected
   NativeBase(this.handle);
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -56,7 +56,7 @@ Pointer<Void> smokeSimpleclassToFfi(SimpleClass value) =>
   _smokeSimpleclassCopyHandle((value as __lib.NativeBase).handle);
 SimpleClass smokeSimpleclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SimpleClass) return instance as SimpleClass;
+  if (instance != null && instance is SimpleClass) return instance;
   final _copiedHandle = _smokeSimpleclassCopyHandle(handle);
   final result = SimpleClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class SimpleInterface {
   factory SimpleInterface(
     String Function() getStringValueLambda,
@@ -117,7 +116,7 @@ Pointer<Void> smokeSimpleinterfaceToFfi(SimpleInterface value) {
 }
 SimpleInterface smokeSimpleinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SimpleInterface) return instance as SimpleInterface;
+  if (instance != null && instance is SimpleInterface) return instance;
   final _typeIdHandle = _smokeSimpleinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -135,7 +135,7 @@ Pointer<Void> smokeClasswithinternallambdaToFfi(ClassWithInternalLambda value) =
   _smokeClasswithinternallambdaCopyHandle((value as __lib.NativeBase).handle);
 ClassWithInternalLambda smokeClasswithinternallambdaFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ClassWithInternalLambda) return instance as ClassWithInternalLambda;
+  if (instance != null && instance is ClassWithInternalLambda) return instance;
   final _copiedHandle = _smokeClasswithinternallambdaCopyHandle(handle);
   final result = ClassWithInternalLambda$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -502,7 +502,7 @@ Pointer<Void> smokeLambdasToFfi(Lambdas value) =>
   _smokeLambdasCopyHandle((value as __lib.NativeBase).handle);
 Lambdas smokeLambdasFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Lambdas) return instance as Lambdas;
+  if (instance != null && instance is Lambdas) return instance;
   final _copiedHandle = _smokeLambdasCopyHandle(handle);
   final result = Lambdas$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -215,7 +215,7 @@ Pointer<Void> smokeLambdaswithstructuredtypesToFfi(LambdasWithStructuredTypes va
   _smokeLambdaswithstructuredtypesCopyHandle((value as __lib.NativeBase).handle);
 LambdasWithStructuredTypes smokeLambdaswithstructuredtypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is LambdasWithStructuredTypes) return instance as LambdasWithStructuredTypes;
+  if (instance != null && instance is LambdasWithStructuredTypes) return instance;
   final _copiedHandle = _smokeLambdaswithstructuredtypesCopyHandle(handle);
   final result = LambdasWithStructuredTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -6,7 +6,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-import 'package:meta/meta.dart';
 abstract class CalculatorListener {
   factory CalculatorListener(
     void Function(double) onCalculationResultLambda,
@@ -266,7 +265,7 @@ Pointer<Void> smokeCalculatorlistenerToFfi(CalculatorListener value) {
 }
 CalculatorListener smokeCalculatorlistenerFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is CalculatorListener) return instance as CalculatorListener;
+  if (instance != null && instance is CalculatorListener) return instance;
   final _typeIdHandle = _smokeCalculatorlistenerGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class InterfaceWithStatic {
   factory InterfaceWithStatic(
     String Function() regularFunctionLambda,
@@ -159,7 +158,7 @@ Pointer<Void> smokeInterfacewithstaticToFfi(InterfaceWithStatic value) {
 }
 InterfaceWithStatic smokeInterfacewithstaticFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is InterfaceWithStatic) return instance as InterfaceWithStatic;
+  if (instance != null && instance is InterfaceWithStatic) return instance;
   final _typeIdHandle = _smokeInterfacewithstaticGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -7,7 +7,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-import 'package:meta/meta.dart';
 abstract class ListenerWithProperties {
   factory ListenerWithProperties(
     String Function() messageGetLambda,
@@ -67,10 +66,8 @@ int smokeListenerwithpropertiesResultenumToFfi(ListenerWithProperties_ResultEnum
   switch (value) {
   case ListenerWithProperties_ResultEnum.none:
     return 0;
-  break;
   case ListenerWithProperties_ResultEnum.result:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for ListenerWithProperties_ResultEnum enum.");
   }
@@ -79,10 +76,8 @@ ListenerWithProperties_ResultEnum smokeListenerwithpropertiesResultenumFromFfi(i
   switch (handle) {
   case 0:
     return ListenerWithProperties_ResultEnum.none;
-  break;
   case 1:
     return ListenerWithProperties_ResultEnum.result;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ListenerWithProperties_ResultEnum enum.");
   }
@@ -502,7 +497,7 @@ Pointer<Void> smokeListenerwithpropertiesToFfi(ListenerWithProperties value) {
 }
 ListenerWithProperties smokeListenerwithpropertiesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ListenerWithProperties) return instance as ListenerWithProperties;
+  if (instance != null && instance is ListenerWithProperties) return instance;
   final _typeIdHandle = _smokeListenerwithpropertiesGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -6,7 +6,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-import 'package:meta/meta.dart';
 abstract class ListenersWithReturnValues {
   factory ListenersWithReturnValues(
     double Function() fetchDataDoubleLambda,
@@ -45,10 +44,8 @@ int smokeListenerswithreturnvaluesResultenumToFfi(ListenersWithReturnValues_Resu
   switch (value) {
   case ListenersWithReturnValues_ResultEnum.none:
     return 0;
-  break;
   case ListenersWithReturnValues_ResultEnum.result:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for ListenersWithReturnValues_ResultEnum enum.");
   }
@@ -57,10 +54,8 @@ ListenersWithReturnValues_ResultEnum smokeListenerswithreturnvaluesResultenumFro
   switch (handle) {
   case 0:
     return ListenersWithReturnValues_ResultEnum.none;
-  break;
   case 1:
     return ListenersWithReturnValues_ResultEnum.result;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for ListenersWithReturnValues_ResultEnum enum.");
   }
@@ -381,7 +376,7 @@ Pointer<Void> smokeListenerswithreturnvaluesToFfi(ListenersWithReturnValues valu
 }
 ListenersWithReturnValues smokeListenerswithreturnvaluesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is ListenersWithReturnValues) return instance as ListenersWithReturnValues;
+  if (instance != null && instance is ListenersWithReturnValues) return instance;
   final _typeIdHandle = _smokeListenerswithreturnvaluesGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -130,7 +130,7 @@ Pointer<Void> smokeLocalesToFfi(Locales value) =>
   _smokeLocalesCopyHandle((value as __lib.NativeBase).handle);
 Locales smokeLocalesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Locales) return instance as Locales;
+  if (instance != null && instance is Locales) return instance;
   final _copiedHandle = _smokeLocalesCopyHandle(handle);
   final result = Locales$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -243,7 +243,7 @@ Pointer<Void> smokeMethodoverloadsToFfi(MethodOverloads value) =>
   _smokeMethodoverloadsCopyHandle((value as __lib.NativeBase).handle);
 MethodOverloads smokeMethodoverloadsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is MethodOverloads) return instance as MethodOverloads;
+  if (instance != null && instance is MethodOverloads) return instance;
   final _copiedHandle = _smokeMethodoverloadsCopyHandle(handle);
   final result = MethodOverloads$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -57,7 +57,7 @@ Pointer<Void> smokeSpecialnamesToFfi(SpecialNames value) =>
   _smokeSpecialnamesCopyHandle((value as __lib.NativeBase).handle);
 SpecialNames smokeSpecialnamesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SpecialNames) return instance as SpecialNames;
+  if (instance != null && instance is SpecialNames) return instance;
   final _copiedHandle = _smokeSpecialnamesCopyHandle(handle);
   final result = SpecialNames$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
@@ -9,10 +9,8 @@ int smokeFreeenumToFfi(FreeEnum value) {
   switch (value) {
   case FreeEnum.foo:
     return 0;
-  break;
   case FreeEnum.bar:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for FreeEnum enum.");
   }
@@ -21,10 +19,8 @@ FreeEnum smokeFreeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return FreeEnum.foo;
-  break;
   case 1:
     return FreeEnum.bar;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for FreeEnum enum.");
   }

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -29,7 +29,6 @@ int smokeLeveloneLeveltwoLevelthreeLevelfourenumToFfi(LevelOne_LevelTwo_LevelThr
   switch (value) {
   case LevelOne_LevelTwo_LevelThree_LevelFourEnum.none:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for LevelOne_LevelTwo_LevelThree_LevelFourEnum enum.");
   }
@@ -38,7 +37,6 @@ LevelOne_LevelTwo_LevelThree_LevelFourEnum smokeLeveloneLeveltwoLevelthreeLevelf
   switch (handle) {
   case 0:
     return LevelOne_LevelTwo_LevelThree_LevelFourEnum.none;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for LevelOne_LevelTwo_LevelThree_LevelFourEnum enum.");
   }
@@ -182,7 +180,7 @@ Pointer<Void> smokeLeveloneLeveltwoLevelthreeToFfi(LevelOne_LevelTwo_LevelThree 
   _smokeLeveloneLeveltwoLevelthreeCopyHandle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo_LevelThree smokeLeveloneLeveltwoLevelthreeFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is LevelOne_LevelTwo_LevelThree) return instance as LevelOne_LevelTwo_LevelThree;
+  if (instance != null && instance is LevelOne_LevelTwo_LevelThree) return instance;
   final _copiedHandle = _smokeLeveloneLeveltwoLevelthreeCopyHandle(handle);
   final result = LevelOne_LevelTwo_LevelThree$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
@@ -220,7 +218,7 @@ Pointer<Void> smokeLeveloneLeveltwoToFfi(LevelOne_LevelTwo value) =>
   _smokeLeveloneLeveltwoCopyHandle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo smokeLeveloneLeveltwoFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is LevelOne_LevelTwo) return instance as LevelOne_LevelTwo;
+  if (instance != null && instance is LevelOne_LevelTwo) return instance;
   final _copiedHandle = _smokeLeveloneLeveltwoCopyHandle(handle);
   final result = LevelOne_LevelTwo$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
@@ -258,7 +256,7 @@ Pointer<Void> smokeLeveloneToFfi(LevelOne value) =>
   _smokeLeveloneCopyHandle((value as __lib.NativeBase).handle);
 LevelOne smokeLeveloneFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is LevelOne) return instance as LevelOne;
+  if (instance != null && instance is LevelOne) return instance;
   final _copiedHandle = _smokeLeveloneCopyHandle(handle);
   final result = LevelOne$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class OuterClass {
   /// @nodoc
   @Deprecated("Does nothing")
@@ -52,7 +51,7 @@ Pointer<Void> smokeOuterclassInnerclassToFfi(OuterClass_InnerClass value) =>
   _smokeOuterclassInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClass_InnerClass smokeOuterclassInnerclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterClass_InnerClass) return instance as OuterClass_InnerClass;
+  if (instance != null && instance is OuterClass_InnerClass) return instance;
   final _copiedHandle = _smokeOuterclassInnerclassCopyHandle(handle);
   final result = OuterClass_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
@@ -151,7 +150,7 @@ Pointer<Void> smokeOuterclassInnerinterfaceToFfi(OuterClass_InnerInterface value
 }
 OuterClass_InnerInterface smokeOuterclassInnerinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterClass_InnerInterface) return instance as OuterClass_InnerInterface;
+  if (instance != null && instance is OuterClass_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterclassInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
@@ -207,7 +206,7 @@ Pointer<Void> smokeOuterclassToFfi(OuterClass value) =>
   _smokeOuterclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClass smokeOuterclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterClass) return instance as OuterClass;
+  if (instance != null && instance is OuterClass) return instance;
   final _copiedHandle = _smokeOuterclassCopyHandle(handle);
   final result = OuterClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -5,7 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
-import 'package:meta/meta.dart';
 abstract class OuterClassWithInheritance implements ParentClass {
   /// @nodoc
   @Deprecated("Does nothing")
@@ -53,7 +52,7 @@ Pointer<Void> smokeOuterclasswithinheritanceInnerclassToFfi(OuterClassWithInheri
   _smokeOuterclasswithinheritanceInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance_InnerClass smokeOuterclasswithinheritanceInnerclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterClassWithInheritance_InnerClass) return instance as OuterClassWithInheritance_InnerClass;
+  if (instance != null && instance is OuterClassWithInheritance_InnerClass) return instance;
   final _copiedHandle = _smokeOuterclasswithinheritanceInnerclassCopyHandle(handle);
   final result = OuterClassWithInheritance_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
@@ -152,7 +151,7 @@ Pointer<Void> smokeOuterclasswithinheritanceInnerinterfaceToFfi(OuterClassWithIn
 }
 OuterClassWithInheritance_InnerInterface smokeOuterclasswithinheritanceInnerinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterClassWithInheritance_InnerInterface) return instance as OuterClassWithInheritance_InnerInterface;
+  if (instance != null && instance is OuterClassWithInheritance_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterclasswithinheritanceInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
@@ -212,7 +211,7 @@ Pointer<Void> smokeOuterclasswithinheritanceToFfi(OuterClassWithInheritance valu
   _smokeOuterclasswithinheritanceCopyHandle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance smokeOuterclasswithinheritanceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterClassWithInheritance) return instance as OuterClassWithInheritance;
+  if (instance != null && instance is OuterClassWithInheritance) return instance;
   final _typeIdHandle = _smokeOuterclasswithinheritanceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class OuterInterface {
   factory OuterInterface(
     String Function(String) fooLambda,
@@ -57,7 +56,7 @@ Pointer<Void> smokeOuterinterfaceInnerclassToFfi(OuterInterface_InnerClass value
   _smokeOuterinterfaceInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterInterface_InnerClass smokeOuterinterfaceInnerclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterInterface_InnerClass) return instance as OuterInterface_InnerClass;
+  if (instance != null && instance is OuterInterface_InnerClass) return instance;
   final _copiedHandle = _smokeOuterinterfaceInnerclassCopyHandle(handle);
   final result = OuterInterface_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
@@ -156,7 +155,7 @@ Pointer<Void> smokeOuterinterfaceInnerinterfaceToFfi(OuterInterface_InnerInterfa
 }
 OuterInterface_InnerInterface smokeOuterinterfaceInnerinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterInterface_InnerInterface) return instance as OuterInterface_InnerInterface;
+  if (instance != null && instance is OuterInterface_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterinterfaceInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
@@ -249,7 +248,7 @@ Pointer<Void> smokeOuterinterfaceToFfi(OuterInterface value) {
 }
 OuterInterface smokeOuterinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterInterface) return instance as OuterInterface;
+  if (instance != null && instance is OuterInterface) return instance;
   final _typeIdHandle = _smokeOuterinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -7,7 +7,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-import 'package:meta/meta.dart';
 final _doNothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -49,10 +48,8 @@ int smokeOuterstructInnerenumToFfi(OuterStruct_InnerEnum value) {
   switch (value) {
   case OuterStruct_InnerEnum.foo:
     return 0;
-  break;
   case OuterStruct_InnerEnum.bar:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for OuterStruct_InnerEnum enum.");
   }
@@ -61,10 +58,8 @@ OuterStruct_InnerEnum smokeOuterstructInnerenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return OuterStruct_InnerEnum.foo;
-  break;
   case 1:
     return OuterStruct_InnerEnum.bar;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for OuterStruct_InnerEnum enum.");
   }
@@ -212,7 +207,7 @@ Pointer<Void> smokeOuterstructInnerclassToFfi(OuterStruct_InnerClass value) =>
   _smokeOuterstructInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterStruct_InnerClass smokeOuterstructInnerclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterStruct_InnerClass) return instance as OuterStruct_InnerClass;
+  if (instance != null && instance is OuterStruct_InnerClass) return instance;
   final _copiedHandle = _smokeOuterstructInnerclassCopyHandle(handle);
   final result = OuterStruct_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
@@ -308,7 +303,7 @@ Pointer<Void> smokeOuterstructInnerinterfaceToFfi(OuterStruct_InnerInterface val
 }
 OuterStruct_InnerInterface smokeOuterstructInnerinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is OuterStruct_InnerInterface) return instance as OuterStruct_InnerInterface;
+  if (instance != null && instance is OuterStruct_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterstructInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -76,7 +76,7 @@ Pointer<Void> smokeUsefreetypesToFfi(UseFreeTypes value) =>
   _smokeUsefreetypesCopyHandle((value as __lib.NativeBase).handle);
 UseFreeTypes smokeUsefreetypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is UseFreeTypes) return instance as UseFreeTypes;
+  if (instance != null && instance is UseFreeTypes) return instance;
   final _copiedHandle = _smokeUsefreetypesCopyHandle(handle);
   final result = UseFreeTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -49,10 +49,8 @@ int smokeNullableSomeenumToFfi(Nullable_SomeEnum value) {
   switch (value) {
   case Nullable_SomeEnum.on:
     return 0;
-  break;
   case Nullable_SomeEnum.off:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Nullable_SomeEnum enum.");
   }
@@ -61,10 +59,8 @@ Nullable_SomeEnum smokeNullableSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Nullable_SomeEnum.on;
-  break;
   case 1:
     return Nullable_SomeEnum.off;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Nullable_SomeEnum enum.");
   }
@@ -783,7 +779,7 @@ Pointer<Void> smokeNullableToFfi(Nullable value) =>
   _smokeNullableCopyHandle((value as __lib.NativeBase).handle);
 Nullable smokeNullableFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Nullable) return instance as Nullable;
+  if (instance != null && instance is Nullable) return instance;
   final _copiedHandle = _smokeNullableCopyHandle(handle);
   final result = Nullable$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -106,7 +106,7 @@ Pointer<Void> smokeOffNestedpackagesToFfi(NestedPackages value) =>
   _smokeOffNestedpackagesCopyHandle((value as __lib.NativeBase).handle);
 NestedPackages smokeOffNestedpackagesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is NestedPackages) return instance as NestedPackages;
+  if (instance != null && instance is NestedPackages) return instance;
   final _copiedHandle = _smokeOffNestedpackagesCopyHandle(handle);
   final result = NestedPackages$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -76,7 +76,7 @@ Pointer<Void> smokePlatformnamesinterfaceToFfi(weeInterface value) =>
   _smokePlatformnamesinterfaceCopyHandle((value as __lib.NativeBase).handle);
 weeInterface smokePlatformnamesinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is weeInterface) return instance as weeInterface;
+  if (instance != null && instance is weeInterface) return instance;
   final _copiedHandle = _smokePlatformnamesinterfaceCopyHandle(handle);
   final result = weeInterface$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class weeListener {
   factory weeListener(
     void Function(String) WeeMethodLambda,
@@ -81,7 +80,7 @@ Pointer<Void> smokePlatformnameslistenerToFfi(weeListener value) {
 }
 weeListener smokePlatformnameslistenerFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is weeListener) return instance as weeListener;
+  if (instance != null && instance is weeListener) return instance;
   final _typeIdHandle = _smokePlatformnameslistenerGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -9,7 +9,6 @@ int smokePlatformnamesBasicenumToFfi(werrEnum value) {
   switch (value) {
   case werrEnum.WEE_ITEM:
     return 0;
-  break;
   default:
     throw StateError("Invalid enum value $value for werrEnum enum.");
   }
@@ -18,7 +17,6 @@ werrEnum smokePlatformnamesBasicenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return werrEnum.WEE_ITEM;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for werrEnum enum.");
   }

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -65,7 +65,7 @@ Pointer<Void> smokeCachedpropertiesToFfi(CachedProperties value) =>
   _smokeCachedpropertiesCopyHandle((value as __lib.NativeBase).handle);
 CachedProperties smokeCachedpropertiesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is CachedProperties) return instance as CachedProperties;
+  if (instance != null && instance is CachedProperties) return instance;
   final _copiedHandle = _smokeCachedpropertiesCopyHandle(handle);
   final result = CachedProperties$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -38,10 +38,8 @@ int smokePropertiesInternalerrorcodeToFfi(Properties_InternalErrorCode value) {
   switch (value) {
   case Properties_InternalErrorCode.errorNone:
     return 0;
-  break;
   case Properties_InternalErrorCode.errorFatal:
     return 999;
-  break;
   default:
     throw StateError("Invalid enum value $value for Properties_InternalErrorCode enum.");
   }
@@ -50,10 +48,8 @@ Properties_InternalErrorCode smokePropertiesInternalerrorcodeFromFfi(int handle)
   switch (handle) {
   case 0:
     return Properties_InternalErrorCode.errorNone;
-  break;
   case 999:
     return Properties_InternalErrorCode.errorFatal;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Properties_InternalErrorCode enum.");
   }
@@ -337,7 +333,7 @@ Pointer<Void> smokePropertiesToFfi(Properties value) =>
   _smokePropertiesCopyHandle((value as __lib.NativeBase).handle);
 Properties smokePropertiesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Properties) return instance as Properties;
+  if (instance != null && instance is Properties) return instance;
   final _copiedHandle = _smokePropertiesCopyHandle(handle);
   final result = Properties$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class PropertiesInterface {
   factory PropertiesInterface(
     PropertiesInterface_ExampleStruct Function() structPropertyGetLambda,
@@ -164,7 +163,7 @@ Pointer<Void> smokePropertiesinterfaceToFfi(PropertiesInterface value) {
 }
 PropertiesInterface smokePropertiesinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is PropertiesInterface) return instance as PropertiesInterface;
+  if (instance != null && instance is PropertiesInterface) return instance;
   final _typeIdHandle = _smokePropertiesinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -64,7 +64,7 @@ Pointer<Void> smokeEnableifenabledToFfi(EnableIfEnabled value) =>
   _smokeEnableifenabledCopyHandle((value as __lib.NativeBase).handle);
 EnableIfEnabled smokeEnableifenabledFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is EnableIfEnabled) return instance as EnableIfEnabled;
+  if (instance != null && instance is EnableIfEnabled) return instance;
   final _copiedHandle = _smokeEnableifenabledCopyHandle(handle);
   final result = EnableIfEnabled$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -29,7 +29,7 @@ Pointer<Void> smokeEnableifskippedToFfi(EnableIfSkipped value) =>
   _smokeEnableifskippedCopyHandle((value as __lib.NativeBase).handle);
 EnableIfSkipped smokeEnableifskippedFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is EnableIfSkipped) return instance as EnableIfSkipped;
+  if (instance != null && instance is EnableIfSkipped) return instance;
   final _copiedHandle = _smokeEnableifskippedCopyHandle(handle);
   final result = EnableIfSkipped$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -5,7 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/skip_proxy.dart';
-import 'package:meta/meta.dart';
 abstract class InheritFromSkipped implements SkipProxy {
   factory InheritFromSkipped(
     String Function(String) notInJavaLambda,
@@ -207,7 +206,7 @@ Pointer<Void> smokeInheritfromskippedToFfi(InheritFromSkipped value) {
 }
 InheritFromSkipped smokeInheritfromskippedFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is InheritFromSkipped) return instance as InheritFromSkipped;
+  if (instance != null && instance is InheritFromSkipped) return instance;
   final _typeIdHandle = _smokeInheritfromskippedGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
@@ -9,10 +9,8 @@ int smokeSkipenumeratorautotagToFfi(SkipEnumeratorAutoTag value) {
   switch (value) {
   case SkipEnumeratorAutoTag.one:
     return 0;
-  break;
   case SkipEnumeratorAutoTag.three:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for SkipEnumeratorAutoTag enum.");
   }
@@ -21,10 +19,8 @@ SkipEnumeratorAutoTag smokeSkipenumeratorautotagFromFfi(int handle) {
   switch (handle) {
   case 0:
     return SkipEnumeratorAutoTag.one;
-  break;
   case 1:
     return SkipEnumeratorAutoTag.three;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for SkipEnumeratorAutoTag enum.");
   }

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
@@ -10,13 +10,10 @@ int smokeSkipenumeratorexplicittagToFfi(SkipEnumeratorExplicitTag value) {
   switch (value) {
   case SkipEnumeratorExplicitTag.zero:
     return 0;
-  break;
   case SkipEnumeratorExplicitTag.one:
     return 3;
-  break;
   case SkipEnumeratorExplicitTag.three:
     return 4;
-  break;
   default:
     throw StateError("Invalid enum value $value for SkipEnumeratorExplicitTag enum.");
   }
@@ -25,13 +22,10 @@ SkipEnumeratorExplicitTag smokeSkipenumeratorexplicittagFromFfi(int handle) {
   switch (handle) {
   case 0:
     return SkipEnumeratorExplicitTag.zero;
-  break;
   case 3:
     return SkipEnumeratorExplicitTag.one;
-  break;
   case 4:
     return SkipEnumeratorExplicitTag.three;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for SkipEnumeratorExplicitTag enum.");
   }

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -54,7 +54,7 @@ Pointer<Void> smokeSkipfunctionsToFfi(SkipFunctions value) =>
   _smokeSkipfunctionsCopyHandle((value as __lib.NativeBase).handle);
 SkipFunctions smokeSkipfunctionsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SkipFunctions) return instance as SkipFunctions;
+  if (instance != null && instance is SkipFunctions) return instance;
   final _copiedHandle = _smokeSkipfunctionsCopyHandle(handle);
   final result = SkipFunctions$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class SkipProxy {
   factory SkipProxy(
     String Function(String) notInJavaLambda,
@@ -212,7 +211,7 @@ Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
 }
 SkipProxy smokeSkipproxyFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SkipProxy) return instance as SkipProxy;
+  if (instance != null && instance is SkipProxy) return instance;
   final _typeIdHandle = _smokeSkipproxyGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class SkipTagsInDart {
   factory SkipTagsInDart(
     void Function() dontSkipTaggedLambda,
@@ -78,7 +77,7 @@ Pointer<Void> smokeSkiptagsindartToFfi(SkipTagsInDart value) {
 }
 SkipTagsInDart smokeSkiptagsindartFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SkipTagsInDart) return instance as SkipTagsInDart;
+  if (instance != null && instance is SkipTagsInDart) return instance;
   final _typeIdHandle = _smokeSkiptagsindartGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -29,7 +29,7 @@ Pointer<Void> smokeSkiptagsonlyToFfi(SkipTagsOnly value) =>
   _smokeSkiptagsonlyCopyHandle((value as __lib.NativeBase).handle);
 SkipTagsOnly smokeSkiptagsonlyFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SkipTagsOnly) return instance as SkipTagsOnly;
+  if (instance != null && instance is SkipTagsOnly) return instance;
   final _copiedHandle = _smokeSkiptagsonlyCopyHandle(handle);
   final result = SkipTagsOnly$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -158,7 +158,7 @@ Pointer<Void> smokeSkiptypesToFfi(SkipTypes value) =>
   _smokeSkiptypesCopyHandle((value as __lib.NativeBase).handle);
 SkipTypes smokeSkiptypesFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SkipTypes) return instance as SkipTypes;
+  if (instance != null && instance is SkipTypes) return instance;
   final _copiedHandle = _smokeSkiptypesCopyHandle(handle);
   final result = SkipTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -25,10 +25,8 @@ int smokeStructsFoobarToFfi(Structs_FooBar value) {
   switch (value) {
   case Structs_FooBar.foo:
     return 0;
-  break;
   case Structs_FooBar.bar:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for Structs_FooBar enum.");
   }
@@ -37,10 +35,8 @@ Structs_FooBar smokeStructsFoobarFromFfi(int handle) {
   switch (handle) {
   case 0:
     return Structs_FooBar.foo;
-  break;
   case 1:
     return Structs_FooBar.bar;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for Structs_FooBar enum.");
   }
@@ -781,7 +777,7 @@ Pointer<Void> smokeStructsToFfi(Structs value) =>
   _smokeStructsCopyHandle((value as __lib.NativeBase).handle);
 Structs smokeStructsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is Structs) return instance as Structs;
+  if (instance != null && instance is Structs) return instance;
   final _copiedHandle = _smokeStructsCopyHandle(handle);
   final result = Structs$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
+++ b/gluecodium/src/test/resources/smoke/stubs_classes/output/dart/lib/src/smoke/some_class.dart
@@ -102,7 +102,7 @@ Pointer<Void> smokeSomeclassToFfi(SomeClass value) =>
   _smokeSomeclassCopyHandle((value as __lib.NativeBase).handle);
 SomeClass smokeSomeclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is SomeClass) return instance as SomeClass;
+  if (instance != null && instance is SomeClass) return instance;
   final _copiedHandle = _smokeSomeclassCopyHandle(handle);
   final result = SomeClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -247,7 +247,7 @@ Pointer<Void> smokeTypedefsToFfi(TypeDefs value) =>
   _smokeTypedefsCopyHandle((value as __lib.NativeBase).handle);
 TypeDefs smokeTypedefsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is TypeDefs) return instance as TypeDefs;
+  if (instance != null && instance is TypeDefs) return instance;
   final _copiedHandle = _smokeTypedefsCopyHandle(handle);
   final result = TypeDefs$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -38,7 +38,7 @@ Pointer<Void> smokeInternalclassToFfi(InternalClass value) =>
   _smokeInternalclassCopyHandle((value as __lib.NativeBase).handle);
 InternalClass smokeInternalclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is InternalClass) return instance as InternalClass;
+  if (instance != null && instance is InternalClass) return instance;
   final _copiedHandle = _smokeInternalclassCopyHandle(handle);
   final result = InternalClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -63,7 +63,7 @@ Pointer<Void> smokeInternalclasswithfunctionsToFfi(InternalClassWithFunctions va
   _smokeInternalclasswithfunctionsCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithFunctions smokeInternalclasswithfunctionsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is InternalClassWithFunctions) return instance as InternalClassWithFunctions;
+  if (instance != null && instance is InternalClassWithFunctions) return instance;
   final _copiedHandle = _smokeInternalclasswithfunctionsCopyHandle(handle);
   final result = InternalClassWithFunctions$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -50,7 +50,7 @@ Pointer<Void> smokeInternalclasswithstaticpropertyToFfi(InternalClassWithStaticP
   _smokeInternalclasswithstaticpropertyCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithStaticProperty smokeInternalclasswithstaticpropertyFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is InternalClassWithStaticProperty) return instance as InternalClassWithStaticProperty;
+  if (instance != null && instance is InternalClassWithStaticProperty) return instance;
   final _copiedHandle = _smokeInternalclasswithstaticpropertyCopyHandle(handle);
   final result = InternalClassWithStaticProperty$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 /// @nodoc
 abstract class InternalInterface {
   factory InternalInterface(
@@ -80,7 +79,7 @@ Pointer<Void> smokeInternalinterfaceToFfi(InternalInterface value) {
 }
 InternalInterface smokeInternalinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is InternalInterface) return instance as InternalInterface;
+  if (instance != null && instance is InternalInterface) return instance;
   final _typeIdHandle = _smokeInternalinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -27,10 +27,8 @@ int smokePublicclassInternalenumToFfi(PublicClass_InternalEnum value) {
   switch (value) {
   case PublicClass_InternalEnum.foo:
     return 0;
-  break;
   case PublicClass_InternalEnum.bar:
     return 1;
-  break;
   default:
     throw StateError("Invalid enum value $value for PublicClass_InternalEnum enum.");
   }
@@ -39,10 +37,8 @@ PublicClass_InternalEnum smokePublicclassInternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
     return PublicClass_InternalEnum.foo;
-  break;
   case 1:
     return PublicClass_InternalEnum.bar;
-  break;
   default:
     throw StateError("Invalid numeric value $handle for PublicClass_InternalEnum enum.");
   }
@@ -356,7 +352,7 @@ Pointer<Void> smokePublicclassToFfi(PublicClass value) =>
   _smokePublicclassCopyHandle((value as __lib.NativeBase).handle);
 PublicClass smokePublicclassFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is PublicClass) return instance as PublicClass;
+  if (instance != null && instance is PublicClass) return instance;
   final _copiedHandle = _smokePublicclassCopyHandle(handle);
   final result = PublicClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -5,7 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/public_class.dart';
-import 'package:meta/meta.dart';
 abstract class PublicInterface {
   /// @nodoc
   @Deprecated("Does nothing")
@@ -114,7 +113,7 @@ Pointer<Void> smokePublicinterfaceToFfi(PublicInterface value) {
 }
 PublicInterface smokePublicinterfaceFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
-  if (instance != null && instance is PublicInterface) return instance as PublicInterface;
+  if (instance != null && instance is PublicInterface) return instance;
   final _typeIdHandle = _smokePublicinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);


### PR DESCRIPTION
Fixed the following Dart warnings:
* unused "meta" package for interfaces
* misused `@protected` annotation in NativeBase
* unnecessary `as` cast in `FromFfi()` for classes and interfaces
* unnecessary `break` statement in enum conversion functions

See: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>