### PR TITLE
Fix validation for @Java(Builder) deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed validation for deprecated `@Java(Builder)` attribute.
+
 ## 9.4.1
 Release date: 2021-08-17
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -182,7 +182,7 @@ class Gluecodium(
                 LimeDeprecationsValidator(
                     limeLogger,
                     generatorOptions.werror.contains(GeneratorOptions.WARNING_DEPRECATED_ATTRIBUTES)
-                ).validate(it.topElements)
+                ).validate(it)
             },
             { LimeFunctionsValidator(limeLogger).validate(it) },
             { LimeSkipValidator(limeLogger).validate(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDeprecationsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDeprecationsValidator.kt
@@ -23,7 +23,8 @@ import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeType.POINTER_EQUATABLE
 import com.here.gluecodium.model.lime.LimeAttributeValueType.BUILDER
-import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
 
 /**
@@ -40,15 +41,14 @@ internal class LimeDeprecationsValidator(
             this.warning(limeElement, message)
         }
 
-    fun validate(limeElements: List<LimeNamedElement>): Boolean {
-        val validationResults = limeElements
-            .filterIsInstance<LimeContainerWithInheritance>()
-            .map { validateContainer(it) }
+    fun validate(limeModel: LimeModel): Boolean {
+        val containers = limeModel.referenceMap.values.filterIsInstance<LimeContainer>()
+        val validationResults = containers.map { validateContainer(it) }
 
         return !werror || !validationResults.contains(false)
     }
 
-    private fun validateContainer(limeContainer: LimeContainerWithInheritance) =
+    private fun validateContainer(limeContainer: LimeContainer) =
         when {
             limeContainer.attributes.have(POINTER_EQUATABLE) -> {
                 logger.logFunction(limeContainer, "@PointerEquatable attribute is deprecated")

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDeprecationsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDeprecationsValidatorTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
+import com.here.gluecodium.model.lime.LimeAttributeType.POINTER_EQUATABLE
+import com.here.gluecodium.model.lime.LimeAttributeValueType.BUILDER
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LimeDeprecationsValidatorTest {
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+
+    private val validator = LimeDeprecationsValidator(mockk(relaxed = true), werror = true)
+
+    @Test
+    fun validateContainerWithNoAttributes() {
+        allElements[""] = object : LimeContainer(EMPTY_PATH) {}
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateContainerWithPointerEquatableAttribute() {
+        val attributes = LimeAttributes.Builder().addAttribute(POINTER_EQUATABLE).build()
+        allElements[""] = object : LimeContainer(EMPTY_PATH, attributes = attributes) {}
+
+        assertFalse(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateContainerWithJavaBuilderAttribute() {
+        val attributes = LimeAttributes.Builder().addAttribute(JAVA, BUILDER).build()
+        allElements[""] = object : LimeContainer(EMPTY_PATH, attributes = attributes) {}
+
+        assertFalse(validator.validate(limeModel))
+    }
+}


### PR DESCRIPTION
Updated LimeDeprecationsValidator so that it correctly validates structs, and
not just classes/interfaces as before. This fixes validation for deprecated
`@Java(Builder)` attribute.

Added unit tests for this validator.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>