### PR TITLE
Add validation for field constructors

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -34,6 +34,7 @@ import com.here.gluecodium.model.lime.LimeModelLoader
 import com.here.gluecodium.model.lime.LimeModelLoaderException
 import com.here.gluecodium.validator.LimeEnumeratorRefsValidator
 import com.here.gluecodium.validator.LimeExternalTypesValidator
+import com.here.gluecodium.validator.LimeFieldConstructorsValidator
 import com.here.gluecodium.validator.LimeFunctionsValidator
 import com.here.gluecodium.validator.LimeGenericTypesValidator
 import com.here.gluecodium.validator.LimeInheritanceValidator
@@ -169,7 +170,8 @@ class Gluecodium(
             { LimeSerializableStructsValidator(limeLogger).validate(it) },
             { LimeInheritanceValidator(limeLogger).validate(it) },
             { LimeFunctionsValidator(limeLogger).validate(it) },
-            { LimeOptimizedListsValidator(limeLogger).validate(it) }
+            { LimeOptimizedListsValidator(limeLogger).validate(it) },
+            { LimeFieldConstructorsValidator(limeLogger).validate(it) }
         )
 
     private fun getIndependentValidators(limeLogger: LimeLogger) =

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFieldConstructorsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFieldConstructorsValidator.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeFieldConstructor
+import com.here.gluecodium.model.lime.LimeFieldRef
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeModelLoaderException
+import com.here.gluecodium.model.lime.LimeStruct
+
+/* *
+ * * Validates all field references by trying to resolve each one and reporting any resulting exceptions.
+ * * Validates that all there are no duplicate field references inside each field constructor.
+ * * Validates that all omitted fields have default values.
+ */
+internal class LimeFieldConstructorsValidator(private val logger: LimeLogger) {
+
+    fun validate(limeModel: LimeModel): Boolean {
+        val allFieldConstructors = limeModel.referenceMap.values.filterIsInstance<LimeFieldConstructor>()
+        val validationResults = allFieldConstructors.map { validateFieldConstructor(it) }
+        return !validationResults.contains(false)
+    }
+
+    private fun validateFieldConstructor(fieldConstructor: LimeFieldConstructor): Boolean {
+        val fieldsRefValidationResults = fieldConstructor.fields.map { validateRef(fieldConstructor.struct, it) }
+        if (fieldsRefValidationResults.contains(false)) return false
+
+        val constructorFields = fieldConstructor.fields.map { it.field }
+        val uniqueFields = constructorFields.map { it.path.toString() }.distinct()
+        if (uniqueFields.size != constructorFields.size) {
+            logger.error(fieldConstructor.struct, "a field constructor should not have duplicate field entries")
+            return false
+        }
+        val omittedFields = fieldConstructor.struct.fields - constructorFields
+        if (omittedFields.any { it.defaultValue == null }) {
+            logger.error(
+                fieldConstructor.struct,
+                "all fields omitted by a field constructor should have default values"
+            )
+            return false
+        }
+        return true
+    }
+
+    private fun validateRef(limeStruct: LimeStruct, limeFieldRef: LimeFieldRef) =
+        try {
+            limeFieldRef.field
+            true
+        } catch (e: LimeModelLoaderException) {
+            logger.error(limeStruct, e.message ?: "")
+            false
+        }
+}

--- a/gluecodium/src/main/resources/templates/lime/LimeFieldConstructor.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeFieldConstructor.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -20,17 +20,6 @@
   !}}
 {{#unless comment.isEmpty}}{{prefix comment "// "}}
 {{/unless}}{{!!
-}}{{#unless constructorComment.isEmpty}}// @constructor {{prefix constructorComment "// " skipFirstLine=true}}
-{{/unless}}{{!!
 }}{{#if attributes.toString}}{{attributes}}
 {{/if}}
-{{visibility}}struct {{escapedName}} {
-{{prefixPartial "lime/LimeExternalDescriptor" "    "}}
-{{#set parentVisibility=visibility}}{{#fields}}
-{{prefixPartial "lime/LimeField" "    "}}
-{{/fields}}{{/set}}
-{{#fieldConstructors}}
-{{prefixPartial "lime/LimeFieldConstructor" "    "}}
-{{/fieldConstructors}}
-{{>lime/LimeContainerContents}}
-}
+field constructor({{#fields}}{{field.name}}{{/fields}})

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFieldConstructorsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFieldConstructorsValidatorTest.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeDirectTypeRef
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeFieldConstructor
+import com.here.gluecodium.model.lime.LimeFieldRef
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeModelLoaderException
+import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeValue
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LimeFieldConstructorsValidatorTest {
+
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+
+    private val fooField = LimeField(LimePath(emptyList(), listOf("foo")), typeRef = LimeBasicTypeRef.INT)
+    private val barField =
+        LimeField(LimePath(emptyList(), listOf("bar")), typeRef = LimeBasicTypeRef.INT, defaultValue = LimeValue.ZERO)
+    private val limeStruct = LimeStruct(EMPTY_PATH, fields = listOf(fooField, barField))
+    private val structTypeRef = LimeDirectTypeRef(limeStruct)
+    private val fooFieldRef = object : LimeFieldRef() { override val field = fooField }
+
+    private val validator = LimeFieldConstructorsValidator(mockk(relaxed = true))
+
+    @Test
+    fun validateThrowingFieldRef() {
+        val throwingFieldRef = object : LimeFieldRef() {
+            override val field
+                get() = throw LimeModelLoaderException("")
+        }
+        allElements[""] = LimeFieldConstructor(EMPTY_PATH, structRef = structTypeRef, fields = listOf(throwingFieldRef))
+
+        assertFalse(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateDuplicateEntries() {
+        allElements[""] = LimeFieldConstructor(
+            EMPTY_PATH,
+            structRef = structTypeRef,
+            fields = listOf(fooFieldRef, fooFieldRef)
+        )
+
+        assertFalse(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateDefaultedOmitted() {
+        allElements[""] = LimeFieldConstructor(EMPTY_PATH, structRef = structTypeRef, fields = listOf(fooFieldRef))
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateNonDefaultedOmitted() {
+        allElements[""] = LimeFieldConstructor(
+            EMPTY_PATH,
+            structRef = structTypeRef,
+            fields = listOf(object : LimeFieldRef() { override val field = barField })
+        )
+
+        assertFalse(validator.validate(limeModel))
+    }
+}

--- a/gluecodium/src/test/resources/smoke/structs/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/FieldConstructors.lime
@@ -1,0 +1,25 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct FieldConstructorWithAnnotationAndComment {
+    stringField: String
+    // Some field constructor
+    @Deprecated("Shouldn't really use it")
+    field constructor(stringField)
+}

--- a/gluecodium/src/test/resources/smoke/structs/output/lime/smoke/FieldConstructorWithAnnotationAndComment.lime
+++ b/gluecodium/src/test/resources/smoke/structs/output/lime/smoke/FieldConstructorWithAnnotationAndComment.lime
@@ -1,0 +1,9 @@
+package smoke
+
+struct FieldConstructorWithAnnotationAndComment {
+    stringField: String
+    // Some field constructor
+    @Deprecated("Shouldn't really use it")
+    field constructor(stringField)
+}
+


### PR DESCRIPTION
Added new validator LimeFieldConstructorsValidator to check against following
conditions:
* all field references point to valid fields
* there are no duplicate field references inside each field constructor
* all omitted fields have default values set

Added unit tests for the new validator.

Added field constructors support to LIME generator, as a basic check that they
are loaded correctly from the LIME file.

Resolves: #1054
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>