### PR TITLE
Revert "Suppress Dart warning about deprecation in an enum (#995)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed runtime issue for interfaces sent from Java to C++ and then back to Java.
+  * Removed suppression of "dart analyze" warning about deprecated element usage. This should be suppressed in a
+    library-level analysis_options.yaml instead.
 
 ## 9.3.5
 Release date: 2021-07-28

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -36,9 +36,6 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
   switch (value) {
 {{#set parent=this}}{{#enumerators}}
   case {{resolveName parent "" "ref"}}{{#if external.dart.converter}}Internal{{/if}}.{{resolveName}}:
-{{#if this.attributes.deprecated}}
-  // ignore: deprecated_member_use_from_same_package
-{{/if}}
     return {{value}};
 {{/enumerators}}{{/set}}
   default:
@@ -48,9 +45,7 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
 
 {{resolveName this "" "ref"}} {{resolveName "Ffi"}}FromFfi(int handle) {
   switch (handle) {
-{{#set parent=this}}{{#enumerators}}{{#if this.attributes.deprecated}}
-  // ignore: deprecated_member_use_from_same_package
-{{/if}}
+{{#set parent=this}}{{#enumerators}}
   case {{value}}:
 {{#if external.dart.converter}}
     return {{external.dart.converter}}.convertFromInternal({{resolveName parent}}Internal.{{resolveName}});

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -57,7 +57,6 @@ enum DeprecationComments_SomeEnum {
 int smokeDeprecationcommentsSomeenumToFfi(DeprecationComments_SomeEnum value) {
   switch (value) {
   case DeprecationComments_SomeEnum.useless:
-  // ignore: deprecated_member_use_from_same_package
     return 0;
   default:
     throw StateError("Invalid enum value $value for DeprecationComments_SomeEnum enum.");
@@ -65,7 +64,6 @@ int smokeDeprecationcommentsSomeenumToFfi(DeprecationComments_SomeEnum value) {
 }
 DeprecationComments_SomeEnum smokeDeprecationcommentsSomeenumFromFfi(int handle) {
   switch (handle) {
-  // ignore: deprecated_member_use_from_same_package
   case 0:
     return DeprecationComments_SomeEnum.useless;
   default:

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -40,7 +40,6 @@ enum DeprecationCommentsOnly_SomeEnum {
 int smokeDeprecationcommentsonlySomeenumToFfi(DeprecationCommentsOnly_SomeEnum value) {
   switch (value) {
   case DeprecationCommentsOnly_SomeEnum.useless:
-  // ignore: deprecated_member_use_from_same_package
     return 0;
   default:
     throw StateError("Invalid enum value $value for DeprecationCommentsOnly_SomeEnum enum.");
@@ -48,7 +47,6 @@ int smokeDeprecationcommentsonlySomeenumToFfi(DeprecationCommentsOnly_SomeEnum v
 }
 DeprecationCommentsOnly_SomeEnum smokeDeprecationcommentsonlySomeenumFromFfi(int handle) {
   switch (handle) {
-  // ignore: deprecated_member_use_from_same_package
   case 0:
     return DeprecationCommentsOnly_SomeEnum.useless;
   default:


### PR DESCRIPTION
As of the latest version of Flutter SDK, the warnings about "deprecated use from the same package" are suppressible on the library-level analysis_options.yaml.  Therefore the explicit per-line suppressions are no longer needed.

This reverts commit 475a2f1864e86a316e5890de95a354e6739d86fd.

See: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>