### PR TITLE
Upgrade testing dependencies

### DIFF
--- a/functional-tests/functional/build.gradle
+++ b/functional-tests/functional/build.gradle
@@ -141,7 +141,7 @@ tasks.configureEach { task ->
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "org.powermock:powermock-reflect:2.0.9"
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/functional-tests/namerules/build.gradle
+++ b/functional-tests/namerules/build.gradle
@@ -117,7 +117,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.4.32"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.32"
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.2'
     testImplementation "org.powermock:powermock-reflect:2.0.9"
     testImplementation 'org.robolectric:robolectric:4.5.1'
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/gluecodium-gradle/build.gradle
+++ b/gluecodium-gradle/build.gradle
@@ -15,9 +15,9 @@ dependencies {
     }
     implementation 'com.natpryce:konfig:1.6.10.0'
 
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
+    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 gradlePlugin {

--- a/gluecodium/build.gradle
+++ b/gluecodium/build.gradle
@@ -39,9 +39,9 @@ dependencies {
     implementation 'org.trimou:trimou-core:2.5.0.Final'
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
+    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 apply plugin: 'application'

--- a/lime-loader/build.gradle
+++ b/lime-loader/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     implementation "org.antlr:antlr4-runtime:4.9.1"
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
+    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 generateGrammarSource {

--- a/lime-runtime/build.gradle
+++ b/lime-runtime/build.gradle
@@ -21,9 +21,9 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.32'
     compileOnly 'org.jetbrains:annotations:13.0'
 
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.10.0'
-    testImplementation 'io.mockk:mockk:1.10.0'
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
+    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'junit:junit:4.13.2'
 }
 
 javadoc.enabled = false


### PR DESCRIPTION
Updgraded testing libraries to resolve "MockK not found" issues:
* MockK to 1.12
* JUnit to 4.13.2

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>