### PR TITLE
Fix another batch of "dart analyze" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Fixed runtime issue for interfaces sent from Java to C++ and then back to Java.
   * Removed suppression of "dart analyze" warning about deprecated element usage. This should be suppressed in a
     library-level analysis_options.yaml instead.
+  * Fixed "dart analyze" warnings about unused imports.
 
 ## 9.3.5
 Release date: 2021-07-28

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -69,7 +69,7 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
         if (limeStruct.attributes.have(LimeAttributeType.EQUATABLE) &&
             limeStruct.fields.any { it.typeRef.type.actualType is LimeGenericType }
         ) {
-            result += listOf(collectionSystemImport, collectionPackageImport)
+            result += listOf(collectionPackageImport)
         }
         if (limeStruct.attributes.have(LimeAttributeType.IMMUTABLE)) {
             result += listOf(metaPackageImport)
@@ -78,7 +78,6 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
     }
 
     companion object {
-        private val collectionSystemImport = DartImport("collection", importType = ImportType.SYSTEM)
         private val collectionPackageImport = DartImport("collection/collection")
         private val metaPackageImport = DartImport("meta/meta")
         private val ffiSystemImport = DartImport("ffi", importType = ImportType.SYSTEM)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -447,9 +447,12 @@ internal class DartGenerator : Generator {
         nameResolvers: Map<String, NameResolver>,
         importResolver: DartImportResolver
     ): GeneratedFile {
-        val fileName = "$SRC_DIR_SUFFIX/generic_types__conversion"
-        val imports = genericTypes.flatMap { importResolver.resolveElementImports(it) }
+        val elementTypeRefs = genericTypes.filterIsInstance<LimeList>().map { it.elementType } +
+            genericTypes.filterIsInstance<LimeSet>().map { it.elementType } +
+            genericTypes.filterIsInstance<LimeMap>().flatMap { listOf(it.keyType, it.valueType) }
+        val imports = (genericTypes + elementTypeRefs).flatMap { importResolver.resolveElementImports(it) }
 
+        val fileName = "$SRC_DIR_SUFFIX/generic_types__conversion"
         val content = TemplateEngine.render(
             "dart/DartGenericTypesConversion",
             mapOf(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -68,10 +68,7 @@ internal class DartImportResolver(
             is LimeBasicType ->
                 if (actualType.typeId.isNumericType || actualType.typeId == LimeBasicType.TypeId.VOID) emptyList()
                 else listOf(builtInTypesConversionImport)
-            is LimeList -> resolveConversionImports(actualType.elementType) + createConversionImport("generic_types")
-            is LimeSet -> resolveConversionImports(actualType.elementType) + createConversionImport("generic_types")
-            is LimeMap -> resolveConversionImports(actualType.keyType) +
-                resolveConversionImports(actualType.valueType) + createConversionImport("generic_types")
+            is LimeGenericType -> listOf(createConversionImport("generic_types"))
             else -> emptyList()
         }
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
@@ -1,6 +1,5 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 class StructWithCollectionDefaults {
   List<String> emptyListField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -1,6 +1,5 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/types_with_defaults.dart';
 class StructWithInitializerDefaults {

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:ffi';
 import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:ffi';
 import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -2,7 +2,6 @@ import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 abstract class GenericTypesWithBasicTypes {
   /// @nodoc

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -2,7 +2,6 @@ import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 abstract class GenericTypesWithGenericTypes {
   /// @nodoc

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/some_skipped_struct.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/some_skipped_struct.dart
@@ -1,4 +1,3 @@
-import 'dart:collection';
 import 'dart:ffi';
 import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;


### PR DESCRIPTION
Removed extraneous "dart:collections" import for `@Equatable` structs with collection fields.

Fixed import resolution for collection types in Dart generator, thus removing the extraneous "basic
types conversion" import for some structs.

Resolves: #895
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>