### PR TITLE
Add support for deprecating "positional defaults" struct ctors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Features:
+  * Added support for generating "positional defaults" struct constructors with a deprecation annotation.
 ### Removed:
   * `@PointerEquatable` and `@Java(Builder)` attributes were removed.
 

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -516,9 +516,11 @@ element is skipped (not generated). Custom tags are case-insensitive.
   generated code. _Annotation_ does not need to be prepended with `@`. _Annotation_ can contain parameters, e.g.
   `@Java(Attribute="Deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing
   quotes need to be backslash-escaped, as in the example.
-  * **PositionalDefaults**: marks a struct to have additional constructors simulating optional positional parameters in
-  Java. Can only be applied to a struct that has at least one field with a default value. Please note that combining
-  this attribute with internal (see `Visibility` above) fields is not supported.
+  * **PositionalDefaults** \[**=** **"**_DeprecationMessage_**"** \]: marks a struct to have additional constructors
+  simulating optional positional parameters in Java. Can only be applied to a struct that has at least one field with a
+  default value. Please note that combining this attribute with internal (see `Visibility` above) fields is not
+  supported. The positional defaults constructors will be generated with a `@Deprecated` annotation, if
+  _DeprecationMessage_ is specified.
 * **@Swift**: marks an element with Swift-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Swift.
   This is the default specification for this attribute.
@@ -549,8 +551,10 @@ element is skipped (not generated). Custom tags are case-insensitive.
   was defined (see `@Skip` above).
   * **@EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Dart only if a custom tag with that
   name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).
-  * **PositionalDefaults**: marks a struct to have a constructor with optional positional parameters in Dart. Can only
-  be applied to a struct that has at least one field with a default value.
+  * **PositionalDefaults** \[**=** **"**_DeprecationMessage_**"** \]: marks a struct to have a constructor with optional
+  positional parameters in Dart. Can only be applied to a struct that has at least one field with a default value. The
+  positional defaults constructor will be generated with a `@Deprecated` annotation, if _DeprecationMessage_ is
+  specified.
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Dart
   generated code. _Annotation_ does not need to be prepended with `@`. _Annotation_ can contain parameters, e.g.
   `@Dart(Attribute="Deprecated(\"It's deprecated.\")")`. If some of the parameters are string literals, their enclosing

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -194,20 +194,17 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}{{+dartFieldsAndConstants}}{{!!
 }}{{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
 {{/fields}}{{/set}}
-{{#if fields}}{{#unless constructors}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
-}}{{prefix this "  /// "}}
-{{#fields}}
-  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
-  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
-{{/fields}}
-{{/unless}}{{/resolveName}}{{/unless}}{{!!
-}}{{#if attributes.dart.positionalDefaults initializedFields}}{{!!
+{{#if fields}}{{!!
+}}{{#if attributes.dart.positionalDefaults initializedFields}}{{>constructorComment}}{{!!
+}}{{#instanceOf attributes.dart.positionalDefaults "String"}}
+  @Deprecated("{{attributes.dart.positionalDefaults}}")
+{{/instanceOf}}{{!!
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}({{!!
   }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}, {{/uninitializedFields}}{{!!
   }}[{{#initializedFields}}{{resolveName typeRef}} {{resolveName}} = {{>constPrefix}}{{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/initializedFields}}])
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
 {{/if}}{{!!
-}}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
+}}{{#unless attributes.dart.positionalDefaults initializedFields}}{{#unless constructors}}{{>constructorComment}}{{/unless}}{{!!
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
 }}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/unless}}
@@ -236,4 +233,12 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}{{#instanceOf type "LimeList"}}const {{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeMap"}}const {{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeSet"}}const {{/instanceOf}}{{!!
-}}{{/set}}{{/constPrefix}}
+}}{{/set}}{{/constPrefix}}{{!!
+
+}}{{+constructorComment}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// "}}
+{{#fields}}
+  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}
+{{/unless}}{{/resolveName}}{{/constructorComment}}

--- a/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
@@ -70,7 +70,7 @@
 {{#fields}}        this.{{resolveName}} = {{resolveName}};
 {{/fields}}
     }
-{{/unless}}{{!!
+{{/unless}}{{/if}}{{/unless}}{{!!
 
 }}{{#if attributes.java.positionalDefaults}}{{#set noAttributes=true struct=this}}
 {{#initializedFields}}{{#set fieldIndex=iter.index}}
@@ -83,9 +83,13 @@
 {{/uninitializedFields}}
 {{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}
      * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
-{{/numExpr}}{{/initializedFields}}
+{{/numExpr}}{{/initializedFields}}{{#instanceOf struct.attributes.java.positionalDefaults "String"}}
+     * @deprecated {{#struct.attributes.java.positionalDefaults}}{{prefix this " * " skipFirstLine=true}}{{/struct.attributes.java.positionalDefaults}}
+{{/instanceOf}}
      */
-{{/unless}}
+{{/unless}}{{#instanceOf struct.attributes.java.positionalDefaults "String"}}
+    @Deprecated("{{struct.attributes.java.positionalDefaults}}")
+{{/instanceOf}}
     {{#struct}}{{>structVisibility}}{{resolveName}}{{/struct}}{{!!
     }}({{#uninitializedFields}}{{>java/JavaParameter}}, {{/uninitializedFields}}{{!!
     }}{{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}{{>java/JavaParameter}}{{/numExpr}}{{!!
@@ -99,7 +103,7 @@
     }
 {{/set}}{{/initializedFields}}
 {{/set}}{{/if}}{{!!
-}}{{/if}}{{/unless}}{{/if}}
+}}{{/if}}
 {{#unless external.java.name}}{{#if attributes.serializable}}{{prefixPartial "java/ParcelableImpl" "    "}}
 
 {{/if}}

--- a/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
@@ -1,0 +1,62 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithSomeDefaults {
+    intField: Int = 42
+    stringField: String
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithAllDefaults {
+    intField: Int = 42
+    stringField: String = "\\Jonny \"Magic\" Smith\n"
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithCollectionDefaults {
+    emptyListField: List<String> = []
+    emptyMapField: Map<String, String> = []
+    emptySetField: Set<String> = []
+    listField: List<String> = ["foo", "bar"]
+    mapField: Map<String, String> = ["foo": "bar"]
+    setField: Set<String> = ["foo", "bar"]
+}
+
+// Foo Bar this is a comment
+// @constructor buzz fizz
+@Dart(PositionalDefaults = "Sorry, this is deprecated.")
+@Java(Skip) @Swift(Skip)
+struct DartDeprecatedPosDefaults {
+    intField: Int = 42
+    stringField: String
+}
+
+// Foo Bar this is a comment
+// @constructor buzz fizz
+@Dart(PositionalDefaults = "Sorry, this is deprecated.")
+@Java(Skip) @Swift(Skip)
+struct DartDeprecatedPosDefaultsCustom {
+    intField: Int = 42
+    stringField: String
+    constructor custom()
+}

--- a/gluecodium/src/test/resources/smoke/defaults/input/JavaPositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/JavaPositionalDefaults.lime
@@ -17,20 +17,6 @@
 
 package smoke
 
-@Dart(PositionalDefaults)
-@Java(Skip) @Swift(Skip)
-struct StructWithSomeDefaults {
-    intField: Int = 42
-    stringField: String
-}
-
-@Dart(PositionalDefaults)
-@Java(Skip) @Swift(Skip)
-struct StructWithAllDefaults {
-    intField: Int = 42
-    stringField: String = "\\Jonny \"Magic\" Smith\n"
-}
-
 // Foo Bar this is a comment
 // @constructor buzz fizz
 @Java(PositionalDefaults)
@@ -48,14 +34,25 @@ struct StructWithJavaPositionalDefaults {
     thirdInitField: String = "\\Jonny \"Magic\" Smith\n"
 }
 
-@Dart(PositionalDefaults)
-@Java(Skip) @Swift(Skip)
-struct StructWithCollectionDefaults {
-    emptyListField: List<String> = []
-    emptyMapField: Map<String, String> = []
-    emptySetField: Set<String> = []
-    listField: List<String> = ["foo", "bar"]
-    mapField: Map<String, String> = ["foo": "bar"]
-    setField: Set<String> = ["foo", "bar"]
+// Foo Bar this is a comment
+// @constructor buzz fizz
+@Java(PositionalDefaults = "Sorry, this is deprecated.")
+@Swift(Skip) @Dart(Skip)
+struct JavaDeprecatedPosDefaults {
+    // first init!
+    firstInitField: Int = 42
+    // first free!
+    firstFreeField: String
 }
 
+// Foo Bar this is a comment
+// @constructor buzz fizz
+@Java(PositionalDefaults = "Sorry, this is deprecated.")
+@Swift(Skip) @Dart(Skip)
+struct JavaDeprecatedPosDefaultsCustom {
+    // first init!
+    firstInitField: Int = 42
+    // first free!
+    firstFreeField: String
+    constructor custom()
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/JavaDeprecatedPosDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/JavaDeprecatedPosDefaults.java
@@ -1,0 +1,38 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+/**
+ * <p>Foo Bar this is a comment</p>
+ */
+public final class JavaDeprecatedPosDefaults {
+    /**
+     * <p>first init!</p>
+     */
+    public int firstInitField;
+    /**
+     * <p>first free!</p>
+     */
+    @NonNull
+    public String firstFreeField;
+    /**
+     * <p>buzz fizz</p>
+     * @param firstFreeField <p>first free!</p>
+     */
+    public JavaDeprecatedPosDefaults(@NonNull final String firstFreeField) {
+        this.firstInitField = 42;
+        this.firstFreeField = firstFreeField;
+    }
+    /**
+     * <p>buzz fizz</p>
+     * @param firstFreeField <p>first free!</p>
+     * @param firstInitField <p>first init!</p>
+     * @deprecated Sorry, this is deprecated.
+     */
+    @Deprecated("Sorry, this is deprecated.")
+    public JavaDeprecatedPosDefaults(@NonNull final String firstFreeField, final int firstInitField) {
+        this.firstFreeField = firstFreeField;
+        this.firstInitField = firstInitField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/JavaDeprecatedPosDefaultsCustom.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/JavaDeprecatedPosDefaultsCustom.java
@@ -1,0 +1,36 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+/**
+ * <p>Foo Bar this is a comment</p>
+ */
+public final class JavaDeprecatedPosDefaultsCustom {
+    /**
+     * <p>first init!</p>
+     */
+    public int firstInitField;
+    /**
+     * <p>first free!</p>
+     */
+    @NonNull
+    public String firstFreeField;
+    public JavaDeprecatedPosDefaultsCustom() {
+        JavaDeprecatedPosDefaultsCustom _other = custom();
+        this.firstInitField = _other.firstInitField;
+        this.firstFreeField = _other.firstFreeField;
+    }
+    /**
+     * <p>buzz fizz</p>
+     * @param firstFreeField <p>first free!</p>
+     * @param firstInitField <p>first init!</p>
+     * @deprecated Sorry, this is deprecated.
+     */
+    @Deprecated("Sorry, this is deprecated.")
+    public JavaDeprecatedPosDefaultsCustom(@NonNull final String firstFreeField, final int firstInitField) {
+        this.firstFreeField = firstFreeField;
+        this.firstInitField = firstInitField;
+    }
+    private static native JavaDeprecatedPosDefaultsCustom custom();
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
@@ -1,0 +1,83 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+/// Foo Bar this is a comment
+class DartDeprecatedPosDefaults {
+  int intField;
+  String stringField;
+  /// buzz fizz
+  /// [intField]
+  /// [stringField]
+  @Deprecated("Sorry, this is deprecated.")
+  DartDeprecatedPosDefaults(String stringField, [int intField = 42])
+    : intField = intField, stringField = stringField;
+  DartDeprecatedPosDefaults.withDefaults(String stringField)
+    : intField = 42, stringField = stringField;
+}
+// DartDeprecatedPosDefaults "private" section, not exported.
+final _smokeDartdeprecatedposdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Pointer<Void>),
+    Pointer<Void> Function(int, Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaults_create_handle'));
+final _smokeDartdeprecatedposdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaults_release_handle'));
+final _smokeDartdeprecatedposdefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaults_get_field_intField'));
+final _smokeDartdeprecatedposdefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaults_get_field_stringField'));
+Pointer<Void> smokeDartdeprecatedposdefaultsToFfi(DartDeprecatedPosDefaults value) {
+  final _intFieldHandle = (value.intField);
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeDartdeprecatedposdefaultsCreateHandle(_intFieldHandle, _stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+DartDeprecatedPosDefaults smokeDartdeprecatedposdefaultsFromFfi(Pointer<Void> handle) {
+  final _intFieldHandle = _smokeDartdeprecatedposdefaultsGetFieldintField(handle);
+  final _stringFieldHandle = _smokeDartdeprecatedposdefaultsGetFieldstringField(handle);
+  try {
+    return DartDeprecatedPosDefaults(
+      stringFromFfi(_stringFieldHandle),
+      (_intFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeDartdeprecatedposdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDartdeprecatedposdefaultsReleaseHandle(handle);
+// Nullable DartDeprecatedPosDefaults
+final _smokeDartdeprecatedposdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaults_create_handle_nullable'));
+final _smokeDartdeprecatedposdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaults_release_handle_nullable'));
+final _smokeDartdeprecatedposdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaults_get_value_nullable'));
+Pointer<Void> smokeDartdeprecatedposdefaultsToFfiNullable(DartDeprecatedPosDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDartdeprecatedposdefaultsToFfi(value);
+  final result = _smokeDartdeprecatedposdefaultsCreateHandleNullable(_handle);
+  smokeDartdeprecatedposdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+DartDeprecatedPosDefaults? smokeDartdeprecatedposdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDartdeprecatedposdefaultsGetValueNullable(handle);
+  final result = smokeDartdeprecatedposdefaultsFromFfi(_handle);
+  smokeDartdeprecatedposdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDartdeprecatedposdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDartdeprecatedposdefaultsReleaseHandleNullable(handle);
+// End of DartDeprecatedPosDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
@@ -1,0 +1,100 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+/// Foo Bar this is a comment
+class DartDeprecatedPosDefaultsCustom {
+  int intField;
+  String stringField;
+  /// buzz fizz
+  /// [intField]
+  /// [stringField]
+  @Deprecated("Sorry, this is deprecated.")
+  DartDeprecatedPosDefaultsCustom(String stringField, [int intField = 42])
+    : intField = intField, stringField = stringField;
+  DartDeprecatedPosDefaultsCustom._copy(DartDeprecatedPosDefaultsCustom _other) : this._(_other.intField, _other.stringField);
+  factory DartDeprecatedPosDefaultsCustom() => DartDeprecatedPosDefaultsCustom._copy($prototype.custom());
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = DartDeprecatedPosDefaultsCustom$Impl();
+}
+// DartDeprecatedPosDefaultsCustom "private" section, not exported.
+final _smokeDartdeprecatedposdefaultscustomCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32, Pointer<Void>),
+    Pointer<Void> Function(int, Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaultsCustom_create_handle'));
+final _smokeDartdeprecatedposdefaultscustomReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaultsCustom_release_handle'));
+final _smokeDartdeprecatedposdefaultscustomGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaultsCustom_get_field_intField'));
+final _smokeDartdeprecatedposdefaultscustomGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaultsCustom_get_field_stringField'));
+/// @nodoc
+@visibleForTesting
+class DartDeprecatedPosDefaultsCustom$Impl {
+  DartDeprecatedPosDefaultsCustom custom() {
+    final _customFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_DartDeprecatedPosDefaultsCustom_custom'));
+    final __resultHandle = _customFfi(__lib.LibraryContext.isolateId);
+    try {
+      return smokeDartdeprecatedposdefaultscustomFromFfi(__resultHandle);
+    } finally {
+      smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(__resultHandle);
+    }
+  }
+}
+Pointer<Void> smokeDartdeprecatedposdefaultscustomToFfi(DartDeprecatedPosDefaultsCustom value) {
+  final _intFieldHandle = (value.intField);
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeDartdeprecatedposdefaultscustomCreateHandle(_intFieldHandle, _stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+DartDeprecatedPosDefaultsCustom smokeDartdeprecatedposdefaultscustomFromFfi(Pointer<Void> handle) {
+  final _intFieldHandle = _smokeDartdeprecatedposdefaultscustomGetFieldintField(handle);
+  final _stringFieldHandle = _smokeDartdeprecatedposdefaultscustomGetFieldstringField(handle);
+  try {
+    return DartDeprecatedPosDefaultsCustom._(
+      stringFromFfi(_stringFieldHandle),
+      (_intFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(Pointer<Void> handle) => _smokeDartdeprecatedposdefaultscustomReleaseHandle(handle);
+// Nullable DartDeprecatedPosDefaultsCustom
+final _smokeDartdeprecatedposdefaultscustomCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaultsCustom_create_handle_nullable'));
+final _smokeDartdeprecatedposdefaultscustomReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaultsCustom_release_handle_nullable'));
+final _smokeDartdeprecatedposdefaultscustomGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DartDeprecatedPosDefaultsCustom_get_value_nullable'));
+Pointer<Void> smokeDartdeprecatedposdefaultscustomToFfiNullable(DartDeprecatedPosDefaultsCustom? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDartdeprecatedposdefaultscustomToFfi(value);
+  final result = _smokeDartdeprecatedposdefaultscustomCreateHandleNullable(_handle);
+  smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(_handle);
+  return result;
+}
+DartDeprecatedPosDefaultsCustom? smokeDartdeprecatedposdefaultscustomFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDartdeprecatedposdefaultscustomGetValueNullable(handle);
+  final result = smokeDartdeprecatedposdefaultscustomFromFfi(_handle);
+  smokeDartdeprecatedposdefaultscustomReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDartdeprecatedposdefaultscustomReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDartdeprecatedposdefaultscustomReleaseHandleNullable(handle);
+// End of DartDeprecatedPosDefaultsCustom "private" section.


### PR DESCRIPTION
Added support for `@Java(PositionalDefaults="deprecation message")` attribute
syntax (also works for Dart). This generates the "positional defaults"
constructor(s) with a `@Deprecated` annotation and the specified deprecation
message.

Added smoke tests.

Resolves: #1038
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>