### PR TITLE
Restore validation of constructor overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Restored validation of constructor overloads for C++, Java, and Swift generators.
+
 ## 9.4.4
 Release date: 2021-08-27
 ### Bug fixes:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
@@ -34,7 +34,7 @@ internal abstract class PlatformSignatureResolver(
     private val activeTags: Set<String>
 ) : LimeSignatureResolver(limeReferenceMap) {
 
-    override fun getAllContainerFunctions(limeContainer: LimeContainer) =
+    override fun getOwnFunctions(limeContainer: LimeContainer) =
         limeContainer.functions
             .filter { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, platformAttributeType) }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -93,7 +93,7 @@ internal class JavaGenerator : Generator {
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
         val signatureResolver = JavaSignatureResolver(limeModel.referenceMap, javaNameRules, activeTags)
-        val overloadsValidator = LimeOverloadsValidator(signatureResolver, limeLogger)
+        val overloadsValidator = LimeOverloadsValidator(signatureResolver, limeLogger, validateConstructors = true)
         val validationResult = overloadsValidator.validate(jniFilteredModel.referenceMap.values)
         if (!validationResult) {
             throw GluecodiumExecutionException("Validation errors found, see log for details.")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -101,7 +101,7 @@ internal class SwiftGenerator : Generator {
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
         val signatureResolver = SwiftSignatureResolver(cbridgeFilteredModel.referenceMap, nameRules, activeTags)
-        val overloadsValidator = LimeOverloadsValidator(signatureResolver, limeLogger)
+        val overloadsValidator = LimeOverloadsValidator(signatureResolver, limeLogger, validateConstructors = true)
         val weakPropertiesValidator = SwiftWeakPropertiesValidator(limeLogger)
         val validationResults = listOf(
             overloadsValidator.validate(cbridgeFilteredModel.referenceMap.values),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -84,7 +84,7 @@ internal class SwiftGeneratorPredicates(
         },
         "isOverriding" to { limeFunction: Any ->
             limeFunction is LimeFunction && limeFunction.isConstructor &&
-                signatureResolver.hasConstructorSignatureClash(limeFunction)
+                signatureResolver.isOverloadingConstructor(limeFunction)
         },
         "isRefEquatable" to { limeField: Any ->
             limeField is LimeField && isRefEquatable(limeField)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
@@ -22,9 +22,16 @@ package com.here.gluecodium.generator.swift
 import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
 
 internal class SwiftSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
     nameRules: SwiftNameRules,
     activeTags: Set<String>
-) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.SWIFT, nameRules, activeTags)
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.SWIFT, nameRules, activeTags) {
+    fun isOverloadingConstructor(limeFunction: LimeFunction): Boolean {
+        val container = getContainer(limeFunction) ?: return false
+        val overloads = getOwnAndParentFunctions(container).filter { it.isConstructor }
+        return hasSignatureClash(limeFunction, overloads)
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeOverloadsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeOverloadsValidator.kt
@@ -26,12 +26,12 @@ import com.here.gluecodium.model.lime.LimeSignatureResolver
 
 internal class LimeOverloadsValidator(
     private val signatureResolver: LimeSignatureResolver,
-    private val logger: LimeLogger
+    private val logger: LimeLogger,
+    private val validateConstructors: Boolean = false
 ) {
     fun validate(limeModel: Collection<LimeElement>): Boolean {
-        val validationResults = limeModel.filterIsInstance<LimeFunction>()
-            .filter { !it.isConstructor }
-            .map { validateFunction(it, signatureResolver) }
+        val validationResults =
+            limeModel.filterIsInstance<LimeFunction>().map { validateFunction(it, signatureResolver) }
         return !validationResults.contains(false)
     }
 
@@ -39,6 +39,10 @@ internal class LimeOverloadsValidator(
         when {
             signatureResolver.hasSignatureClash(limeFunction) -> {
                 logger.error(limeFunction, "function has conflicting overloads")
+                false
+            }
+            validateConstructors && signatureResolver.hasConstructorSignatureClash(limeFunction) -> {
+                logger.error(limeFunction, "constructor has conflicting overloads")
                 false
             }
             else -> true


### PR DESCRIPTION
Updated LimeSignatureResolver to detect overloads correctly:
* For function overloads, only container's own functions are taken into account,
not parent container's functions (in case of inheritance).
* For constructor overloads, the same applies, except function names are ignored
(as all constructors have the same "name").
* For Swift constructor overrides detection, parent container's functions are
taken into account. Moved the dedicated predicate to SwiftSignatureResolver as
it is not needed elsewhere.

Updated LimeOverloadsValidator to optionally validate constructor overloads
(needed in Java and Swift, not needed in C++).

Updated LimeOverloadsValidatorTest unit tests accordingly.

Resolves: #1034
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>