### PR TITLE
Allow overloading on parameter names in Swift validation

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.generator.swift.SwiftNameRules
-import com.here.gluecodium.generator.swift.SwiftSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -38,6 +37,7 @@ import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
+import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
@@ -46,7 +46,7 @@ internal class CBridgeNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val swiftNameRules: SwiftNameRules,
     private val internalPrefix: String,
-    private val signatureResolver: SwiftSignatureResolver
+    private val signatureResolver: LimeSignatureResolver
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     override fun resolveName(element: Any): String =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
@@ -27,10 +27,10 @@ import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeSignatureResolver
 
-internal abstract class PlatformSignatureResolver(
+internal open class PlatformSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val platformAttributeType: LimeAttributeType,
-    private val nameRules: NameRules,
+    protected val nameRules: NameRules,
     private val activeTags: Set<String>
 ) : LimeSignatureResolver(limeReferenceMap) {
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeParameter
 
 internal class SwiftSignatureResolver(
     limeReferenceMap: Map<String, LimeElement>,
@@ -34,4 +35,7 @@ internal class SwiftSignatureResolver(
         val overloads = getOwnAndParentFunctions(container).filter { it.isConstructor }
         return hasSignatureClash(limeFunction, overloads)
     }
+
+    override fun getParameterSignature(limeParameter: LimeParameter) =
+        nameRules.getName(limeParameter) + ": " + getTypeName(limeParameter.typeRef)
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
@@ -100,3 +100,9 @@ class NullableOverloads {
     fun foo(input: String)
     fun foo(input: String?)
 }
+
+@Java(Skip) @Dart(Skip)
+class SwiftConstructorOverloads {
+    constructor make(input: String)
+    constructor make_do(throughput: String)
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftConstructorOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SwiftConstructorOverloads.swift
@@ -1,0 +1,108 @@
+//
+//
+import Foundation
+public class SwiftConstructorOverloads {
+    public init(input: String) {
+        let _result = SwiftConstructorOverloads.make(input: input)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_SwiftConstructorOverloads_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+    }
+    public init(throughput: String) {
+        let _result = SwiftConstructorOverloads.makeDo(throughput: throughput)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_SwiftConstructorOverloads_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+    }
+    let c_instance : _baseRef
+    init(cSwiftConstructorOverloads: _baseRef) {
+        guard cSwiftConstructorOverloads != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cSwiftConstructorOverloads
+    }
+    deinit {
+        smoke_SwiftConstructorOverloads_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_SwiftConstructorOverloads_release_handle(c_instance)
+    }
+    private static func make(input: String) -> _baseRef {
+        let c_input = moveToCType(input)
+        let c_result_handle = smoke_SwiftConstructorOverloads_make(c_input.ref)
+        return moveFromCType(c_result_handle)
+    }
+    private static func makeDo(throughput: String) -> _baseRef {
+        let c_throughput = moveToCType(throughput)
+        let c_result_handle = smoke_SwiftConstructorOverloads_makeDo(c_throughput.ref)
+        return moveFromCType(c_result_handle)
+    }
+}
+internal func getRef(_ ref: SwiftConstructorOverloads?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_SwiftConstructorOverloads_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_SwiftConstructorOverloads_release_handle)
+        : RefHolder(handle_copy)
+}
+extension SwiftConstructorOverloads: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+extension SwiftConstructorOverloads: Hashable {
+    /// :nodoc:
+    public static func == (lhs: SwiftConstructorOverloads, rhs: SwiftConstructorOverloads) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+internal func SwiftConstructorOverloads_copyFromCType(_ handle: _baseRef) -> SwiftConstructorOverloads {
+    if let swift_pointer = smoke_SwiftConstructorOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SwiftConstructorOverloads {
+        return re_constructed
+    }
+    let result = SwiftConstructorOverloads(cSwiftConstructorOverloads: smoke_SwiftConstructorOverloads_copy_handle(handle))
+    smoke_SwiftConstructorOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SwiftConstructorOverloads_moveFromCType(_ handle: _baseRef) -> SwiftConstructorOverloads {
+    if let swift_pointer = smoke_SwiftConstructorOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SwiftConstructorOverloads {
+        smoke_SwiftConstructorOverloads_release_handle(handle)
+        return re_constructed
+    }
+    let result = SwiftConstructorOverloads(cSwiftConstructorOverloads: handle)
+    smoke_SwiftConstructorOverloads_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func SwiftConstructorOverloads_copyFromCType(_ handle: _baseRef) -> SwiftConstructorOverloads? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SwiftConstructorOverloads_moveFromCType(handle) as SwiftConstructorOverloads
+}
+internal func SwiftConstructorOverloads_moveFromCType(_ handle: _baseRef) -> SwiftConstructorOverloads? {
+    guard handle != 0 else {
+        return nil
+    }
+    return SwiftConstructorOverloads_moveFromCType(handle) as SwiftConstructorOverloads
+}
+internal func copyToCType(_ swiftClass: SwiftConstructorOverloads) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SwiftConstructorOverloads) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: SwiftConstructorOverloads?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: SwiftConstructorOverloads?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
@@ -80,7 +80,9 @@ open class LimeSignatureResolver(private val referenceMap: Map<String, LimeEleme
 
     protected open fun getNullableSuffix(limeTypeRef: LimeTypeRef) = if (limeTypeRef.isNullable) "?" else ""
 
-    private fun computeSignature(limeFunction: LimeFunction) = limeFunction.parameters.map { getTypeName(it.typeRef) }
+    protected open fun getParameterSignature(limeParameter: LimeParameter) = getTypeName(limeParameter.typeRef)
+
+    private fun computeSignature(limeFunction: LimeFunction) = limeFunction.parameters.map { getParameterSignature(it) }
 
     protected fun getTypeName(limeTypeRef: LimeTypeRef): String =
         when (val limeType = limeTypeRef.type) {


### PR DESCRIPTION
Updated SwiftSignatureResolver to include parameter names in function's
signature. This lets the overloads validtion in the Swift generator to allow
overloading on parameter names (as the language allows it too).

See: #1034
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>