### PR TITLE
Fix clashing lambdas in Swift

### DIFF
--- a/functional-tests/functional/input/lime/Lambdas.lime
+++ b/functional-tests/functional/input/lime/Lambdas.lime
@@ -75,3 +75,6 @@ class ClassWithInternalLambda {
     internal lambda InternalLambda = (String) -> Boolean
     internal static fun invokeInternalLambda(`lambda`: InternalLambda, value: String): Boolean
 }
+
+@Java(Skip) # TODO: #1026: fix in Java and remove this skip
+lambda SignatureClashLambda = () -> String

--- a/gluecodium/src/main/resources/templates/swift/ConversionPrefixFrom.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ConversionPrefixFrom.mustache
@@ -20,6 +20,7 @@
   !}}
 {{#typeRef.type.actualType}}{{#instanceOf this "LimeInterface"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeClass"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeLambda"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
 }}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
 }}{{#unlessPredicate "hasCppTypeAttribute"}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeSet"}}{{internalPrefix}}{{/instanceOf}}{{!!

--- a/gluecodium/src/main/resources/templates/swift/ConversionPrefixTo.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ConversionPrefixTo.mustache
@@ -18,7 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#typeRef.type.actualType}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
+{{#typeRef.type.actualType}}{{#instanceOf this "LimeLambda"}}{{resolveName typeRef "mangled"}}{{/instanceOf}}{{!!
+}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
 }}{{#unlessPredicate "hasCppTypeAttribute"}}{{#instanceOf this "LimeList"}}{{internalPrefix}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeSet"}}{{internalPrefix}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeMap"}}{{internalPrefix}}{{/instanceOf}}{{!!

--- a/gluecodium/src/main/resources/templates/swift/SwiftLambdaConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftLambdaConversion.mustache
@@ -18,10 +18,10 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{conversionVisibility}} func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
-    return moveFromCType({{resolveName "CBridge"}}_copy_handle(handle))
+{{conversionVisibility}} func {{resolveName "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+    return {{resolveName "mangled"}}moveFromCType({{resolveName "CBridge"}}_copy_handle(handle))
 }
-{{conversionVisibility}} func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
+{{conversionVisibility}} func {{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
     let refHolder = RefHolder(ref: handle, release: {{resolveName "CBridge"}}_release_handle)
     return { ({{#parameters}}p{{iter.position}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
     }} -> {{resolveName returnType}} in
@@ -33,20 +33,20 @@
     }
 }
 
-{{conversionVisibility}} func copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+{{conversionVisibility}} func {{resolveName "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as {{resolveName this "" "ref"}}
+    return {{resolveName "mangled"}}copyFromCType(handle) as {{resolveName this "" "ref"}}
 }
-{{conversionVisibility}} func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
+{{conversionVisibility}} func {{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as {{resolveName this "" "ref"}}
+    return {{resolveName "mangled"}}moveFromCType(handle) as {{resolveName this "" "ref"}}
 }
 
-{{conversionVisibility}} func createFunctionalTable(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> {{resolveName "CBridge"}}_FunctionTable {
+{{conversionVisibility}} func {{resolveName "mangled"}}createFunctionalTable(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> {{resolveName "CBridge"}}_FunctionTable {
     class {{resolveName "CBridge"}}_Holder {
         let closure: {{resolveName this "" "ref"}}
         init(_ closure: @escaping {{resolveName this "" "ref"}}) {
@@ -70,28 +70,28 @@
     return functions
 }
 
-{{conversionVisibility}} func copyToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
-    let handle = {{resolveName "CBridge"}}_create_proxy(createFunctionalTable(swiftType))
+{{conversionVisibility}} func {{resolveName "mangled"}}copyToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
+    let handle = {{resolveName "CBridge"}}_create_proxy({{resolveName "mangled"}}createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-{{conversionVisibility}} func moveToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
-    let handle = {{resolveName "CBridge"}}_create_proxy(createFunctionalTable(swiftType))
+{{conversionVisibility}} func {{resolveName "mangled"}}moveToCType(_ swiftType: @escaping {{resolveName this "" "ref"}}) -> RefHolder {
+    let handle = {{resolveName "CBridge"}}_create_proxy({{resolveName "mangled"}}createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: {{resolveName "CBridge"}}_release_handle)
 }
 
-{{conversionVisibility}} func copyToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
+{{conversionVisibility}} func {{resolveName "mangled"}}copyToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
 
-    let handle = {{resolveName "CBridge"}}_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = {{resolveName "CBridge"}}_create_optional_proxy({{resolveName "mangled"}}createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-{{conversionVisibility}} func moveToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
+{{conversionVisibility}} func {{resolveName "mangled"}}moveToCType(_ swiftType: {{resolveName this "" "ref"}}?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
 
-    let handle = {{resolveName "CBridge"}}_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = {{resolveName "CBridge"}}_create_optional_proxy({{resolveName "mangled"}}createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: {{resolveName "CBridge"}}_release_handle)
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesLambda.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesLambda.swift
@@ -3,28 +3,28 @@
 import Foundation
 @OnLambda
 public typealias AttributesLambda = () -> Void
-internal func copyFromCType(_ handle: _baseRef) -> AttributesLambda {
-    return moveFromCType(smoke_AttributesLambda_copy_handle(handle))
+internal func AttributesLambda_copyFromCType(_ handle: _baseRef) -> AttributesLambda {
+    return AttributesLambda_moveFromCType(smoke_AttributesLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesLambda {
+internal func AttributesLambda_moveFromCType(_ handle: _baseRef) -> AttributesLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
     return { () -> Void in
         return moveFromCType(smoke_AttributesLambda_call(refHolder.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> AttributesLambda? {
+internal func AttributesLambda_copyFromCType(_ handle: _baseRef) -> AttributesLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as AttributesLambda
+    return AttributesLambda_copyFromCType(handle) as AttributesLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> AttributesLambda? {
+internal func AttributesLambda_moveFromCType(_ handle: _baseRef) -> AttributesLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as AttributesLambda
+    return AttributesLambda_moveFromCType(handle) as AttributesLambda
 }
-internal func createFunctionalTable(_ swiftType: @escaping AttributesLambda) -> smoke_AttributesLambda_FunctionTable {
+internal func AttributesLambda_createFunctionalTable(_ swiftType: @escaping AttributesLambda) -> smoke_AttributesLambda_FunctionTable {
     class smoke_AttributesLambda_Holder {
         let closure: AttributesLambda
         init(_ closure: @escaping AttributesLambda) {
@@ -44,25 +44,25 @@ internal func createFunctionalTable(_ swiftType: @escaping AttributesLambda) -> 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
-    let handle = smoke_AttributesLambda_create_proxy(createFunctionalTable(swiftType))
+internal func AttributesLambda_copyToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
+    let handle = smoke_AttributesLambda_create_proxy(AttributesLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
-    let handle = smoke_AttributesLambda_create_proxy(createFunctionalTable(swiftType))
+internal func AttributesLambda_moveToCType(_ swiftType: @escaping AttributesLambda) -> RefHolder {
+    let handle = smoke_AttributesLambda_create_proxy(AttributesLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: AttributesLambda?) -> RefHolder {
+internal func AttributesLambda_copyToCType(_ swiftType: AttributesLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_AttributesLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_AttributesLambda_create_optional_proxy(AttributesLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: AttributesLambda?) -> RefHolder {
+internal func AttributesLambda_moveToCType(_ swiftType: AttributesLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_AttributesLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_AttributesLambda_create_optional_proxy(AttributesLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_AttributesLambda_release_handle)
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -215,10 +215,10 @@ internal func copyToCType(_ swiftClass: Comments?) -> RefHolder {
 internal func moveToCType(_ swiftClass: Comments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
-    return moveFromCType(smoke_Comments_SomeLambda_copy_handle(handle))
+internal func Comments_SomeLambda_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
+    return Comments_SomeLambda_moveFromCType(smoke_Comments_SomeLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
+internal func Comments_SomeLambda_moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
         let _p0 = moveToCType(p0)
@@ -226,19 +226,19 @@ internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
         return moveFromCType(smoke_Comments_SomeLambda_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
+internal func Comments_SomeLambda_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Comments.SomeLambda
+    return Comments_SomeLambda_copyFromCType(handle) as Comments.SomeLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
+internal func Comments_SomeLambda_moveFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Comments.SomeLambda
+    return Comments_SomeLambda_moveFromCType(handle) as Comments.SomeLambda
 }
-internal func createFunctionalTable(_ swiftType: @escaping Comments.SomeLambda) -> smoke_Comments_SomeLambda_FunctionTable {
+internal func Comments_SomeLambda_createFunctionalTable(_ swiftType: @escaping Comments.SomeLambda) -> smoke_Comments_SomeLambda_FunctionTable {
     class smoke_Comments_SomeLambda_Holder {
         let closure: Comments.SomeLambda
         init(_ closure: @escaping Comments.SomeLambda) {
@@ -258,26 +258,26 @@ internal func createFunctionalTable(_ swiftType: @escaping Comments.SomeLambda) 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
-    let handle = smoke_Comments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+internal func Comments_SomeLambda_copyToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
+    let handle = smoke_Comments_SomeLambda_create_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
-    let handle = smoke_Comments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+internal func Comments_SomeLambda_moveToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
+    let handle = smoke_Comments_SomeLambda_create_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
+internal func Comments_SomeLambda_copyToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Comments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Comments_SomeLambda_create_optional_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
+internal func Comments_SomeLambda_moveToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Comments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Comments_SomeLambda_create_optional_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
 }
 internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeStruct {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
@@ -150,10 +150,10 @@ internal func copyToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
 internal func moveToCType(_ swiftClass: ExcludedComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
-    return moveFromCType(smoke_ExcludedComments_SomeLambda_copy_handle(handle))
+internal func ExcludedComments_SomeLambda_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
+    return ExcludedComments_SomeLambda_moveFromCType(smoke_ExcludedComments_SomeLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
+internal func ExcludedComments_SomeLambda_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
         let _p0 = moveToCType(p0)
@@ -161,19 +161,19 @@ internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda {
         return moveFromCType(smoke_ExcludedComments_SomeLambda_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
+internal func ExcludedComments_SomeLambda_copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as ExcludedComments.SomeLambda
+    return ExcludedComments_SomeLambda_copyFromCType(handle) as ExcludedComments.SomeLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
+internal func ExcludedComments_SomeLambda_moveFromCType(_ handle: _baseRef) -> ExcludedComments.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as ExcludedComments.SomeLambda
+    return ExcludedComments_SomeLambda_moveFromCType(handle) as ExcludedComments.SomeLambda
 }
-internal func createFunctionalTable(_ swiftType: @escaping ExcludedComments.SomeLambda) -> smoke_ExcludedComments_SomeLambda_FunctionTable {
+internal func ExcludedComments_SomeLambda_createFunctionalTable(_ swiftType: @escaping ExcludedComments.SomeLambda) -> smoke_ExcludedComments_SomeLambda_FunctionTable {
     class smoke_ExcludedComments_SomeLambda_Holder {
         let closure: ExcludedComments.SomeLambda
         init(_ closure: @escaping ExcludedComments.SomeLambda) {
@@ -193,26 +193,26 @@ internal func createFunctionalTable(_ swiftType: @escaping ExcludedComments.Some
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
-    let handle = smoke_ExcludedComments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+internal func ExcludedComments_SomeLambda_copyToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedComments_SomeLambda_create_proxy(ExcludedComments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
-    let handle = smoke_ExcludedComments_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+internal func ExcludedComments_SomeLambda_moveToCType(_ swiftType: @escaping ExcludedComments.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedComments_SomeLambda_create_proxy(ExcludedComments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
+internal func ExcludedComments_SomeLambda_copyToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(ExcludedComments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
+internal func ExcludedComments_SomeLambda_moveToCType(_ swiftType: ExcludedComments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_ExcludedComments_SomeLambda_create_optional_proxy(ExcludedComments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedComments_SomeLambda_release_handle)
 }
 internal func copyFromCType(_ handle: _baseRef) -> ExcludedComments.SomeStruct {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
@@ -135,10 +135,10 @@ internal func copyToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
 internal func moveToCType(_ swiftClass: ExcludedCommentsOnly?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
-    return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_copy_handle(handle))
+internal func ExcludedCommentsOnly_SomeLambda_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
+    return ExcludedCommentsOnly_SomeLambda_moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
+internal func ExcludedCommentsOnly_SomeLambda_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda {
     let refHolder = RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
     return { (p0: String, p1: Int32) -> Double in
         let _p0 = moveToCType(p0)
@@ -146,19 +146,19 @@ internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLamb
         return moveFromCType(smoke_ExcludedCommentsOnly_SomeLambda_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
+internal func ExcludedCommentsOnly_SomeLambda_copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as ExcludedCommentsOnly.SomeLambda
+    return ExcludedCommentsOnly_SomeLambda_copyFromCType(handle) as ExcludedCommentsOnly.SomeLambda
 }
-internal func moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
+internal func ExcludedCommentsOnly_SomeLambda_moveFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeLambda? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as ExcludedCommentsOnly.SomeLambda
+    return ExcludedCommentsOnly_SomeLambda_moveFromCType(handle) as ExcludedCommentsOnly.SomeLambda
 }
-internal func createFunctionalTable(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> smoke_ExcludedCommentsOnly_SomeLambda_FunctionTable {
+internal func ExcludedCommentsOnly_SomeLambda_createFunctionalTable(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> smoke_ExcludedCommentsOnly_SomeLambda_FunctionTable {
     class smoke_ExcludedCommentsOnly_SomeLambda_Holder {
         let closure: ExcludedCommentsOnly.SomeLambda
         init(_ closure: @escaping ExcludedCommentsOnly.SomeLambda) {
@@ -178,26 +178,26 @@ internal func createFunctionalTable(_ swiftType: @escaping ExcludedCommentsOnly.
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
-    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+internal func ExcludedCommentsOnly_SomeLambda_copyToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(ExcludedCommentsOnly_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
-    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(createFunctionalTable(swiftType))
+internal func ExcludedCommentsOnly_SomeLambda_moveToCType(_ swiftType: @escaping ExcludedCommentsOnly.SomeLambda) -> RefHolder {
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_proxy(ExcludedCommentsOnly_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
 }
-internal func copyToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
+internal func ExcludedCommentsOnly_SomeLambda_copyToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(ExcludedCommentsOnly_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
+internal func ExcludedCommentsOnly_SomeLambda_moveToCType(_ swiftType: ExcludedCommentsOnly.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_ExcludedCommentsOnly_SomeLambda_create_optional_proxy(ExcludedCommentsOnly_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_ExcludedCommentsOnly_SomeLambda_release_handle)
 }
 internal func copyFromCType(_ handle: _baseRef) -> ExcludedCommentsOnly.SomeStruct {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MapScene.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/MapScene.swift
@@ -17,12 +17,12 @@ public class MapScene {
     }
     public func loadScene(mapScheme: Int32, callback: MapScene.LoadSceneCallback?) -> Void {
         let c_mapScheme = moveToCType(mapScheme)
-        let c_callback = moveToCType(callback)
+        let c_callback = MapScene_LoadSceneCallback_moveToCType(callback)
         smoke_MapScene_loadScene_Int_LoadSceneCallback(self.c_instance, c_mapScheme.ref, c_callback.ref)
     }
     public func loadScene(configurationFile: String, callback: MapScene.LoadSceneCallback?) -> Void {
         let c_configurationFile = moveToCType(configurationFile)
-        let c_callback = moveToCType(callback)
+        let c_callback = MapScene_LoadSceneCallback_moveToCType(callback)
         smoke_MapScene_loadScene_String_LoadSceneCallback(self.c_instance, c_configurationFile.ref, c_callback.ref)
     }
 }
@@ -92,29 +92,29 @@ internal func copyToCType(_ swiftClass: MapScene?) -> RefHolder {
 internal func moveToCType(_ swiftClass: MapScene?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback {
-    return moveFromCType(smoke_MapScene_LoadSceneCallback_copy_handle(handle))
+internal func MapScene_LoadSceneCallback_copyFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback {
+    return MapScene_LoadSceneCallback_moveFromCType(smoke_MapScene_LoadSceneCallback_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback {
+internal func MapScene_LoadSceneCallback_moveFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_MapScene_LoadSceneCallback_release_handle)
     return { (p0: String?) -> Void in
         let _p0 = moveToCType(p0)
         return moveFromCType(smoke_MapScene_LoadSceneCallback_call(refHolder.ref, _p0.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback? {
+internal func MapScene_LoadSceneCallback_copyFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as MapScene.LoadSceneCallback
+    return MapScene_LoadSceneCallback_copyFromCType(handle) as MapScene.LoadSceneCallback
 }
-internal func moveFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback? {
+internal func MapScene_LoadSceneCallback_moveFromCType(_ handle: _baseRef) -> MapScene.LoadSceneCallback? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as MapScene.LoadSceneCallback
+    return MapScene_LoadSceneCallback_moveFromCType(handle) as MapScene.LoadSceneCallback
 }
-internal func createFunctionalTable(_ swiftType: @escaping MapScene.LoadSceneCallback) -> smoke_MapScene_LoadSceneCallback_FunctionTable {
+internal func MapScene_LoadSceneCallback_createFunctionalTable(_ swiftType: @escaping MapScene.LoadSceneCallback) -> smoke_MapScene_LoadSceneCallback_FunctionTable {
     class smoke_MapScene_LoadSceneCallback_Holder {
         let closure: MapScene.LoadSceneCallback
         init(_ closure: @escaping MapScene.LoadSceneCallback) {
@@ -134,25 +134,25 @@ internal func createFunctionalTable(_ swiftType: @escaping MapScene.LoadSceneCal
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping MapScene.LoadSceneCallback) -> RefHolder {
-    let handle = smoke_MapScene_LoadSceneCallback_create_proxy(createFunctionalTable(swiftType))
+internal func MapScene_LoadSceneCallback_copyToCType(_ swiftType: @escaping MapScene.LoadSceneCallback) -> RefHolder {
+    let handle = smoke_MapScene_LoadSceneCallback_create_proxy(MapScene_LoadSceneCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping MapScene.LoadSceneCallback) -> RefHolder {
-    let handle = smoke_MapScene_LoadSceneCallback_create_proxy(createFunctionalTable(swiftType))
+internal func MapScene_LoadSceneCallback_moveToCType(_ swiftType: @escaping MapScene.LoadSceneCallback) -> RefHolder {
+    let handle = smoke_MapScene_LoadSceneCallback_create_proxy(MapScene_LoadSceneCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_MapScene_LoadSceneCallback_release_handle)
 }
-internal func copyToCType(_ swiftType: MapScene.LoadSceneCallback?) -> RefHolder {
+internal func MapScene_LoadSceneCallback_copyToCType(_ swiftType: MapScene.LoadSceneCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_MapScene_LoadSceneCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_MapScene_LoadSceneCallback_create_optional_proxy(MapScene_LoadSceneCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: MapScene.LoadSceneCallback?) -> RefHolder {
+internal func MapScene_LoadSceneCallback_moveToCType(_ swiftType: MapScene.LoadSceneCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_MapScene_LoadSceneCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_MapScene_LoadSceneCallback_create_optional_proxy(MapScene_LoadSceneCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_MapScene_LoadSceneCallback_release_handle)
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -21,13 +21,13 @@ public class Lambdas {
     }
     public func deconfuse(value: String, confuser: @escaping Lambdas.Convoluter) -> Lambdas.Producer {
         let c_value = moveToCType(value)
-        let c_confuser = moveToCType(confuser)
+        let c_confuser = Lambdas_Convoluter_moveToCType(confuser)
         let c_result_handle = smoke_Lambdas_deconfuse(self.c_instance, c_value.ref, c_confuser.ref)
-        return moveFromCType(c_result_handle)
+        return Lambdas_Producer_moveFromCType(c_result_handle)
     }
     public static func fuse(items: [String], callback: @escaping Lambdas.Indexer) -> [Int32: String] {
         let c_items = foobar_moveToCType(items)
-        let c_callback = moveToCType(callback)
+        let c_callback = Lambdas_Indexer_moveToCType(callback)
         let c_result_handle = smoke_Lambdas_fuse(c_items.ref, c_callback.ref)
         return foobar_moveFromCType(c_result_handle)
     }
@@ -98,28 +98,28 @@ internal func copyToCType(_ swiftClass: Lambdas?) -> RefHolder {
 internal func moveToCType(_ swiftClass: Lambdas?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Producer {
-    return moveFromCType(smoke_Lambdas_Producer_copy_handle(handle))
+internal func Lambdas_Producer_copyFromCType(_ handle: _baseRef) -> Lambdas.Producer {
+    return Lambdas_Producer_moveFromCType(smoke_Lambdas_Producer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Producer {
+internal func Lambdas_Producer_moveFromCType(_ handle: _baseRef) -> Lambdas.Producer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Producer_release_handle)
     return { () -> String in
         return moveFromCType(smoke_Lambdas_Producer_call(refHolder.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
+internal func Lambdas_Producer_copyFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Producer
+    return Lambdas_Producer_copyFromCType(handle) as Lambdas.Producer
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
+internal func Lambdas_Producer_moveFromCType(_ handle: _baseRef) -> Lambdas.Producer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Producer
+    return Lambdas_Producer_moveFromCType(handle) as Lambdas.Producer
 }
-internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Producer) -> smoke_Lambdas_Producer_FunctionTable {
+internal func Lambdas_Producer_createFunctionalTable(_ swiftType: @escaping Lambdas.Producer) -> smoke_Lambdas_Producer_FunctionTable {
     class smoke_Lambdas_Producer_Holder {
         let closure: Lambdas.Producer
         init(_ closure: @escaping Lambdas.Producer) {
@@ -139,51 +139,51 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Producer) -> 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
-    let handle = smoke_Lambdas_Producer_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Producer_copyToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
+    let handle = smoke_Lambdas_Producer_create_proxy(Lambdas_Producer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
-    let handle = smoke_Lambdas_Producer_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Producer_moveToCType(_ swiftType: @escaping Lambdas.Producer) -> RefHolder {
+    let handle = smoke_Lambdas_Producer_create_proxy(Lambdas_Producer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Producer_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
+internal func Lambdas_Producer_copyToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Producer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Producer_create_optional_proxy(Lambdas_Producer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
+internal func Lambdas_Producer_moveToCType(_ swiftType: Lambdas.Producer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Producer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Producer_create_optional_proxy(Lambdas_Producer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Producer_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
-    return moveFromCType(smoke_Lambdas_Convoluter_copy_handle(handle))
+internal func Lambdas_Convoluter_copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
+    return Lambdas_Convoluter_moveFromCType(smoke_Lambdas_Convoluter_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
+internal func Lambdas_Convoluter_moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Convoluter_release_handle)
     return { (p0: String) -> Lambdas.Producer in
         let _p0 = moveToCType(p0)
-        return moveFromCType(smoke_Lambdas_Convoluter_call(refHolder.ref, _p0.ref))
+        return Lambdas_Producer_moveFromCType(smoke_Lambdas_Convoluter_call(refHolder.ref, _p0.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
+internal func Lambdas_Convoluter_copyFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Convoluter
+    return Lambdas_Convoluter_copyFromCType(handle) as Lambdas.Convoluter
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
+internal func Lambdas_Convoluter_moveFromCType(_ handle: _baseRef) -> Lambdas.Convoluter? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Convoluter
+    return Lambdas_Convoluter_moveFromCType(handle) as Lambdas.Convoluter
 }
-internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Convoluter) -> smoke_Lambdas_Convoluter_FunctionTable {
+internal func Lambdas_Convoluter_createFunctionalTable(_ swiftType: @escaping Lambdas.Convoluter) -> smoke_Lambdas_Convoluter_FunctionTable {
     class smoke_Lambdas_Convoluter_Holder {
         let closure: Lambdas.Convoluter
         init(_ closure: @escaping Lambdas.Convoluter) {
@@ -199,55 +199,55 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Convoluter) -
     }
     functions.smoke_Lambdas_Convoluter_call = { swift_closure_pointer, p0 in
         let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_Lambdas_Convoluter_Holder
-        return copyToCType(closure_holder.closure(moveFromCType(p0))).ref
+        return Lambdas_Producer_copyToCType(closure_holder.closure(moveFromCType(p0))).ref
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
-    let handle = smoke_Lambdas_Convoluter_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Convoluter_copyToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
+    let handle = smoke_Lambdas_Convoluter_create_proxy(Lambdas_Convoluter_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
-    let handle = smoke_Lambdas_Convoluter_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Convoluter_moveToCType(_ swiftType: @escaping Lambdas.Convoluter) -> RefHolder {
+    let handle = smoke_Lambdas_Convoluter_create_proxy(Lambdas_Convoluter_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Convoluter_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
+internal func Lambdas_Convoluter_copyToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Convoluter_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Convoluter_create_optional_proxy(Lambdas_Convoluter_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
+internal func Lambdas_Convoluter_moveToCType(_ swiftType: Lambdas.Convoluter?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Convoluter_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Convoluter_create_optional_proxy(Lambdas_Convoluter_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Convoluter_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
-    return moveFromCType(smoke_Lambdas_Consumer_copy_handle(handle))
+internal func Lambdas_Consumer_copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
+    return Lambdas_Consumer_moveFromCType(smoke_Lambdas_Consumer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
+internal func Lambdas_Consumer_moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Consumer_release_handle)
     return { (p0: String) -> Void in
         let _p0 = moveToCType(p0)
         return moveFromCType(smoke_Lambdas_Consumer_call(refHolder.ref, _p0.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
+internal func Lambdas_Consumer_copyFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Consumer
+    return Lambdas_Consumer_copyFromCType(handle) as Lambdas.Consumer
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
+internal func Lambdas_Consumer_moveFromCType(_ handle: _baseRef) -> Lambdas.Consumer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Consumer
+    return Lambdas_Consumer_moveFromCType(handle) as Lambdas.Consumer
 }
-internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Consumer) -> smoke_Lambdas_Consumer_FunctionTable {
+internal func Lambdas_Consumer_createFunctionalTable(_ swiftType: @escaping Lambdas.Consumer) -> smoke_Lambdas_Consumer_FunctionTable {
     class smoke_Lambdas_Consumer_Holder {
         let closure: Lambdas.Consumer
         init(_ closure: @escaping Lambdas.Consumer) {
@@ -267,32 +267,32 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Consumer) -> 
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
-    let handle = smoke_Lambdas_Consumer_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Consumer_copyToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
+    let handle = smoke_Lambdas_Consumer_create_proxy(Lambdas_Consumer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
-    let handle = smoke_Lambdas_Consumer_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Consumer_moveToCType(_ swiftType: @escaping Lambdas.Consumer) -> RefHolder {
+    let handle = smoke_Lambdas_Consumer_create_proxy(Lambdas_Consumer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Consumer_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
+internal func Lambdas_Consumer_copyToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Consumer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Consumer_create_optional_proxy(Lambdas_Consumer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
+internal func Lambdas_Consumer_moveToCType(_ swiftType: Lambdas.Consumer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Consumer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Consumer_create_optional_proxy(Lambdas_Consumer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Consumer_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
-    return moveFromCType(smoke_Lambdas_Indexer_copy_handle(handle))
+internal func Lambdas_Indexer_copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
+    return Lambdas_Indexer_moveFromCType(smoke_Lambdas_Indexer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
+internal func Lambdas_Indexer_moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_Indexer_release_handle)
     return { (p0: String, p1: Float) -> Int32 in
         let _p0 = moveToCType(p0)
@@ -300,19 +300,19 @@ internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer {
         return moveFromCType(smoke_Lambdas_Indexer_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
+internal func Lambdas_Indexer_copyFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.Indexer
+    return Lambdas_Indexer_copyFromCType(handle) as Lambdas.Indexer
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
+internal func Lambdas_Indexer_moveFromCType(_ handle: _baseRef) -> Lambdas.Indexer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.Indexer
+    return Lambdas_Indexer_moveFromCType(handle) as Lambdas.Indexer
 }
-internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Indexer) -> smoke_Lambdas_Indexer_FunctionTable {
+internal func Lambdas_Indexer_createFunctionalTable(_ swiftType: @escaping Lambdas.Indexer) -> smoke_Lambdas_Indexer_FunctionTable {
     class smoke_Lambdas_Indexer_Holder {
         let closure: Lambdas.Indexer
         init(_ closure: @escaping Lambdas.Indexer) {
@@ -332,51 +332,51 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.Indexer) -> s
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
-    let handle = smoke_Lambdas_Indexer_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Indexer_copyToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
+    let handle = smoke_Lambdas_Indexer_create_proxy(Lambdas_Indexer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
-    let handle = smoke_Lambdas_Indexer_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_Indexer_moveToCType(_ swiftType: @escaping Lambdas.Indexer) -> RefHolder {
+    let handle = smoke_Lambdas_Indexer_create_proxy(Lambdas_Indexer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Indexer_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
+internal func Lambdas_Indexer_copyToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Indexer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Indexer_create_optional_proxy(Lambdas_Indexer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
+internal func Lambdas_Indexer_moveToCType(_ swiftType: Lambdas.Indexer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_Indexer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_Indexer_create_optional_proxy(Lambdas_Indexer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_Indexer_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
-    return moveFromCType(smoke_Lambdas_NullableConfuser_copy_handle(handle))
+internal func Lambdas_NullableConfuser_copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
+    return Lambdas_NullableConfuser_moveFromCType(smoke_Lambdas_NullableConfuser_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
+internal func Lambdas_NullableConfuser_moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser {
     let refHolder = RefHolder(ref: handle, release: smoke_Lambdas_NullableConfuser_release_handle)
     return { (p0: String?) -> Lambdas.Producer? in
         let _p0 = moveToCType(p0)
-        return moveFromCType(smoke_Lambdas_NullableConfuser_call(refHolder.ref, _p0.ref))
+        return Lambdas_Producer_moveFromCType(smoke_Lambdas_NullableConfuser_call(refHolder.ref, _p0.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
+internal func Lambdas_NullableConfuser_copyFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as Lambdas.NullableConfuser
+    return Lambdas_NullableConfuser_copyFromCType(handle) as Lambdas.NullableConfuser
 }
-internal func moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
+internal func Lambdas_NullableConfuser_moveFromCType(_ handle: _baseRef) -> Lambdas.NullableConfuser? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as Lambdas.NullableConfuser
+    return Lambdas_NullableConfuser_moveFromCType(handle) as Lambdas.NullableConfuser
 }
-internal func createFunctionalTable(_ swiftType: @escaping Lambdas.NullableConfuser) -> smoke_Lambdas_NullableConfuser_FunctionTable {
+internal func Lambdas_NullableConfuser_createFunctionalTable(_ swiftType: @escaping Lambdas.NullableConfuser) -> smoke_Lambdas_NullableConfuser_FunctionTable {
     class smoke_Lambdas_NullableConfuser_Holder {
         let closure: Lambdas.NullableConfuser
         init(_ closure: @escaping Lambdas.NullableConfuser) {
@@ -392,29 +392,29 @@ internal func createFunctionalTable(_ swiftType: @escaping Lambdas.NullableConfu
     }
     functions.smoke_Lambdas_NullableConfuser_call = { swift_closure_pointer, p0 in
         let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_Lambdas_NullableConfuser_Holder
-        return copyToCType(closure_holder.closure(moveFromCType(p0))).ref
+        return Lambdas_Producer_copyToCType(closure_holder.closure(moveFromCType(p0))).ref
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
-    let handle = smoke_Lambdas_NullableConfuser_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_NullableConfuser_copyToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
+    let handle = smoke_Lambdas_NullableConfuser_create_proxy(Lambdas_NullableConfuser_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
-    let handle = smoke_Lambdas_NullableConfuser_create_proxy(createFunctionalTable(swiftType))
+internal func Lambdas_NullableConfuser_moveToCType(_ swiftType: @escaping Lambdas.NullableConfuser) -> RefHolder {
+    let handle = smoke_Lambdas_NullableConfuser_create_proxy(Lambdas_NullableConfuser_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_NullableConfuser_release_handle)
 }
-internal func copyToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
+internal func Lambdas_NullableConfuser_copyToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_NullableConfuser_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_NullableConfuser_create_optional_proxy(Lambdas_NullableConfuser_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
+internal func Lambdas_NullableConfuser_moveToCType(_ swiftType: Lambdas.NullableConfuser?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_Lambdas_NullableConfuser_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_Lambdas_NullableConfuser_create_optional_proxy(Lambdas_NullableConfuser_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Lambdas_NullableConfuser_release_handle)
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasInterface.swift
@@ -18,7 +18,7 @@ internal class _LambdasInterface: LambdasInterface {
         smoke_LambdasInterface_release_handle(c_instance)
     }
     public func takeScreenshot(callback: @escaping LambdasInterface.TakeScreenshotCallback) -> Void {
-        let c_callback = moveToCType(callback)
+        let c_callback = LambdasInterface_TakeScreenshotCallback_moveToCType(callback)
         smoke_LambdasInterface_takeScreenshot(self.c_instance, c_callback.ref)
     }
 }
@@ -46,7 +46,7 @@ internal func getRef(_ ref: LambdasInterface?, owning: Bool = true) -> RefHolder
     }
     functions.smoke_LambdasInterface_takeScreenshot = {(swift_class_pointer, callback) in
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! LambdasInterface
-        swift_class.takeScreenshot(callback: moveFromCType(callback))
+        swift_class.takeScreenshot(callback: LambdasInterface_TakeScreenshotCallback_moveFromCType(callback))
     }
     let proxy = smoke_LambdasInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_LambdasInterface_release_handle) : RefHolder(proxy)
@@ -113,29 +113,29 @@ internal func copyToCType(_ swiftClass: LambdasInterface?) -> RefHolder {
 internal func moveToCType(_ swiftClass: LambdasInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
-    return moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_copy_handle(handle))
+internal func LambdasInterface_TakeScreenshotCallback_copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
+    return LambdasInterface_TakeScreenshotCallback_moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
+internal func LambdasInterface_TakeScreenshotCallback_moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasInterface_TakeScreenshotCallback_release_handle)
     return { (p0: Data?) -> Void in
         let _p0 = moveToCType(p0)
         return moveFromCType(smoke_LambdasInterface_TakeScreenshotCallback_call(refHolder.ref, _p0.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
+internal func LambdasInterface_TakeScreenshotCallback_copyFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as LambdasInterface.TakeScreenshotCallback
+    return LambdasInterface_TakeScreenshotCallback_copyFromCType(handle) as LambdasInterface.TakeScreenshotCallback
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
+internal func LambdasInterface_TakeScreenshotCallback_moveFromCType(_ handle: _baseRef) -> LambdasInterface.TakeScreenshotCallback? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as LambdasInterface.TakeScreenshotCallback
+    return LambdasInterface_TakeScreenshotCallback_moveFromCType(handle) as LambdasInterface.TakeScreenshotCallback
 }
-internal func createFunctionalTable(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> smoke_LambdasInterface_TakeScreenshotCallback_FunctionTable {
+internal func LambdasInterface_TakeScreenshotCallback_createFunctionalTable(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> smoke_LambdasInterface_TakeScreenshotCallback_FunctionTable {
     class smoke_LambdasInterface_TakeScreenshotCallback_Holder {
         let closure: LambdasInterface.TakeScreenshotCallback
         init(_ closure: @escaping LambdasInterface.TakeScreenshotCallback) {
@@ -155,25 +155,25 @@ internal func createFunctionalTable(_ swiftType: @escaping LambdasInterface.Take
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
-    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_proxy(createFunctionalTable(swiftType))
+internal func LambdasInterface_TakeScreenshotCallback_copyToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
+    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_proxy(LambdasInterface_TakeScreenshotCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
-    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_proxy(createFunctionalTable(swiftType))
+internal func LambdasInterface_TakeScreenshotCallback_moveToCType(_ swiftType: @escaping LambdasInterface.TakeScreenshotCallback) -> RefHolder {
+    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_proxy(LambdasInterface_TakeScreenshotCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasInterface_TakeScreenshotCallback_release_handle)
 }
-internal func copyToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
+internal func LambdasInterface_TakeScreenshotCallback_copyToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_optional_proxy(LambdasInterface_TakeScreenshotCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
+internal func LambdasInterface_TakeScreenshotCallback_moveToCType(_ swiftType: LambdasInterface.TakeScreenshotCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_LambdasInterface_TakeScreenshotCallback_create_optional_proxy(LambdasInterface_TakeScreenshotCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasInterface_TakeScreenshotCallback_release_handle)
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/LambdasWithStructuredTypes.swift
@@ -16,11 +16,11 @@ public class LambdasWithStructuredTypes {
         smoke_LambdasWithStructuredTypes_release_handle(c_instance)
     }
     public func doClassStuff(callback: @escaping LambdasWithStructuredTypes.ClassCallback) -> Void {
-        let c_callback = moveToCType(callback)
+        let c_callback = LambdasWithStructuredTypes_ClassCallback_moveToCType(callback)
         smoke_LambdasWithStructuredTypes_doClassStuff(self.c_instance, c_callback.ref)
     }
     public func doStructStuff(callback: @escaping LambdasWithStructuredTypes.StructCallback) -> Void {
-        let c_callback = moveToCType(callback)
+        let c_callback = LambdasWithStructuredTypes_StructCallback_moveToCType(callback)
         smoke_LambdasWithStructuredTypes_doStructStuff(self.c_instance, c_callback.ref)
     }
 }
@@ -90,29 +90,29 @@ internal func copyToCType(_ swiftClass: LambdasWithStructuredTypes?) -> RefHolde
 internal func moveToCType(_ swiftClass: LambdasWithStructuredTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
-    return moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle))
+internal func LambdasWithStructuredTypes_ClassCallback_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
+    return LambdasWithStructuredTypes_ClassCallback_moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
+internal func LambdasWithStructuredTypes_ClassCallback_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_ClassCallback_release_handle)
     return { (p0: LambdasInterface) -> Void in
         let _p0 = moveToCType(p0)
         return moveFromCType(smoke_LambdasWithStructuredTypes_ClassCallback_call(refHolder.ref, _p0.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
+internal func LambdasWithStructuredTypes_ClassCallback_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
+    return LambdasWithStructuredTypes_ClassCallback_copyFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
+internal func LambdasWithStructuredTypes_ClassCallback_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.ClassCallback? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
+    return LambdasWithStructuredTypes_ClassCallback_moveFromCType(handle) as LambdasWithStructuredTypes.ClassCallback
 }
-internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> smoke_LambdasWithStructuredTypes_ClassCallback_FunctionTable {
+internal func LambdasWithStructuredTypes_ClassCallback_createFunctionalTable(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> smoke_LambdasWithStructuredTypes_ClassCallback_FunctionTable {
     class smoke_LambdasWithStructuredTypes_ClassCallback_Holder {
         let closure: LambdasWithStructuredTypes.ClassCallback
         init(_ closure: @escaping LambdasWithStructuredTypes.ClassCallback) {
@@ -132,51 +132,51 @@ internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructured
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
-    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(createFunctionalTable(swiftType))
+internal func LambdasWithStructuredTypes_ClassCallback_copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
+    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(LambdasWithStructuredTypes_ClassCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
-    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(createFunctionalTable(swiftType))
+internal func LambdasWithStructuredTypes_ClassCallback_moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.ClassCallback) -> RefHolder {
+    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy(LambdasWithStructuredTypes_ClassCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_ClassCallback_release_handle)
 }
-internal func copyToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
+internal func LambdasWithStructuredTypes_ClassCallback_copyToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_optional_proxy(LambdasWithStructuredTypes_ClassCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
+internal func LambdasWithStructuredTypes_ClassCallback_moveToCType(_ swiftType: LambdasWithStructuredTypes.ClassCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_LambdasWithStructuredTypes_ClassCallback_create_optional_proxy(LambdasWithStructuredTypes_ClassCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_ClassCallback_release_handle)
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
-    return moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle))
+internal func LambdasWithStructuredTypes_StructCallback_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
+    return LambdasWithStructuredTypes_StructCallback_moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
+internal func LambdasWithStructuredTypes_StructCallback_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback {
     let refHolder = RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_StructCallback_release_handle)
     return { (p0: LambdasDeclarationOrder.SomeStruct) -> Void in
         let _p0 = moveToCType(p0)
         return moveFromCType(smoke_LambdasWithStructuredTypes_StructCallback_call(refHolder.ref, _p0.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
+internal func LambdasWithStructuredTypes_StructCallback_copyFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as LambdasWithStructuredTypes.StructCallback
+    return LambdasWithStructuredTypes_StructCallback_copyFromCType(handle) as LambdasWithStructuredTypes.StructCallback
 }
-internal func moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
+internal func LambdasWithStructuredTypes_StructCallback_moveFromCType(_ handle: _baseRef) -> LambdasWithStructuredTypes.StructCallback? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as LambdasWithStructuredTypes.StructCallback
+    return LambdasWithStructuredTypes_StructCallback_moveFromCType(handle) as LambdasWithStructuredTypes.StructCallback
 }
-internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> smoke_LambdasWithStructuredTypes_StructCallback_FunctionTable {
+internal func LambdasWithStructuredTypes_StructCallback_createFunctionalTable(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> smoke_LambdasWithStructuredTypes_StructCallback_FunctionTable {
     class smoke_LambdasWithStructuredTypes_StructCallback_Holder {
         let closure: LambdasWithStructuredTypes.StructCallback
         init(_ closure: @escaping LambdasWithStructuredTypes.StructCallback) {
@@ -196,25 +196,25 @@ internal func createFunctionalTable(_ swiftType: @escaping LambdasWithStructured
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
-    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(createFunctionalTable(swiftType))
+internal func LambdasWithStructuredTypes_StructCallback_copyToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
+    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(LambdasWithStructuredTypes_StructCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
-    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(createFunctionalTable(swiftType))
+internal func LambdasWithStructuredTypes_StructCallback_moveToCType(_ swiftType: @escaping LambdasWithStructuredTypes.StructCallback) -> RefHolder {
+    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_proxy(LambdasWithStructuredTypes_StructCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_StructCallback_release_handle)
 }
-internal func copyToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
+internal func LambdasWithStructuredTypes_StructCallback_copyToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_optional_proxy(LambdasWithStructuredTypes_StructCallback_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
+internal func LambdasWithStructuredTypes_StructCallback_moveToCType(_ swiftType: LambdasWithStructuredTypes.StructCallback?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_LambdasWithStructuredTypes_StructCallback_create_optional_proxy(LambdasWithStructuredTypes_StructCallback_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_LambdasWithStructuredTypes_StructCallback_release_handle)
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/StandaloneProducer.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/StandaloneProducer.swift
@@ -2,28 +2,28 @@
 //
 import Foundation
 public typealias StandaloneProducer = () -> String
-internal func copyFromCType(_ handle: _baseRef) -> StandaloneProducer {
-    return moveFromCType(smoke_StandaloneProducer_copy_handle(handle))
+internal func StandaloneProducer_copyFromCType(_ handle: _baseRef) -> StandaloneProducer {
+    return StandaloneProducer_moveFromCType(smoke_StandaloneProducer_copy_handle(handle))
 }
-internal func moveFromCType(_ handle: _baseRef) -> StandaloneProducer {
+internal func StandaloneProducer_moveFromCType(_ handle: _baseRef) -> StandaloneProducer {
     let refHolder = RefHolder(ref: handle, release: smoke_StandaloneProducer_release_handle)
     return { () -> String in
         return moveFromCType(smoke_StandaloneProducer_call(refHolder.ref))
     }
 }
-internal func copyFromCType(_ handle: _baseRef) -> StandaloneProducer? {
+internal func StandaloneProducer_copyFromCType(_ handle: _baseRef) -> StandaloneProducer? {
     guard handle != 0 else {
         return nil
     }
-    return copyFromCType(handle) as StandaloneProducer
+    return StandaloneProducer_copyFromCType(handle) as StandaloneProducer
 }
-internal func moveFromCType(_ handle: _baseRef) -> StandaloneProducer? {
+internal func StandaloneProducer_moveFromCType(_ handle: _baseRef) -> StandaloneProducer? {
     guard handle != 0 else {
         return nil
     }
-    return moveFromCType(handle) as StandaloneProducer
+    return StandaloneProducer_moveFromCType(handle) as StandaloneProducer
 }
-internal func createFunctionalTable(_ swiftType: @escaping StandaloneProducer) -> smoke_StandaloneProducer_FunctionTable {
+internal func StandaloneProducer_createFunctionalTable(_ swiftType: @escaping StandaloneProducer) -> smoke_StandaloneProducer_FunctionTable {
     class smoke_StandaloneProducer_Holder {
         let closure: StandaloneProducer
         init(_ closure: @escaping StandaloneProducer) {
@@ -43,25 +43,25 @@ internal func createFunctionalTable(_ swiftType: @escaping StandaloneProducer) -
     }
     return functions
 }
-internal func copyToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
-    let handle = smoke_StandaloneProducer_create_proxy(createFunctionalTable(swiftType))
+internal func StandaloneProducer_copyToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
+    let handle = smoke_StandaloneProducer_create_proxy(StandaloneProducer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
-    let handle = smoke_StandaloneProducer_create_proxy(createFunctionalTable(swiftType))
+internal func StandaloneProducer_moveToCType(_ swiftType: @escaping StandaloneProducer) -> RefHolder {
+    let handle = smoke_StandaloneProducer_create_proxy(StandaloneProducer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_StandaloneProducer_release_handle)
 }
-internal func copyToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
+internal func StandaloneProducer_copyToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_StandaloneProducer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_StandaloneProducer_create_optional_proxy(StandaloneProducer_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
-internal func moveToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
+internal func StandaloneProducer_moveToCType(_ swiftType: StandaloneProducer?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
-    let handle = smoke_StandaloneProducer_create_optional_proxy(createFunctionalTable(swiftType))
+    let handle = smoke_StandaloneProducer_create_optional_proxy(StandaloneProducer_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_StandaloneProducer_release_handle)
 }


### PR DESCRIPTION
Updated Swift templates to generate an explicit disambiguation prefix for lambdas conversion
functions. This fixes a compilation issue when two lambda types have the same signature.

See: #1026
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>