### PR TITLE
Add support for "field constructors" in Java

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -149,7 +149,7 @@ feature(StructsImmutable cpp android swift dart SOURCES
     input/lime/PlainDataStructuresImmutable.lime
 )
 
-feature(FieldConstructors cpp SOURCES
+feature(FieldConstructors cpp android SOURCES
     input/src/cpp/FieldConstructors.cpp
 
     input/lime/FieldConstructors.lime

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/FieldConstructorsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/FieldConstructorsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertEquals;
+
+import android.os.Build;
+import com.here.android.RobolectricApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.M, application = RobolectricApplication.class)
+public final class FieldConstructorsTest {
+
+  @Test
+  public void withPartialDefaults2() {
+    FieldConstructorsPartialDefaults result = new FieldConstructorsPartialDefaults(7, "foo");
+
+    assertEquals("foo", result.stringField);
+    assertEquals(7, result.intField);
+    assertEquals(true, result.boolField);
+  }
+
+  @Test
+  public void withPartialDefaults3() {
+    FieldConstructorsPartialDefaults result = new FieldConstructorsPartialDefaults(false, 7, "foo");
+
+    assertEquals("foo", result.stringField);
+    assertEquals(7, result.intField);
+    assertEquals(false, result.boolField);
+  }
+
+  @Test
+  public void withAllDefaults0() {
+    FieldConstructorsAllDefaults result = new FieldConstructorsAllDefaults();
+
+    assertEquals("nonsense", result.stringField);
+    assertEquals(42, result.intField);
+    assertEquals(true, result.boolField);
+  }
+
+  @Test
+  public void withAllDefaults1() {
+    FieldConstructorsAllDefaults result = new FieldConstructorsAllDefaults(7);
+
+    assertEquals("nonsense", result.stringField);
+    assertEquals(7, result.intField);
+    assertEquals(true, result.boolField);
+  }
+
+  @Test
+  public void immutableNoClash() {
+    ImmutableStructNoClash result = new ImmutableStructNoClash("foo", 7, false);
+
+    assertEquals("foo", result.stringField);
+    assertEquals(7, result.intField);
+    assertEquals(false, result.boolField);
+  }
+
+  @Test
+  public void immutableWithClash() {
+    ImmutableStructWithClash result = new ImmutableStructWithClash(false, 7, "foo");
+
+    assertEquals("foo", result.stringField);
+    assertEquals(7, result.intField);
+    assertEquals(false, result.boolField);
+  }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
@@ -20,6 +20,8 @@
 package com.here.gluecodium.generator.java
 
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeStruct
@@ -30,9 +32,7 @@ import com.here.gluecodium.model.lime.LimeTypeRef
  */
 internal object JavaGeneratorPredicates {
     val predicates = mapOf(
-        "hasAnyComment" to { limeElement: Any ->
-            CommonGeneratorPredicates.hasAnyComment(limeElement, "Java")
-        },
+        "hasAnyComment" to { CommonGeneratorPredicates.hasAnyComment(it, "Java") },
         "hasInternalAllArgsConstructor" to { limeStruct: Any ->
             limeStruct is LimeStruct && limeStruct.fields.any { it.visibility.isInternal }
         },
@@ -54,6 +54,11 @@ internal object JavaGeneratorPredicates {
                 limeInterface.properties.any { it.isStatic } -> true
                 else -> false
             }
+        },
+        "needsAllFieldsConstructor" to { limeStruct: Any ->
+            limeStruct is LimeStruct &&
+                !limeStruct.attributes.have(LimeAttributeType.JAVA, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&
+                CommonGeneratorPredicates.needsAllFieldsConstructor(limeStruct)
         },
         "needsDisposer" to { limeClass: Any ->
             limeClass is LimeClass && limeClass.parent?.type?.actualType !is LimeClass

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -92,7 +92,7 @@ internal class JavaNameResolver(
 
         val exactElement = limeReferenceMap[limeComment.path.toString()] as? LimeNamedElement
 
-        val commentedElement = exactElement ?: getParentElement(limeComment.path)
+        val commentedElement = exactElement ?: getParentElement(limeComment.path, withSuffix = true)
         return commentsProcessor.process(commentedElement.fullName, commentText, limeToJavaNames, limeLogger)
     }
 

--- a/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStruct.mustache
@@ -38,72 +38,7 @@
 {{/fields}}
     }
 {{/constructors}}{{/set}}
-{{#if fields}}{{#unless constructors}}
-
-{{#unless constructorComment.isEmpty}}
-    /**
-{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
-{{#uninitializedFields}}
-     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
-{{/uninitializedFields}}
-     */
-{{/unless}}
-    {{#unlessPredicate "hasInternalFreeArgsConstructor"}}{{>structVisibility}}{{/unlessPredicate}}{{resolveName}}{{!!
-    }}({{#set noAttributes=true}}{{joinPartial uninitializedFields "java/JavaParameter" ", "}}{{/set}}) {
-{{#fields}}        this.{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
-                   }}{{#unless defaultValue}}{{resolveName}}{{/unless}};
-{{/fields}}
-    }
-
-{{#if initializedFields}}
-{{#unless attributes.java.positionalDefaults}}
-{{#unless constructorComment.isEmpty}}
-    /**
-{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
-{{#fields}}
-     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
-{{/fields}}
-     */
-{{/unless}}
-    {{#unlessPredicate "hasInternalAllArgsConstructor"}}{{>structVisibility}}{{/unlessPredicate}}{{resolveName}}{{!!
-    }}({{joinPartial fields "java/JavaParameter" ", "}}) {
-{{#fields}}        this.{{resolveName}} = {{resolveName}};
-{{/fields}}
-    }
-{{/unless}}{{/if}}{{/unless}}{{!!
-
-}}{{#if attributes.java.positionalDefaults}}{{#set noAttributes=true struct=this}}
-{{#initializedFields}}{{#set fieldIndex=iter.index}}
-
-{{#unless constructorComment.isEmpty}}
-    /**
-{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
-{{#uninitializedFields}}
-     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
-{{/uninitializedFields}}
-{{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}
-     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
-{{/numExpr}}{{/initializedFields}}{{#instanceOf struct.attributes.java.positionalDefaults "String"}}
-     * @deprecated {{#struct.attributes.java.positionalDefaults}}{{prefix this " * " skipFirstLine=true}}{{/struct.attributes.java.positionalDefaults}}
-{{/instanceOf}}
-     */
-{{/unless}}{{#instanceOf struct.attributes.java.positionalDefaults "String"}}
-    @Deprecated("{{struct.attributes.java.positionalDefaults}}")
-{{/instanceOf}}
-    {{#struct}}{{>structVisibility}}{{resolveName}}{{/struct}}{{!!
-    }}({{#uninitializedFields}}{{>java/JavaParameter}}, {{/uninitializedFields}}{{!!
-    }}{{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}{{>java/JavaParameter}}{{/numExpr}}{{!!
-    }}{{#numExpr iter.index fieldIndex op="lt"}}, {{/numExpr}}{{/initializedFields}}) {
-{{#uninitializedFields}}        this.{{resolveName}} = {{resolveName}};
-{{/uninitializedFields}}
-{{#initializedFields}}        {{#numExpr iter.index fieldIndex op="le"}}this.{{resolveName}} = {{resolveName}};
-{{/numExpr}}{{!!
-}}{{#numExpr iter.index fieldIndex op="gt"}}this.{{resolveName}} = {{resolveName defaultValue}};
-{{/numExpr}}{{/initializedFields}}
-    }
-{{/set}}{{/initializedFields}}
-{{/set}}{{/if}}{{!!
-}}{{/if}}
+{{>java/JavaStructConstructors}}
 {{#unless external.java.name}}{{#if attributes.serializable}}{{prefixPartial "java/ParcelableImpl" "    "}}
 
 {{/if}}

--- a/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
@@ -1,0 +1,121 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if fields}}{{#unless constructors}}{{!!
+
+}}{{#unless fieldConstructors}}{{#if initializedFields}}
+
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
+{{#uninitializedFields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/uninitializedFields}}
+     */
+{{/unless}}
+    {{#unlessPredicate "hasInternalFreeArgsConstructor"}}{{>structVisibility}}{{/unlessPredicate}}{{resolveName}}{{!!
+    }}({{#set noAttributes=true}}{{joinPartial uninitializedFields "java/JavaParameter" ", "}}{{/set}}) {
+{{#fields}}        this.{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
+                   }}{{#unless defaultValue}}{{resolveName}}{{/unless}};
+{{/fields}}
+    }
+{{/if}}{{/unless}}{{!!
+
+}}{{#ifPredicate "needsAllFieldsConstructor"}}
+
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
+{{#fields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/fields}}
+     */
+{{/unless}}
+    {{#unlessPredicate "hasInternalAllArgsConstructor"}}{{>structVisibility}}{{/unlessPredicate}}{{resolveName}}{{!!
+    }}({{#set noAttributes=true}}{{joinPartial fields "java/JavaParameter" ", "}}{{/set}}) {
+{{#fields}}        this.{{resolveName}} = {{resolveName}};
+{{/fields}}
+    }
+{{/ifPredicate}}{{/unless}}{{!!
+
+}}{{#set struct=this}}{{#fieldConstructors}}
+{{#ifPredicate "hasAnyComment"}}
+    /**
+
+{{#unless comment.isEmpty}}{{#resolveName comment}}{{prefix this "     * "}}
+{{/resolveName}}{{/unless}}{{!!
+}}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{prefix this "     * "}}
+{{/unless}}{{/resolveName}}{{/if}}{{!!
+}}{{#if comment.isExcluded}}
+     * @exclude
+{{/if}}{{!!
+}}{{#if attributes.deprecated}}
+     * @deprecated {{resolveName attributes.deprecated.message}}
+{{/if}}{{!!
+}}{{#fields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/fields}}
+     */{{#if attributes.deprecated}}
+    @Deprecated
+{{/if}}{{/ifPredicate}}
+{{prefixPartial "java/JavaAttributes" "    "}}
+    {{#struct}}{{>structVisibility}}{{/struct}}{{resolveName struct}}({{!!
+    }}{{#set noAttributes=true}}{{joinPartial fields "java/JavaParameter" ", "}}{{/set}}) {
+{{#fields}}        this.{{resolveName}} = {{resolveName}};
+{{/fields}}
+{{#omittedFields}}        this.{{resolveName}} = {{resolveName defaultValue}};
+{{/omittedFields}}
+    }
+{{/fieldConstructors}}{{/set}}{{!!
+
+}}{{#unless fieldConstructors}}{{#if attributes.java.positionalDefaults}}{{#set noAttributes=true struct=this}}
+{{#initializedFields}}{{#set fieldIndex=iter.index}}
+
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
+{{#uninitializedFields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/uninitializedFields}}
+{{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/numExpr}}{{/initializedFields}}{{#instanceOf struct.attributes.java.positionalDefaults "String"}}
+     * @deprecated {{#struct.attributes.java.positionalDefaults}}{{prefix this " * " skipFirstLine=true}}{{/struct.attributes.java.positionalDefaults}}
+{{/instanceOf}}
+     */
+{{/unless}}{{#instanceOf struct.attributes.java.positionalDefaults "String"}}
+    @Deprecated("{{struct.attributes.java.positionalDefaults}}")
+{{/instanceOf}}
+    {{#struct}}{{>structVisibility}}{{resolveName}}{{/struct}}{{!!
+    }}({{#set noAttributes=true}}{{#uninitializedFields}}{{>java/JavaParameter}}, {{/uninitializedFields}}{{!!
+    }}{{#initializedFields}}{{#numExpr iter.index fieldIndex op="le"}}{{>java/JavaParameter}}{{/numExpr}}{{!!
+    }}{{#numExpr iter.index fieldIndex op="lt"}}, {{/numExpr}}{{/initializedFields}}{{/set}}) {
+{{#uninitializedFields}}        this.{{resolveName}} = {{resolveName}};
+{{/uninitializedFields}}
+{{#initializedFields}}        {{#numExpr iter.index fieldIndex op="le"}}this.{{resolveName}} = {{resolveName}};
+{{/numExpr}}{{!!
+}}{{#numExpr iter.index fieldIndex op="gt"}}this.{{resolveName}} = {{resolveName defaultValue}};
+{{/numExpr}}{{/initializedFields}}
+    }
+{{/set}}{{/initializedFields}}
+{{/set}}{{/if}}{{/unless}}{{!!
+}}{{/if}}{{!!
+
+}}{{+structVisibility}}{{#unless external.java.converter}}{{resolveName visibility}}{{/unless}}{{/structVisibility}}

--- a/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
@@ -79,7 +79,11 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
     }}{{#unlessPredicate "hasCppSetter"}}{{resolveName this "C++"}} = n_{{resolveName this "C++"}}{{/unlessPredicate}}{{!!
     }};{{/unlessPredicate}}
 {{/fields}}
-    {{#ifPredicate struct "hasImmutableFields"}}return {{resolveName "C++ FQN"}}({{#fields}}std::move(n_{{resolveName "C++"}}){{#if iter.hasNext}}, {{/if}}{{/fields}});{{/ifPredicate}}{{!!
+    {{#ifPredicate struct "hasImmutableFields"}}return {{resolveName "C++ FQN"}}({{!!
+    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{!!
+    }}{{#fields}}std::move(n_{{resolveName "C++"}}){{#if iter.hasNext}}, {{/if}}{{/fields}}{{/allFieldsConstructor}}{{/if}}{{!!
+    }}{{#unless allFieldsConstructor}}{{#fields}}std::move(n_{{resolveName "C++"}}){{#if iter.hasNext}}, {{/if}}{{/fields}}{{/unless}}{{!!
+    }});{{/ifPredicate}}{{!!
     }}{{#unlessPredicate struct "hasImmutableFields"}}return _nout;{{/unlessPredicate}}
 }
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithBothComments.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithBothComments.java
@@ -1,0 +1,19 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+/**
+ * <p>SomeStruct</p>
+ */
+public final class FieldConstructorWithBothComments {
+    @NonNull
+    public String stringField;
+    /**
+     * <p>This comment takes precedence</p>
+     * @param stringField
+     */
+    public FieldConstructorWithBothComments(@NonNull final String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithComment.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithComment.java
@@ -1,0 +1,22 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+/**
+ * <p>SomeStruct</p>
+ */
+public final class FieldConstructorWithComment {
+    /**
+     * <p>Some field</p>
+     */
+    @NonNull
+    public String stringField;
+    /**
+     * <p>Some field constructor</p>
+     * @param stringField <p>Some field</p>
+     */
+    public FieldConstructorWithComment(@NonNull final String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithDeprecationAndComment.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithDeprecationAndComment.java
@@ -1,0 +1,18 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldConstructorWithDeprecationAndComment {
+    @NonNull
+    public String stringField;
+    /**
+     * <p>Some field constructor</p>
+     * @deprecated <p>Shouldn't really use it</p>
+     * @param stringField
+     */
+    @Deprecated
+    public FieldConstructorWithDeprecationAndComment(@NonNull final String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithDeprecationOnly.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithDeprecationOnly.java
@@ -1,0 +1,17 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldConstructorWithDeprecationOnly {
+    @NonNull
+    public String stringField;
+    /**
+     * @deprecated <p>Shouldn't really use it</p>
+     * @param stringField
+     */
+    @Deprecated
+    public FieldConstructorWithDeprecationOnly(@NonNull final String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithExcluded.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithExcluded.java
@@ -1,0 +1,20 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldConstructorWithExcluded {
+    /**
+     * <p>Some field</p>
+     */
+    @NonNull
+    public String stringField;
+    /**
+     * <p>Some field constructor</p>
+     * @exclude
+     * @param stringField <p>Some field</p>
+     */
+    public FieldConstructorWithExcluded(@NonNull final String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithExcludedOnly.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithExcludedOnly.java
@@ -1,0 +1,16 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldConstructorWithExcludedOnly {
+    @NonNull
+    public String stringField;
+    /**
+     * @exclude
+     * @param stringField
+     */
+    public FieldConstructorWithExcludedOnly(@NonNull final String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithParentComment.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorWithParentComment.java
@@ -1,0 +1,19 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+/**
+ * <p>SomeStruct</p>
+ */
+public final class FieldConstructorWithParentComment {
+    @NonNull
+    public String stringField;
+    /**
+     * <p>There are constructors</p>
+     * @param stringField
+     */
+    public FieldConstructorWithParentComment(@NonNull final String stringField) {
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsAllDefaults.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsAllDefaults.java
@@ -1,0 +1,31 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldConstructorsAllDefaults {
+    @NonNull
+    public String stringField;
+    public int intField;
+    public boolean boolField;
+    public FieldConstructorsAllDefaults() {
+        this.stringField = "nonsense";
+        this.intField = 42;
+        this.boolField = true;
+    }
+    public FieldConstructorsAllDefaults(final int intField) {
+        this.intField = intField;
+        this.stringField = "nonsense";
+        this.boolField = true;
+    }
+    public FieldConstructorsAllDefaults(final int intField, @NonNull final String stringField) {
+        this.intField = intField;
+        this.stringField = stringField;
+        this.boolField = true;
+    }
+    public FieldConstructorsAllDefaults(final boolean boolField, final int intField, @NonNull final String stringField) {
+        this.boolField = boolField;
+        this.intField = intField;
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsPartialDefaults.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsPartialDefaults.java
@@ -1,0 +1,21 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldConstructorsPartialDefaults {
+    @NonNull
+    public String stringField;
+    public int intField;
+    public boolean boolField;
+    public FieldConstructorsPartialDefaults(final int intField, @NonNull final String stringField) {
+        this.intField = intField;
+        this.stringField = stringField;
+        this.boolField = true;
+    }
+    public FieldConstructorsPartialDefaults(final boolean boolField, final int intField, @NonNull final String stringField) {
+        this.boolField = boolField;
+        this.intField = intField;
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldCustomConstructorsMix.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldCustomConstructorsMix.java
@@ -1,0 +1,23 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldCustomConstructorsMix {
+    @NonNull
+    public String stringField;
+    public int intField;
+    public boolean boolField;
+    public FieldCustomConstructorsMix(final int intValue, final double dummy) {
+        FieldCustomConstructorsMix _other = createMe(intValue, dummy);
+        this.stringField = _other.stringField;
+        this.intField = _other.intField;
+        this.boolField = _other.boolField;
+    }
+    public FieldCustomConstructorsMix(final int intField) {
+        this.intField = intField;
+        this.stringField = "nonsense";
+        this.boolField = true;
+    }
+    private static native FieldCustomConstructorsMix createMe(final int intValue, final double dummy);
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/ImmutableStructNoClash.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/ImmutableStructNoClash.java
@@ -1,0 +1,21 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class ImmutableStructNoClash {
+    @NonNull
+    public final String stringField;
+    public final int intField;
+    public final boolean boolField;
+    public ImmutableStructNoClash(@NonNull final String stringField, final int intField, final boolean boolField) {
+        this.stringField = stringField;
+        this.intField = intField;
+        this.boolField = boolField;
+    }
+    public ImmutableStructNoClash() {
+        this.stringField = "nonsense";
+        this.intField = 42;
+        this.boolField = true;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/ImmutableStructWithClash.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/ImmutableStructWithClash.java
@@ -1,0 +1,21 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class ImmutableStructWithClash {
+    @NonNull
+    public final String stringField;
+    public final int intField;
+    public final boolean boolField;
+    public ImmutableStructWithClash() {
+        this.stringField = "nonsense";
+        this.intField = 42;
+        this.boolField = true;
+    }
+    public ImmutableStructWithClash(final boolean boolField, final int intField, @NonNull final String stringField) {
+        this.boolField = boolField;
+        this.intField = intField;
+        this.stringField = stringField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/jni/com_example_smoke_ImmutableStructWithClash__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/jni/com_example_smoke_ImmutableStructWithClash__Conversion.cpp
@@ -1,0 +1,57 @@
+/*
+ *
+ */
+#include "com_example_smoke_ImmutableStructWithClash__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::ImmutableStructWithClash
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::ImmutableStructWithClash*)
+{
+    ::std::string n_string_field = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "stringField",
+        (::std::string*)nullptr );
+    int32_t n_int_field = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "intField",
+        (int32_t*)nullptr );
+    bool n_bool_field = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "boolField",
+        (bool*)nullptr );
+    return ::smoke::ImmutableStructWithClash(std::move(n_bool_field), std::move(n_int_field), std::move(n_string_field));
+}
+::gluecodium::optional<::smoke::ImmutableStructWithClash>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::ImmutableStructWithClash>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::ImmutableStructWithClash>(convert_from_jni(_jenv, _jinput, (::smoke::ImmutableStructWithClash*)nullptr))
+        : ::gluecodium::optional<::smoke::ImmutableStructWithClash>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/ImmutableStructWithClash", com_example_smoke_ImmutableStructWithClash, ::smoke::ImmutableStructWithClash)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::ImmutableStructWithClash& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::ImmutableStructWithClash>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.string_field);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::ImmutableStructWithClash> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}


### PR DESCRIPTION
Extracted existing Java Mustache template for field-based struct constructors
into a standalone template file (to simplify maintanance).

Added support for "field constructors" to the new extracted
template.

Updated JNI template for struct conversion to make use of a "reordered"
all-fields constructor if one is present.

Added functional and smoke tests.

Resolves: #1056
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
