### PR TITLE
Add computed properties to LimeFieldConstructor

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFieldConstructorsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFieldConstructorsValidator.kt
@@ -40,17 +40,16 @@ internal class LimeFieldConstructorsValidator(private val logger: LimeLogger) {
     }
 
     private fun validateFieldConstructor(fieldConstructor: LimeFieldConstructor): Boolean {
-        val fieldsRefValidationResults = fieldConstructor.fields.map { validateRef(fieldConstructor.struct, it) }
+        val fieldsRefValidationResults = fieldConstructor.fieldRefs.map { validateRef(fieldConstructor.struct, it) }
         if (fieldsRefValidationResults.contains(false)) return false
 
-        val constructorFields = fieldConstructor.fields.map { it.field }
+        val constructorFields = fieldConstructor.fields
         val uniqueFields = constructorFields.map { it.path.toString() }.distinct()
         if (uniqueFields.size != constructorFields.size) {
             logger.error(fieldConstructor.struct, "a field constructor should not have duplicate field entries")
             return false
         }
-        val omittedFields = fieldConstructor.struct.fields - constructorFields
-        if (omittedFields.any { it.defaultValue == null }) {
+        if (fieldConstructor.omittedFields.any { it.defaultValue == null }) {
             logger.error(
                 fieldConstructor.struct,
                 "all fields omitted by a field constructor should have default values"

--- a/gluecodium/src/main/resources/templates/lime/LimeFieldConstructor.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeFieldConstructor.mustache
@@ -22,4 +22,4 @@
 {{/unless}}{{!!
 }}{{#if attributes.toString}}{{attributes}}
 {{/if}}
-field constructor({{#fields}}{{field.name}}{{/fields}})
+field constructor({{#fields}}{{name}}{{/fields}})

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFieldConstructorsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFieldConstructorsValidatorTest.kt
@@ -59,7 +59,7 @@ class LimeFieldConstructorsValidatorTest {
             override val field
                 get() = throw LimeModelLoaderException("")
         }
-        allElements[""] = LimeFieldConstructor(EMPTY_PATH, structRef = structTypeRef, fields = listOf(throwingFieldRef))
+        allElements[""] = LimeFieldConstructor(EMPTY_PATH, structRef = structTypeRef, fieldRefs = listOf(throwingFieldRef))
 
         assertFalse(validator.validate(limeModel))
     }
@@ -69,7 +69,7 @@ class LimeFieldConstructorsValidatorTest {
         allElements[""] = LimeFieldConstructor(
             EMPTY_PATH,
             structRef = structTypeRef,
-            fields = listOf(fooFieldRef, fooFieldRef)
+            fieldRefs = listOf(fooFieldRef, fooFieldRef)
         )
 
         assertFalse(validator.validate(limeModel))
@@ -77,7 +77,7 @@ class LimeFieldConstructorsValidatorTest {
 
     @Test
     fun validateDefaultedOmitted() {
-        allElements[""] = LimeFieldConstructor(EMPTY_PATH, structRef = structTypeRef, fields = listOf(fooFieldRef))
+        allElements[""] = LimeFieldConstructor(EMPTY_PATH, structRef = structTypeRef, fieldRefs = listOf(fooFieldRef))
 
         assertTrue(validator.validate(limeModel))
     }
@@ -87,7 +87,7 @@ class LimeFieldConstructorsValidatorTest {
         allElements[""] = LimeFieldConstructor(
             EMPTY_PATH,
             structRef = structTypeRef,
-            fields = listOf(object : LimeFieldRef() { override val field = barField })
+            fieldRefs = listOf(object : LimeFieldRef() { override val field = barField })
         )
 
         assertFalse(validator.validate(limeModel))

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -279,7 +279,7 @@ internal class AntlrLimeModelBuilder(
             comment = structuredCommentsStack.peek().description,
             attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
             structRef = structTypeRef,
-            fields = ctx.simpleId().map { LimeLazyFieldRef(structTypeRef, convertSimpleId(it)) },
+            fieldRefs = ctx.simpleId().map { LimeLazyFieldRef(structTypeRef, convertSimpleId(it)) },
         )
 
         storeResultAndPopStacks(limeElement)

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeFieldConstructor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeFieldConstructor.kt
@@ -24,8 +24,12 @@ class LimeFieldConstructor(
     comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
     val structRef: LimeTypeRef,
-    val fields: List<LimeFieldRef> = emptyList()
+    val fieldRefs: List<LimeFieldRef> = emptyList()
 ) : LimeNamedElement(path, LimeVisibility.PUBLIC, comment, attributes) {
     val struct
         get() = structRef.type as LimeStruct
+    val fields
+        get() = fieldRefs.map { it.field }
+    val omittedFields
+        get() = struct.fields - fields
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
@@ -67,4 +67,7 @@ class LimeStruct(
     @Suppress("unused")
     val internalFields
         get() = fields.filter { it.visibility.isInternal }
+
+    val allFieldsConstructor
+        get() = fieldConstructors.firstOrNull { it.fieldRefs.size == fields.size }
 }


### PR DESCRIPTION
Added several properties to LimeFieldConstructor and LimeStruct to simplify the
usage of LimeFieldConstructor both in code and in templates.

See: #1052
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>