### PR TITLE
Add missing conversion functions for nullabe unsigned ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed Dart compilation issues when default visibility of C++ symbols is set to "hidden" in the build system.
+  * Fixed Java compilation issue for nullable unsigned integer types, again.
 
 ## 9.3.4
 Release date: 2021-07-26

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.cpp
@@ -1,97 +1,67 @@
-{{!!
-  !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
-  !
-  ! Licensed under the Apache License, Version 2.0 (the "License");
-  ! you may not use this file except in compliance with the License.
-  ! You may obtain a copy of the License at
-  !
-  !     http://www.apache.org/licenses/LICENSE-2.0
-  !
-  ! Unless required by applicable law or agreed to in writing, software
-  ! distributed under the License is distributed on an "AS IS" BASIS,
-  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ! See the License for the specific language governing permissions and
-  ! limitations under the License.
-  !
-  ! SPDX-License-Identifier: Apache-2.0
-  ! License-Filename: LICENSE
-  !
-  !}}
-{{>java/CopyrightHeader}}
-
+/*
+ *
+ */
 #include "BoxingConversionUtils.h"
-
 #include "JniCallJavaMethod.h"
 #include "JniCppConversionUtils.h"
-
 namespace
 {
 template<typename T>
-{{>common/InternalNamespace}}jni::JniReference<jobject>
+::gluecodium::jni::JniReference<jobject>
 box_value_in_object( JNIEnv* env, const char* className, const char* signature, T param )
 {
-    auto javaClass = {{>common/InternalNamespace}}jni::find_class(env, className );
+    auto javaClass = ::gluecodium::jni::find_class(env, className );
     auto theConstructor = env->GetMethodID( javaClass.get(), "<init>", signature );
-    return {{>common/InternalNamespace}}jni::new_object(env, javaClass, theConstructor, param );
+    return ::gluecodium::jni::new_object(env, javaClass, theConstructor, param );
 }
-
 jint
-unbox_short_value( JNIEnv* env, const {{>common/InternalNamespace}}jni::JniReference<jobject>& jvalue )
+unbox_short_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& jvalue )
 {
-    auto javaIntegerClass = {{>common/InternalNamespace}}jni::find_class( env, "java/lang/Short" );
+    auto javaIntegerClass = ::gluecodium::jni::find_class( env, "java/lang/Short" );
     auto intValueMethodId = env->GetMethodID( javaIntegerClass.get(), "shortValue", "()S" );
-    return {{>common/InternalNamespace}}jni::call_java_method<jshort>( env, jvalue, intValueMethodId );
+    return ::gluecodium::jni::call_java_method<jshort>( env, jvalue, intValueMethodId );
 }
-
 jint
-unbox_int_value( JNIEnv* env, const {{>common/InternalNamespace}}jni::JniReference<jobject>& jvalue )
+unbox_int_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& jvalue )
 {
-    auto javaIntegerClass = {{>common/InternalNamespace}}jni::find_class( env, "java/lang/Integer" );
+    auto javaIntegerClass = ::gluecodium::jni::find_class( env, "java/lang/Integer" );
     auto intValueMethodId = env->GetMethodID( javaIntegerClass.get(), "intValue", "()I" );
-    return {{>common/InternalNamespace}}jni::call_java_method<jint>( env, jvalue, intValueMethodId );
+    return ::gluecodium::jni::call_java_method<jint>( env, jvalue, intValueMethodId );
 }
-
 jlong
-unbox_long_value( JNIEnv* env, const {{>common/InternalNamespace}}jni::JniReference<jobject>& jvalue )
+unbox_long_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& jvalue )
 {
-    auto javaLongClass = {{>common/InternalNamespace}}jni::find_class( env, "java/lang/Long" );
+    auto javaLongClass = ::gluecodium::jni::find_class( env, "java/lang/Long" );
     auto longValueMethodId = env->GetMethodID( javaLongClass.get(), "longValue", "()J" );
-    return {{>common/InternalNamespace}}jni::call_java_method<jlong>( env, jvalue, longValueMethodId );
+    return ::gluecodium::jni::call_java_method<jlong>( env, jvalue, longValueMethodId );
 }
-
 template<typename T>
-{{>common/InternalNamespace}}jni::JniReference<jobject>
+::gluecodium::jni::JniReference<jobject>
 box_uint_in_object( JNIEnv* env, T param )
 {
-    auto javaClass = {{>common/InternalNamespace}}jni::find_class(env, "java/lang/Long" );
+    auto javaClass = ::gluecodium::jni::find_class(env, "java/lang/Long" );
     auto theConstructor = env->GetMethodID( javaClass.get(), "<init>", "(J)V" );
     return new_object(env, javaClass, theConstructor, static_cast< int64_t >( param ) );
 }
-
 template<>
-{{>common/InternalNamespace}}jni::JniReference<jobject>
+::gluecodium::jni::JniReference<jobject>
 box_uint_in_object( JNIEnv* env, uint8_t param )
 {
-    auto javaClass = {{>common/InternalNamespace}}jni::find_class(env, "java/lang/Short" );
+    auto javaClass = ::gluecodium::jni::find_class(env, "java/lang/Short" );
     auto theConstructor = env->GetMethodID( javaClass.get(), "<init>", "(S)V" );
     return new_object(env, javaClass, theConstructor, static_cast< int16_t >( param ) );
 }
-
 template<>
-{{>common/InternalNamespace}}jni::JniReference<jobject>
+::gluecodium::jni::JniReference<jobject>
 box_uint_in_object( JNIEnv* env, uint16_t param )
 {
-    auto javaClass = {{>common/InternalNamespace}}jni::find_class(env, "java/lang/Integer" );
+    auto javaClass = ::gluecodium::jni::find_class(env, "java/lang/Integer" );
     auto theConstructor = env->GetMethodID( javaClass.get(), "<init>", "(I)V" );
     return new_object(env, javaClass, theConstructor, static_cast< int32_t >( param ) );
 }
 }
-
-{{#internalNamespace}}
-namespace {{.}}
+namespace gluecodium
 {
-{{/internalNamespace}}
 namespace jni
 {
 JniReference<jobject>
@@ -99,67 +69,56 @@ convert_to_jni( JNIEnv* env, const bool nvalue )
 {
     return box_value_in_object<jboolean>( env, "java/lang/Boolean", "(Z)V", nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const double nvalue )
 {
     return box_value_in_object<jdouble>( env, "java/lang/Double", "(D)V", nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const float nvalue )
 {
     return box_value_in_object<jfloat>( env, "java/lang/Float", "(F)V", nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int8_t nvalue )
 {
     return box_value_in_object<jbyte>( env, "java/lang/Byte", "(B)V", nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int16_t nvalue )
 {
     return box_value_in_object<jshort>( env, "java/lang/Short", "(S)V", nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int32_t nvalue )
 {
     return box_value_in_object<jint>( env, "java/lang/Integer", "(I)V", nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int64_t nvalue )
 {
     return box_value_in_object<jlong>( env, "java/lang/Long", "(J)V", nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint8_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint16_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint32_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
-
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint64_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
-
 bool
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* )
 {
@@ -167,7 +126,6 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* )
     auto booleanValueMethodId = env->GetMethodID( javaBooleanClass.get(), "booleanValue", "()Z" );
     return call_java_method<jboolean>( env, jvalue, booleanValueMethodId );
 }
-
 double
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* )
 {
@@ -175,7 +133,6 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* )
     auto doubleValueMethodId = env->GetMethodID( javaDoubleClass.get(), "doubleValue", "()D" );
     return call_java_method<jdouble>( env, jvalue, doubleValueMethodId );
 }
-
 float
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* )
 {
@@ -183,7 +140,6 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* )
     auto floatValueMethodId = env->GetMethodID( javaFloatClass.get(), "floatValue", "()F" );
     return call_java_method<jfloat>( env, jvalue, floatValueMethodId );
 }
-
 int8_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* )
 {
@@ -191,7 +147,6 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* )
     auto byteValueMethodId = env->GetMethodID( javaByteClass.get(), "byteValue", "()B" );
     return call_java_method<jbyte>( env, jvalue, byteValueMethodId );
 }
-
 int16_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* )
 {
@@ -199,242 +154,211 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* )
     auto shortValueMethodId = env->GetMethodID( javaShortClass.get(), "shortValue", "()S" );
     return call_java_method<jshort>( env, jvalue, shortValueMethodId );
 }
-
 int32_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int32_t* )
 {
     return unbox_int_value( env, jvalue );
 }
-
 int64_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int64_t* )
 {
     return unbox_long_value( env, jvalue );
 }
-
 uint8_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint8_t* )
 {
     return unbox_short_value( env, jvalue );
 }
-
 uint16_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint16_t* )
 {
     return unbox_int_value( env, jvalue );
 }
-
 uint32_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint32_t* )
 {
     return unbox_long_value( env, jvalue );
 }
-
 uint64_t
 convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint64_t* )
 {
     return unbox_long_value( env, jvalue );
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<bool> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<bool> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<float> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<float> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<double> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<double> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<int8_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<int8_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<int16_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<int16_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<int32_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<int32_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<int64_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<int64_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint8_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint8_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint16_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint16_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint32_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint32_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
 JniReference<jobject>
-convert_to_jni( JNIEnv* env, {{>common/InternalNamespace}}optional<uint64_t> nvalue )
+convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint64_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
-
-{{>common/InternalNamespace}}optional<bool>
+::gluecodium::optional<bool>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<bool>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<bool>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<jboolean>( env, jvalue, "booleanValue", "()Z" );
-    return {{>common/InternalNamespace}}optional<bool>( unboxedValue );
+    return ::gluecodium::optional<bool>( unboxedValue );
 }
-
-{{>common/InternalNamespace}}optional<float>
+::gluecodium::optional<float>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<float>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<float>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<jfloat>( env, jvalue, "floatValue", "()F" );
-    return {{>common/InternalNamespace}}optional<float>( unboxedValue );
+    return ::gluecodium::optional<float>( unboxedValue );
 }
-
-{{>common/InternalNamespace}}optional<double>
+::gluecodium::optional<double>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<double>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<double>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<jdouble>( env, jvalue, "doubleValue", "()D" );
-    return {{>common/InternalNamespace}}optional<double>( unboxedValue );
+    return ::gluecodium::optional<double>( unboxedValue );
 }
-
-{{>common/InternalNamespace}}optional<int8_t>
+::gluecodium::optional<int8_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<int8_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int8_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int8_t>( env, jvalue, "byteValue", "()B" );
-    return {{>common/InternalNamespace}}optional<int8_t>( unboxedValue );
+    return ::gluecodium::optional<int8_t>( unboxedValue );
 }
-
-{{>common/InternalNamespace}}optional<int16_t>
+::gluecodium::optional<int16_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<int16_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int16_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int16_t>( env, jvalue, "shortValue", "()S" );
-    return {{>common/InternalNamespace}}optional<int16_t>( unboxedValue );
+    return ::gluecodium::optional<int16_t>( unboxedValue );
 }
-
-{{>common/InternalNamespace}}optional<int32_t>
+::gluecodium::optional<int32_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<int32_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int32_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int32_t>( env, jvalue, "intValue", "()I" );
-    return {{>common/InternalNamespace}}optional<int32_t>( unboxedValue );
+    return ::gluecodium::optional<int32_t>( unboxedValue );
 }
-
-{{>common/InternalNamespace}}optional<int64_t>
+::gluecodium::optional<int64_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<int64_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int64_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int64_t>( env, jvalue, "longValue", "()J" );
-    return {{>common/InternalNamespace}}optional<int64_t>( unboxedValue );
+    return ::gluecodium::optional<int64_t>( unboxedValue );
 }
-
-{{>common/InternalNamespace}}optional<uint8_t>
+::gluecodium::optional<uint8_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<uint8_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint8_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int16_t>( env, jvalue, "shortValue", "()S" );
-    return {{>common/InternalNamespace}}optional<uint8_t>( static_cast<uint8_t>( unboxedValue ) );
+    return ::gluecodium::optional<uint8_t>( static_cast<uint8_t>( unboxedValue ) );
 }
-
-{{>common/InternalNamespace}}optional<uint16_t>
+::gluecodium::optional<uint16_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<uint16_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint16_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int32_t>( env, jvalue, "intValue", "()I" );
-    return {{>common/InternalNamespace}}optional<uint16_t>( static_cast<uint16_t>( unboxedValue ) );
+    return ::gluecodium::optional<uint16_t>( static_cast<uint16_t>( unboxedValue ) );
 }
-
-{{>common/InternalNamespace}}optional<uint32_t>
+::gluecodium::optional<uint32_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<uint32_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint32_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int64_t>( env, jvalue, "longValue", "()J" );
-    return {{>common/InternalNamespace}}optional<uint32_t>( static_cast<uint32_t>( unboxedValue ) );
+    return ::gluecodium::optional<uint32_t>( static_cast<uint32_t>( unboxedValue ) );
 }
-
-{{>common/InternalNamespace}}optional<uint64_t>
+::gluecodium::optional<uint64_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}optional<uint64_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint64_t>* )
 {
     if ( !jvalue )
     {
         return {};
     }
     auto unboxedValue = call_java_method<int64_t>( env, jvalue, "longValue", "()J" );
-    return {{>common/InternalNamespace}}optional<uint64_t>( static_cast<uint64_t>( unboxedValue ) );
+    return ::gluecodium::optional<uint64_t>( static_cast<uint64_t>( unboxedValue ) );
 }
-
 }
-{{#internalNamespace}}
 }
-{{/internalNamespace}}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.h
@@ -1,0 +1,71 @@
+/*
+ *
+ */
+#pragma once
+#include "JniReference.h"
+#include "gluecodium/Optional.h"
+#include <jni.h>
+namespace gluecodium
+{
+namespace jni
+{
+// The following functions are converting and boxing primitive values into Java boxed types.
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const bool nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const double nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const float nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const int8_t nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const int16_t nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const int32_t nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const int64_t nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint8_t nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint16_t nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint32_t nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint64_t nvalue );
+// The following functions are unboxing and converting primitive values from Java boxed types.
+JNIEXPORT bool convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* );
+JNIEXPORT double convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* );
+JNIEXPORT float convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* );
+JNIEXPORT int8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* );
+JNIEXPORT int16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* );
+JNIEXPORT int32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int32_t* );
+JNIEXPORT int64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int64_t* );
+JNIEXPORT uint8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint8_t* );
+JNIEXPORT uint16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint16_t* );
+JNIEXPORT uint32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint32_t* );
+JNIEXPORT uint64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint64_t* );
+// Boxing/unboxing conversion functions for nullable types
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<bool> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<float> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<double> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<int8_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<int16_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<int32_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<int64_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint8_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint16_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint32_t> nvalue );
+JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, ::gluecodium::optional<uint64_t> nvalue );
+JNIEXPORT ::gluecodium::optional<bool> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<bool>* );
+JNIEXPORT ::gluecodium::optional<float> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<float>* );
+JNIEXPORT ::gluecodium::optional<double> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<double>* );
+JNIEXPORT ::gluecodium::optional<int8_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int8_t>* );
+JNIEXPORT ::gluecodium::optional<int16_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int16_t>* );
+JNIEXPORT ::gluecodium::optional<int32_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int32_t>* );
+JNIEXPORT ::gluecodium::optional<int64_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<int64_t>* );
+JNIEXPORT ::gluecodium::optional<uint8_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint8_t>* );
+JNIEXPORT ::gluecodium::optional<uint16_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint16_t>* );
+JNIEXPORT ::gluecodium::optional<uint32_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint32_t>* );
+JNIEXPORT ::gluecodium::optional<uint64_t> convert_from_jni(
+    JNIEnv* env, const JniReference<jobject>& jvalue, ::gluecodium::optional<uint64_t>* );
+}
+}


### PR DESCRIPTION
Added missing JNI functions for nullabe unsigned integer types to
BoxingConversionUtilsImplementation template.

Added smoke test reference files for both header and impl of "BoxingConversionUtils", as the
functional compilation test does not catch this issue on Linux.

Resolves: #1003
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>