### PR TITLE
Use retain predicate in PlatformsSignatureResolver

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
@@ -45,10 +45,9 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 internal class CBridgeNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val swiftNameRules: SwiftNameRules,
-    private val internalPrefix: String
+    private val internalPrefix: String,
+    private val signatureResolver: SwiftSignatureResolver
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
-
-    private val signatureResolver = SwiftSignatureResolver(limeReferenceMap, swiftNameRules)
 
     override fun resolveName(element: Any): String =
         when (element) {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
@@ -19,6 +19,7 @@
 
 package com.here.gluecodium.generator.common
 
+import com.here.gluecodium.common.LimeModelSkipPredicates
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeContainer
@@ -29,11 +30,13 @@ import com.here.gluecodium.model.lime.LimeSignatureResolver
 internal abstract class PlatformSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val platformAttributeType: LimeAttributeType,
-    private val nameRules: NameRules
+    private val nameRules: NameRules,
+    private val activeTags: Set<String>
 ) : LimeSignatureResolver(limeReferenceMap) {
 
     override fun getAllContainerFunctions(limeContainer: LimeContainer) =
-        limeContainer.functions.filterNot { it.attributes.have(platformAttributeType, LimeAttributeValueType.SKIP) }
+        limeContainer.functions
+            .filter { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, platformAttributeType) }
 
     override fun getFunctionName(limeFunction: LimeFunction) =
         limeFunction.attributes.get(platformAttributeType, LimeAttributeValueType.NAME, String::class.java)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSignatureResolver.kt
@@ -26,4 +26,4 @@ import com.here.gluecodium.model.lime.LimeElement
 internal class CppSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
     nameRules: CppNameRules
-) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.CPP, nameRules)
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.CPP, nameRules, emptySet())

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -92,8 +92,8 @@ internal class JavaGenerator : Generator {
             .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, JAVA, retainFunctions = false) }
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
-        val overloadsValidator =
-            LimeOverloadsValidator(JavaSignatureResolver(limeModel.referenceMap, javaNameRules), limeLogger)
+        val signatureResolver = JavaSignatureResolver(limeModel.referenceMap, javaNameRules, activeTags)
+        val overloadsValidator = LimeOverloadsValidator(signatureResolver, limeLogger)
         val validationResult = overloadsValidator.validate(jniFilteredModel.topElements)
         if (!validationResult) {
             throw GluecodiumExecutionException("Validation errors found, see log for details.")
@@ -104,7 +104,8 @@ internal class JavaGenerator : Generator {
             basePackages = basePackages,
             javaNameRules = javaNameRules,
             limeLogger = limeLogger,
-            commentsProcessor = commentsProcessor
+            commentsProcessor = commentsProcessor,
+            signatureResolver = signatureResolver
         )
         val importResolver = JavaImportResolver(
             limeReferenceMap = limeModel.referenceMap,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -55,11 +55,11 @@ internal class JavaNameResolver(
     private val basePackages: List<String>,
     private val javaNameRules: JavaNameRules,
     private val limeLogger: LimeLogger,
-    private val commentsProcessor: CommentsProcessor
+    private val commentsProcessor: CommentsProcessor,
+    private val signatureResolver: JavaSignatureResolver
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     private val valueResolver = JavaValueResolver(this)
-    private val signatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules)
     private val limeToJavaNames = buildPathMap()
 
     override fun resolveName(element: Any): String =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaSignatureResolver.kt
@@ -26,8 +26,9 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal class JavaSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
-    nameRules: JavaNameRules
-) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.JAVA, nameRules) {
+    nameRules: JavaNameRules,
+    activeTags: Set<String>
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.JAVA, nameRules, activeTags) {
 
     override fun getArrayName(elementType: LimeTypeRef) = TYPE_ERASED_ARRAY
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -48,7 +48,7 @@ internal class JniGeneratorPredicates(
     cppNameResolver: CppNameResolver,
     activeTags: Set<String>
 ) {
-    private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules)
+    private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules, activeTags)
 
     val predicates = mapOf(
         "hasConstructors" to { limeContainer: Any ->

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -44,10 +44,11 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 /**
  * List of predicates used by `ifPredicate`/`unlessPredicate` template helpers in Swift generator.
  */
-internal class SwiftGeneratorPredicates(limeReferenceMap: Map<String, LimeElement>, nameRules: SwiftNameRules) {
-
-    private val signatureResolver = SwiftSignatureResolver(limeReferenceMap, nameRules)
-
+internal class SwiftGeneratorPredicates(
+    limeReferenceMap: Map<String, LimeElement>,
+    nameRules: SwiftNameRules,
+    private val signatureResolver: SwiftSignatureResolver
+) {
     val predicates = mapOf(
         "hasAnyComment" to { limeElement: Any ->
             CommonGeneratorPredicates.hasAnyComment(limeElement, "Swift")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -57,7 +57,8 @@ internal class SwiftNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val nameRules: SwiftNameRules,
     private val limeLogger: LimeLogger,
-    private val commentsProcessor: CommentsProcessor
+    private val commentsProcessor: CommentsProcessor,
+    private val signatureResolver: SwiftSignatureResolver
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     private val limeToSwiftNames = buildPathMap()
@@ -196,7 +197,6 @@ internal class SwiftNameResolver(
             .associateBy({ it.fullName }, { resolveFullName(it) })
             .toMutableMap()
 
-        val signatureResolver = SwiftSignatureResolver(limeReferenceMap, nameRules)
         limeReferenceMap.values.filterIsInstance<LimeFunction>().forEach { function ->
             val ambiguousKey = function.path.withSuffix("").toString()
             val functionCommentRef = resolveCommentRef(function, signatureResolver)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
@@ -25,5 +25,6 @@ import com.here.gluecodium.model.lime.LimeElement
 
 internal class SwiftSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
-    nameRules: SwiftNameRules
-) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.SWIFT, nameRules)
+    nameRules: SwiftNameRules,
+    activeTags: Set<String>
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.SWIFT, nameRules, activeTags)


### PR DESCRIPTION
Updated PlatformsSignatureResolver to use `LimeModelSkipPredicates.shouldRetainElement()` instead of
simply checking the `SKIP` attribute. This is a part of the fix of the misuse of `SKIP` attribute.

See: #1000
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>