### PR TITLE
Fix another batch of "dart analyze" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed runtime issue for interfaces sent from Java to C++ and then back to Java.
+  * Suppressed more "dart analyze" warnings about deprecated element usage.
 
 ## 9.3.5
 Release date: 2021-07-28

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -69,7 +69,7 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
         if (limeStruct.attributes.have(LimeAttributeType.EQUATABLE) &&
             limeStruct.fields.any { it.typeRef.type.actualType is LimeGenericType }
         ) {
-            result += listOf(collectionSystemImport, collectionPackageImport)
+            result += listOf(collectionPackageImport)
         }
         if (limeStruct.attributes.have(LimeAttributeType.IMMUTABLE)) {
             result += listOf(metaPackageImport)
@@ -78,7 +78,6 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
     }
 
     companion object {
-        private val collectionSystemImport = DartImport("collection", importType = ImportType.SYSTEM)
         private val collectionPackageImport = DartImport("collection/collection")
         private val metaPackageImport = DartImport("meta/meta")
         private val ffiSystemImport = DartImport("ffi", importType = ImportType.SYSTEM)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartExport.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartExport.kt
@@ -19,6 +19,10 @@
 
 package com.here.gluecodium.generator.dart
 
-data class DartExport(val filePath: String, val show: List<String>) : Comparable<DartExport> {
+data class DartExport(
+    val filePath: String,
+    val show: List<String>,
+    val hasDeprecations: Boolean
+) : Comparable<DartExport> {
     override fun compareTo(other: DartExport) = filePath.compareTo(other.filePath)
 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -125,11 +125,20 @@ class {{resolveName}}$Impl extends {{#if hasClassParent}}{{resolveName parent}}$
 }}{{#if attributes.pointerEquatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}
 }
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
   _{{resolveName "Ffi"}}CopyHandle((value as __lib.NativeBase).handle);
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
+{{#if this.attributes.deprecated}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
   if (instance != null && instance is {{resolveName}}) return instance;
 
 {{#if this.parent visibility.isOpen logic="or"}}
@@ -150,9 +159,15 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
 void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) =>
   _{{resolveName "Ffi"}}ReleaseHandle(handle);
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfiNullable({{resolveName}}? value) =>
   value != null ? {{resolveName "Ffi"}}ToFfi(value) : Pointer<Void>.fromAddress(0);
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{resolveName}}? {{resolveName "Ffi"}}FromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? {{resolveName "Ffi"}}FromFfi(handle) : null;
 

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -29,16 +29,19 @@ enum {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
 
 // {{resolveName}} "private" section, not exported.
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external.dart.converter}}External{{/if}}) {
 {{#if external.dart.converter}}
   final value = {{external.dart.converter}}.convertToInternal(valueExternal);
 {{/if}}
   switch (value) {
 {{#set parent=this}}{{#enumerators}}
-  case {{resolveName parent "" "ref"}}{{#if external.dart.converter}}Internal{{/if}}.{{resolveName}}:
-{{#if this.attributes.deprecated}}
+{{#if this.attributes.deprecated parent.attributes.deprecated logic="or"}}
   // ignore: deprecated_member_use_from_same_package
 {{/if}}
+  case {{resolveName parent "" "ref"}}{{#if external.dart.converter}}Internal{{/if}}.{{resolveName}}:
     return {{value}};
 {{/enumerators}}{{/set}}
   default:
@@ -46,12 +49,16 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
   }
 }
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{resolveName this "" "ref"}} {{resolveName "Ffi"}}FromFfi(int handle) {
   switch (handle) {
-{{#set parent=this}}{{#enumerators}}{{#if this.attributes.deprecated}}
-  // ignore: deprecated_member_use_from_same_package
-{{/if}}
+{{#set parent=this}}{{#enumerators}}
   case {{value}}:
+{{#if this.attributes.deprecated parent.attributes.deprecated logic="or"}}
+    // ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{#if external.dart.converter}}
     return {{external.dart.converter}}.convertFromInternal({{resolveName parent}}Internal.{{resolveName}});
 {{/if}}{{#unless external.dart.converter}}

--- a/gluecodium/src/main/resources/templates/dart/DartExports.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartExports.mustache
@@ -21,5 +21,8 @@
 {{#if copyrightHeader}}{{prefix copyrightHeader "// "}}{{/if}}
 
 {{#files}}
+{{#if hasDeprecations}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 export '{{filePath}}'{{#if show}} show {{join show delimiter=", "}}{{/if}};
 {{/files}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -31,9 +31,9 @@
 ///{{/unless}}{{/resolveName}}{{/if}}{{!!
 }}{{#if visibility.isInternal comment.isExcluded logic="or"}}
 /// @nodoc{{/if}}{{!!
-}}{{#if attributes.deprecated}}
+}}{{#if attributes.deprecated}}{{#unless isConstructor}}
 @Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
-{{/if}}{{!!
+{{/unless}}{{/if}}{{!!
 }}{{#if attributes.dart.attribute}}
 
 {{#attributes.dart.attribute}}

--- a/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartGenericTypesConversion.mustache
@@ -82,6 +82,9 @@ final _{{resolveName "Ffi"}}IteratorGet = __lib.catchArgumentError(() => __lib.n
 >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_iterator_get'));
 {{/notInstanceOf}}
 
+{{#ifPredicate "hasDeprecatedElementTypes"}}
+// ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
   final _result = _{{resolveName "Ffi"}}CreateHandle();
 {{#instanceOf this "LimeMap"}}
@@ -103,7 +106,13 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
   return _result;
 }
 
+{{#ifPredicate "hasDeprecatedElementTypes"}}
+// ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
+{{#ifPredicate "hasDeprecatedElementTypes"}}
+  // ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
   final result = {{resolveName}}{{#instanceOf this "LimeList"}}.empty(growable: true){{/instanceOf}}{{!!
   }}{{#notInstanceOf this "LimeList"}}(){{/notInstanceOf}};
   final _iteratorHandle = _{{resolveName "Ffi"}}Iterator(handle);

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -21,6 +21,9 @@
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
+{{#ifPredicate "hasDeprecatedParameters"}}
+  // ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
   factory {{resolveName}}(
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
     {{>dart/DartLambdaType}} {{resolveName}}Lambda,
@@ -104,14 +107,28 @@ final _{{resolveName "Ffi"}}GetTypeId = __lib.catchArgumentError(() => __lib.nat
 
 {{/functions}}{{!!
 }}{{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 class {{resolveName}}$Lambdas implements {{resolveName}} {
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
+{{#ifPredicate "hasDeprecatedParameters"}}
+  // ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
   {{>dart/DartLambdaType}} {{resolveName}}Lambda;
 {{/unless}}{{/each}}
 {{#each inheritedProperties properties}}{{#unless isStatic}}{{#set property=this}}
-{{#getter}}  {{>dart/DartLambdaType}} {{resolveName property}}GetLambda;
+{{#getter}}
+{{#if property.typeRef.type.attributes.deprecated}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
+  {{>dart/DartLambdaType}} {{resolveName property}}GetLambda;
 {{/getter}}{{!!
-}}{{#setter}}  {{>dart/DartLambdaType}} {{resolveName property}}SetLambda;
+}}{{#setter}}
+{{#if property.typeRef.type.attributes.deprecated}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
+  {{>dart/DartLambdaType}} {{resolveName property}}SetLambda;
 {{/setter}}
 {{/set}}{{/unless}}{{/each}}
 
@@ -131,20 +148,32 @@ class {{resolveName}}$Lambdas implements {{resolveName}} {
 
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
   @override
+{{#ifPredicate "hasDeprecatedParameters"}}
+  // ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
   {{>dart/DartFunctionSignature}} =>
     {{resolveName}}Lambda({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/unless}}{{/each}}
 {{#each inheritedProperties properties}}{{#unless isStatic}}
   @override
+{{#if typeRef.type.attributes.deprecated}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
   {{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} => {{resolveName}}GetLambda();
 {{#if setter}}
   @override
+{{#if typeRef.type.attributes.deprecated}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
   set {{resolveName visibility}}{{resolveName}}({{resolveName typeRef}} value) => {{resolveName}}SetLambda(value);
 {{/if}}
 {{/unless}}{{/each}}
 }
 {{/if}}
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 class {{resolveName}}$Impl extends __lib.NativeBase implements {{resolveName}} {
 
   {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
@@ -175,6 +204,9 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}Static({{!!
 {{/if}}{{#unless returnType.isVoid}}
   {{resolveName returnType.typeRef}}{{#unless returnType.typeRef.isNullable}}?{{/unless}} _resultObject;{{/unless}}
   try {
+{{#if this.attributes.deprecated parent.attributes.deprecated logic="or"}}
+    // ignore: deprecated_member_use_from_same_package
+{{/if}}
     {{#unless returnType.isVoid}}_resultObject = {{/unless}}{{!!
   }}(_obj as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
   }}{{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
@@ -197,6 +229,9 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}Static({{!!
 
 {{#each inheritedProperties properties}}{{#unless isStatic}}
 int _{{resolveName parent "Ffi"}}{{resolveName}}GetStatic(Object _obj, Pointer<{{resolveName typeRef "FfiApiTypes"}}> _result) {
+{{#if this.attributes.deprecated parent.attributes.deprecated logic="or"}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
   _result.value = {{#set call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{!!
   }}(_obj as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}});
   return 0;
@@ -205,6 +240,9 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}GetStatic(Object _obj, Pointer<{
 
 int _{{resolveName parent "Ffi"}}{{resolveName}}SetStatic(Object _obj, {{resolveName typeRef "FfiDartTypes"}} _value) {
   try {
+{{#if this.attributes.deprecated parent.attributes.deprecated logic="or"}}
+    // ignore: deprecated_member_use_from_same_package
+{{/if}}
     (_obj as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}} =
       {{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
   } finally {
@@ -215,6 +253,9 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}SetStatic(Object _obj, {{resolve
 {{/if}}
 {{/unless}}{{/each}}{{/set}}
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
   if (value is __lib.NativeBase) return _{{resolveName "Ffi"}}CopyHandle((value as __lib.NativeBase).handle);
 
@@ -232,8 +273,14 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
   return result;
 }
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
+{{#if this.attributes.deprecated}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
   if (instance != null && instance is {{resolveName}}) return instance;
 
   final _typeIdHandle = _{{resolveName "Ffi"}}GetTypeId(handle);
@@ -252,9 +299,15 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
 void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) =>
   _{{resolveName "Ffi"}}ReleaseHandle(handle);
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfiNullable({{resolveName}}? value) =>
   value != null ? {{resolveName "Ffi"}}ToFfi(value) : Pointer<Void>.fromAddress(0);
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{resolveName}}? {{resolveName "Ffi"}}FromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? {{resolveName "Ffi"}}FromFfi(handle) : null;
 

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -71,6 +71,9 @@ int _{{resolveName lambda "Ffi"}}{{resolveName}}Static({{!!
 }
 {{/asFunction}}{{/set}}
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
   _{{resolveName "Ffi"}}CreateProxy(
     __lib.getObjectToken(value),
@@ -79,6 +82,9 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
     Pointer.fromFunction<{{>ffiApi}}>(_{{resolveName lambda "Ffi"}}{{resolveName}}Static, __lib.unknownError){{/asFunction}}{{/set}}
   );
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
   final _copiedHandle = _{{resolveName "Ffi"}}CopyHandle(handle);
   final _impl = {{resolveName}}$Impl(_copiedHandle);

--- a/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartNullableTypeConversion.mustache
@@ -31,6 +31,9 @@ final _{{resolveName "Ffi"}}GetValueNullable = __lib.catchArgumentError(() => __
     {{resolveName "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{libraryName}}_{{internalPrefix}}{{resolveName "FfiSnakeCase"}}_get_value_nullable'));
 
+{{#ifPredicate "hasDeprecatedElementTypes"}}
+// ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfiNullable({{resolveName this "" "ref"}}? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = {{resolveName "Ffi"}}ToFfi(value);
@@ -39,6 +42,9 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfiNullable({{resolveName this "" "ref"}}? 
   return result;
 }
 
+{{#ifPredicate "hasDeprecatedElementTypes"}}
+// ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
 {{resolveName this "" "ref"}}? {{resolveName "Ffi"}}FromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _{{resolveName "Ffi"}}GetValueNullable(handle);

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -62,6 +62,9 @@ class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{#if testabl
     if (identical(this, other)) return true;
     if (other is! {{resolveName}}) return false;
     {{resolveName}} _other = other;
+{{#ifPredicate "hasDeprecatedFields"}}
+    // ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
     return {{joinPartial fields "dartFieldEq" " &&
         "}};
   }
@@ -70,6 +73,9 @@ class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{#if testabl
   int get hashCode {
     int result = 7;
 {{#fields}}
+{{#if this.attributes.deprecated}}
+    // ignore: deprecated_member_use_from_same_package
+{{/if}}
     result = 31 * result + {{>dartFieldHash}};
 {{/fields}}
     return result;
@@ -113,11 +119,18 @@ final _{{resolveName parent "Ffi"}}GetField{{resolveName "Ffi"}} = __lib.catchAr
 
 {{>dart/DartOptimizedLists}}
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external.dart.converter}}External{{/if}}) {
 {{#if external.dart.converter}}
   final value = {{external.dart.converter}}.convertToInternal(valueExternal);
 {{/if}}
-{{#fields}}{{#if typeRef.attributes.optimized}}
+{{#fields}}
+{{#if this.attributes.deprecated}}
+  // ignore: deprecated_member_use_from_same_package
+{{/if}}
+{{#if typeRef.attributes.optimized}}
   final _{{resolveName}}Handle = (value.{{resolveName visibility}}{{resolveName}} as __lib.LazyList).handle;
 {{/if}}{{#unless typeRef.attributes.optimized}}
   final _{{resolveName}}Handle = {{#set call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(value.{{resolveName visibility}}{{resolveName}});
@@ -129,12 +142,17 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
   return _result;
 }
 
+{{#if this.attributes.deprecated}}
+// ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{resolveName this "" "ref"}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
 {{#set parent=this}}{{#fields}}
-  final _{{resolveName}}Handle = {{!!
-  }}_{{resolveName parent "Ffi"}}GetField{{resolveName "Ffi"}}(handle);
+  final _{{resolveName}}Handle = _{{resolveName parent "Ffi"}}GetField{{resolveName "Ffi"}}(handle);
 {{/fields}}{{/set}}
   try {
+{{#if this.attributes.deprecated}}
+    // ignore: deprecated_member_use_from_same_package
+{{/if}}
 {{#if external.dart.converter}}
     final resultInternal = {{resolveName}}Internal{{#if testableMode}}$Impl{{/if}}{{#if constructors}}._{{/if}}(
 {{#set container=this}}{{#fields}}
@@ -217,7 +235,11 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
 }}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/unless}}
-{{#if constructors}}  {{resolveName}}{{#if testableMode}}$Impl{{/if}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
+{{#if constructors}}
+{{#ifPredicate "hasDeprecatedFields"}}
+  // ignore: deprecated_member_use_from_same_package
+{{/ifPredicate}}
+  {{resolveName}}{{#if testableMode}}$Impl{{/if}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
 }}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/if}}{{#unless constructors}}{{#if initializedFields}}
   {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -42,6 +42,7 @@ final _smokeAttributeswithdeprecatedSomestructGetFieldfield = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_get_field_field'));
 Pointer<Void> smokeAttributeswithdeprecatedSomestructToFfi(AttributesWithDeprecated_SomeStruct value) {
+  // ignore: deprecated_member_use_from_same_package
   final _fieldHandle = stringToFfi(value.field);
   final _result = _smokeAttributeswithdeprecatedSomestructCreateHandle(_fieldHandle);
   stringReleaseFfiHandle(_fieldHandle);
@@ -133,10 +134,13 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
     stringReleaseFfiHandle(_valueHandle);
   }
 }
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeAttributeswithdeprecatedToFfi(AttributesWithDeprecated value) =>
   _smokeAttributeswithdeprecatedCopyHandle((value as __lib.NativeBase).handle);
+// ignore: deprecated_member_use_from_same_package
 AttributesWithDeprecated smokeAttributeswithdeprecatedFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
+  // ignore: deprecated_member_use_from_same_package
   if (instance != null && instance is AttributesWithDeprecated) return instance;
   final _copiedHandle = _smokeAttributeswithdeprecatedCopyHandle(handle);
   final result = AttributesWithDeprecated$Impl(_copiedHandle);
@@ -146,8 +150,10 @@ AttributesWithDeprecated smokeAttributeswithdeprecatedFromFfi(Pointer<Void> hand
 }
 void smokeAttributeswithdeprecatedReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAttributeswithdeprecatedReleaseHandle(handle);
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeAttributeswithdeprecatedToFfiNullable(AttributesWithDeprecated? value) =>
   value != null ? smokeAttributeswithdeprecatedToFfi(value) : Pointer<Void>.fromAddress(0);
+// ignore: deprecated_member_use_from_same_package
 AttributesWithDeprecated? smokeAttributeswithdeprecatedFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeAttributeswithdeprecatedFromFfi(handle) : null;
 void smokeAttributeswithdeprecatedReleaseFfiHandleNullable(Pointer<Void> handle) =>

--- a/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
@@ -98,3 +98,23 @@ interface DeprecationCommentsOnly {
 struct DeprecatedWithNoMessage {
     field: String
 }
+
+@Equatable
+@Deprecated("Unfortunately, this struct is deprecated. Use [comments.SomeStruct] instead.")
+struct DeprecatedEquatableStruct {
+    @Deprecated("Unfortunately, this field is deprecated.\nUse [comments.SomeStruct.someField] instead.")
+    someField: String
+}
+
+struct DeprecatedStructCtor {
+    constructor foo()
+    @Deprecated("Unfortunately, this field is deprecated.\nUse [comments.SomeStruct.someField] instead.")
+    someField: String
+}
+
+interface DeprecatedFromLambdas {
+    fun foo(input: DeprecatedEquatableStruct)
+    property bar: DeprecatedEquatableStruct
+}
+
+typealias ListOfDeprecatedStructs = List<DeprecatedWithNoMessage>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/smoke.dart
@@ -1,0 +1,24 @@
+export 'src/smoke/comments.dart' show Comments, Comments_SomeEnum, Comments_SomeLambda, Comments_SomeStruct, Comments_SomethingWrongException;
+export 'src/smoke/comments_interface.dart' show CommentsInterface, CommentsInterface_SomeEnum, CommentsInterface_SomeStruct;
+export 'src/smoke/comments_links.dart' show CommentsLinks, CommentsLinks_RandomStruct;
+export 'src/smoke/comments_markdown.dart' show CommentsMarkdown;
+export 'src/smoke/comments_on_cstring.dart' show CommentsOnCstring;
+export 'src/smoke/comments_type_collection.dart' show CommentsTypeCollection, TypeCollectionEnum, TypeCollectionStruct, typeCollectionConstant;
+// ignore: deprecated_member_use_from_same_package
+export 'src/smoke/deprecated_equatable_struct.dart' show DeprecatedEquatableStruct;
+export 'src/smoke/deprecated_from_lambdas.dart' show DeprecatedFromLambdas;
+export 'src/smoke/deprecated_struct_ctor.dart' show DeprecatedStructCtor;
+// ignore: deprecated_member_use_from_same_package
+export 'src/smoke/deprecated_with_no_message.dart' show DeprecatedWithNoMessage;
+// ignore: deprecated_member_use_from_same_package
+export 'src/smoke/deprecation_comments.dart' show DeprecationComments, DeprecationComments_SomeEnum, DeprecationComments_SomeStruct, DeprecationComments_SomethingWrongException;
+// ignore: deprecated_member_use_from_same_package
+export 'src/smoke/deprecation_comments_only.dart' show DeprecationCommentsOnly, DeprecationCommentsOnly_SomeEnum, DeprecationCommentsOnly_SomeStruct;
+export 'src/smoke/excluded_comments.dart' show ExcludedComments, ExcludedComments_SomeEnum, ExcludedComments_SomeLambda, ExcludedComments_SomeStruct, ExcludedComments_SomethingWrongException;
+export 'src/smoke/excluded_comments_interface.dart' show ExcludedCommentsInterface;
+export 'src/smoke/excluded_comments_only.dart' show ExcludedCommentsOnly, ExcludedCommentsOnly_SomeEnum, ExcludedCommentsOnly_SomeLambda, ExcludedCommentsOnly_SomeStruct, ExcludedCommentsOnly_SomethingWrongException;
+export 'src/smoke/long_comments.dart' show LongComments;
+export 'src/smoke/map_scene.dart' show MapScene, MapScene_LoadSceneCallback;
+export 'src/smoke/multi_line_comments.dart' show MultiLineComments;
+export 'src/smoke/platform_comments.dart' show PlatformComments, PlatformComments_SomeEnum, PlatformComments_Something, PlatformComments_SomethingWrongException;
+export 'src/smoke/unicode_comments.dart' show UnicodeComments;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/generic_types__conversion.dart
@@ -1,0 +1,93 @@
+import 'package:library/src/smoke/deprecated_with_no_message.dart';
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+final _foobarListofSmokeDeprecatedwithnomessageCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_create_handle'));
+final _foobarListofSmokeDeprecatedwithnomessageReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_release_handle'));
+final _foobarListofSmokeDeprecatedwithnomessageInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Pointer<Void>),
+    void Function(Pointer<Void>, Pointer<Void>)
+  >('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_insert'));
+final _foobarListofSmokeDeprecatedwithnomessageIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_iterator'));
+final _foobarListofSmokeDeprecatedwithnomessageIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_iterator_release_handle'));
+final _foobarListofSmokeDeprecatedwithnomessageIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_iterator_is_valid'));
+final _foobarListofSmokeDeprecatedwithnomessageIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_iterator_increment'));
+final _foobarListofSmokeDeprecatedwithnomessageIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_iterator_get'));
+// ignore: deprecated_member_use_from_same_package
+Pointer<Void> foobarListofSmokeDeprecatedwithnomessageToFfi(List<DeprecatedWithNoMessage> value) {
+  final _result = _foobarListofSmokeDeprecatedwithnomessageCreateHandle();
+  for (final element in value) {
+    final _elementHandle = smokeDeprecatedwithnomessageToFfi(element);
+    _foobarListofSmokeDeprecatedwithnomessageInsert(_result, _elementHandle);
+    smokeDeprecatedwithnomessageReleaseFfiHandle(_elementHandle);
+  }
+  return _result;
+}
+// ignore: deprecated_member_use_from_same_package
+List<DeprecatedWithNoMessage> foobarListofSmokeDeprecatedwithnomessageFromFfi(Pointer<Void> handle) {
+  // ignore: deprecated_member_use_from_same_package
+  final result = List<DeprecatedWithNoMessage>.empty(growable: true);
+  final _iteratorHandle = _foobarListofSmokeDeprecatedwithnomessageIterator(handle);
+  while (_foobarListofSmokeDeprecatedwithnomessageIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _foobarListofSmokeDeprecatedwithnomessageIteratorGet(_iteratorHandle);
+    try {
+      result.add(smokeDeprecatedwithnomessageFromFfi(_elementHandle));
+    } finally {
+      smokeDeprecatedwithnomessageReleaseFfiHandle(_elementHandle);
+    }
+    _foobarListofSmokeDeprecatedwithnomessageIteratorIncrement(_iteratorHandle);
+  }
+  _foobarListofSmokeDeprecatedwithnomessageIteratorReleaseHandle(_iteratorHandle);
+  return result;
+}
+void foobarListofSmokeDeprecatedwithnomessageReleaseFfiHandle(Pointer<Void> handle) => _foobarListofSmokeDeprecatedwithnomessageReleaseHandle(handle);
+final _foobarListofSmokeDeprecatedwithnomessageCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_create_handle_nullable'));
+final _foobarListofSmokeDeprecatedwithnomessageReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_release_handle_nullable'));
+final _foobarListofSmokeDeprecatedwithnomessageGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_foobar_ListOf_smoke_DeprecatedWithNoMessage_get_value_nullable'));
+// ignore: deprecated_member_use_from_same_package
+Pointer<Void> foobarListofSmokeDeprecatedwithnomessageToFfiNullable(List<DeprecatedWithNoMessage>? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = foobarListofSmokeDeprecatedwithnomessageToFfi(value);
+  final result = _foobarListofSmokeDeprecatedwithnomessageCreateHandleNullable(_handle);
+  foobarListofSmokeDeprecatedwithnomessageReleaseFfiHandle(_handle);
+  return result;
+}
+// ignore: deprecated_member_use_from_same_package
+List<DeprecatedWithNoMessage>? foobarListofSmokeDeprecatedwithnomessageFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _foobarListofSmokeDeprecatedwithnomessageGetValueNullable(handle);
+  final result = foobarListofSmokeDeprecatedwithnomessageFromFfi(_handle);
+  foobarListofSmokeDeprecatedwithnomessageReleaseFfiHandle(_handle);
+  return result;
+}
+void foobarListofSmokeDeprecatedwithnomessageReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _foobarListofSmokeDeprecatedwithnomessageReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_equatable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_equatable_struct.dart
@@ -1,0 +1,90 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+@Deprecated("Unfortunately, this struct is deprecated. Use [Comments_SomeStruct] instead.")
+class DeprecatedEquatableStruct {
+  @Deprecated("Unfortunately, this field is deprecated.\nUse [Comments_SomeStruct.someField] instead.")
+  String someField;
+  DeprecatedEquatableStruct(this.someField);
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other)) return true;
+    if (other is! DeprecatedEquatableStruct) return false;
+    DeprecatedEquatableStruct _other = other;
+    // ignore: deprecated_member_use_from_same_package
+    return someField == _other.someField;
+  }
+  @override
+  int get hashCode {
+    int result = 7;
+    // ignore: deprecated_member_use_from_same_package
+    result = 31 * result + someField.hashCode;
+    return result;
+  }
+}
+// DeprecatedEquatableStruct "private" section, not exported.
+final _smokeDeprecatedequatablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedEquatableStruct_create_handle'));
+final _smokeDeprecatedequatablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecatedEquatableStruct_release_handle'));
+final _smokeDeprecatedequatablestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedEquatableStruct_get_field_someField'));
+// ignore: deprecated_member_use_from_same_package
+Pointer<Void> smokeDeprecatedequatablestructToFfi(DeprecatedEquatableStruct value) {
+  // ignore: deprecated_member_use_from_same_package
+  final _someFieldHandle = stringToFfi(value.someField);
+  final _result = _smokeDeprecatedequatablestructCreateHandle(_someFieldHandle);
+  stringReleaseFfiHandle(_someFieldHandle);
+  return _result;
+}
+// ignore: deprecated_member_use_from_same_package
+DeprecatedEquatableStruct smokeDeprecatedequatablestructFromFfi(Pointer<Void> handle) {
+  final _someFieldHandle = _smokeDeprecatedequatablestructGetFieldsomeField(handle);
+  try {
+    // ignore: deprecated_member_use_from_same_package
+    return DeprecatedEquatableStruct(
+      stringFromFfi(_someFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_someFieldHandle);
+  }
+}
+void smokeDeprecatedequatablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeDeprecatedequatablestructReleaseHandle(handle);
+// Nullable DeprecatedEquatableStruct
+final _smokeDeprecatedequatablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedEquatableStruct_create_handle_nullable'));
+final _smokeDeprecatedequatablestructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecatedEquatableStruct_release_handle_nullable'));
+final _smokeDeprecatedequatablestructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedEquatableStruct_get_value_nullable'));
+// ignore: deprecated_member_use_from_same_package
+Pointer<Void> smokeDeprecatedequatablestructToFfiNullable(DeprecatedEquatableStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDeprecatedequatablestructToFfi(value);
+  final result = _smokeDeprecatedequatablestructCreateHandleNullable(_handle);
+  smokeDeprecatedequatablestructReleaseFfiHandle(_handle);
+  return result;
+}
+// ignore: deprecated_member_use_from_same_package
+DeprecatedEquatableStruct? smokeDeprecatedequatablestructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDeprecatedequatablestructGetValueNullable(handle);
+  final result = smokeDeprecatedequatablestructFromFfi(_handle);
+  smokeDeprecatedequatablestructReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDeprecatedequatablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDeprecatedequatablestructReleaseHandleNullable(handle);
+// End of DeprecatedEquatableStruct "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_from_lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_from_lambdas.dart
@@ -1,0 +1,157 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/deprecated_equatable_struct.dart';
+abstract class DeprecatedFromLambdas {
+  // ignore: deprecated_member_use_from_same_package
+  factory DeprecatedFromLambdas(
+    void Function(DeprecatedEquatableStruct) fooLambda,
+    DeprecatedEquatableStruct Function() barGetLambda,
+    void Function(DeprecatedEquatableStruct) barSetLambda
+  ) => DeprecatedFromLambdas$Lambdas(
+    fooLambda,
+    barGetLambda,
+    barSetLambda
+  );
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
+  void foo(DeprecatedEquatableStruct input);
+  DeprecatedEquatableStruct get bar;
+  set bar(DeprecatedEquatableStruct value);
+}
+// DeprecatedFromLambdas "private" section, not exported.
+final _smokeDeprecatedfromlambdasRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_DeprecatedFromLambdas_register_finalizer'));
+final _smokeDeprecatedfromlambdasCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedFromLambdas_copy_handle'));
+final _smokeDeprecatedfromlambdasReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecatedFromLambdas_release_handle'));
+final _smokeDeprecatedfromlambdasCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer, Pointer, Pointer)
+  >('library_smoke_DeprecatedFromLambdas_create_proxy'));
+final _smokeDeprecatedfromlambdasGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedFromLambdas_get_type_id'));
+class DeprecatedFromLambdas$Lambdas implements DeprecatedFromLambdas {
+  // ignore: deprecated_member_use_from_same_package
+  void Function(DeprecatedEquatableStruct) fooLambda;
+  // ignore: deprecated_member_use_from_same_package
+  DeprecatedEquatableStruct Function() barGetLambda;
+  // ignore: deprecated_member_use_from_same_package
+  void Function(DeprecatedEquatableStruct) barSetLambda;
+  DeprecatedFromLambdas$Lambdas(
+    this.fooLambda,
+    this.barGetLambda,
+    this.barSetLambda
+  );
+  @override
+  void release() {}
+  @override
+  // ignore: deprecated_member_use_from_same_package
+  void foo(DeprecatedEquatableStruct input) =>
+    fooLambda(input);
+  @override
+  // ignore: deprecated_member_use_from_same_package
+  DeprecatedEquatableStruct get bar => barGetLambda();
+  @override
+  // ignore: deprecated_member_use_from_same_package
+  set bar(DeprecatedEquatableStruct value) => barSetLambda(value);
+}
+class DeprecatedFromLambdas$Impl extends __lib.NativeBase implements DeprecatedFromLambdas {
+  DeprecatedFromLambdas$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  void foo(DeprecatedEquatableStruct input) {
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecatedFromLambdas_foo__DeprecatedEquatableStruct'));
+    final _inputHandle = smokeDeprecatedequatablestructToFfi(input);
+    final _handle = this.handle;
+    _fooFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+    smokeDeprecatedequatablestructReleaseFfiHandle(_inputHandle);
+  }
+  DeprecatedEquatableStruct get bar {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_DeprecatedFromLambdas_bar_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return smokeDeprecatedequatablestructFromFfi(__resultHandle);
+    } finally {
+      smokeDeprecatedequatablestructReleaseFfiHandle(__resultHandle);
+    }
+  }
+  set bar(DeprecatedEquatableStruct value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecatedFromLambdas_bar_set__DeprecatedEquatableStruct'));
+    final _valueHandle = smokeDeprecatedequatablestructToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    smokeDeprecatedequatablestructReleaseFfiHandle(_valueHandle);
+  }
+}
+int _smokeDeprecatedfromlambdasfooStatic(Object _obj, Pointer<Void> input) {
+  try {
+    (_obj as DeprecatedFromLambdas).foo(smokeDeprecatedequatablestructFromFfi(input));
+  } finally {
+    smokeDeprecatedequatablestructReleaseFfiHandle(input);
+  }
+  return 0;
+}
+int _smokeDeprecatedfromlambdasbarGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
+  _result.value = smokeDeprecatedequatablestructToFfi((_obj as DeprecatedFromLambdas).bar);
+  return 0;
+}
+int _smokeDeprecatedfromlambdasbarSetStatic(Object _obj, Pointer<Void> _value) {
+  try {
+    (_obj as DeprecatedFromLambdas).bar =
+      smokeDeprecatedequatablestructFromFfi(_value);
+  } finally {
+    smokeDeprecatedequatablestructReleaseFfiHandle(_value);
+  }
+  return 0;
+}
+Pointer<Void> smokeDeprecatedfromlambdasToFfi(DeprecatedFromLambdas value) {
+  if (value is __lib.NativeBase) return _smokeDeprecatedfromlambdasCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeDeprecatedfromlambdasCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeDeprecatedfromlambdasfooStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeDeprecatedfromlambdasbarGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeDeprecatedfromlambdasbarSetStatic, __lib.unknownError)
+  );
+  return result;
+}
+DeprecatedFromLambdas smokeDeprecatedfromlambdasFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is DeprecatedFromLambdas) return instance;
+  final _typeIdHandle = _smokeDeprecatedfromlambdasGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeDeprecatedfromlambdasCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : DeprecatedFromLambdas$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeDeprecatedfromlambdasRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeDeprecatedfromlambdasReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeDeprecatedfromlambdasReleaseHandle(handle);
+Pointer<Void> smokeDeprecatedfromlambdasToFfiNullable(DeprecatedFromLambdas? value) =>
+  value != null ? smokeDeprecatedfromlambdasToFfi(value) : Pointer<Void>.fromAddress(0);
+DeprecatedFromLambdas? smokeDeprecatedfromlambdasFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeDeprecatedfromlambdasFromFfi(handle) : null;
+void smokeDeprecatedfromlambdasReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDeprecatedfromlambdasReleaseHandle(handle);
+// End of DeprecatedFromLambdas "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_struct_ctor.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_struct_ctor.dart
@@ -1,0 +1,81 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class DeprecatedStructCtor {
+  @Deprecated("Unfortunately, this field is deprecated.\nUse [Comments_SomeStruct.someField] instead.")
+  String someField;
+  DeprecatedStructCtor._(this.someField);
+  // ignore: deprecated_member_use_from_same_package
+  DeprecatedStructCtor._copy(DeprecatedStructCtor _other) : this._(_other.someField);
+  DeprecatedStructCtor() : this._copy(_foo());
+  static DeprecatedStructCtor _foo() {
+    final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_DeprecatedStructCtor_foo'));
+    final __resultHandle = _fooFfi(__lib.LibraryContext.isolateId);
+    try {
+      return smokeDeprecatedstructctorFromFfi(__resultHandle);
+    } finally {
+      smokeDeprecatedstructctorReleaseFfiHandle(__resultHandle);
+    }
+  }
+}
+// DeprecatedStructCtor "private" section, not exported.
+final _smokeDeprecatedstructctorCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedStructCtor_create_handle'));
+final _smokeDeprecatedstructctorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecatedStructCtor_release_handle'));
+final _smokeDeprecatedstructctorGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedStructCtor_get_field_someField'));
+Pointer<Void> smokeDeprecatedstructctorToFfi(DeprecatedStructCtor value) {
+  // ignore: deprecated_member_use_from_same_package
+  final _someFieldHandle = stringToFfi(value.someField);
+  final _result = _smokeDeprecatedstructctorCreateHandle(_someFieldHandle);
+  stringReleaseFfiHandle(_someFieldHandle);
+  return _result;
+}
+DeprecatedStructCtor smokeDeprecatedstructctorFromFfi(Pointer<Void> handle) {
+  final _someFieldHandle = _smokeDeprecatedstructctorGetFieldsomeField(handle);
+  try {
+    return DeprecatedStructCtor._(
+      stringFromFfi(_someFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_someFieldHandle);
+  }
+}
+void smokeDeprecatedstructctorReleaseFfiHandle(Pointer<Void> handle) => _smokeDeprecatedstructctorReleaseHandle(handle);
+// Nullable DeprecatedStructCtor
+final _smokeDeprecatedstructctorCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedStructCtor_create_handle_nullable'));
+final _smokeDeprecatedstructctorReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DeprecatedStructCtor_release_handle_nullable'));
+final _smokeDeprecatedstructctorGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DeprecatedStructCtor_get_value_nullable'));
+Pointer<Void> smokeDeprecatedstructctorToFfiNullable(DeprecatedStructCtor? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDeprecatedstructctorToFfi(value);
+  final result = _smokeDeprecatedstructctorCreateHandleNullable(_handle);
+  smokeDeprecatedstructctorReleaseFfiHandle(_handle);
+  return result;
+}
+DeprecatedStructCtor? smokeDeprecatedstructctorFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDeprecatedstructctorGetValueNullable(handle);
+  final result = smokeDeprecatedstructctorFromFfi(_handle);
+  smokeDeprecatedstructctorReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDeprecatedstructctorReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDeprecatedstructctorReleaseHandleNullable(handle);
+// End of DeprecatedStructCtor "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
@@ -19,15 +19,18 @@ final _smokeDeprecatedwithnomessageGetFieldfield = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_get_field_field'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecatedwithnomessageToFfi(DeprecatedWithNoMessage value) {
   final _fieldHandle = stringToFfi(value.field);
   final _result = _smokeDeprecatedwithnomessageCreateHandle(_fieldHandle);
   stringReleaseFfiHandle(_fieldHandle);
   return _result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecatedWithNoMessage smokeDeprecatedwithnomessageFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeDeprecatedwithnomessageGetFieldfield(handle);
   try {
+    // ignore: deprecated_member_use_from_same_package
     return DeprecatedWithNoMessage(
       stringFromFfi(_fieldHandle)
     );
@@ -49,6 +52,7 @@ final _smokeDeprecatedwithnomessageGetValueNullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecatedWithNoMessage_get_value_nullable'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecatedwithnomessageToFfiNullable(DeprecatedWithNoMessage? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecatedwithnomessageToFfi(value);
@@ -56,6 +60,7 @@ Pointer<Void> smokeDeprecatedwithnomessageToFfiNullable(DeprecatedWithNoMessage?
   smokeDeprecatedwithnomessageReleaseFfiHandle(_handle);
   return result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecatedWithNoMessage? smokeDeprecatedwithnomessageFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecatedwithnomessageGetValueNullable(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -7,6 +7,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 abstract class DeprecationComments {
+  // ignore: deprecated_member_use_from_same_package
   factory DeprecationComments(
     bool Function(String) someMethodWithAllCommentsLambda,
     bool Function() isSomePropertyGetLambda,
@@ -54,19 +55,21 @@ enum DeprecationComments_SomeEnum {
     useless
 }
 // DeprecationComments_SomeEnum "private" section, not exported.
+// ignore: deprecated_member_use_from_same_package
 int smokeDeprecationcommentsSomeenumToFfi(DeprecationComments_SomeEnum value) {
   switch (value) {
-  case DeprecationComments_SomeEnum.useless:
   // ignore: deprecated_member_use_from_same_package
+  case DeprecationComments_SomeEnum.useless:
     return 0;
   default:
     throw StateError("Invalid enum value $value for DeprecationComments_SomeEnum enum.");
   }
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationComments_SomeEnum smokeDeprecationcommentsSomeenumFromFfi(int handle) {
   switch (handle) {
-  // ignore: deprecated_member_use_from_same_package
   case 0:
+    // ignore: deprecated_member_use_from_same_package
     return DeprecationComments_SomeEnum.useless;
   default:
     throw StateError("Invalid numeric value $handle for DeprecationComments_SomeEnum enum.");
@@ -85,6 +88,7 @@ final _smokeDeprecationcommentsSomeenumGetValueNullable = __lib.catchArgumentErr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeEnum_get_value_nullable'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsSomeenumToFfiNullable(DeprecationComments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsSomeenumToFfi(value);
@@ -92,6 +96,7 @@ Pointer<Void> smokeDeprecationcommentsSomeenumToFfiNullable(DeprecationComments_
   smokeDeprecationcommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationComments_SomeEnum? smokeDeprecationcommentsSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsSomeenumGetValueNullable(handle);
@@ -128,15 +133,19 @@ final _smokeDeprecationcommentsSomestructGetFieldsomeField = __lib.catchArgument
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_get_field_someField'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsSomestructToFfi(DeprecationComments_SomeStruct value) {
+  // ignore: deprecated_member_use_from_same_package
   final _someFieldHandle = booleanToFfi(value.someField);
   final _result = _smokeDeprecationcommentsSomestructCreateHandle(_someFieldHandle);
   booleanReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationComments_SomeStruct smokeDeprecationcommentsSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeDeprecationcommentsSomestructGetFieldsomeField(handle);
   try {
+    // ignore: deprecated_member_use_from_same_package
     return DeprecationComments_SomeStruct(
       booleanFromFfi(_someFieldHandle)
     );
@@ -158,6 +167,7 @@ final _smokeDeprecationcommentsSomestructGetValueNullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_get_value_nullable'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsSomestructToFfiNullable(DeprecationComments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsSomestructToFfi(value);
@@ -165,6 +175,7 @@ Pointer<Void> smokeDeprecationcommentsSomestructToFfiNullable(DeprecationComment
   smokeDeprecationcommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationComments_SomeStruct? smokeDeprecationcommentsSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsSomestructGetValueNullable(handle);
@@ -196,9 +207,13 @@ final _smokeDeprecationcommentsGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_get_type_id'));
+// ignore: deprecated_member_use_from_same_package
 class DeprecationComments$Lambdas implements DeprecationComments {
+  // ignore: deprecated_member_use_from_same_package
   bool Function(String) someMethodWithAllCommentsLambda;
+  // ignore: deprecated_member_use_from_same_package
   bool Function() isSomePropertyGetLambda;
+  // ignore: deprecated_member_use_from_same_package
   void Function(bool) isSomePropertySetLambda;
   String Function() propertyButNotAccessorsGetLambda;
   void Function(String) propertyButNotAccessorsSetLambda;
@@ -212,17 +227,21 @@ class DeprecationComments$Lambdas implements DeprecationComments {
   @override
   void release() {}
   @override
+  // ignore: deprecated_member_use_from_same_package
   bool someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
+  // ignore: deprecated_member_use_from_same_package
   bool get isSomeProperty => isSomePropertyGetLambda();
   @override
+  // ignore: deprecated_member_use_from_same_package
   set isSomeProperty(bool value) => isSomePropertySetLambda(value);
   @override
   String get propertyButNotAccessors => propertyButNotAccessorsGetLambda();
   @override
   set propertyButNotAccessors(String value) => propertyButNotAccessorsSetLambda(value);
 }
+// ignore: deprecated_member_use_from_same_package
 class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationComments {
   DeprecationComments$Impl(Pointer<Void> handle) : super(handle);
   @override
@@ -285,6 +304,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
 int _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
   bool? _resultObject;
   try {
+    // ignore: deprecated_member_use_from_same_package
     _resultObject = (_obj as DeprecationComments).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
   } finally {
@@ -293,11 +313,13 @@ int _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(Object _obj, Pointe
   return 0;
 }
 int _smokeDeprecationcommentsisSomePropertyGetStatic(Object _obj, Pointer<Uint8> _result) {
+  // ignore: deprecated_member_use_from_same_package
   _result.value = booleanToFfi((_obj as DeprecationComments).isSomeProperty);
   return 0;
 }
 int _smokeDeprecationcommentsisSomePropertySetStatic(Object _obj, int _value) {
   try {
+    // ignore: deprecated_member_use_from_same_package
     (_obj as DeprecationComments).isSomeProperty =
       booleanFromFfi(_value);
   } finally {
@@ -306,11 +328,13 @@ int _smokeDeprecationcommentsisSomePropertySetStatic(Object _obj, int _value) {
   return 0;
 }
 int _smokeDeprecationcommentspropertyButNotAccessorsGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
+  // ignore: deprecated_member_use_from_same_package
   _result.value = stringToFfi((_obj as DeprecationComments).propertyButNotAccessors);
   return 0;
 }
 int _smokeDeprecationcommentspropertyButNotAccessorsSetStatic(Object _obj, Pointer<Void> _value) {
   try {
+    // ignore: deprecated_member_use_from_same_package
     (_obj as DeprecationComments).propertyButNotAccessors =
       stringFromFfi(_value);
   } finally {
@@ -318,6 +342,7 @@ int _smokeDeprecationcommentspropertyButNotAccessorsSetStatic(Object _obj, Point
   }
   return 0;
 }
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsToFfi(DeprecationComments value) {
   if (value is __lib.NativeBase) return _smokeDeprecationcommentsCopyHandle((value as __lib.NativeBase).handle);
   final result = _smokeDeprecationcommentsCreateProxy(
@@ -332,8 +357,10 @@ Pointer<Void> smokeDeprecationcommentsToFfi(DeprecationComments value) {
   );
   return result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationComments smokeDeprecationcommentsFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
+  // ignore: deprecated_member_use_from_same_package
   if (instance != null && instance is DeprecationComments) return instance;
   final _typeIdHandle = _smokeDeprecationcommentsGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
@@ -348,8 +375,10 @@ DeprecationComments smokeDeprecationcommentsFromFfi(Pointer<Void> handle) {
 }
 void smokeDeprecationcommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDeprecationcommentsReleaseHandle(handle);
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsToFfiNullable(DeprecationComments? value) =>
   value != null ? smokeDeprecationcommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+// ignore: deprecated_member_use_from_same_package
 DeprecationComments? smokeDeprecationcommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDeprecationcommentsFromFfi(handle) : null;
 void smokeDeprecationcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -6,6 +6,7 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 @Deprecated("Unfortunately, this interface is deprecated.")
 abstract class DeprecationCommentsOnly {
+  // ignore: deprecated_member_use_from_same_package
   factory DeprecationCommentsOnly(
     bool Function(String) someMethodWithAllCommentsLambda,
     bool Function() isSomePropertyGetLambda,
@@ -37,19 +38,21 @@ enum DeprecationCommentsOnly_SomeEnum {
     useless
 }
 // DeprecationCommentsOnly_SomeEnum "private" section, not exported.
+// ignore: deprecated_member_use_from_same_package
 int smokeDeprecationcommentsonlySomeenumToFfi(DeprecationCommentsOnly_SomeEnum value) {
   switch (value) {
-  case DeprecationCommentsOnly_SomeEnum.useless:
   // ignore: deprecated_member_use_from_same_package
+  case DeprecationCommentsOnly_SomeEnum.useless:
     return 0;
   default:
     throw StateError("Invalid enum value $value for DeprecationCommentsOnly_SomeEnum enum.");
   }
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationCommentsOnly_SomeEnum smokeDeprecationcommentsonlySomeenumFromFfi(int handle) {
   switch (handle) {
-  // ignore: deprecated_member_use_from_same_package
   case 0:
+    // ignore: deprecated_member_use_from_same_package
     return DeprecationCommentsOnly_SomeEnum.useless;
   default:
     throw StateError("Invalid numeric value $handle for DeprecationCommentsOnly_SomeEnum enum.");
@@ -68,6 +71,7 @@ final _smokeDeprecationcommentsonlySomeenumGetValueNullable = __lib.catchArgumen
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsonlySomeenumToFfiNullable(DeprecationCommentsOnly_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsonlySomeenumToFfi(value);
@@ -75,6 +79,7 @@ Pointer<Void> smokeDeprecationcommentsonlySomeenumToFfiNullable(DeprecationComme
   smokeDeprecationcommentsonlySomeenumReleaseFfiHandle(_handle);
   return result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationCommentsOnly_SomeEnum? smokeDeprecationcommentsonlySomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsonlySomeenumGetValueNullable(handle);
@@ -104,15 +109,19 @@ final _smokeDeprecationcommentsonlySomestructGetFieldsomeField = __lib.catchArgu
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsonlySomestructToFfi(DeprecationCommentsOnly_SomeStruct value) {
+  // ignore: deprecated_member_use_from_same_package
   final _someFieldHandle = booleanToFfi(value.someField);
   final _result = _smokeDeprecationcommentsonlySomestructCreateHandle(_someFieldHandle);
   booleanReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationCommentsOnly_SomeStruct smokeDeprecationcommentsonlySomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeDeprecationcommentsonlySomestructGetFieldsomeField(handle);
   try {
+    // ignore: deprecated_member_use_from_same_package
     return DeprecationCommentsOnly_SomeStruct(
       booleanFromFfi(_someFieldHandle)
     );
@@ -134,6 +143,7 @@ final _smokeDeprecationcommentsonlySomestructGetValueNullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable'));
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsonlySomestructToFfiNullable(DeprecationCommentsOnly_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsonlySomestructToFfi(value);
@@ -141,6 +151,7 @@ Pointer<Void> smokeDeprecationcommentsonlySomestructToFfiNullable(DeprecationCom
   smokeDeprecationcommentsonlySomestructReleaseFfiHandle(_handle);
   return result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationCommentsOnly_SomeStruct? smokeDeprecationcommentsonlySomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsonlySomestructGetValueNullable(handle);
@@ -172,9 +183,13 @@ final _smokeDeprecationcommentsonlyGetTypeId = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_get_type_id'));
+// ignore: deprecated_member_use_from_same_package
 class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
+  // ignore: deprecated_member_use_from_same_package
   bool Function(String) someMethodWithAllCommentsLambda;
+  // ignore: deprecated_member_use_from_same_package
   bool Function() isSomePropertyGetLambda;
+  // ignore: deprecated_member_use_from_same_package
   void Function(bool) isSomePropertySetLambda;
   DeprecationCommentsOnly$Lambdas(
     this.someMethodWithAllCommentsLambda,
@@ -184,13 +199,17 @@ class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
   @override
   void release() {}
   @override
+  // ignore: deprecated_member_use_from_same_package
   bool someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
+  // ignore: deprecated_member_use_from_same_package
   bool get isSomeProperty => isSomePropertyGetLambda();
   @override
+  // ignore: deprecated_member_use_from_same_package
   set isSomeProperty(bool value) => isSomePropertySetLambda(value);
 }
+// ignore: deprecated_member_use_from_same_package
 class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements DeprecationCommentsOnly {
   DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
@@ -231,6 +250,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
 int _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
   bool? _resultObject;
   try {
+    // ignore: deprecated_member_use_from_same_package
     _resultObject = (_obj as DeprecationCommentsOnly).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
   } finally {
@@ -239,11 +259,13 @@ int _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(Object _obj, Po
   return 0;
 }
 int _smokeDeprecationcommentsonlyisSomePropertyGetStatic(Object _obj, Pointer<Uint8> _result) {
+  // ignore: deprecated_member_use_from_same_package
   _result.value = booleanToFfi((_obj as DeprecationCommentsOnly).isSomeProperty);
   return 0;
 }
 int _smokeDeprecationcommentsonlyisSomePropertySetStatic(Object _obj, int _value) {
   try {
+    // ignore: deprecated_member_use_from_same_package
     (_obj as DeprecationCommentsOnly).isSomeProperty =
       booleanFromFfi(_value);
   } finally {
@@ -251,6 +273,7 @@ int _smokeDeprecationcommentsonlyisSomePropertySetStatic(Object _obj, int _value
   }
   return 0;
 }
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsonlyToFfi(DeprecationCommentsOnly value) {
   if (value is __lib.NativeBase) return _smokeDeprecationcommentsonlyCopyHandle((value as __lib.NativeBase).handle);
   final result = _smokeDeprecationcommentsonlyCreateProxy(
@@ -263,8 +286,10 @@ Pointer<Void> smokeDeprecationcommentsonlyToFfi(DeprecationCommentsOnly value) {
   );
   return result;
 }
+// ignore: deprecated_member_use_from_same_package
 DeprecationCommentsOnly smokeDeprecationcommentsonlyFromFfi(Pointer<Void> handle) {
   final instance = __lib.getCachedInstance(handle);
+  // ignore: deprecated_member_use_from_same_package
   if (instance != null && instance is DeprecationCommentsOnly) return instance;
   final _typeIdHandle = _smokeDeprecationcommentsonlyGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
@@ -279,8 +304,10 @@ DeprecationCommentsOnly smokeDeprecationcommentsonlyFromFfi(Pointer<Void> handle
 }
 void smokeDeprecationcommentsonlyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDeprecationcommentsonlyReleaseHandle(handle);
+// ignore: deprecated_member_use_from_same_package
 Pointer<Void> smokeDeprecationcommentsonlyToFfiNullable(DeprecationCommentsOnly? value) =>
   value != null ? smokeDeprecationcommentsonlyToFfi(value) : Pointer<Void>.fromAddress(0);
+// ignore: deprecated_member_use_from_same_package
 DeprecationCommentsOnly? smokeDeprecationcommentsonlyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDeprecationcommentsonlyFromFfi(handle) : null;
 void smokeDeprecationcommentsonlyReleaseFfiHandleNullable(Pointer<Void> handle) =>

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:ffi';
 import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:ffi';
 import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/some_skipped_struct.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/some_skipped_struct.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:ffi';
 import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;


### PR DESCRIPTION
Moved the suppression comment for "deprecated_member_use_from_same_package" Dart analyzer warnings
to the corrent line for it to have effect.

Removed extraneous "dart:collections" import for `@Equatable` structs with collection fields.

Resolves: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>