### PR TITLE
Add support for "field constructors" in Swift

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -149,7 +149,7 @@ feature(StructsImmutable cpp android swift dart SOURCES
     input/lime/PlainDataStructuresImmutable.lime
 )
 
-feature(FieldConstructors cpp android SOURCES
+feature(FieldConstructors cpp android swift SOURCES
     input/src/cpp/FieldConstructors.cpp
 
     input/lime/FieldConstructors.lime

--- a/functional-tests/functional/swift/Tests/FieldConstructorsTests.swift
+++ b/functional-tests/functional/swift/Tests/FieldConstructorsTests.swift
@@ -1,0 +1,82 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import functional
+
+class FieldConstructorsTests: XCTestCase {
+
+    func testPartialDefaults2() {
+        let result = FieldConstructorsPartialDefaults(intField: 7, stringField: "foo")
+
+        XCTAssertEqual(result.stringField, "foo")
+        XCTAssertEqual(result.intField, 7)
+        XCTAssertEqual(result.boolField, true)
+    }
+
+    func testPartialDefaults3() {
+        let result = FieldConstructorsPartialDefaults(boolField: false, intField: 7, stringField: "foo")
+
+        XCTAssertEqual(result.stringField, "foo")
+        XCTAssertEqual(result.intField, 7)
+        XCTAssertEqual(result.boolField, false)
+    }
+
+    func testAllDefaults0() {
+        let result = FieldConstructorsAllDefaults()
+
+        XCTAssertEqual(result.stringField, "nonsense")
+        XCTAssertEqual(result.intField, 42)
+        XCTAssertEqual(result.boolField, true)
+    }
+
+    func testAllDefaults1() {
+        let result = FieldConstructorsAllDefaults(intField: 7)
+
+        XCTAssertEqual(result.stringField, "nonsense")
+        XCTAssertEqual(result.intField, 7)
+        XCTAssertEqual(result.boolField, true)
+    }
+
+    func testImmutableNoClash() {
+        let result = ImmutableStructNoClash(stringField: "foo", intField: 7, boolField: false)
+
+        XCTAssertEqual(result.stringField, "foo")
+        XCTAssertEqual(result.intField, 7)
+        XCTAssertEqual(result.boolField, false)
+    }
+
+    func testImmutableWithClash() {
+        let result = ImmutableStructWithClash(boolField: false, intField: 7, stringField: "foo")
+
+        XCTAssertEqual(result.stringField, "foo")
+        XCTAssertEqual(result.intField, 7)
+        XCTAssertEqual(result.boolField, false)
+    }
+
+    static var allTests = [
+        ("testPartialDefaults2", testPartialDefaults2),
+        ("testPartialDefaults3", testPartialDefaults3),
+        ("testAllDefaults0", testAllDefaults0),
+        ("testAllDefaults1", testAllDefaults1),
+        ("testImmutableNoClash", testImmutableNoClash),
+        ("testImmutableWithClash", testImmutableWithClash)
+    ]
+}

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -45,6 +45,7 @@ func getAllTests() -> [XCTestCaseEntry] {
         testCase(ErrorsInInterfaceTests.allTests),
         testCase(ErrorsTests.allTests),
         testCase(ExtensionsTests.allTests),
+        testCase(FieldConstructorsTests.allTests),
         testCase(InheritanceTests.allTests),
         testCase(InterfacesTests.allTests),
         testCase(InterfaceWithStaticTests.allTests),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -89,6 +89,7 @@ internal class SwiftGeneratorPredicates(
         "isRefEquatable" to { limeField: Any ->
             limeField is LimeField && isRefEquatable(limeField)
         },
+        "needsAllFieldsConstructor" to { CommonGeneratorPredicates.needsAllFieldsConstructor(it) },
         "needsExplicitHashable" to { limeStruct: Any ->
             limeStruct is LimeStruct && limeStruct.attributes.have(LimeAttributeType.EQUATABLE) &&
                 limeStruct.fields.any { isRefEquatable(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -155,7 +155,7 @@ internal class SwiftNameResolver(
         if (commentText.isBlank()) return ""
 
         val exactElement = limeReferenceMap[limeComment.path.toString()] as? LimeNamedElement
-        val commentedElement = exactElement ?: getParentElement(limeComment.path)
+        val commentedElement = exactElement ?: getParentElement(limeComment.path, withSuffix = true)
         return commentsProcessor.process(commentedElement.fullName, commentText, limeToSwiftNames, limeLogger)
     }
 

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeStructImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeStructImpl.mustache
@@ -28,7 +28,7 @@ _baseRef
 {{>setCppFieldValue}}
 {{/fields}}{{/set}}
 {{#ifPredicate "hasImmutableFields"}}{{!!
-}}    {{resolveName "C++"}}* _struct = new ( ::std::nothrow ) {{resolveName "C++"}}( {{#fields}}_{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} );{{/ifPredicate}}
+}}    {{resolveName "C++"}}* _struct = new ( ::std::nothrow ) {{resolveName "C++"}}( {{>immutableFieldsInit}} );{{/ifPredicate}}
     return reinterpret_cast<_baseRef>( _struct );
 }
 
@@ -48,7 +48,7 @@ _baseRef
 {{/fields}}{{/set}}
 {{#ifPredicate "hasImmutableFields"}}{{!!
 }}    auto _struct = new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{resolveName "C++"}}>( {{!!
-}}{{resolveName "C++"}}( {{#fields}}_{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} ) );{{/ifPredicate}}
+}}{{resolveName "C++"}}( {{>immutableFieldsInit}} ) );{{/ifPredicate}}
     return reinterpret_cast<_baseRef>( _struct );
 }
 
@@ -111,4 +111,11 @@ void {{resolveName}}_release_optional_handle(_baseRef handle) {
 }}{{#notInstanceOf typeRef.type.actualType "LimeEnumeration"}}{{resolveName field}}{{/notInstanceOf}}{{!!
 }}{{/unlessPredicate}}{{/set}}{{!!
 }}{{#unlessPredicate structElement "hasImmutableFields"}}{{#ifPredicate "hasCppSetter"}} ){{/ifPredicate}}{{/unlessPredicate}};
-{{/setCppFieldValue}}
+{{/setCppFieldValue}}{{!!
+
+}}{{+immutableFieldsInit}}{{#if allFieldsConstructor}}{{!!
+}}{{#allFieldsConstructor}}{{#fields}}_{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/allFieldsConstructor}}{{!!
+}}{{/if}}{{!!
+}}{{#unless allFieldsConstructor}}{{!!
+}}{{#fields}}_{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{!!
+}}{{/unless}}{{/immutableFieldsInit}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
@@ -1,0 +1,97 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#unless constructors}}{{#unless fieldConstructors}}{{#ifPredicate "needsReducedConstructor"}}
+
+{{#resolveName constructorComment}}{{#unless this.isEmpty}}
+{{prefix this "    /// "}}
+{{#if publicFields}}
+    /// - Parameters
+{{#publicFields}}
+    ///   - {{resolveName}}: {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "    ///       " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/publicFields}}
+{{/if}}
+{{/unless}}{{/resolveName}}
+    {{>swift/TypeVisibility}} init({{joinPartial publicFields "initParameter" ", "}}) {
+{{#publicFields}}
+        self.{{resolveName}} = {{resolveName}}
+{{/publicFields}}
+{{#internalFields}}
+        self.{{resolveName}} = {{defaultValue}}
+{{/internalFields}}
+    }
+{{/ifPredicate}}{{/unless}}{{!!
+
+}}{{#fieldConstructors}}
+{{#ifPredicate "hasAnyComment"}}{{!!
+}}{{#unless this.comment.isEmpty}}{{#resolveName this.comment}}{{prefix this "    /// "}}{{/resolveName}}
+{{/unless}}{{!!
+}}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{prefix this "    /// "}}
+{{/unless}}{{/resolveName}}{{/if}}{{!!
+}}{{#if fields}}
+    /// - Parameters
+{{#fields}}
+    ///   - {{resolveName}}: {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "    ///       " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}{{/if}}{{!!
+}}{{#if this.comment.isExcluded}}    /// :nodoc:
+{{/if}}{{/ifPredicate}}{{!!
+}}{{#attributes.deprecated}}
+    @available(*, deprecated{{#if message}}, message: "{{resolveName message}}"{{/if}}){{/attributes.deprecated}}
+{{prefixPartial "swift/SwiftAttributes" "    "}}
+    {{>swift/TypeVisibility}} init({{!!
+    }}{{#fields}}{{>ctorParameter}}{{#if iter.hasNext}}, {{/if}}{{/fields}}) {
+{{#fields}}
+        self.{{resolveName}} = {{resolveName}}
+{{/fields}}
+{{#omittedFields}}
+        self.{{resolveName}} = {{resolveName defaultValue}}
+{{/omittedFields}}
+    }
+{{/fieldConstructors}}{{!!
+
+}}{{#ifPredicate "needsAllFieldsConstructor"}}
+
+{{#resolveName constructorComment}}{{#unless this.isEmpty}}
+{{prefix this "    /// "}}
+{{#if publicFields}}
+    /// - Parameters
+{{#fields}}
+    ///   - {{resolveName}}: {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "    ///       " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}
+{{/if}}
+{{/unless}}{{/resolveName}}
+    {{#if internalFields}}internal{{/if}}{{!!
+    }}{{#unless internalFields}}{{>swift/TypeVisibility}}{{/unless}}{{!!
+    }} init({{joinPartial fields "initParameter" ", "}}) {
+{{#fields}}
+        self.{{resolveName}} = {{resolveName}}
+{{/fields}}
+    }
+{{/ifPredicate}}{{!!
+
+}}{{/unless}}{{!!
+
+}}{{+ctorParameter}}{{!!
+}}{{resolveName}}: {{#unless typeRef.isNullable}}{{#instanceOf typeRef.type.actualType "LimeLambda"}}@escaping {{/instanceOf}}{{/unless}}{{!!
+}}{{resolveName typeRef}}{{/ctorParameter}}{{!!
+
+}}{{+initParameter}}{{!!
+}}{{>ctorParameter}}{{#if defaultValue}} = {{resolveName defaultValue}}{{/if}}{{!!
+}}{{#unless defaultValue}}{{#if typeRef.isNullable}} = nil{{/if}}{{/unless}}{{/initParameter}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructDefinition.mustache
@@ -31,44 +31,9 @@
 {{prefixPartial "swift/SwiftComment" "    "}}{{prefixPartial "swift/SwiftAttributes" "    "}}
 {{/if}}
     {{resolveName visibility}} {{#if isImmutable}}let{{/if}}{{#unless isImmutable}}var{{/unless}} {{resolveName}}: {{resolveName typeRef}}
-{{/fields}}{{/set}}{{#unless constructors}}{{#ifPredicate "needsReducedConstructor"}}
+{{/fields}}{{/set}}{{!!
 
-{{#resolveName constructorComment}}{{#unless this.isEmpty}}
-{{prefix this "    /// "}}
-{{#if publicFields}}
-    /// - Parameters
-{{#publicFields}}
-    ///   - {{resolveName}}: {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "    ///       " skipFirstLine=true}}{{/unless}}{{/resolveName}}
-{{/publicFields}}
-{{/if}}
-{{/unless}}{{/resolveName}}
-    {{>swift/TypeVisibility}} init({{joinPartial publicFields "initParameter" ", "}}) {
-{{#publicFields}}
-        self.{{resolveName}} = {{resolveName}}
-{{/publicFields}}
-{{#internalFields}}
-        self.{{resolveName}} = {{defaultValue}}
-{{/internalFields}}
-    }
-{{/ifPredicate}}
-
-{{#resolveName constructorComment}}{{#unless this.isEmpty}}
-{{prefix this "    /// "}}
-{{#if publicFields}}
-    /// - Parameters
-{{#fields}}
-    ///   - {{resolveName}}: {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "    ///       " skipFirstLine=true}}{{/unless}}{{/resolveName}}
-{{/fields}}
-{{/if}}
-{{/unless}}{{/resolveName}}
-    {{#if internalFields}}internal{{/if}}{{!!
-    }}{{#unless internalFields}}{{>swift/TypeVisibility}}{{/unless}}{{!!
-    }} init({{joinPartial fields "initParameter" ", "}}) {
-{{#fields}}
-        self.{{resolveName}} = {{resolveName}}
-{{/fields}}
-    }
-{{/unless}}
+}}{{>swift/SwiftStructConstructors}}
 
     internal init(cHandle: _baseRef) {
 {{#set container=this}}{{#fields}}{{#if typeRef.attributes.optimized}}
@@ -150,9 +115,4 @@ extension {{resolveName}} {
         }}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/set}})
     }
 }
-{{/ifPredicate}}{{!!
-
-}}{{+initParameter}}{{!!
-}}{{resolveName}}: {{#unless typeRef.isNullable}}{{#instanceOf typeRef.type.actualType "LimeLambda"}}@escaping {{/instanceOf}}{{/unless}}{{!!
-}}{{resolveName typeRef}}{{#if defaultValue}} = {{resolveName defaultValue}}{{/if}}{{!!
-}}{{#unless defaultValue}}{{#if typeRef.isNullable}} = nil{{/if}}{{/unless}}{{/initParameter}}
+{{/ifPredicate}}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cbridge/src/smoke/cbridge_ImmutableStructWithClash.cpp
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cbridge/src/smoke/cbridge_ImmutableStructWithClash.cpp
@@ -1,0 +1,54 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_ImmutableStructWithClash.h"
+#include "cbridge/include/StringHandle.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "gluecodium/Optional.h"
+#include "smoke/ImmutableStructWithClash.h"
+#include <cstdint>
+#include <memory>
+#include <new>
+#include <string>
+_baseRef
+smoke_ImmutableStructWithClash_create_handle( _baseRef stringField, int32_t intField, bool boolField )
+{
+    auto _stringField = Conversion<::std::string>::toCpp( stringField );
+    auto _intField = intField;
+    auto _boolField = boolField;
+    ::smoke::ImmutableStructWithClash* _struct = new ( ::std::nothrow ) ::smoke::ImmutableStructWithClash( _boolField, _intField, _stringField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_ImmutableStructWithClash_release_handle( _baseRef handle )
+{
+    delete get_pointer<::smoke::ImmutableStructWithClash>( handle );
+}
+_baseRef
+smoke_ImmutableStructWithClash_create_optional_handle(_baseRef stringField, int32_t intField, bool boolField)
+{
+    auto _stringField = Conversion<::std::string>::toCpp( stringField );
+    auto _intField = intField;
+    auto _boolField = boolField;
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::ImmutableStructWithClash>( ::smoke::ImmutableStructWithClash( _boolField, _intField, _stringField ) );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_ImmutableStructWithClash_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::smoke::ImmutableStructWithClash>*>( handle ) );
+}
+void smoke_ImmutableStructWithClash_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::smoke::ImmutableStructWithClash>*>( handle );
+}
+_baseRef smoke_ImmutableStructWithClash_stringField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::ImmutableStructWithClash>(handle);
+    return Conversion<::std::string>::toBaseRef(struct_pointer->string_field);
+}
+int32_t smoke_ImmutableStructWithClash_intField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::ImmutableStructWithClash>(handle);
+    return struct_pointer->int_field;
+}
+bool smoke_ImmutableStructWithClash_boolField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::ImmutableStructWithClash>(handle);
+    return struct_pointer->bool_field;
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithBothComments.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithBothComments.swift
@@ -1,0 +1,55 @@
+//
+//
+import Foundation
+/// SomeStruct
+public struct FieldConstructorWithBothComments {
+    public var stringField: String
+    /// This comment takes precedence
+    /// - Parameters
+    ///   - stringField:
+    public init(stringField: String) {
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorWithBothComments_stringField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithBothComments {
+    return FieldConstructorWithBothComments(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithBothComments {
+    defer {
+        smoke_FieldConstructorWithBothComments_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithBothComments) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithBothComments_create_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithBothComments) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithBothComments_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithBothComments? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorWithBothComments_unwrap_optional_handle(handle)
+    return FieldConstructorWithBothComments(cHandle: unwrappedHandle) as FieldConstructorWithBothComments
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithBothComments? {
+    defer {
+        smoke_FieldConstructorWithBothComments_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithBothComments?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithBothComments_create_optional_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithBothComments?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithBothComments_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithComment.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithComment.swift
@@ -1,0 +1,56 @@
+//
+//
+import Foundation
+/// SomeStruct
+public struct FieldConstructorWithComment {
+    /// Some field
+    public var stringField: String
+    /// Some field constructor
+    /// - Parameters
+    ///   - stringField: Some field
+    public init(stringField: String) {
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorWithComment_stringField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithComment {
+    return FieldConstructorWithComment(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithComment {
+    defer {
+        smoke_FieldConstructorWithComment_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithComment) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithComment_create_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithComment) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithComment_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithComment? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorWithComment_unwrap_optional_handle(handle)
+    return FieldConstructorWithComment(cHandle: unwrappedHandle) as FieldConstructorWithComment
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithComment? {
+    defer {
+        smoke_FieldConstructorWithComment_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithComment?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithComment_create_optional_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithComment?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithComment_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithDeprecationAndComment.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithDeprecationAndComment.swift
@@ -1,0 +1,55 @@
+//
+//
+import Foundation
+public struct FieldConstructorWithDeprecationAndComment {
+    public var stringField: String
+    /// Some field constructor
+    /// - Parameters
+    ///   - stringField:
+    @available(*, deprecated, message: "Shouldn't really use it")
+    public init(stringField: String) {
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorWithDeprecationAndComment_stringField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationAndComment {
+    return FieldConstructorWithDeprecationAndComment(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationAndComment {
+    defer {
+        smoke_FieldConstructorWithDeprecationAndComment_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithDeprecationAndComment) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithDeprecationAndComment_create_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithDeprecationAndComment) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithDeprecationAndComment_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationAndComment? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorWithDeprecationAndComment_unwrap_optional_handle(handle)
+    return FieldConstructorWithDeprecationAndComment(cHandle: unwrappedHandle) as FieldConstructorWithDeprecationAndComment
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationAndComment? {
+    defer {
+        smoke_FieldConstructorWithDeprecationAndComment_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithDeprecationAndComment?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithDeprecationAndComment_create_optional_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithDeprecationAndComment?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithDeprecationAndComment_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithDeprecationOnly.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithDeprecationOnly.swift
@@ -1,0 +1,54 @@
+//
+//
+import Foundation
+public struct FieldConstructorWithDeprecationOnly {
+    public var stringField: String
+    /// - Parameters
+    ///   - stringField:
+    @available(*, deprecated, message: "Shouldn't really use it")
+    public init(stringField: String) {
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorWithDeprecationOnly_stringField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationOnly {
+    return FieldConstructorWithDeprecationOnly(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationOnly {
+    defer {
+        smoke_FieldConstructorWithDeprecationOnly_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithDeprecationOnly) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithDeprecationOnly_create_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithDeprecationOnly) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithDeprecationOnly_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationOnly? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorWithDeprecationOnly_unwrap_optional_handle(handle)
+    return FieldConstructorWithDeprecationOnly(cHandle: unwrappedHandle) as FieldConstructorWithDeprecationOnly
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithDeprecationOnly? {
+    defer {
+        smoke_FieldConstructorWithDeprecationOnly_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithDeprecationOnly?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithDeprecationOnly_create_optional_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithDeprecationOnly?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithDeprecationOnly_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithExcluded.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithExcluded.swift
@@ -1,0 +1,56 @@
+//
+//
+import Foundation
+public struct FieldConstructorWithExcluded {
+    /// Some field
+    public var stringField: String
+    /// Some field constructor
+    /// - Parameters
+    ///   - stringField: Some field
+    /// :nodoc:
+    public init(stringField: String) {
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorWithExcluded_stringField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithExcluded {
+    return FieldConstructorWithExcluded(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithExcluded {
+    defer {
+        smoke_FieldConstructorWithExcluded_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithExcluded) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithExcluded_create_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithExcluded) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithExcluded_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithExcluded? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorWithExcluded_unwrap_optional_handle(handle)
+    return FieldConstructorWithExcluded(cHandle: unwrappedHandle) as FieldConstructorWithExcluded
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithExcluded? {
+    defer {
+        smoke_FieldConstructorWithExcluded_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithExcluded?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithExcluded_create_optional_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithExcluded?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithExcluded_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithExcludedOnly.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithExcludedOnly.swift
@@ -1,0 +1,54 @@
+//
+//
+import Foundation
+public struct FieldConstructorWithExcludedOnly {
+    public var stringField: String
+    /// - Parameters
+    ///   - stringField:
+    /// :nodoc:
+    public init(stringField: String) {
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorWithExcludedOnly_stringField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithExcludedOnly {
+    return FieldConstructorWithExcludedOnly(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithExcludedOnly {
+    defer {
+        smoke_FieldConstructorWithExcludedOnly_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithExcludedOnly) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithExcludedOnly_create_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithExcludedOnly) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithExcludedOnly_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithExcludedOnly? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorWithExcludedOnly_unwrap_optional_handle(handle)
+    return FieldConstructorWithExcludedOnly(cHandle: unwrappedHandle) as FieldConstructorWithExcludedOnly
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithExcludedOnly? {
+    defer {
+        smoke_FieldConstructorWithExcludedOnly_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithExcludedOnly?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithExcludedOnly_create_optional_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithExcludedOnly?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithExcludedOnly_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithParentComment.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorWithParentComment.swift
@@ -1,0 +1,55 @@
+//
+//
+import Foundation
+/// SomeStruct
+public struct FieldConstructorWithParentComment {
+    public var stringField: String
+    /// There are constructors
+    /// - Parameters
+    ///   - stringField:
+    public init(stringField: String) {
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorWithParentComment_stringField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithParentComment {
+    return FieldConstructorWithParentComment(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithParentComment {
+    defer {
+        smoke_FieldConstructorWithParentComment_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithParentComment) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithParentComment_create_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithParentComment) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithParentComment_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorWithParentComment? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorWithParentComment_unwrap_optional_handle(handle)
+    return FieldConstructorWithParentComment(cHandle: unwrappedHandle) as FieldConstructorWithParentComment
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorWithParentComment? {
+    defer {
+        smoke_FieldConstructorWithParentComment_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorWithParentComment?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    return RefHolder(smoke_FieldConstructorWithParentComment_create_optional_handle(c_stringField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorWithParentComment?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorWithParentComment_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsAllDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsAllDefaults.swift
@@ -1,0 +1,76 @@
+//
+//
+import Foundation
+public struct FieldConstructorsAllDefaults {
+    public var stringField: String
+    public var intField: Int32
+    public var boolField: Bool
+    public init() {
+        self.stringField = "nonsense"
+        self.intField = 42
+        self.boolField = true
+    }
+    public init(intField: Int32) {
+        self.intField = intField
+        self.stringField = "nonsense"
+        self.boolField = true
+    }
+    public init(intField: Int32, stringField: String) {
+        self.intField = intField
+        self.stringField = stringField
+        self.boolField = true
+    }
+    public init(boolField: Bool, intField: Int32, stringField: String) {
+        self.boolField = boolField
+        self.intField = intField
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorsAllDefaults_stringField_get(cHandle))
+        intField = moveFromCType(smoke_FieldConstructorsAllDefaults_intField_get(cHandle))
+        boolField = moveFromCType(smoke_FieldConstructorsAllDefaults_boolField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsAllDefaults {
+    return FieldConstructorsAllDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsAllDefaults {
+    defer {
+        smoke_FieldConstructorsAllDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsAllDefaults) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_FieldConstructorsAllDefaults_create_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsAllDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsAllDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsAllDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorsAllDefaults_unwrap_optional_handle(handle)
+    return FieldConstructorsAllDefaults(cHandle: unwrappedHandle) as FieldConstructorsAllDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsAllDefaults? {
+    defer {
+        smoke_FieldConstructorsAllDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsAllDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_FieldConstructorsAllDefaults_create_optional_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsAllDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsAllDefaults_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsPartialDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsPartialDefaults.swift
@@ -1,0 +1,66 @@
+//
+//
+import Foundation
+public struct FieldConstructorsPartialDefaults {
+    public var stringField: String
+    public var intField: Int32
+    public var boolField: Bool
+    public init(intField: Int32, stringField: String) {
+        self.intField = intField
+        self.stringField = stringField
+        self.boolField = true
+    }
+    public init(boolField: Bool, intField: Int32, stringField: String) {
+        self.boolField = boolField
+        self.intField = intField
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorsPartialDefaults_stringField_get(cHandle))
+        intField = moveFromCType(smoke_FieldConstructorsPartialDefaults_intField_get(cHandle))
+        boolField = moveFromCType(smoke_FieldConstructorsPartialDefaults_boolField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsPartialDefaults {
+    return FieldConstructorsPartialDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsPartialDefaults {
+    defer {
+        smoke_FieldConstructorsPartialDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsPartialDefaults) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_FieldConstructorsPartialDefaults_create_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsPartialDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsPartialDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsPartialDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorsPartialDefaults_unwrap_optional_handle(handle)
+    return FieldConstructorsPartialDefaults(cHandle: unwrappedHandle) as FieldConstructorsPartialDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsPartialDefaults? {
+    defer {
+        smoke_FieldConstructorsPartialDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsPartialDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_FieldConstructorsPartialDefaults_create_optional_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsPartialDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsPartialDefaults_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/ImmutableStructNoClash.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/ImmutableStructNoClash.swift
@@ -1,0 +1,66 @@
+//
+//
+import Foundation
+public struct ImmutableStructNoClash {
+    public let stringField: String
+    public let intField: Int32
+    public let boolField: Bool
+    public init() {
+        self.stringField = "nonsense"
+        self.intField = 42
+        self.boolField = true
+    }
+    public init(stringField: String = "nonsense", intField: Int32 = 42, boolField: Bool = true) {
+        self.stringField = stringField
+        self.intField = intField
+        self.boolField = boolField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_ImmutableStructNoClash_stringField_get(cHandle))
+        intField = moveFromCType(smoke_ImmutableStructNoClash_intField_get(cHandle))
+        boolField = moveFromCType(smoke_ImmutableStructNoClash_boolField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> ImmutableStructNoClash {
+    return ImmutableStructNoClash(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> ImmutableStructNoClash {
+    defer {
+        smoke_ImmutableStructNoClash_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ImmutableStructNoClash) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_ImmutableStructNoClash_create_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: ImmutableStructNoClash) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ImmutableStructNoClash_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ImmutableStructNoClash? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_ImmutableStructNoClash_unwrap_optional_handle(handle)
+    return ImmutableStructNoClash(cHandle: unwrappedHandle) as ImmutableStructNoClash
+}
+internal func moveFromCType(_ handle: _baseRef) -> ImmutableStructNoClash? {
+    defer {
+        smoke_ImmutableStructNoClash_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ImmutableStructNoClash?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_ImmutableStructNoClash_create_optional_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: ImmutableStructNoClash?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ImmutableStructNoClash_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/ImmutableStructWithClash.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/ImmutableStructWithClash.swift
@@ -1,0 +1,66 @@
+//
+//
+import Foundation
+public struct ImmutableStructWithClash {
+    public let stringField: String
+    public let intField: Int32
+    public let boolField: Bool
+    public init() {
+        self.stringField = "nonsense"
+        self.intField = 42
+        self.boolField = true
+    }
+    public init(boolField: Bool, intField: Int32, stringField: String) {
+        self.boolField = boolField
+        self.intField = intField
+        self.stringField = stringField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_ImmutableStructWithClash_stringField_get(cHandle))
+        intField = moveFromCType(smoke_ImmutableStructWithClash_intField_get(cHandle))
+        boolField = moveFromCType(smoke_ImmutableStructWithClash_boolField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> ImmutableStructWithClash {
+    return ImmutableStructWithClash(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> ImmutableStructWithClash {
+    defer {
+        smoke_ImmutableStructWithClash_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ImmutableStructWithClash) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_ImmutableStructWithClash_create_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: ImmutableStructWithClash) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ImmutableStructWithClash_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ImmutableStructWithClash? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_ImmutableStructWithClash_unwrap_optional_handle(handle)
+    return ImmutableStructWithClash(cHandle: unwrappedHandle) as ImmutableStructWithClash
+}
+internal func moveFromCType(_ handle: _baseRef) -> ImmutableStructWithClash? {
+    defer {
+        smoke_ImmutableStructWithClash_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ImmutableStructWithClash?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_ImmutableStructWithClash_create_optional_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: ImmutableStructWithClash?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ImmutableStructWithClash_release_optional_handle)
+}


### PR DESCRIPTION
Extracted existing Swift Mustache template for field-based struct constructors
into a standalone template file (to simplify maintanance).

Added support for "field constructors" to the new extracted
template.

Updated CBridge template for struct conversion to make use of a "reordered"
all-fields constructor if one is present.

Added functional and smoke tests.

Resolves: #1057
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>