### PR TITLE
Fix missing inheritance includes in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Restored validation of constructor overloads for C++, Java, and Swift generators.
+  * Fixed missing C++ includes for some cases of class inheritance.
 
 ## 9.4.4
 Release date: 2021-08-27

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppForwardDeclarationsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppForwardDeclarationsCollector.kt
@@ -28,7 +28,8 @@ internal class CppForwardDeclarationsCollector(private val nameResolver: CppName
 
     override fun collectImports(limeElement: LimeNamedElement): List<CppForwardDeclarationGroup> {
         val allTypeRefs = collectTypeRefs(LimeTypeHelper.getAllTypes(limeElement))
-        val forwardDeclaredTypes = collectForwardDeclaredTypes(allTypeRefs).distinctBy { it.path }.sortedBy { it.path }
+        val forwardDeclaredTypes =
+            collectForwardDeclaredTypes(limeElement, allTypeRefs).distinctBy { it.path }.sortedBy { it.path }
         return createForwardDeclarationGroup("", forwardDeclaredTypes, 0, nameResolver).subGroups
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppHeaderIncludesCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppHeaderIncludesCollector.kt
@@ -45,7 +45,7 @@ internal class CppHeaderIncludesCollector(
                         (it is LimeInterface || it.visibility.isOpen)
                 }
         val allTypeRefs = collectTypeRefs(allTypes)
-        val forwardDeclaredTypes = collectForwardDeclaredTypes(allTypeRefs)
+        val forwardDeclaredTypes = collectForwardDeclaredTypes(limeElement, allTypeRefs)
 
         val allValues = LimeTypeHelper.getAllValues(limeElement)
         val equatableTypes = allTypes.filter { it.external?.cpp == null && it.attributes.have(LimeAttributeType.EQUATABLE) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImportsCollector.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
+import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
@@ -36,10 +37,16 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal abstract class CppImportsCollector<T> : ImportsCollector<T> {
 
-    protected fun collectForwardDeclaredTypes(allTypeRefs: List<LimeTypeRef>) =
-        allTypeRefs.map { it.type }
+    protected fun collectForwardDeclaredTypes(
+        limeElement: LimeNamedElement,
+        allTypeRefs: List<LimeTypeRef>
+    ): List<LimeContainerWithInheritance> {
+        val filteredPaths = listOf(limeElement.path) +
+            listOfNotNull((limeElement as? LimeContainerWithInheritance)?.parent?.type?.path)
+        return allTypeRefs.map { it.type }
             .filterIsInstance<LimeContainerWithInheritance>()
-            .filter { !it.path.hasParent && it.external?.cpp == null }
+            .filter { !it.path.hasParent && it.external?.cpp == null && !filteredPaths.contains(it.path) }
+    }
 
     protected fun collectTypeRefs(allTypes: List<LimeType>): List<LimeTypeRef> {
         val containers = allTypes.filterIsInstance<LimeContainer>()

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
@@ -11,9 +11,6 @@
 #include <string>
 #include <system_error>
 namespace smoke {
-    class CppRefReturnType;
-}
-namespace smoke {
 class _GLUECODIUM_CPP_EXPORT CppRefReturnType {
 public:
     CppRefReturnType();

--- a/gluecodium/src/test/resources/smoke/constructors/output/cpp/include/smoke/Constructors.h
+++ b/gluecodium/src/test/resources/smoke/constructors/output/cpp/include/smoke/Constructors.h
@@ -13,9 +13,6 @@
 #include <system_error>
 #include <vector>
 namespace smoke {
-    class Constructors;
-}
-namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Constructors {
 public:
     Constructors();

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableClass.h
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableClass.h
@@ -9,7 +9,6 @@
 #include <memory>
 #include <string>
 namespace smoke {
-    class EquatableClass;
     class PointerEquatableClass;
 }
 namespace smoke {

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Class.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Class.h
@@ -10,9 +10,6 @@
 #include <memory>
 #include <system_error>
 namespace package {
-    class Class;
-}
-namespace package {
 class _GLUECODIUM_CPP_EXPORT Class: public ::package::Interface {
 public:
     Class();

--- a/gluecodium/src/test/resources/smoke/inheritance/input/Inheritance.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/Inheritance.lime
@@ -49,3 +49,8 @@ interface ParentWithClassReferences {
 }
 
 class ChildWithParentClassReferences : ParentWithClassReferences {}
+
+@Skip(Java, Dart, Swift)
+class ForwardDeclarationBug : ParentClass {
+    fun foo(bar: ParentClass)
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ForwardDeclarationBug.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ForwardDeclarationBug.h
@@ -1,0 +1,21 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentClass.h"
+#include <memory>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ForwardDeclarationBug: public ::smoke::ParentClass {
+public:
+    ForwardDeclarationBug();
+    virtual ~ForwardDeclarationBug() = 0;
+public:
+    /**
+     *
+     * \param[in] bar @NotNull
+     */
+    virtual void foo( const ::std::shared_ptr< ::smoke::ParentClass >& bar ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleClass.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleClass.h
@@ -7,9 +7,6 @@
 #include <memory>
 #include <string>
 namespace smoke {
-    class SimpleClass;
-}
-namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SimpleClass {
 public:
     SimpleClass();

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleInterface.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleInterface.h
@@ -8,9 +8,6 @@
 #include <memory>
 #include <string>
 namespace smoke {
-    class SimpleInterface;
-}
-namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SimpleInterface {
 public:
     SimpleInterface();

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cpp/include/namerules/NameRules.h
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cpp/include/namerules/NameRules.h
@@ -12,9 +12,6 @@
 #include <system_error>
 #include <vector>
 namespace namerules {
-    class NameRules;
-}
-namespace namerules {
 class _GLUECODIUM_CPP_EXPORT NameRules {
 public:
     NameRules();

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/NestedReferences.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/NestedReferences.h
@@ -7,9 +7,6 @@
 #include <memory>
 #include <string>
 namespace smoke {
-    class NestedReferences;
-}
-namespace smoke {
 class _GLUECODIUM_CPP_EXPORT NestedReferences {
 public:
     NestedReferences();

--- a/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooInterface.h
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooInterface.h
@@ -9,9 +9,6 @@
 #include <memory>
 #include <string>
 namespace smoke {
-    class fooInterface;
-}
-namespace smoke {
 class _GLUECODIUM_CPP_EXPORT fooInterface {
 public:
     fooInterface();


### PR DESCRIPTION
Updated CppImportsCollector to exclude class/interface inheritance parent types
from the list of types that need to be forward-declared. This restores a missing
include for the inheritance parent type for cases where that type was also
referenced elsewhere in the child type.

Added/updated smoke tests.

Resolves: #1068
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>