### PR TITLE
Remove `_copy()` ctor from Dart structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release date: 2021-08-19
   * Added support for generating "positional defaults" struct constructors with a deprecation annotation.
 ### Bug fixes:
   * Fixed duplicate documentation for static functions on structs in Dart.
+  * Fixed testability issues for structs with custom constructors in Dart.
 ### Removed:
   * `@PointerEquatable` and `@Java(Builder)` attributes were removed.
 

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -36,8 +36,7 @@ class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
   }}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}{{!!
   }}{{/unless}}({{!!
   }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
-  }}) => {{resolveName parent}}{{#if external.dart.converter}}Internal{{/if}}._copy({{!!
-  }}$prototype.{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}));
+  }}) => $prototype.{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/constructors}}
 {{#functions}}{{#unless isConstructor}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
@@ -208,9 +207,7 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
 }}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 {{/unless}}
-{{#if constructors}}  {{resolveName}}{{#if constructors}}._copy{{/if}}({{resolveName}} _other) : {{!!
-}}this._({{#fields}}_other.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
-{{/if}}{{#unless constructors}}{{#if initializedFields}}
+{{#unless constructors}}{{#if initializedFields}}
   {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
   }}.withDefaults({{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
@@ -12,8 +12,7 @@ class DartDeprecatedPosDefaultsCustom {
   @Deprecated("Sorry, this is deprecated.")
   DartDeprecatedPosDefaultsCustom(String stringField, [int intField = 42])
     : intField = intField, stringField = stringField;
-  DartDeprecatedPosDefaultsCustom._copy(DartDeprecatedPosDefaultsCustom _other) : this._(_other.intField, _other.stringField);
-  factory DartDeprecatedPosDefaultsCustom() => DartDeprecatedPosDefaultsCustom._copy($prototype.custom());
+  factory DartDeprecatedPosDefaultsCustom() => $prototype.custom();
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = DartDeprecatedPosDefaultsCustom$Impl();

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -55,8 +55,7 @@ void smokePlatformnamesBasicenumReleaseFfiHandleNullable(Pointer<Void> handle) =
 class weeStruct {
   String WEE_FIELD;
   weeStruct._(this.WEE_FIELD);
-  weeStruct._copy(weeStruct _other) : this._(_other.WEE_FIELD);
-  factory weeStruct.WeeCreate(String WeeParameter) => weeStruct._copy($prototype.WeeCreate(WeeParameter));
+  factory weeStruct.WeeCreate(String WeeParameter) => $prototype.WeeCreate(WeeParameter);
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = weeStruct$Impl();

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -23,10 +23,9 @@ class Vector {
   double x;
   double y;
   Vector._(this.x, this.y);
-  Vector._copy(Vector _other) : this._(_other.x, _other.y);
-  factory Vector(double x, double y) => Vector._copy($prototype.$init(x, y));
-  factory Vector.copy(Vector other) => Vector._copy($prototype.copy(other));
-  factory Vector.create(int input) => Vector._copy($prototype.create(input));
+  factory Vector(double x, double y) => $prototype.$init(x, y);
+  factory Vector.copy(Vector other) => $prototype.copy(other);
+  factory Vector.create(int input) => $prototype.create(input);
   double distanceTo(Vector other) {
     final _distanceToFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>), double Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_StructsWithMethods_Vector_distanceTo__Vector'));
     final _otherHandle = smokeStructswithmethodsVectorToFfi(other);


### PR DESCRIPTION
Updated DartStruct template to remove `_copy()` constructor. It was an
unnecessary level of indirection that also impeded testability.

See: #1028
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>