### PR TITLE
Fix Java compilation for nullabe unsigned ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed compilation issues caused by tag-based platform-specific skip attributes when the custom tag is not set.
+  * Fixed Java compilation issues for nullable unsigned integer types.
 
 ## 9.3.3
 Release date: 2021-07-20

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -345,7 +345,7 @@ feature(Nullable cpp android swift dart SOURCES
     input/src/cpp/NullableCollections.cpp
 
     input/lime/NullableInstances.lime
-    input/lime/NullableInterface.lime
+    input/lime/Nullability.lime
     input/lime/NullableCollections.lime
 )
 

--- a/functional-tests/functional/input/lime/Nullability.lime
+++ b/functional-tests/functional/input/lime/Nullability.lime
@@ -62,6 +62,7 @@ class NullableInterface {
     fun methodWithNullableIntsStruct(
         input: NullableIntsStruct
     ): NullableIntsStruct
+
     fun methodWithString(
         input: String?
     ): String?
@@ -74,6 +75,8 @@ class NullableInterface {
     fun methodWithInt(
         input: Long?
     ): Long?
+    fun methodWithUint(input: UInt?): UInt?
+
     fun methodWithSomeStruct(
         input: SomeStruct?
     ): SomeStruct?

--- a/functional-tests/functional/input/src/cpp/NullableInterfaceImpl.cpp
+++ b/functional-tests/functional/input/src/cpp/NullableInterfaceImpl.cpp
@@ -67,6 +67,9 @@ NullableInterfaceImpl::method_with_int( const optional< int64_t >& input )
     return input;
 }
 
+optional<uint32_t>
+NullableInterfaceImpl::method_with_uint(const optional<uint32_t>& input) { return input; }
+
 optional< NullableInterface::SomeStruct >
 NullableInterfaceImpl::method_with_some_struct( const optional< NullableInterface::SomeStruct >& input )
 {

--- a/functional-tests/functional/input/src/cpp/NullableInterfaceImpl.h
+++ b/functional-tests/functional/input/src/cpp/NullableInterfaceImpl.h
@@ -41,6 +41,7 @@ public:
         const Optional< double >& input ) override;
     Optional< int64_t > method_with_int(
         const Optional< int64_t >& input ) override;
+    Optional<uint32_t> method_with_uint(const Optional<uint32_t>& input) override;
     Optional< SomeStruct > method_with_some_struct(
         const Optional< SomeStruct >& input ) override;
     Optional< SomeEnum > method_with_some_enum(

--- a/gluecodium/src/main/resources/templates/jni/utils/BoxingConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/BoxingConversionUtilsHeader.mustache
@@ -70,6 +70,10 @@ JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalN
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<int16_t> nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<int32_t> nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<int64_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint8_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint16_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint32_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint64_t> nvalue );
 
 JNIEXPORT {{>common/InternalNamespace}}optional<bool> convert_from_jni(
     JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<bool>* );


### PR DESCRIPTION
Added missing JNI function exports for nullabe unsigned integer types to BoxingConversionUtilsHeader
template. The implementation was already there, just the header exports were missing.

Added a functional test as a regression test.

Resolves: #1003
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>