### PR TITLE
Fix extraneous exports/imports in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Improved mockability of `$prototype` for structs with methods in Dart.
+  * Fixed extraneous exports and extraneous imports in Dart.
 
 ## 9.4.3
 Release date: 2021-08-20

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
@@ -31,7 +31,7 @@ import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
 
-internal class GenericImportsCollector<T>(
+internal open class GenericImportsCollector<T>(
     private val importsResolver: ImportsResolver<T>,
     private val retainPredicate: ((LimeNamedElement) -> Boolean)? = null,
     private val collectTypeRefImports: Boolean = false,
@@ -85,7 +85,7 @@ internal class GenericImportsCollector<T>(
             listOfNotNull(limeFunction.thrownType?.typeRef) +
             if (collectFunctionErrorType) listOfNotNull(limeFunction.exception?.errorType) else emptyList()
 
-    private fun collectParentTypeRefs(limeContainer: LimeContainerWithInheritance): List<LimeTypeRef> {
+    protected open fun collectParentTypeRefs(limeContainer: LimeContainerWithInheritance): List<LimeTypeRef> {
         val parentTypeRef = limeContainer.parent ?: return emptyList()
         return limeContainer.inheritedFunctions.flatMap { collectTypeRefs(it) } +
             limeContainer.inheritedProperties.map { it.typeRef } + parentTypeRef

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -138,8 +138,7 @@ internal class DartGenerator : Generator {
         val importResolver =
             DartImportResolver(dartFilteredModel.referenceMap, dartNameResolver, "$libraryName/$SRC_DIR_SUFFIX")
         val declarationImportResolver = DartDeclarationImportResolver("$libraryName/$SRC_DIR_SUFFIX")
-        val importsCollector =
-            GenericImportsCollector(importResolver, collectTypeRefImports = true, parentTypeFilter = { true })
+        val importsCollector = DartImportsCollector(importResolver)
         val declarationImportsCollector = GenericImportsCollector(declarationImportResolver, collectOwnImports = true)
 
         val includeResolver = FfiCppIncludeResolver(ffiFilteredModel.referenceMap, cppNameRules, internalNamespace)
@@ -197,7 +196,8 @@ internal class DartGenerator : Generator {
         val allTypes = LimeTypeHelper.getAllTypes(rootElement).filterNot { it is LimeTypeAlias }
         val nonExternalTypes = allTypes.filter { it.external?.dart == null }
         val freeConstants = (rootElement as? LimeTypesCollection)?.constants ?: emptyList()
-        val allSymbols = (nonExternalTypes + freeConstants).filterNot { it.visibility.isInternal }
+        val allSymbols =
+            (nonExternalTypes + freeConstants).filter { it !is LimeTypesCollection && !it.visibility.isInternal }
         if (allSymbols.isNotEmpty()) {
             val allNames = allSymbols.map { dartNameResolver.resolveName(it) }
             val testNames = allSymbols

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.generator.common.GenericImportsCollector
+import com.here.gluecodium.generator.common.ImportsResolver
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeTypeRef
+
+internal class DartImportsCollector(importsResolver: ImportsResolver<DartImport>) :
+    GenericImportsCollector<DartImport>(importsResolver, collectTypeRefImports = true, parentTypeFilter = { true }) {
+
+    override fun collectParentTypeRefs(limeContainer: LimeContainerWithInheritance): List<LimeTypeRef> {
+        val parentTypeRef = limeContainer.parent
+        return when (parentTypeRef?.type?.actualType) {
+            is LimeInterface -> super.collectParentTypeRefs(limeContainer)
+            else -> listOfNotNull(parentTypeRef)
+        }
+    }
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/input/InheritanceIncludes.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/InheritanceIncludes.lime
@@ -45,3 +45,13 @@ interface ParentInterfaceWithIncludes {
 
 @Dart(Skip)
 class ChildClassWithIncludes: ParentInterfaceWithIncludes {}
+
+@Skip(Java, Swift)
+open class ParentClassWithImports {
+    fun rootMethod(input1: IncludableStruct, input2: IncludableEnum): IncludableClass
+    property rootProperty: IncludableLambda
+}
+
+@Skip(Java, Swift)
+class ChildClassWithImports: ParentClassWithImports {}
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
@@ -1,5 +1,6 @@
 import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/child_class_from_interface.dart';
+import 'package:library/src/smoke/child_class_with_imports.dart';
 import 'package:library/src/smoke/child_class_with_lambda.dart';
 import 'package:library/src/smoke/child_interface.dart';
 import 'package:library/src/smoke/child_with_parent_class_references.dart';
@@ -7,11 +8,13 @@ import 'package:library/src/smoke/interface_with_lambda.dart';
 import 'package:library/src/smoke/internal_child.dart';
 import 'package:library/src/smoke/internal_parent.dart';
 import 'package:library/src/smoke/parent_class.dart';
+import 'package:library/src/smoke/parent_class_with_imports.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
 final Map<String, Function> typeRepository = {
   "smoke_ChildClassFromClass": (handle) => ChildClassFromClass$Impl(handle),
   "smoke_ChildClassFromInterface": (handle) => ChildClassFromInterface$Impl(handle),
+  "smoke_ChildClassWithImports": (handle) => ChildClassWithImports$Impl(handle),
   "smoke_ChildClassWithLambda": (handle) => ChildClassWithLambda$Impl(handle),
   "smoke_ChildInterface": (handle) => ChildInterface$Impl(handle),
   "smoke_ChildWithParentClassReferences": (handle) => ChildWithParentClassReferences$Impl(handle),
@@ -19,6 +22,7 @@ final Map<String, Function> typeRepository = {
   "smoke_InternalChild": (handle) => InternalChild$Impl(handle),
   "smoke_InternalParent": (handle) => InternalParent$Impl(handle),
   "smoke_ParentClass": (handle) => ParentClass$Impl(handle),
+  "smoke_ParentClassWithImports": (handle) => ParentClassWithImports$Impl(handle),
   "smoke_ParentInterface": (handle) => ParentInterface$Impl(handle),
   "smoke_ParentWithClassReferences": (handle) => ParentWithClassReferences$Impl(handle),
  };

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
@@ -1,0 +1,59 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/parent_class_with_imports.dart';
+abstract class ChildClassWithImports implements ParentClassWithImports {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
+}
+// ChildClassWithImports "private" section, not exported.
+final _smokeChildclasswithimportsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_ChildClassWithImports_register_finalizer'));
+final _smokeChildclasswithimportsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ChildClassWithImports_copy_handle'));
+final _smokeChildclasswithimportsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ChildClassWithImports_release_handle'));
+final _smokeChildclasswithimportsGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ChildClassWithImports_get_type_id'));
+class ChildClassWithImports$Impl extends ParentClassWithImports$Impl implements ChildClassWithImports {
+  ChildClassWithImports$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+}
+Pointer<Void> smokeChildclasswithimportsToFfi(ChildClassWithImports value) =>
+  _smokeChildclasswithimportsCopyHandle((value as __lib.NativeBase).handle);
+ChildClassWithImports smokeChildclasswithimportsFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is ChildClassWithImports) return instance;
+  final _typeIdHandle = _smokeChildclasswithimportsGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeChildclasswithimportsCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : ChildClassWithImports$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeChildclasswithimportsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeChildclasswithimportsReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeChildclasswithimportsReleaseHandle(handle);
+Pointer<Void> smokeChildclasswithimportsToFfiNullable(ChildClassWithImports? value) =>
+  value != null ? smokeChildclasswithimportsToFfi(value) : Pointer<Void>.fromAddress(0);
+ChildClassWithImports? smokeChildclasswithimportsFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeChildclasswithimportsFromFfi(handle) : null;
+void smokeChildclasswithimportsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeChildclasswithimportsReleaseHandle(handle);
+// End of ChildClassWithImports "private" section.

--- a/gluecodium/src/test/resources/smoke/visibility/input/Visibility.lime
+++ b/gluecodium/src/test/resources/smoke/visibility/input/Visibility.lime
@@ -88,3 +88,10 @@ struct PublicStructWithNonDefaultInternalField {
 internal class InternalClassWithStaticProperty {
     static property fooBar: String
 }
+
+@Skip(Java, Swift)
+types DontExportInDart {
+    struct DoExportInDart {
+        stringField: String
+    }
+}

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/smoke.dart
@@ -1,4 +1,4 @@
+export 'src/smoke/dont_export_in_dart.dart' show DoExportInDart;
 export 'src/smoke/public_class.dart' show PublicClass, PublicClass_PublicStruct, PublicClass_PublicStructWithInternalDefaults;
 export 'src/smoke/public_interface.dart' show PublicInterface;
 export 'src/smoke/public_struct_with_non_default_internal_field.dart' show PublicStructWithNonDefaultInternalField;
-export 'src/smoke/public_type_collection.dart' show PublicTypeCollection;


### PR DESCRIPTION
Fixed extraneous exports for type collections in Dart.

Fixed extraneous imports for inherited functions/properties in classes in Dart.

Resolves: #1061
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>