### PR TITLE
Add support for in-platform tag-enabling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Features:
+  * Added support for tag-based platform-specific "enable" attribute in IDL (e.g. `@Java(EnableIf="Tag1")`, similarly
+    for Swift and Dart). Elements marked with such attribute will be present in that platform's generated code only if
+    any of these specific used-defined tags are present.
 ### Bug fixes:
   * Fixed runtime issue for interfaces sent from Java to C++ and then back to Java.
   * Removed suppression of "dart analyze" warning about deprecated element usage. This should be suppressed in a

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -504,7 +504,7 @@ case-insensitive. There are three predefined tags that do not need to be specifi
 for C++.
 * **@EnableIf(**\[**Tag** **=**\] **"**_CustomTag_**"**__)__ or **@EnableIf(**__CustomTag__**)**: marks an element to be
 enabled only if a custom tag with that name was defined through command-line parameters. If the tag is not present, the
-element is skipped ((not generated). Custom tags are case-insensitive.
+element is skipped (not generated). Custom tags are case-insensitive.
 * **@Java**: marks an element with Java-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Java.
   This is the default specification for this attribute.
@@ -513,6 +513,8 @@ element is skipped ((not generated). Custom tags are case-insensitive.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Java. Can be applied to
   any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
   was defined (see `@Skip` above).
+  * **@EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Java only if a custom tag with that
+  name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).   
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Java
   generated code. _Annotation_ does not need to be prepended with `@`. _Annotation_ can contain parameters, e.g.
   `@Java(Attribute="Deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing
@@ -534,6 +536,8 @@ element is skipped ((not generated). Custom tags are case-insensitive.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Swift. Can be applied to
   any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
   was defined (see `@Skip` above).
+  * **@EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Swift only if a custom tag with that
+  name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).
   * **Weak**: marks a property in an interface as `weak` in Swift. Property should have a nullable type. Please note
   that `weak` properties are still represented with "strong" pointers on C++ side. Due to this limitation, if an
   interface type is used for such property, that interface can only have methods that return nullable values or `void`.
@@ -548,6 +552,8 @@ element is skipped ((not generated). Custom tags are case-insensitive.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Dart. Can be applied to
   any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
   was defined (see `@Skip` above).
+  * **@EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Dart only if a custom tag with that
+  name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).
   * **PositionalDefaults**: marks a struct to have a constructor with optional positional parameters in Dart. Can only
   be applied to a struct that has at least one field with a default value.
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Dart

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -426,6 +426,7 @@ feature(SkipAttribute cpp android swift dart SOURCES
     input/lime/SkipTagsInPlatform.lime
     input/lime/SkipEnumerator.lime
     input/lime/EnableIfEnabled.lime
+    input/lime/EnableIfInPlatform.lime
     input/lime/EnableIfSkipped.lime
 
     input/src/cpp/Skip.cpp

--- a/functional-tests/functional/input/lime/EnableIfInPlatform.lime
+++ b/functional-tests/functional/input/lime/EnableIfInPlatform.lime
@@ -1,0 +1,48 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Skip(Swift, Dart)
+interface EnableTagsInJava {
+    @Java(EnableIf = "Lite")
+    fun enableTagged()
+    @Java(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Java(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}
+
+@Skip(Java, Dart)
+interface EnableTagsInSwift {
+    @Swift(EnableIf = "Lite")
+    fun enableTagged()
+    @Swift(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Swift(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}
+
+@Skip(Java, Swift)
+interface EnableTagsInDart {
+    @Dart(EnableIf = "Lite")
+    fun enableTagged()
+    @Dart(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Dart(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}

--- a/gluecodium/src/test/resources/smoke/skip/input/EnableIfInPlatform.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/EnableIfInPlatform.lime
@@ -1,0 +1,48 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Skip(Swift, Dart)
+interface EnableTagsInJava {
+    @Java(EnableIf = "Lite")
+    fun enableTagged()
+    @Java(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Java(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}
+
+@Skip(Java, Dart)
+interface EnableTagsInSwift {
+    @Swift(EnableIf = "Lite")
+    fun enableTagged()
+    @Swift(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Swift(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}
+
+@Skip(Java, Swift)
+interface EnableTagsInDart {
+    @Dart(EnableIf = "Lite")
+    fun enableTagged()
+    @Dart(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Dart(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/EnableTagsInJava.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/EnableTagsInJava.java
@@ -1,0 +1,8 @@
+/*
+ *
+ */
+package com.example.smoke;
+public interface EnableTagsInJava {
+    void enableTagged();
+    void enableTaggedList();
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_EnableTagsInJavaImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_EnableTagsInJavaImplCppProxy.cpp
@@ -1,0 +1,43 @@
+/*
+ *
+ */
+#include "com_example_smoke_EnableTagsInJavaImplCppProxy.h"
+#include "com_example_smoke_EnableTagsInJava__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+namespace gluecodium
+{
+namespace jni
+{
+com_example_smoke_EnableTagsInJava_CppProxy::com_example_smoke_EnableTagsInJava_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode )
+    : CppProxyBase( _jenv, std::move( globalRef ), _jHashCode, "com_example_smoke_EnableTagsInJava" ) {
+}
+void
+com_example_smoke_EnableTagsInJava_CppProxy::enable_tagged(  ) {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    callJavaMethod<void>( "enableTagged", "()V", jniEnv  );
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+}
+void
+com_example_smoke_EnableTagsInJava_CppProxy::dont_enable_tagged(  ) {
+}
+void
+com_example_smoke_EnableTagsInJava_CppProxy::enable_tagged_list(  ) {
+    JNIEnv* jniEnv = getJniEnvironment( );
+    callJavaMethod<void>( "enableTaggedList", "()V", jniEnv  );
+    if ( jniEnv->ExceptionCheck( ) )
+    {
+        jniEnv->ExceptionDescribe( );
+        jniEnv->ExceptionClear( );
+        jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
+            "See the log for more information about the exception (including Java stack trace)." );
+    }
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_EnableTagsInSwift.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_EnableTagsInSwift.cpp
@@ -1,0 +1,82 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_EnableTagsInSwift.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/CachedProxyBase.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/EnableTagsInSwift.h"
+#include <memory>
+#include <new>
+void smoke_EnableTagsInSwift_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(handle);
+}
+_baseRef smoke_EnableTagsInSwift_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(handle)))
+        : 0;
+}
+const void* smoke_EnableTagsInSwift_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(handle)->get())
+        : nullptr;
+}
+void smoke_EnableTagsInSwift_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(handle)->get(), swift_pointer);
+}
+void smoke_EnableTagsInSwift_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(handle)->get());
+}
+extern "C" {
+extern void* _CBridgeInitsmoke_EnableTagsInSwift(_baseRef handle);
+}
+namespace {
+struct smoke_EnableTagsInSwiftRegisterInit {
+    smoke_EnableTagsInSwiftRegisterInit() {
+        get_init_repository().add_init("smoke_EnableTagsInSwift", &_CBridgeInitsmoke_EnableTagsInSwift);
+    }
+} s_smoke_EnableTagsInSwift_register_init;
+}
+void* smoke_EnableTagsInSwift_get_typed(_baseRef handle) {
+    const auto& real_type_id = ::gluecodium::get_type_repository().get_id(get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(handle)->get());
+    auto init_function = get_init_repository().get_init(real_type_id);
+    return init_function ? init_function(handle) : _CBridgeInitsmoke_EnableTagsInSwift(handle);
+}
+void smoke_EnableTagsInSwift_enableTagged(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(_instance)->get()->enable_tagged();
+}
+void smoke_EnableTagsInSwift_enableTaggedList(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(_instance)->get()->enable_tagged_list();
+}
+class smoke_EnableTagsInSwiftProxy : public ::smoke::EnableTagsInSwift, public CachedProxyBase<smoke_EnableTagsInSwiftProxy> {
+public:
+    smoke_EnableTagsInSwiftProxy(smoke_EnableTagsInSwift_FunctionTable&& functions)
+     : mFunctions(::std::move(functions))
+    {
+    }
+    virtual ~smoke_EnableTagsInSwiftProxy() {
+        mFunctions.release(mFunctions.swift_pointer);
+    }
+    smoke_EnableTagsInSwiftProxy(const smoke_EnableTagsInSwiftProxy&) = delete;
+    smoke_EnableTagsInSwiftProxy& operator=(const smoke_EnableTagsInSwiftProxy&) = delete;
+    void enable_tagged() override {
+        mFunctions.smoke_EnableTagsInSwift_enableTagged(mFunctions.swift_pointer);
+    }
+    void dont_enable_tagged() override {
+    }
+    void enable_tagged_list() override {
+        mFunctions.smoke_EnableTagsInSwift_enableTaggedList(mFunctions.swift_pointer);
+    }
+private:
+    smoke_EnableTagsInSwift_FunctionTable mFunctions;
+};
+_baseRef smoke_EnableTagsInSwift_create_proxy(smoke_EnableTagsInSwift_FunctionTable functionTable) {
+    auto proxy = smoke_EnableTagsInSwiftProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr< ::smoke::EnableTagsInSwift >(proxy)) : 0;
+}
+const void* smoke_EnableTagsInSwift_get_swift_object_from_cache(_baseRef handle) {
+    return handle ? smoke_EnableTagsInSwiftProxy::get_swift_object(get_pointer<::std::shared_ptr< ::smoke::EnableTagsInSwift >>(handle)->get()) : nullptr;
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_EnableTagsInDart.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_EnableTagsInDart.cpp
@@ -1,0 +1,120 @@
+#include "ffi_smoke_EnableTagsInDart.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "CallbacksQueue.h"
+#include "IsolateContext.h"
+#include "ProxyCache.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/EnableTagsInDart.h"
+#include <memory>
+#include <memory>
+#include <new>
+class smoke_EnableTagsInDart_Proxy : public smoke::EnableTagsInDart {
+public:
+    smoke_EnableTagsInDart_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f2)
+        : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0), f2(f2) {
+        library_cache_dart_handle_by_raw_pointer(this, isolate_id, dart_handle);
+    }
+    ~smoke_EnableTagsInDart_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_EnableTagsInDart");
+        auto raw_pointer_local = this;
+        auto isolate_id_local = isolate_id;
+        auto dart_persistent_handle_local = dart_persistent_handle;
+        auto deleter = [raw_pointer_local, isolate_id_local, dart_persistent_handle_local]() {
+            library_uncache_dart_handle_by_raw_pointer(raw_pointer_local, isolate_id_local);
+            Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
+        };
+        if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
+            deleter();
+        } else {
+            gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
+        }
+    }
+    smoke_EnableTagsInDart_Proxy(const smoke_EnableTagsInDart_Proxy&) = delete;
+    smoke_EnableTagsInDart_Proxy& operator=(const smoke_EnableTagsInDart_Proxy&) = delete;
+    void
+    enable_tagged() override {
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
+        ); });
+    }
+    void
+    dont_enable_tagged() override {
+    }
+    void
+    enable_tagged_list() override {
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f2))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
+        ); });
+    }
+private:
+    const uint64_t token;
+    const int32_t isolate_id;
+    const Dart_PersistentHandle dart_persistent_handle;
+    const FfiOpaqueHandle f0;
+    const FfiOpaqueHandle f2;
+    inline void dispatch(std::function<void()>&& callback) const
+    {
+        gluecodium::ffi::IsolateContext::is_current(isolate_id)
+            ? callback()
+            : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
+    }
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+library_smoke_EnableTagsInDart_enableTagged(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::EnableTagsInDart>>::toCpp(_self)).enable_tagged();
+}
+void
+library_smoke_EnableTagsInDart_enableTaggedList(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::EnableTagsInDart>>::toCpp(_self)).enable_tagged_list();
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_EnableTagsInDart_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::EnableTagsInDart>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_EnableTagsInDart_release_handle(handle);
+}
+void
+library_smoke_EnableTagsInDart_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_EnableTagsInDart_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_EnableTagsInDart_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::EnableTagsInDart>(
+            *reinterpret_cast<std::shared_ptr<smoke::EnableTagsInDart>*>(handle)
+        )
+    );
+}
+void
+library_smoke_EnableTagsInDart_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::EnableTagsInDart>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_EnableTagsInDart_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f2) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_EnableTagsInDart_Proxy>(token, isolate_id, "smoke_EnableTagsInDart");
+    std::shared_ptr<smoke_EnableTagsInDart_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EnableTagsInDart_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_EnableTagsInDart_Proxy>(
+            new (std::nothrow) smoke_EnableTagsInDart_Proxy(token, isolate_id, dart_handle, f0, f2)
+        );
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_EnableTagsInDart", *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
+}
+FfiOpaqueHandle
+library_smoke_EnableTagsInDart_get_type_id(FfiOpaqueHandle handle) {
+    const auto& type_id = ::gluecodium::get_type_repository().get_id(reinterpret_cast<std::shared_ptr<smoke::EnableTagsInDart>*>(handle)->get());
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::string(type_id));
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
@@ -1,0 +1,122 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+abstract class EnableTagsInDart {
+  factory EnableTagsInDart(
+    void Function() enableTaggedLambda,
+    void Function() enableTaggedListLambda,
+  ) => EnableTagsInDart$Lambdas(
+    enableTaggedLambda,
+    enableTaggedListLambda,
+  );
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
+  void enableTagged();
+  void enableTaggedList();
+}
+// EnableTagsInDart "private" section, not exported.
+final _smokeEnabletagsindartRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_EnableTagsInDart_register_finalizer'));
+final _smokeEnabletagsindartCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_EnableTagsInDart_copy_handle'));
+final _smokeEnabletagsindartReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_EnableTagsInDart_release_handle'));
+final _smokeEnabletagsindartCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer, Pointer)
+  >('library_smoke_EnableTagsInDart_create_proxy'));
+final _smokeEnabletagsindartGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_EnableTagsInDart_get_type_id'));
+class EnableTagsInDart$Lambdas implements EnableTagsInDart {
+  void Function() enableTaggedLambda;
+  void Function() enableTaggedListLambda;
+  EnableTagsInDart$Lambdas(
+    this.enableTaggedLambda,
+    this.enableTaggedListLambda,
+  );
+  @override
+  void release() {}
+  @override
+  void enableTagged() =>
+    enableTaggedLambda();
+  @override
+  void enableTaggedList() =>
+    enableTaggedListLambda();
+}
+class EnableTagsInDart$Impl extends __lib.NativeBase implements EnableTagsInDart {
+  EnableTagsInDart$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  void enableTagged() {
+    final _enableTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_EnableTagsInDart_enableTagged'));
+    final _handle = this.handle;
+    _enableTaggedFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  @override
+  void enableTaggedList() {
+    final _enableTaggedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_EnableTagsInDart_enableTaggedList'));
+    final _handle = this.handle;
+    _enableTaggedListFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+}
+int _smokeEnabletagsindartenableTaggedStatic(Object _obj) {
+  try {
+    (_obj as EnableTagsInDart).enableTagged();
+  } finally {
+  }
+  return 0;
+}
+int _smokeEnabletagsindartenableTaggedListStatic(Object _obj) {
+  try {
+    (_obj as EnableTagsInDart).enableTaggedList();
+  } finally {
+  }
+  return 0;
+}
+Pointer<Void> smokeEnabletagsindartToFfi(EnableTagsInDart value) {
+  if (value is __lib.NativeBase) return _smokeEnabletagsindartCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeEnabletagsindartCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Uint8 Function(Handle)>(_smokeEnabletagsindartenableTaggedStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle)>(_smokeEnabletagsindartenableTaggedListStatic, __lib.unknownError)
+  );
+  return result;
+}
+EnableTagsInDart smokeEnabletagsindartFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is EnableTagsInDart) return instance;
+  final _typeIdHandle = _smokeEnabletagsindartGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeEnabletagsindartCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : EnableTagsInDart$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeEnabletagsindartRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeEnabletagsindartReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeEnabletagsindartReleaseHandle(handle);
+Pointer<Void> smokeEnabletagsindartToFfiNullable(EnableTagsInDart? value) =>
+  value != null ? smokeEnabletagsindartToFfi(value) : Pointer<Void>.fromAddress(0);
+EnableTagsInDart? smokeEnabletagsindartFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeEnabletagsindartFromFfi(handle) : null;
+void smokeEnabletagsindartReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeEnabletagsindartReleaseHandle(handle);
+// End of EnableTagsInDart "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/EnableTagsInSwift.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/EnableTagsInSwift.swift
@@ -1,0 +1,121 @@
+//
+//
+import Foundation
+public protocol EnableTagsInSwift : AnyObject {
+    func enableTagged() -> Void
+    func enableTaggedList() -> Void
+}
+internal class _EnableTagsInSwift: EnableTagsInSwift {
+    let c_instance : _baseRef
+    init(cEnableTagsInSwift: _baseRef) {
+        guard cEnableTagsInSwift != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cEnableTagsInSwift
+    }
+    deinit {
+        smoke_EnableTagsInSwift_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_EnableTagsInSwift_release_handle(c_instance)
+    }
+    public func enableTagged() -> Void {
+        smoke_EnableTagsInSwift_enableTagged(self.c_instance)
+    }
+    public func enableTaggedList() -> Void {
+        smoke_EnableTagsInSwift_enableTaggedList(self.c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_EnableTagsInSwift")
+internal func _CBridgeInitsmoke_EnableTagsInSwift(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _EnableTagsInSwift(cEnableTagsInSwift: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: EnableTagsInSwift?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_EnableTagsInSwift_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_EnableTagsInSwift_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_EnableTagsInSwift_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_EnableTagsInSwift_enableTagged = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! EnableTagsInSwift
+        swift_class.enableTagged()
+    }
+    functions.smoke_EnableTagsInSwift_enableTaggedList = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! EnableTagsInSwift
+        swift_class.enableTaggedList()
+    }
+    let proxy = smoke_EnableTagsInSwift_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_EnableTagsInSwift_release_handle) : RefHolder(proxy)
+}
+extension _EnableTagsInSwift: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+internal func EnableTagsInSwift_copyFromCType(_ handle: _baseRef) -> EnableTagsInSwift {
+    if let swift_pointer = smoke_EnableTagsInSwift_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnableTagsInSwift {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_EnableTagsInSwift_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnableTagsInSwift {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_EnableTagsInSwift_get_typed(smoke_EnableTagsInSwift_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? EnableTagsInSwift {
+        smoke_EnableTagsInSwift_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func EnableTagsInSwift_moveFromCType(_ handle: _baseRef) -> EnableTagsInSwift {
+    if let swift_pointer = smoke_EnableTagsInSwift_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnableTagsInSwift {
+        smoke_EnableTagsInSwift_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_EnableTagsInSwift_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? EnableTagsInSwift {
+        smoke_EnableTagsInSwift_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_EnableTagsInSwift_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? EnableTagsInSwift {
+        smoke_EnableTagsInSwift_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func EnableTagsInSwift_copyFromCType(_ handle: _baseRef) -> EnableTagsInSwift? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EnableTagsInSwift_moveFromCType(handle) as EnableTagsInSwift
+}
+internal func EnableTagsInSwift_moveFromCType(_ handle: _baseRef) -> EnableTagsInSwift? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EnableTagsInSwift_moveFromCType(handle) as EnableTagsInSwift
+}
+internal func copyToCType(_ swiftClass: EnableTagsInSwift) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: EnableTagsInSwift) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: EnableTagsInSwift?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: EnableTagsInSwift?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -189,6 +189,7 @@ internal object AntlrLimeConverter {
             "Const" -> LimeAttributeValueType.CONST
             "CString" -> LimeAttributeValueType.CSTRING
             "Default" -> LimeAttributeValueType.DEFAULT
+            "EnableIf" -> LimeAttributeValueType.ENABLE_IF
             "Extension" -> LimeAttributeValueType.EXTENSION
             "FunctionName" -> LimeAttributeValueType.FUNCTION_NAME
             "Label" -> LimeAttributeValueType.LABEL

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
@@ -21,6 +21,7 @@ package com.here.gluecodium.common
 
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.ENABLE_IF
 import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeAttributeValueType.TAG
 import com.here.gluecodium.model.lime.LimeElement
@@ -34,13 +35,13 @@ object LimeModelSkipPredicates {
         activeTags: Set<String>,
         platformAttribute: LimeAttributeType? = null,
         retainFunctions: Boolean = false
-    ) =
-        when {
-            isSkippedByTags(limeElement, activeTags) -> false
-            retainFunctions && (limeElement is LimeFunction || limeElement is LimeProperty) -> true
-            platformAttribute?.let { hasTagsMatch(limeElement, it, SKIP, activeTags) } == true -> false
-            else -> true
-        }
+    ) = when {
+        isSkippedByTags(limeElement, activeTags) -> false
+        retainFunctions && (limeElement is LimeFunction || limeElement is LimeProperty) -> true
+        platformAttribute == null -> true
+        isSkippedByTagsOnPlatform(limeElement, activeTags, platformAttribute) -> false
+        else -> true
+    }
 
     fun shouldRetainCheckParent(
         limeElement: LimeNamedElement,
@@ -61,6 +62,18 @@ object LimeModelSkipPredicates {
         if (isEnabled == false) return true
 
         val isSkipped = hasTagsMatch(limeElement, LimeAttributeType.SKIP, TAG, activeTags)
+        return isSkipped ?: false
+    }
+
+    private fun isSkippedByTagsOnPlatform(
+        limeElement: LimeNamedElement,
+        activeTags: Set<String>,
+        platformAttribute: LimeAttributeType
+    ): Boolean {
+        val isEnabled = hasTagsMatch(limeElement, platformAttribute, ENABLE_IF, activeTags)
+        if (isEnabled == false) return true
+
+        val isSkipped = hasTagsMatch(limeElement, platformAttribute, SKIP, activeTags)
         return isSkipped ?: false
     }
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -27,6 +27,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     CONST("Const"),
     CSTRING("CString"),
     DEFAULT("Default"),
+    ENABLE_IF("EnableIf"),
     EXTENSION("Extension"),
     FUNCTION_NAME("FunctionName"),
     LABEL("Label"),


### PR DESCRIPTION
Updated LimeModelSkipPredicates to support `@Java(EnableIf = "CustomTag")` syntax (also for Swift
and Dart). Updating the predicates is sufficient to add the support for all three platforms, no
changes in any individual generator are required.

Added smoke and functional tests.

Resolves: #996
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>