### PR TITLE
Fix `SKIP` attribute misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issues caused by tag-based platform-specific skip attributes when the custom tag is not set.
+
 ## 9.3.3
 Release date: 2021-07-20
 ### Bug fixes:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGeneratorPredicates.kt
@@ -37,8 +37,8 @@ import com.here.gluecodium.model.lime.LimeTypeRef
  */
 internal class CBridgeGeneratorPredicates(
     cppNameResolver: CppNameResolver,
-    limeReferenceMap: Map<String, LimeElement>,
-    activeTags: Set<String>
+    private val limeReferenceMap: Map<String, LimeElement>,
+    private val activeTags: Set<String>
 ) {
     val predicates = mapOf(
         "hasCppGetter" to { limeField: Any ->
@@ -64,8 +64,10 @@ internal class CBridgeGeneratorPredicates(
             }
         },
         "shouldRetain" to { limeElement: Any ->
-            limeElement is LimeNamedElement &&
-                LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, SWIFT, limeReferenceMap)
+            limeElement is LimeNamedElement && shouldRetain(limeElement)
         }
     )
+
+    fun shouldRetain(limeElement: LimeNamedElement) =
+        LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, SWIFT, limeReferenceMap)
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeHeaderIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeHeaderIncludeResolver.kt
@@ -24,8 +24,6 @@ import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.EQUATABLE
 import com.here.gluecodium.model.lime.LimeAttributeType.POINTER_EQUATABLE
-import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
-import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeContainer
@@ -47,9 +45,8 @@ internal class CBridgeHeaderIncludeResolver(
     private val fileNames: CBridgeFileNames
 ) : ReferenceMapBasedResolver(limeReferenceMap), ImportsResolver<Include> {
 
-    override fun resolveElementImports(limeElement: LimeElement): List<Include> {
-        if (limeElement.attributes.have(SWIFT, SKIP)) return emptyList()
-        return when (limeElement) {
+    override fun resolveElementImports(limeElement: LimeElement) =
+        when (limeElement) {
             is LimeConstant -> emptyList()
             is LimeTypeRef -> resolveTypeRefIncludes(limeElement)
             is LimeReturnType -> resolveTypeRefIncludes(limeElement.typeRef)
@@ -62,7 +59,6 @@ internal class CBridgeHeaderIncludeResolver(
             is LimeMap -> resolveTypeRefIncludes(limeElement.keyType) + resolveTypeRefIncludes(limeElement.valueType)
             else -> emptyList()
         }
-    }
 
     private fun resolveContainerIncludes(limeContainer: LimeContainer) =
         when {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
@@ -24,8 +24,6 @@ import com.here.gluecodium.generator.common.ImportsResolver
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.cpp.CppIncludeResolver
 import com.here.gluecodium.generator.cpp.CppLibraryIncludes
-import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
-import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeContainer
@@ -50,9 +48,8 @@ import java.io.File
 internal class CBridgeImplIncludeResolver(private val cppIncludeResolver: CppIncludeResolver) :
     ImportsResolver<Include> {
 
-    override fun resolveElementImports(limeElement: LimeElement): List<Include> {
-        if (limeElement.attributes.have(SWIFT, SKIP)) return emptyList()
-        return when (limeElement) {
+    override fun resolveElementImports(limeElement: LimeElement) =
+        when (limeElement) {
             is LimeTypesCollection, is LimeConstant -> emptyList()
             is LimeTypeRef -> resolveTypeRefIncludes(limeElement)
             is LimeReturnType -> resolveTypeRefIncludes(limeElement.typeRef)
@@ -66,7 +63,6 @@ internal class CBridgeImplIncludeResolver(private val cppIncludeResolver: CppInc
             is LimeType -> cppIncludeResolver.resolveElementImports(limeElement)
             else -> emptyList()
         }
-    }
 
     private fun resolveClassInterfaceIncludes(limeContainer: LimeContainerWithInheritance): List<Include> {
         val containerIncludes = resolveContainerIncludes(limeContainer)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
@@ -20,8 +20,6 @@
 package com.here.gluecodium.generator.java
 
 import com.here.gluecodium.generator.common.ImportsCollector
-import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
-import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeContainer
@@ -33,10 +31,13 @@ import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeStruct
 
-internal class JavaImportCollector(private val importsResolver: JavaImportResolver) : ImportsCollector<JavaImport> {
+internal class JavaImportCollector(
+    private val importsResolver: JavaImportResolver,
+    private val retainPredicate: (LimeNamedElement) -> Boolean
+) : ImportsCollector<JavaImport> {
 
     override fun collectImports(limeElement: LimeNamedElement): List<JavaImport> {
-        if (limeElement.attributes.have(JAVA, SKIP)) return emptyList()
+        if (!retainPredicate(limeElement)) return emptyList()
 
         val nestedImports = when (limeElement) {
             is LimeStruct ->

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -43,10 +43,10 @@ import com.here.gluecodium.model.lime.LimeTypeRef
  * List of predicates used by `ifPredicate`/`unlessPredicate` template helpers in JNI generator.
  */
 internal class JniGeneratorPredicates(
-    limeReferenceMap: Map<String, LimeElement>,
+    private val limeReferenceMap: Map<String, LimeElement>,
     javaNameRules: JavaNameRules,
     cppNameResolver: CppNameResolver,
-    activeTags: Set<String>
+    private val activeTags: Set<String>
 ) {
     private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules, activeTags)
 
@@ -87,10 +87,12 @@ internal class JniGeneratorPredicates(
                 limeFunction.returnType.typeRef.type is LimeClass
         },
         "shouldRetain" to { limeElement: Any ->
-            limeElement is LimeNamedElement &&
-                LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, JAVA, limeReferenceMap)
+            limeElement is LimeNamedElement && shouldRetain(limeElement)
         }
     )
+
+    fun shouldRetain(limeElement: LimeNamedElement) =
+        LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, JAVA, limeReferenceMap)
 
     companion object {
         fun hasThrowingFunctions(limeElement: LimeNamedElement) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniIncludeCollector.kt
@@ -21,8 +21,6 @@ package com.here.gluecodium.generator.jni
 
 import com.here.gluecodium.generator.common.ImportsCollector
 import com.here.gluecodium.generator.common.Include
-import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
-import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeFunction
@@ -31,7 +29,10 @@ import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeStruct
 
-internal class JniIncludeCollector(private val includeResolver: JniIncludeResolver) : ImportsCollector<Include> {
+internal class JniIncludeCollector(
+    private val includeResolver: JniIncludeResolver,
+    private val retainPredicate: (LimeNamedElement) -> Boolean
+) : ImportsCollector<Include> {
 
     override fun collectImports(limeElement: LimeNamedElement) =
         when (limeElement) {
@@ -48,8 +49,8 @@ internal class JniIncludeCollector(private val includeResolver: JniIncludeResolv
 
     private fun collectImplIncludes(functions: List<LimeFunction>, properties: List<LimeProperty>): List<Include> {
         val allFunctions = functions +
-            properties.filterNot { it.attributes.have(JAVA, SKIP) }.flatMap { listOfNotNull(it.getter, it.setter) }
-        return allFunctions.filterNot { it.attributes.have(JAVA, SKIP) }
+            properties.filter(retainPredicate).flatMap { listOfNotNull(it.getter, it.setter) }
+        return allFunctions.filter(retainPredicate)
             .flatMap { collectFunctionTypes(it) }
             .flatMap { includeResolver.resolveElementImports(it) }
     }

--- a/gluecodium/src/test/resources/smoke/skip/input/OtherPackage.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/OtherPackage.lime
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package dont.smoke
+
+enum DontSmokeEnum {
+    FOO
+}

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTagsIncludes.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTagsIncludes.lime
@@ -1,0 +1,35 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Dart(Skip = "Pro")
+enum SomeSkippedEnum {
+    FOO
+}
+
+@Dart(Skip = "Pro")
+@Equatable
+struct SomeSkippedStruct {
+    field: List<SomeSkippedEnum>
+}
+
+@Java(Skip = "Pro")
+@Swift(Skip = "Pro")
+class SomeSkippedClass {
+    fun doFoo(): dont.smoke.DontSmokeEnum
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SomeSkippedClass.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SomeSkippedClass.java
@@ -1,0 +1,24 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+import com.example.dont.smoke.DontSmokeEnum;
+public final class SomeSkippedClass extends NativeBase {
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected SomeSkippedClass(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    @NonNull
+    public native DontSmokeEnum doFoo();
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SomeSkippedClass.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SomeSkippedClass.cpp
@@ -1,0 +1,31 @@
+/*
+ *
+ */
+#include "com_example_dont_smoke_DontSmokeEnum__Conversion.h"
+#include "com_example_smoke_SomeSkippedClass.h"
+#include "com_example_smoke_SomeSkippedClass__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+jobject
+Java_com_example_smoke_SomeSkippedClass_doFoo(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SomeSkippedClass>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    auto result = (*pInstanceSharedPointer)->do_foo();
+    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SomeSkippedClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SomeSkippedClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SomeSkippedClass.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SomeSkippedClass.cpp
@@ -1,0 +1,34 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_SomeSkippedClass.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "dont/smoke/DontSmokeEnum.h"
+#include "smoke/SomeSkippedClass.h"
+#include <memory>
+#include <new>
+void smoke_SomeSkippedClass_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::SomeSkippedClass >>(handle);
+}
+_baseRef smoke_SomeSkippedClass_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::SomeSkippedClass >>(handle)))
+        : 0;
+}
+const void* smoke_SomeSkippedClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SomeSkippedClass >>(handle)->get())
+        : nullptr;
+}
+void smoke_SomeSkippedClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::SomeSkippedClass >>(handle)->get(), swift_pointer);
+}
+void smoke_SomeSkippedClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SomeSkippedClass >>(handle)->get());
+}
+dont_smoke_DontSmokeEnum smoke_SomeSkippedClass_doFoo(_baseRef _instance) {
+    return static_cast<dont_smoke_DontSmokeEnum>(get_pointer<::std::shared_ptr< ::smoke::SomeSkippedClass >>(_instance)->get()->do_foo());
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/generic_types__conversion.dart
@@ -1,2 +1,88 @@
+import 'package:library/src/smoke/some_skipped_enum.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+final _listofSmokeSomeskippedenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_ListOf_smoke_SomeSkippedEnum_create_handle'));
+final _listofSmokeSomeskippedenumReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_smoke_SomeSkippedEnum_release_handle'));
+final _listofSmokeSomeskippedenumInsert = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Uint32),
+    void Function(Pointer<Void>, int)
+  >('library_ListOf_smoke_SomeSkippedEnum_insert'));
+final _listofSmokeSomeskippedenumIterator = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+>('library_ListOf_smoke_SomeSkippedEnum_iterator'));
+final _listofSmokeSomeskippedenumIteratorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_smoke_SomeSkippedEnum_iterator_release_handle'));
+final _listofSmokeSomeskippedenumIteratorIsValid = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int8 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+>('library_ListOf_smoke_SomeSkippedEnum_iterator_is_valid'));
+final _listofSmokeSomeskippedenumIteratorIncrement = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+>('library_ListOf_smoke_SomeSkippedEnum_iterator_increment'));
+final _listofSmokeSomeskippedenumIteratorGet = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+>('library_ListOf_smoke_SomeSkippedEnum_iterator_get'));
+Pointer<Void> listofSmokeSomeskippedenumToFfi(List<SomeSkippedEnum> value) {
+  final _result = _listofSmokeSomeskippedenumCreateHandle();
+  for (final element in value) {
+    final _elementHandle = smokeSomeskippedenumToFfi(element);
+    _listofSmokeSomeskippedenumInsert(_result, _elementHandle);
+    smokeSomeskippedenumReleaseFfiHandle(_elementHandle);
+  }
+  return _result;
+}
+List<SomeSkippedEnum> listofSmokeSomeskippedenumFromFfi(Pointer<Void> handle) {
+  final result = List<SomeSkippedEnum>.empty(growable: true);
+  final _iteratorHandle = _listofSmokeSomeskippedenumIterator(handle);
+  while (_listofSmokeSomeskippedenumIteratorIsValid(handle, _iteratorHandle) != 0) {
+    final _elementHandle = _listofSmokeSomeskippedenumIteratorGet(_iteratorHandle);
+    try {
+      result.add(smokeSomeskippedenumFromFfi(_elementHandle));
+    } finally {
+      smokeSomeskippedenumReleaseFfiHandle(_elementHandle);
+    }
+    _listofSmokeSomeskippedenumIteratorIncrement(_iteratorHandle);
+  }
+  _listofSmokeSomeskippedenumIteratorReleaseHandle(_iteratorHandle);
+  return result;
+}
+void listofSmokeSomeskippedenumReleaseFfiHandle(Pointer<Void> handle) => _listofSmokeSomeskippedenumReleaseHandle(handle);
+final _listofSmokeSomeskippedenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_smoke_SomeSkippedEnum_create_handle_nullable'));
+final _listofSmokeSomeskippedenumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_ListOf_smoke_SomeSkippedEnum_release_handle_nullable'));
+final _listofSmokeSomeskippedenumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_ListOf_smoke_SomeSkippedEnum_get_value_nullable'));
+Pointer<Void> listofSmokeSomeskippedenumToFfiNullable(List<SomeSkippedEnum>? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = listofSmokeSomeskippedenumToFfi(value);
+  final result = _listofSmokeSomeskippedenumCreateHandleNullable(_handle);
+  listofSmokeSomeskippedenumReleaseFfiHandle(_handle);
+  return result;
+}
+List<SomeSkippedEnum>? listofSmokeSomeskippedenumFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _listofSmokeSomeskippedenumGetValueNullable(handle);
+  final result = listofSmokeSomeskippedenumFromFfi(_handle);
+  listofSmokeSomeskippedenumReleaseFfiHandle(_handle);
+  return result;
+}
+void listofSmokeSomeskippedenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _listofSmokeSomeskippedenumReleaseHandleNullable(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/some_skipped_struct.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/some_skipped_struct.dart
@@ -1,0 +1,83 @@
+import 'dart:collection';
+import 'dart:ffi';
+import 'package:collection/collection.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/generic_types__conversion.dart';
+import 'package:library/src/smoke/some_skipped_enum.dart';
+class SomeSkippedStruct {
+  List<SomeSkippedEnum> field;
+  SomeSkippedStruct(this.field);
+  @override
+  bool operator ==(dynamic other) {
+    if (identical(this, other)) return true;
+    if (other is! SomeSkippedStruct) return false;
+    SomeSkippedStruct _other = other;
+    return DeepCollectionEquality().equals(field, _other.field);
+  }
+  @override
+  int get hashCode {
+    int result = 7;
+    result = 31 * result + DeepCollectionEquality().hash(field);
+    return result;
+  }
+}
+// SomeSkippedStruct "private" section, not exported.
+final _smokeSomeskippedstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SomeSkippedStruct_create_handle'));
+final _smokeSomeskippedstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SomeSkippedStruct_release_handle'));
+final _smokeSomeskippedstructGetFieldfield = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SomeSkippedStruct_get_field_field'));
+Pointer<Void> smokeSomeskippedstructToFfi(SomeSkippedStruct value) {
+  final _fieldHandle = listofSmokeSomeskippedenumToFfi(value.field);
+  final _result = _smokeSomeskippedstructCreateHandle(_fieldHandle);
+  listofSmokeSomeskippedenumReleaseFfiHandle(_fieldHandle);
+  return _result;
+}
+SomeSkippedStruct smokeSomeskippedstructFromFfi(Pointer<Void> handle) {
+  final _fieldHandle = _smokeSomeskippedstructGetFieldfield(handle);
+  try {
+    return SomeSkippedStruct(
+      listofSmokeSomeskippedenumFromFfi(_fieldHandle)
+    );
+  } finally {
+    listofSmokeSomeskippedenumReleaseFfiHandle(_fieldHandle);
+  }
+}
+void smokeSomeskippedstructReleaseFfiHandle(Pointer<Void> handle) => _smokeSomeskippedstructReleaseHandle(handle);
+// Nullable SomeSkippedStruct
+final _smokeSomeskippedstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SomeSkippedStruct_create_handle_nullable'));
+final _smokeSomeskippedstructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SomeSkippedStruct_release_handle_nullable'));
+final _smokeSomeskippedstructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SomeSkippedStruct_get_value_nullable'));
+Pointer<Void> smokeSomeskippedstructToFfiNullable(SomeSkippedStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeSomeskippedstructToFfi(value);
+  final result = _smokeSomeskippedstructCreateHandleNullable(_handle);
+  smokeSomeskippedstructReleaseFfiHandle(_handle);
+  return result;
+}
+SomeSkippedStruct? smokeSomeskippedstructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeSomeskippedstructGetValueNullable(handle);
+  final result = smokeSomeskippedstructFromFfi(_handle);
+  smokeSomeskippedstructReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeSomeskippedstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeSomeskippedstructReleaseHandleNullable(handle);
+// End of SomeSkippedStruct "private" section.


### PR DESCRIPTION
Updated Java, Swift, and Dart generators to stop (mis)using `SKIP` attribute directly and instead
use the retain predicate that accounts for active tags.

Added smoke tests.

Resolves: #1000
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>