### PR TITLE
Remove secondary contructor of LimeOverloadsValidator

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
@@ -26,7 +26,7 @@ import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeSignatureResolver
 
-internal open class PlatformSignatureResolver(
+internal abstract class PlatformSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val platformAttributeType: LimeAttributeType,
     private val nameRules: NameRules

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGenerator.kt
@@ -33,7 +33,6 @@ import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.nameRuleSetFromConfig
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.CppGeneratorPredicates.predicates
-import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeType.EQUATABLE
 import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeContainer
@@ -90,8 +89,8 @@ internal class CppGenerator : Generator {
             LimeModelFilter.filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags) }
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
-        val overloadsValidator =
-            LimeOverloadsValidator(filteredModel.referenceMap, LimeAttributeType.CPP, nameRules, limeLogger)
+        val signatureResolver = CppSignatureResolver(filteredModel.referenceMap, nameRules)
+        val overloadsValidator = LimeOverloadsValidator(signatureResolver, limeLogger)
         val validationResult = overloadsValidator.validate(filteredModel.topElements)
         if (!validationResult) {
             throw GluecodiumExecutionException("Validation errors found, see log for details.")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.NameResolver
-import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.CPP
 import com.here.gluecodium.model.lime.LimeAttributeType.OPTIMIZED
@@ -73,7 +72,7 @@ internal class CppNameResolver(
     private val optionalTypeName = (listOf("") + internalNamespace + "optional").joinToString("::")
     private val localeTypeName = (listOf("") + internalNamespace + "Locale").joinToString("::")
 
-    private val signatureResolver = PlatformSignatureResolver(limeReferenceMap, CPP, nameCache.nameRules)
+    private val signatureResolver = CppSignatureResolver(limeReferenceMap, nameCache.nameRules)
     private val limeToCppNames = buildPathMap()
 
     override fun resolveName(element: Any): String =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSignatureResolver.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.cpp
+
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeElement
+
+internal class CppSignatureResolver(
+    limeReferenceMap: Map<String, LimeElement>,
+    nameRules: CppNameRules
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.CPP, nameRules)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -92,7 +92,8 @@ internal class JavaGenerator : Generator {
             .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, JAVA, retainFunctions = false) }
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
-        val overloadsValidator = LimeOverloadsValidator(limeModel.referenceMap, JAVA, javaNameRules, limeLogger)
+        val overloadsValidator =
+            LimeOverloadsValidator(JavaSignatureResolver(limeModel.referenceMap, javaNameRules), limeLogger)
         val validationResult = overloadsValidator.validate(jniFilteredModel.topElements)
         if (!validationResult) {
             throw GluecodiumExecutionException("Validation errors found, see log for details.")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -100,7 +100,8 @@ internal class SwiftGenerator : Generator {
             .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, SWIFT, retainFunctions = false) }
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
-        val overloadsValidator = LimeOverloadsValidator(limeModel.referenceMap, SWIFT, nameRules, limeLogger)
+        val overloadsValidator =
+            LimeOverloadsValidator(SwiftSignatureResolver(limeModel.referenceMap, nameRules), limeLogger)
         val weakPropertiesValidator = SwiftWeakPropertiesValidator(limeLogger)
         val validationResults = listOf(
             overloadsValidator.validate(cbridgeFilteredModel.topElements),

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeOverloadsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeOverloadsValidator.kt
@@ -20,9 +20,6 @@
 package com.here.gluecodium.validator
 
 import com.here.gluecodium.common.LimeLogger
-import com.here.gluecodium.generator.common.NameRules
-import com.here.gluecodium.generator.common.PlatformSignatureResolver
-import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeSignatureResolver
@@ -31,13 +28,6 @@ internal class LimeOverloadsValidator(
     private val signatureResolver: LimeSignatureResolver,
     private val logger: LimeLogger
 ) {
-    constructor(
-        referenceMap: Map<String, LimeElement>,
-        platformAttributeType: LimeAttributeType,
-        nameRules: NameRules,
-        logger: LimeLogger
-    ) : this(PlatformSignatureResolver(referenceMap, platformAttributeType, nameRules), logger)
-
     fun validate(limeModel: Collection<LimeElement>): Boolean {
         val validationResults =
             limeModel.filterIsInstance<LimeFunction>().map { validateFunction(it, signatureResolver) }


### PR DESCRIPTION
Refactored LimeOverloadsValidator to remove the secondary constructor and always pass an explicit
LimeSignatureResolver instead. This reduces the coupling between these two classes and make
LimeOverloadsValidator unaffected by future LimeSignatureResolver refactorings.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>