### PR TITLE
Sort Dart library exports alphabetically

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -204,7 +204,7 @@ internal class DartGenerator : Generator {
         if (allSymbols.isNotEmpty()) {
             exportsCollector
                 .getOrPut(rootElement.path.head) { mutableListOf() }
-                .add(DartExport(relativePath, allSymbols))
+                .add(DartExport(relativePath, allSymbols.sorted()))
         }
         typeRepositoriesCollector += getTypeRepositories(allTypes)
         val optimizedLists = OptimizedListsCollector().getAllOptimizedLists(rootElement)
@@ -341,7 +341,7 @@ internal class DartGenerator : Generator {
     ): List<GeneratedFile> {
         val exportFiles = exports.map {
             GeneratedFile(
-                TemplateEngine.render("dart/DartExports", mapOf("files" to it.value), nameResolvers),
+                TemplateEngine.render("dart/DartExports", mapOf("files" to it.value.sorted()), nameResolvers),
                 "$LIB_DIR/${it.key.joinToString(".")}.dart"
             )
         }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/smoke.dart
@@ -1,6 +1,6 @@
-export 'src/smoke/lambdas.dart' show Lambdas, Lambdas_Producer, Lambdas_Confuser, Lambdas_Consumer, Lambdas_Indexer, Lambdas_NullableConfuser;
-export 'src/smoke/standalone_producer.dart' show StandaloneProducer;
-export 'src/smoke/lambdas_declaration_order.dart' show LambdasDeclarationOrder, LambdasDeclarationOrder_SomeStruct, LambdasDeclarationOrder_SomeCallback;
+export 'src/smoke/class_with_internal_lambda.dart' show ClassWithInternalLambda;
+export 'src/smoke/lambdas.dart' show Lambdas, Lambdas_Confuser, Lambdas_Consumer, Lambdas_Indexer, Lambdas_NullableConfuser, Lambdas_Producer;
+export 'src/smoke/lambdas_declaration_order.dart' show LambdasDeclarationOrder, LambdasDeclarationOrder_SomeCallback, LambdasDeclarationOrder_SomeStruct;
 export 'src/smoke/lambdas_interface.dart' show LambdasInterface, LambdasInterface_TakeScreenshotCallback;
 export 'src/smoke/lambdas_with_structured_types.dart' show LambdasWithStructuredTypes, LambdasWithStructuredTypes_ClassCallback, LambdasWithStructuredTypes_StructCallback;
-export 'src/smoke/class_with_internal_lambda.dart' show ClassWithInternalLambda;
+export 'src/smoke/standalone_producer.dart' show StandaloneProducer;

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/smoke.dart
@@ -1,4 +1,4 @@
-export 'src/smoke/public_interface.dart' show PublicInterface;
 export 'src/smoke/public_class.dart' show PublicClass, PublicClass_PublicStruct, PublicClass_PublicStructWithInternalDefaults;
-export 'src/smoke/public_type_collection.dart' show PublicTypeCollection;
+export 'src/smoke/public_interface.dart' show PublicInterface;
 export 'src/smoke/public_struct_with_non_default_internal_field.dart' show PublicStructWithNonDefaultInternalField;
+export 'src/smoke/public_type_collection.dart' show PublicTypeCollection;


### PR DESCRIPTION
Added two explicit alphabetical sortings to the list of library exports in Dart:
* the lines are sorted by the file name
* the exported symbols in each line are sorted by name

This makes the ordering of the exports stable, making sure the results do not vary between platfoms
and are not affected by the declarations ordering in the IDL files.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>