### PR TITLE
Add support for "field constructors" in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for defining "field constructors" for structs in IDL.
+
 ## 9.4.5
 Release date: 2021-09-10
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -210,6 +210,19 @@ some top-level element).
   * a constructor can have any number of parameters (zero or more).
   * a constructor can be declared as throwing an exception (optionally, also see `Exception` below).
 
+#### Field Constructor
+
+* Syntax: **field constructor** __(__\[*field-list*\]__)__
+* where *field-list* is a comma-separated list of field names
+* Example: `field constructor(latitude, longitude)`
+* Can be placed in: struct
+* Description: declares a field-based constructor in the struct type:
+  * a field constructor can have any number of parameters (zero or more), corresponding to the fields of the struct.
+  * the order of field constructor parameters can be arbitrary; it can differ from the order in which the fields
+  themselves are declared in the struct.
+  * each field constructor declaration must include all uninitialized fields of the struct (i.e. fields which do not
+  have a default value specified for them); initialized fields could be included or excluded arbitrarily.
+
 #### Property
 
 * Syntax: \[**static**\] **property** *PropertyName*__:__ *PropertyType*

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -149,7 +149,7 @@ feature(StructsImmutable cpp android swift dart SOURCES
     input/lime/PlainDataStructuresImmutable.lime
 )
 
-feature(FieldConstructors cpp android swift SOURCES
+feature(FieldConstructors cpp android swift dart SOURCES
     input/src/cpp/FieldConstructors.cpp
 
     input/lime/FieldConstructors.lime

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -34,6 +34,7 @@ import "test/EquatableStructs_test.dart" as EquatableStructsTests;
 import "test/Enums_test.dart" as EnumsTests;
 import "test/Exceptions_test.dart" as Exceptions;
 import "test/ExternalTypes_test.dart" as ExternalTypes;
+import "test/FieldConstructors_test.dart" as FieldConstructors;
 import "test/Inheritance_test.dart" as InheritanceTests;
 import "test/Interfaces_test.dart" as InterfacesTests;
 import "test/InterfaceWithStatic_test.dart" as InterfaceWithStaticTests;
@@ -78,6 +79,7 @@ final _allTests = [
   EnumsTests.main,
   Exceptions.main,
   ExternalTypes.main,
+  FieldConstructors.main,
   InheritanceTests.main,
   InterfacesTests.main,
   InterfaceWithStaticTests.main,

--- a/functional-tests/functional/dart/test/FieldConstructors_test.dart
+++ b/functional-tests/functional/dart/test/FieldConstructors_test.dart
@@ -1,0 +1,70 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("FieldConstuctors");
+
+void main() {
+  _testSuite.test("With partial defaults 2", () {
+    final result = FieldConstructorsPartialDefaults.withTrue(7, "foo");
+
+    expect(result.stringField, "foo");
+    expect(result.intField, 7);
+    expect(result.boolField, true);
+  });
+  _testSuite.test("With partial defaults 3", () {
+    final result = FieldConstructorsPartialDefaults(false, 7, "foo");
+
+    expect(result.stringField, "foo");
+    expect(result.intField, 7);
+    expect(result.boolField, false);
+  });
+  _testSuite.test("With all defaults 0", () {
+    final result = FieldConstructorsAllDefaults.withAll();
+
+    expect(result.stringField, "nonsense");
+    expect(result.intField, 42);
+    expect(result.boolField, true);
+  });
+  _testSuite.test("With all defaults 1", () {
+    final result = FieldConstructorsAllDefaults.withTrueNonsense(7);
+
+    expect(result.stringField, "nonsense");
+    expect(result.intField, 7);
+    expect(result.boolField, true);
+  });
+  _testSuite.test("Immutable no clash", () {
+    final result = ImmutableStructNoClash("foo", 7, false);
+
+    expect(result.stringField, "foo");
+    expect(result.intField, 7);
+    expect(result.boolField, false);
+  });
+  _testSuite.test("Immutable with clash", () {
+    final result = ImmutableStructWithClash(false, 7, "foo");
+
+    expect(result.stringField, "foo");
+    expect(result.intField, 7);
+    expect(result.boolField, false);
+  });
+}

--- a/functional-tests/functional/input/lime/FieldConstructors.lime
+++ b/functional-tests/functional/input/lime/FieldConstructors.lime
@@ -21,7 +21,9 @@ struct FieldConstructorsPartialDefaults {
     stringField: String
     intField: Int
     boolField: Boolean = true
+    @Dart("withTrue")
     field constructor(intField, stringField)
+    @Dart(Default)
     field constructor(boolField, intField, stringField)
 }
 
@@ -29,9 +31,13 @@ struct FieldConstructorsAllDefaults {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withAll")
     field constructor()
+    @Dart("withTrueNonsense")
     field constructor(intField)
+    @Dart("withTrue")
     field constructor(intField, stringField)
+    @Dart(Default)
     field constructor(boolField, intField, stringField)
 }
 
@@ -40,6 +46,7 @@ struct ImmutableStructNoClash {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withAll")
     field constructor()
 }
 
@@ -48,7 +55,9 @@ struct ImmutableStructWithClash {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withAll")
     field constructor()
+    @Dart(Default)
     field constructor(boolField, intField, stringField)
 }
 
@@ -56,6 +65,8 @@ struct FieldCustomConstructorsMix {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withTrueNonsense")
     field constructor(intField)
+    @Dart(Default)
     constructor createMe(intValue: Int, dummy: Double)
 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -20,11 +20,9 @@
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
-{{#set parent=this}}{{#constructors}}
+{{#set parent=this container=this}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
-  factory {{resolveName parent}}{{#unless attributes.dart.default}}{{!!
-  }}{{#isEq constructors.size 1}}{{#if attributes.dart.name}}.{{resolveName}}{{/if}}{{/isEq}}{{!!
-  }}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}{{/unless}}({{!!
+  factory {{resolveName parent}}{{>dart/DartConstructorName}}({{!!
   }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
   }}) => $prototype.{{resolveName visibility}}{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/constructors}}{{/set}}

--- a/gluecodium/src/main/resources/templates/dart/DartConstructorName.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartConstructorName.mustache
@@ -1,0 +1,24 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#unless attributes.dart.default}}{{!!
+}}{{#ifPredicate container "hasSingleConstructor"}}{{#if attributes.dart.name}}.{{resolveName}}{{/if}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate container "hasSingleConstructor"}}.{{resolveName}}{{/unlessPredicate}}{{!!
+}}{{/unless}}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -27,14 +27,14 @@
 {{#if attributes.immutable}}
 @immutable{{/if}}
 class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
-{{>dartFieldsAndConstants}}
-{{#set parent=this isStruct=true}}{{#constructors}}
+{{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
+{{/fields}}{{/set}}
+{{>dart/DartStructConstructors}}
+{{#set isInClass=true}}{{#constants}}{{prefixPartial "dart/DartConstant" "  "}}
+{{/constants}}{{/set}}
+{{#set parent=this container=this isStruct=true}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
-  factory {{resolveName parent}}{{#if external.dart.converter}}Internal{{/if}}{{!!
-  }}{{#unless attributes.dart.default}}{{!!
-  }}{{#isEq constructors.size 1}}{{#if attributes.dart.name}}.{{resolveName}}{{/if}}{{/isEq}}{{!!
-  }}{{#isNotEq constructors.size 1}}.{{resolveName}}{{/isNotEq}}{{!!
-  }}{{/unless}}({{!!
+  factory {{resolveName parent}}{{#if external.dart.converter}}Internal{{/if}}{{>dart/DartConstructorName}}({{!!
   }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
   }}) => $prototype.{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/constructors}}
@@ -147,17 +147,26 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
     );
     return {{external.dart.converter}}.convertFromInternal(resultInternal);
 {{/if}}{{#unless external.dart.converter}}
-    return {{resolveName this "" "ref"}}{{#if constructors}}._{{/if}}(
-{{#set container=this}}{{#if attributes.dart.positionalDefaults initializedFields}}
+    return {{resolveName this "" "ref"}}{{#set container=this}}{{!!
+    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{>dart/DartConstructorName}}{{/allFieldsConstructor}}{{/if}}{{!!
+    }}{{#unless allfieldsConstructor}}{{#if constructors}}._{{/if}}{{/unless}}(
+{{#if attributes.dart.positionalDefaults initializedFields}}
 {{#each uninitializedFields initializedFields}}
 {{>fromFfiFieldInit}}
 {{/each}}
 {{/if}}{{!!
-}}{{#unless attributes.dart.positionalDefaults initializedFields}}
+}}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
+}}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}
 {{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}
-{{/unless}}{{/set}}
+{{/allFieldsConstructor}}{{/if}}{{!!
+}}{{#unless allFieldsConstructor}}
+{{#fields}}
+{{>fromFfiFieldInit}}
+{{/fields}}
+{{/unless}}{{!!
+}}{{/unless}}{{/set}}
     );
 {{/unless}}
   } finally {
@@ -191,33 +200,6 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}{{resolveName visibility}}{{resolveName}}.hashCode{{/notInstanceOf}}{{/notInstanceOf}}{{/notInstanceOf}}{{!!
 }}{{/dartFieldHash}}{{!!
 
-}}{{+dartFieldsAndConstants}}{{!!
-}}{{#set parent=this}}{{#fields}}{{prefixPartial "dart/DartField" "  "}}
-{{/fields}}{{/set}}
-{{#if fields}}{{!!
-}}{{#if attributes.dart.positionalDefaults initializedFields}}{{>constructorComment}}{{!!
-}}{{#instanceOf attributes.dart.positionalDefaults "String"}}
-  @Deprecated("{{attributes.dart.positionalDefaults}}")
-{{/instanceOf}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}({{!!
-  }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}, {{/uninitializedFields}}{{!!
-  }}[{{#initializedFields}}{{resolveName typeRef}} {{resolveName}} = {{>constPrefix}}{{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/initializedFields}}])
-    : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
-{{/if}}{{!!
-}}{{#unless attributes.dart.positionalDefaults initializedFields}}{{#unless constructors}}{{>constructorComment}}{{/unless}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
-}}{{#if constructors}}._{{/if}}({{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
-{{/unless}}
-{{#unless constructors}}{{#if initializedFields}}
-  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{implSuffix}}{{!!
-  }}.withDefaults({{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
-    : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
-    }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
-{{/if}}{{/unless}}{{/if}}
-{{#set isInClass=true}}{{#constants}}{{prefixPartial "dart/DartConstant" "  "}}
-{{/constants}}{{/set}}{{!!
-}}{{/dartFieldsAndConstants}}{{!!
-
 }}{{+fromFfiFieldInit}}{{!!
 }}      {{#if typeRef.attributes.optimized}}{{!!
 }}{{#resolveName}}{{#setJoin "varName" "_" this "Handle" delimiter=""}}{{!!
@@ -225,18 +207,4 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}{{prefixPartial "dart/InitLazyList" "      " skipFirstLine=true}}{{/set}}{{/setJoin}}{{/resolveName}}{{/if}}{{!!
 }}{{#unless typeRef.attributes.optimized}}{{!!
 }}{{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle){{/unless}}{{#if iter.hasNext}}, {{/if}}
-{{/fromFfiFieldInit}}{{!!
-
-}}{{+constPrefix}}{{#set type=typeRef.type.actualType}}{{!!
-}}{{#instanceOf type "LimeList"}}const {{/instanceOf}}{{!!
-}}{{#instanceOf type "LimeMap"}}const {{/instanceOf}}{{!!
-}}{{#instanceOf type "LimeSet"}}const {{/instanceOf}}{{!!
-}}{{/set}}{{/constPrefix}}{{!!
-
-}}{{+constructorComment}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
-}}{{prefix this "  /// "}}
-{{#fields}}
-  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
-  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
-{{/fields}}
-{{/unless}}{{/resolveName}}{{/constructorComment}}
+{{/fromFfiFieldInit}}

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -1,0 +1,87 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if fields}}{{!!
+}}{{#if attributes.dart.positionalDefaults initializedFields}}{{>constructorComment}}{{!!
+}}{{#instanceOf attributes.dart.positionalDefaults "String"}}
+  @Deprecated("{{attributes.dart.positionalDefaults}}")
+{{/instanceOf}}{{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}({{!!
+  }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}, {{/uninitializedFields}}{{!!
+  }}[{{#initializedFields}}{{resolveName typeRef}} {{resolveName}} = {{>constPrefix}}{{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/initializedFields}}])
+    : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
+{{/if}}{{!!
+
+}}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
+
+}}{{#if constructors}}{{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}._({{>thisDotFields}});
+{{/if}}{{!!
+
+}}{{#unless constructors}}{{#unless allFieldsConstructor}}{{!!
+}}{{>constructorComment}}{{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}({{>thisDotFields}});
+{{/unless}}{{/unless}}{{!!
+
+}}{{/unless}}
+{{#unless constructors}}{{#unless fieldConstructors}}{{#if initializedFields}}
+  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
+  }}.withDefaults({{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
+    : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
+    }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
+{{/if}}{{/unless}}{{/unless}}{{/if}}{{!!
+
+}}{{#set struct=this container=this}}{{#fieldConstructors}}
+{{#unless comment.isEmpty}}{{#resolveName comment}}{{!!
+}}{{prefix this "  /// "}}{{/resolveName}}
+{{/unless}}{{!!
+}}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// "}}
+{{/unless}}{{/resolveName}}{{/if}}
+{{#ifPredicate "hasAnyComment"}}{{#fields}}
+  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}{{/ifPredicate}}{{!!
+}}{{#if this.comment.isExcluded}}
+  /// @nodoc
+{{/if}}{{!!
+}}{{#if this.attributes.deprecated}}
+  @Deprecated("{{#resolveName this.attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
+{{/if}}{{>dart/DartAttributes}}{{!!
+}}  {{#if struct.attributes.immutable}}const {{/if}}{{resolveName struct}}{{#if external.dart.converter}}Internal{{/if}}{{!!
+}}{{>dart/DartConstructorName}}({{>thisDotFields}}){{#if omittedFields}}
+      : {{#omittedFields}}{{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/omittedFields}}{{/if}};
+{{/fieldConstructors}}{{/set}}{{!!
+
+}}{{+constPrefix}}{{#set type=typeRef.type.actualType}}{{!!
+}}{{#instanceOf type "LimeList"}}const {{/instanceOf}}{{!!
+}}{{#instanceOf type "LimeMap"}}const {{/instanceOf}}{{!!
+}}{{#instanceOf type "LimeSet"}}const {{/instanceOf}}{{!!
+}}{{/set}}{{/constPrefix}}{{!!
+
+}}{{+constructorComment}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// "}}
+{{#fields}}
+  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}
+{{/unless}}{{/resolveName}}{{/constructorComment}}{{!!
+
+}}{{+thisDotFields}}{{#fields}}this.{{resolveName visibility}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/thisDotFields}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -137,7 +137,9 @@ FfiOpaqueHandle
 {{#nonExternalStructs}}
 FfiOpaqueHandle
 {{libraryName}}_{{resolveName}}_create_handle({{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}) {
-    auto _result = new (std::nothrow) {{resolveName "C++"}}({{joinPartial fields "ffiFieldToCpp" ", "}});
+    auto _result = new (std::nothrow) {{resolveName "C++"}}({{!!
+    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{joinPartial fields "ffiFieldToCpp" ", "}}{{/allFieldsConstructor}}{{/if}}{{!!
+    }}{{#unless allFieldsConstructor}}{{joinPartial fields "ffiFieldToCpp" ", "}}{{/unless}});
     return reinterpret_cast<FfiOpaqueHandle>(_result);
 }
 

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/dart/DartOverloadsValidatorFieldConstructorsTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/dart/DartOverloadsValidatorFieldConstructorsTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFieldConstructor
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeLazyTypeRef
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeStruct
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class DartOverloadsValidatorFieldConstructorsTest {
+
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val fc1 = LimeFieldConstructor(EMPTY_PATH, structRef = LimeLazyTypeRef("", allElements))
+    private val fc2 = LimeFieldConstructor(EMPTY_PATH, structRef = LimeLazyTypeRef("", allElements))
+    private val constructor = LimeFunction(EMPTY_PATH, isConstructor = true)
+    private val limeStruct =
+        LimeStruct(EMPTY_PATH, functions = listOf(constructor), fieldConstructors = listOf(fc1, fc2))
+
+    @MockK private lateinit var nameResolver: DartNameResolver
+
+    private lateinit var validator: DartOverloadsValidator
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        validator = DartOverloadsValidator(nameResolver, mockk(relaxed = true), true)
+        allElements[""] = limeStruct
+    }
+
+    @Test
+    fun validateTwoFieldConstructorsValid() {
+        every { nameResolver.resolveName(fc1) } returns "foo"
+        every { nameResolver.resolveName(fc2) } returns "bar"
+
+        val result = validator.validate(allElements.values)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateTwoFieldConstructorsInvalid() {
+        every { nameResolver.resolveName(fc1) } returns "foo"
+        every { nameResolver.resolveName(fc2) } returns "foo"
+
+        val result = validator.validate(allElements.values)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun validateFieldCustomConstructorsValid() {
+        every { nameResolver.resolveName(fc1) } returns "foo"
+        every { nameResolver.resolveName(constructor) } returns "bar"
+
+        val result = validator.validate(allElements.values)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateFieldCustomConstructorsInvalid() {
+        every { nameResolver.resolveName(fc1) } returns "foo"
+        every { nameResolver.resolveName(constructor) } returns "foo"
+
+        val result = validator.validate(allElements.values)
+
+        assertFalse(result)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
@@ -21,7 +21,9 @@ struct FieldConstructorsPartialDefaults {
     stringField: String
     intField: Int
     boolField: Boolean = true
+    @Dart("withTrue")
     field constructor(intField, stringField)
+    @Dart(Default)
     field constructor(boolField, intField, stringField)
 }
 
@@ -29,9 +31,13 @@ struct FieldConstructorsAllDefaults {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withAll")
     field constructor()
+    @Dart("withTrueNonsense")
     field constructor(intField)
+    @Dart("withTrue")
     field constructor(intField, stringField)
+    @Dart(Default)
     field constructor(boolField, intField, stringField)
 }
 
@@ -40,6 +46,7 @@ struct ImmutableStructNoClash {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withAll")
     field constructor()
 }
 
@@ -48,7 +55,9 @@ struct ImmutableStructWithClash {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withAll")
     field constructor()
+    @Dart(Default)
     field constructor(boolField, intField, stringField)
 }
 
@@ -56,6 +65,8 @@ struct FieldCustomConstructorsMix {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
+    @Dart("withTrueNonsense")
     field constructor(intField)
+    @Dart(Default)
     constructor createMe(intValue: Int, dummy: Double)
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/ffi/ffi_smoke_ImmutableStructWithClash.cpp
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/ffi/ffi_smoke_ImmutableStructWithClash.cpp
@@ -1,0 +1,61 @@
+#include "ffi_smoke_ImmutableStructWithClash.h"
+#include "ConversionBase.h"
+#include "smoke/ImmutableStructWithClash.h"
+#include <cstdint>
+#include <string>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_ImmutableStructWithClash_create_handle(FfiOpaqueHandle stringField, int32_t intField, bool boolField) {
+    auto _result = new (std::nothrow) smoke::ImmutableStructWithClash(gluecodium::ffi::Conversion<bool>::toCpp(boolField), gluecodium::ffi::Conversion<int32_t>::toCpp(intField), gluecodium::ffi::Conversion<std::string>::toCpp(stringField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_ImmutableStructWithClash_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<smoke::ImmutableStructWithClash*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ImmutableStructWithClash_get_field_stringField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        reinterpret_cast<smoke::ImmutableStructWithClash*>(handle)->string_field
+    );
+}
+int32_t
+library_smoke_ImmutableStructWithClash_get_field_intField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<int32_t>::toFfi(
+        reinterpret_cast<smoke::ImmutableStructWithClash*>(handle)->int_field
+    );
+}
+bool
+library_smoke_ImmutableStructWithClash_get_field_boolField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<bool>::toFfi(
+        reinterpret_cast<smoke::ImmutableStructWithClash*>(handle)->bool_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_ImmutableStructWithClash_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<smoke::ImmutableStructWithClash>(
+            gluecodium::ffi::Conversion<smoke::ImmutableStructWithClash>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_ImmutableStructWithClash_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<smoke::ImmutableStructWithClash>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ImmutableStructWithClash_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<smoke::ImmutableStructWithClash>::toFfi(
+        **reinterpret_cast<gluecodium::optional<smoke::ImmutableStructWithClash>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_both_comments.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_both_comments.dart
@@ -1,0 +1,70 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+/// SomeStruct
+class FieldConstructorWithBothComments {
+  String stringField;
+  /// This comment takes precedence
+  /// [stringField]
+  FieldConstructorWithBothComments(this.stringField);
+}
+// FieldConstructorWithBothComments "private" section, not exported.
+final _smokeFieldconstructorwithbothcommentsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithBothComments_create_handle'));
+final _smokeFieldconstructorwithbothcommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithBothComments_release_handle'));
+final _smokeFieldconstructorwithbothcommentsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithBothComments_get_field_stringField'));
+Pointer<Void> smokeFieldconstructorwithbothcommentsToFfi(FieldConstructorWithBothComments value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeFieldconstructorwithbothcommentsCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+FieldConstructorWithBothComments smokeFieldconstructorwithbothcommentsFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorwithbothcommentsGetFieldstringField(handle);
+  try {
+    return FieldConstructorWithBothComments(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeFieldconstructorwithbothcommentsReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithbothcommentsReleaseHandle(handle);
+// Nullable FieldConstructorWithBothComments
+final _smokeFieldconstructorwithbothcommentsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithBothComments_create_handle_nullable'));
+final _smokeFieldconstructorwithbothcommentsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithBothComments_release_handle_nullable'));
+final _smokeFieldconstructorwithbothcommentsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithBothComments_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorwithbothcommentsToFfiNullable(FieldConstructorWithBothComments? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorwithbothcommentsToFfi(value);
+  final result = _smokeFieldconstructorwithbothcommentsCreateHandleNullable(_handle);
+  smokeFieldconstructorwithbothcommentsReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorWithBothComments? smokeFieldconstructorwithbothcommentsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorwithbothcommentsGetValueNullable(handle);
+  final result = smokeFieldconstructorwithbothcommentsFromFfi(_handle);
+  smokeFieldconstructorwithbothcommentsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorwithbothcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorwithbothcommentsReleaseHandleNullable(handle);
+// End of FieldConstructorWithBothComments "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_comment.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_comment.dart
@@ -1,0 +1,71 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+/// SomeStruct
+class FieldConstructorWithComment {
+  /// Some field
+  String stringField;
+  /// Some field constructor
+  /// [stringField] Some field
+  FieldConstructorWithComment(this.stringField);
+}
+// FieldConstructorWithComment "private" section, not exported.
+final _smokeFieldconstructorwithcommentCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithComment_create_handle'));
+final _smokeFieldconstructorwithcommentReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithComment_release_handle'));
+final _smokeFieldconstructorwithcommentGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithComment_get_field_stringField'));
+Pointer<Void> smokeFieldconstructorwithcommentToFfi(FieldConstructorWithComment value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeFieldconstructorwithcommentCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+FieldConstructorWithComment smokeFieldconstructorwithcommentFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorwithcommentGetFieldstringField(handle);
+  try {
+    return FieldConstructorWithComment(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeFieldconstructorwithcommentReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithcommentReleaseHandle(handle);
+// Nullable FieldConstructorWithComment
+final _smokeFieldconstructorwithcommentCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithComment_create_handle_nullable'));
+final _smokeFieldconstructorwithcommentReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithComment_release_handle_nullable'));
+final _smokeFieldconstructorwithcommentGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithComment_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorwithcommentToFfiNullable(FieldConstructorWithComment? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorwithcommentToFfi(value);
+  final result = _smokeFieldconstructorwithcommentCreateHandleNullable(_handle);
+  smokeFieldconstructorwithcommentReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorWithComment? smokeFieldconstructorwithcommentFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorwithcommentGetValueNullable(handle);
+  final result = smokeFieldconstructorwithcommentFromFfi(_handle);
+  smokeFieldconstructorwithcommentReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorwithcommentReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorwithcommentReleaseHandleNullable(handle);
+// End of FieldConstructorWithComment "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_and_comment.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_and_comment.dart
@@ -1,0 +1,70 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class FieldConstructorWithDeprecationAndComment {
+  String stringField;
+  /// Some field constructor
+  /// [stringField]
+  @Deprecated("Shouldn't really use it")
+  FieldConstructorWithDeprecationAndComment(this.stringField);
+}
+// FieldConstructorWithDeprecationAndComment "private" section, not exported.
+final _smokeFieldconstructorwithdeprecationandcommentCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationAndComment_create_handle'));
+final _smokeFieldconstructorwithdeprecationandcommentReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationAndComment_release_handle'));
+final _smokeFieldconstructorwithdeprecationandcommentGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationAndComment_get_field_stringField'));
+Pointer<Void> smokeFieldconstructorwithdeprecationandcommentToFfi(FieldConstructorWithDeprecationAndComment value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeFieldconstructorwithdeprecationandcommentCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+FieldConstructorWithDeprecationAndComment smokeFieldconstructorwithdeprecationandcommentFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorwithdeprecationandcommentGetFieldstringField(handle);
+  try {
+    return FieldConstructorWithDeprecationAndComment(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithdeprecationandcommentReleaseHandle(handle);
+// Nullable FieldConstructorWithDeprecationAndComment
+final _smokeFieldconstructorwithdeprecationandcommentCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationAndComment_create_handle_nullable'));
+final _smokeFieldconstructorwithdeprecationandcommentReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationAndComment_release_handle_nullable'));
+final _smokeFieldconstructorwithdeprecationandcommentGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationAndComment_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorwithdeprecationandcommentToFfiNullable(FieldConstructorWithDeprecationAndComment? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorwithdeprecationandcommentToFfi(value);
+  final result = _smokeFieldconstructorwithdeprecationandcommentCreateHandleNullable(_handle);
+  smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorWithDeprecationAndComment? smokeFieldconstructorwithdeprecationandcommentFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorwithdeprecationandcommentGetValueNullable(handle);
+  final result = smokeFieldconstructorwithdeprecationandcommentFromFfi(_handle);
+  smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorwithdeprecationandcommentReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorwithdeprecationandcommentReleaseHandleNullable(handle);
+// End of FieldConstructorWithDeprecationAndComment "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_only.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_only.dart
@@ -1,0 +1,69 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class FieldConstructorWithDeprecationOnly {
+  String stringField;
+  /// [stringField]
+  @Deprecated("Shouldn't really use it")
+  FieldConstructorWithDeprecationOnly(this.stringField);
+}
+// FieldConstructorWithDeprecationOnly "private" section, not exported.
+final _smokeFieldconstructorwithdeprecationonlyCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationOnly_create_handle'));
+final _smokeFieldconstructorwithdeprecationonlyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationOnly_release_handle'));
+final _smokeFieldconstructorwithdeprecationonlyGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationOnly_get_field_stringField'));
+Pointer<Void> smokeFieldconstructorwithdeprecationonlyToFfi(FieldConstructorWithDeprecationOnly value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeFieldconstructorwithdeprecationonlyCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+FieldConstructorWithDeprecationOnly smokeFieldconstructorwithdeprecationonlyFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorwithdeprecationonlyGetFieldstringField(handle);
+  try {
+    return FieldConstructorWithDeprecationOnly(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeFieldconstructorwithdeprecationonlyReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithdeprecationonlyReleaseHandle(handle);
+// Nullable FieldConstructorWithDeprecationOnly
+final _smokeFieldconstructorwithdeprecationonlyCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationOnly_create_handle_nullable'));
+final _smokeFieldconstructorwithdeprecationonlyReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationOnly_release_handle_nullable'));
+final _smokeFieldconstructorwithdeprecationonlyGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithDeprecationOnly_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorwithdeprecationonlyToFfiNullable(FieldConstructorWithDeprecationOnly? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorwithdeprecationonlyToFfi(value);
+  final result = _smokeFieldconstructorwithdeprecationonlyCreateHandleNullable(_handle);
+  smokeFieldconstructorwithdeprecationonlyReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorWithDeprecationOnly? smokeFieldconstructorwithdeprecationonlyFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorwithdeprecationonlyGetValueNullable(handle);
+  final result = smokeFieldconstructorwithdeprecationonlyFromFfi(_handle);
+  smokeFieldconstructorwithdeprecationonlyReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorwithdeprecationonlyReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorwithdeprecationonlyReleaseHandleNullable(handle);
+// End of FieldConstructorWithDeprecationOnly "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded.dart
@@ -1,0 +1,71 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class FieldConstructorWithExcluded {
+  /// Some field
+  String stringField;
+  /// Some field constructor
+  /// [stringField] Some field
+  /// @nodoc
+  FieldConstructorWithExcluded(this.stringField);
+}
+// FieldConstructorWithExcluded "private" section, not exported.
+final _smokeFieldconstructorwithexcludedCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcluded_create_handle'));
+final _smokeFieldconstructorwithexcludedReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcluded_release_handle'));
+final _smokeFieldconstructorwithexcludedGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcluded_get_field_stringField'));
+Pointer<Void> smokeFieldconstructorwithexcludedToFfi(FieldConstructorWithExcluded value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeFieldconstructorwithexcludedCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+FieldConstructorWithExcluded smokeFieldconstructorwithexcludedFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorwithexcludedGetFieldstringField(handle);
+  try {
+    return FieldConstructorWithExcluded(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeFieldconstructorwithexcludedReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithexcludedReleaseHandle(handle);
+// Nullable FieldConstructorWithExcluded
+final _smokeFieldconstructorwithexcludedCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcluded_create_handle_nullable'));
+final _smokeFieldconstructorwithexcludedReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcluded_release_handle_nullable'));
+final _smokeFieldconstructorwithexcludedGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcluded_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorwithexcludedToFfiNullable(FieldConstructorWithExcluded? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorwithexcludedToFfi(value);
+  final result = _smokeFieldconstructorwithexcludedCreateHandleNullable(_handle);
+  smokeFieldconstructorwithexcludedReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorWithExcluded? smokeFieldconstructorwithexcludedFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorwithexcludedGetValueNullable(handle);
+  final result = smokeFieldconstructorwithexcludedFromFfi(_handle);
+  smokeFieldconstructorwithexcludedReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorwithexcludedReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorwithexcludedReleaseHandleNullable(handle);
+// End of FieldConstructorWithExcluded "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded_only.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded_only.dart
@@ -1,0 +1,69 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class FieldConstructorWithExcludedOnly {
+  String stringField;
+  /// [stringField]
+  /// @nodoc
+  FieldConstructorWithExcludedOnly(this.stringField);
+}
+// FieldConstructorWithExcludedOnly "private" section, not exported.
+final _smokeFieldconstructorwithexcludedonlyCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcludedOnly_create_handle'));
+final _smokeFieldconstructorwithexcludedonlyReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcludedOnly_release_handle'));
+final _smokeFieldconstructorwithexcludedonlyGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcludedOnly_get_field_stringField'));
+Pointer<Void> smokeFieldconstructorwithexcludedonlyToFfi(FieldConstructorWithExcludedOnly value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeFieldconstructorwithexcludedonlyCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+FieldConstructorWithExcludedOnly smokeFieldconstructorwithexcludedonlyFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorwithexcludedonlyGetFieldstringField(handle);
+  try {
+    return FieldConstructorWithExcludedOnly(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeFieldconstructorwithexcludedonlyReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithexcludedonlyReleaseHandle(handle);
+// Nullable FieldConstructorWithExcludedOnly
+final _smokeFieldconstructorwithexcludedonlyCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcludedOnly_create_handle_nullable'));
+final _smokeFieldconstructorwithexcludedonlyReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcludedOnly_release_handle_nullable'));
+final _smokeFieldconstructorwithexcludedonlyGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithExcludedOnly_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorwithexcludedonlyToFfiNullable(FieldConstructorWithExcludedOnly? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorwithexcludedonlyToFfi(value);
+  final result = _smokeFieldconstructorwithexcludedonlyCreateHandleNullable(_handle);
+  smokeFieldconstructorwithexcludedonlyReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorWithExcludedOnly? smokeFieldconstructorwithexcludedonlyFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorwithexcludedonlyGetValueNullable(handle);
+  final result = smokeFieldconstructorwithexcludedonlyFromFfi(_handle);
+  smokeFieldconstructorwithexcludedonlyReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorwithexcludedonlyReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorwithexcludedonlyReleaseHandleNullable(handle);
+// End of FieldConstructorWithExcludedOnly "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_parent_comment.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_parent_comment.dart
@@ -1,0 +1,70 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+/// SomeStruct
+class FieldConstructorWithParentComment {
+  String stringField;
+  /// There are constructors
+  /// [stringField]
+  FieldConstructorWithParentComment(this.stringField);
+}
+// FieldConstructorWithParentComment "private" section, not exported.
+final _smokeFieldconstructorwithparentcommentCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithParentComment_create_handle'));
+final _smokeFieldconstructorwithparentcommentReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithParentComment_release_handle'));
+final _smokeFieldconstructorwithparentcommentGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithParentComment_get_field_stringField'));
+Pointer<Void> smokeFieldconstructorwithparentcommentToFfi(FieldConstructorWithParentComment value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeFieldconstructorwithparentcommentCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+FieldConstructorWithParentComment smokeFieldconstructorwithparentcommentFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorwithparentcommentGetFieldstringField(handle);
+  try {
+    return FieldConstructorWithParentComment(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeFieldconstructorwithparentcommentReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorwithparentcommentReleaseHandle(handle);
+// Nullable FieldConstructorWithParentComment
+final _smokeFieldconstructorwithparentcommentCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithParentComment_create_handle_nullable'));
+final _smokeFieldconstructorwithparentcommentReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithParentComment_release_handle_nullable'));
+final _smokeFieldconstructorwithparentcommentGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorWithParentComment_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorwithparentcommentToFfiNullable(FieldConstructorWithParentComment? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorwithparentcommentToFfi(value);
+  final result = _smokeFieldconstructorwithparentcommentCreateHandleNullable(_handle);
+  smokeFieldconstructorwithparentcommentReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorWithParentComment? smokeFieldconstructorwithparentcommentFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorwithparentcommentGetValueNullable(handle);
+  final result = smokeFieldconstructorwithparentcommentFromFfi(_handle);
+  smokeFieldconstructorwithparentcommentReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorwithparentcommentReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorwithparentcommentReleaseHandleNullable(handle);
+// End of FieldConstructorWithParentComment "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_all_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_all_defaults.dart
@@ -1,0 +1,91 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class FieldConstructorsAllDefaults {
+  String stringField;
+  int intField;
+  bool boolField;
+  FieldConstructorsAllDefaults.withAll()
+      : stringField = "nonsense", intField = 42, boolField = true;
+  FieldConstructorsAllDefaults.withTrueNonsense(this.intField)
+      : stringField = "nonsense", boolField = true;
+  FieldConstructorsAllDefaults.withTrue(this.intField, this.stringField)
+      : boolField = true;
+  FieldConstructorsAllDefaults(this.boolField, this.intField, this.stringField);
+}
+// FieldConstructorsAllDefaults "private" section, not exported.
+final _smokeFieldconstructorsalldefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_FieldConstructorsAllDefaults_create_handle'));
+final _smokeFieldconstructorsalldefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsAllDefaults_release_handle'));
+final _smokeFieldconstructorsalldefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsAllDefaults_get_field_stringField'));
+final _smokeFieldconstructorsalldefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsAllDefaults_get_field_intField'));
+final _smokeFieldconstructorsalldefaultsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsAllDefaults_get_field_boolField'));
+Pointer<Void> smokeFieldconstructorsalldefaultsToFfi(FieldConstructorsAllDefaults value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeFieldconstructorsalldefaultsCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+FieldConstructorsAllDefaults smokeFieldconstructorsalldefaultsFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorsalldefaultsGetFieldstringField(handle);
+  final _intFieldHandle = _smokeFieldconstructorsalldefaultsGetFieldintField(handle);
+  final _boolFieldHandle = _smokeFieldconstructorsalldefaultsGetFieldboolField(handle);
+  try {
+    return FieldConstructorsAllDefaults(
+      booleanFromFfi(_boolFieldHandle),
+      (_intFieldHandle),
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeFieldconstructorsalldefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorsalldefaultsReleaseHandle(handle);
+// Nullable FieldConstructorsAllDefaults
+final _smokeFieldconstructorsalldefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsAllDefaults_create_handle_nullable'));
+final _smokeFieldconstructorsalldefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsAllDefaults_release_handle_nullable'));
+final _smokeFieldconstructorsalldefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsAllDefaults_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorsalldefaultsToFfiNullable(FieldConstructorsAllDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorsalldefaultsToFfi(value);
+  final result = _smokeFieldconstructorsalldefaultsCreateHandleNullable(_handle);
+  smokeFieldconstructorsalldefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorsAllDefaults? smokeFieldconstructorsalldefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorsalldefaultsGetValueNullable(handle);
+  final result = smokeFieldconstructorsalldefaultsFromFfi(_handle);
+  smokeFieldconstructorsalldefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorsalldefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorsalldefaultsReleaseHandleNullable(handle);
+// End of FieldConstructorsAllDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_partial_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_partial_defaults.dart
@@ -1,0 +1,87 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class FieldConstructorsPartialDefaults {
+  String stringField;
+  int intField;
+  bool boolField;
+  FieldConstructorsPartialDefaults.withTrue(this.intField, this.stringField)
+      : boolField = true;
+  FieldConstructorsPartialDefaults(this.boolField, this.intField, this.stringField);
+}
+// FieldConstructorsPartialDefaults "private" section, not exported.
+final _smokeFieldconstructorspartialdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_FieldConstructorsPartialDefaults_create_handle'));
+final _smokeFieldconstructorspartialdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsPartialDefaults_release_handle'));
+final _smokeFieldconstructorspartialdefaultsGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsPartialDefaults_get_field_stringField'));
+final _smokeFieldconstructorspartialdefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsPartialDefaults_get_field_intField'));
+final _smokeFieldconstructorspartialdefaultsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsPartialDefaults_get_field_boolField'));
+Pointer<Void> smokeFieldconstructorspartialdefaultsToFfi(FieldConstructorsPartialDefaults value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeFieldconstructorspartialdefaultsCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+FieldConstructorsPartialDefaults smokeFieldconstructorspartialdefaultsFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldconstructorspartialdefaultsGetFieldstringField(handle);
+  final _intFieldHandle = _smokeFieldconstructorspartialdefaultsGetFieldintField(handle);
+  final _boolFieldHandle = _smokeFieldconstructorspartialdefaultsGetFieldboolField(handle);
+  try {
+    return FieldConstructorsPartialDefaults(
+      booleanFromFfi(_boolFieldHandle),
+      (_intFieldHandle),
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeFieldconstructorspartialdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorspartialdefaultsReleaseHandle(handle);
+// Nullable FieldConstructorsPartialDefaults
+final _smokeFieldconstructorspartialdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsPartialDefaults_create_handle_nullable'));
+final _smokeFieldconstructorspartialdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsPartialDefaults_release_handle_nullable'));
+final _smokeFieldconstructorspartialdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsPartialDefaults_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorspartialdefaultsToFfiNullable(FieldConstructorsPartialDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorspartialdefaultsToFfi(value);
+  final result = _smokeFieldconstructorspartialdefaultsCreateHandleNullable(_handle);
+  smokeFieldconstructorspartialdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorsPartialDefaults? smokeFieldconstructorspartialdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorspartialdefaultsGetValueNullable(handle);
+  final result = smokeFieldconstructorspartialdefaultsFromFfi(_handle);
+  smokeFieldconstructorspartialdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorspartialdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorspartialdefaultsReleaseHandleNullable(handle);
+// End of FieldConstructorsPartialDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_custom_constructors_mix.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_custom_constructors_mix.dart
@@ -1,0 +1,107 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+class FieldCustomConstructorsMix {
+  String stringField;
+  int intField;
+  bool boolField;
+  FieldCustomConstructorsMix._(this.stringField, this.intField, this.boolField);
+  FieldCustomConstructorsMix.withTrueNonsense(this.intField)
+      : stringField = "nonsense", boolField = true;
+  factory FieldCustomConstructorsMix(int intValue, double dummy) => $prototype.$init(intValue, dummy);
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = FieldCustomConstructorsMix$Impl();
+}
+// FieldCustomConstructorsMix "private" section, not exported.
+final _smokeFieldcustomconstructorsmixCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_FieldCustomConstructorsMix_create_handle'));
+final _smokeFieldcustomconstructorsmixReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldCustomConstructorsMix_release_handle'));
+final _smokeFieldcustomconstructorsmixGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldCustomConstructorsMix_get_field_stringField'));
+final _smokeFieldcustomconstructorsmixGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_FieldCustomConstructorsMix_get_field_intField'));
+final _smokeFieldcustomconstructorsmixGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_FieldCustomConstructorsMix_get_field_boolField'));
+/// @nodoc
+@visibleForTesting
+class FieldCustomConstructorsMix$Impl {
+  FieldCustomConstructorsMix $init(int intValue, double dummy) {
+    final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Int32, Double), Pointer<Void> Function(int, int, double)>('library_smoke_FieldCustomConstructorsMix_createMe__Int_Double'));
+    final _intValueHandle = (intValue);
+    final _dummyHandle = (dummy);
+    final __resultHandle = _$initFfi(__lib.LibraryContext.isolateId, _intValueHandle, _dummyHandle);
+    try {
+      return smokeFieldcustomconstructorsmixFromFfi(__resultHandle);
+    } finally {
+      smokeFieldcustomconstructorsmixReleaseFfiHandle(__resultHandle);
+    }
+  }
+}
+Pointer<Void> smokeFieldcustomconstructorsmixToFfi(FieldCustomConstructorsMix value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeFieldcustomconstructorsmixCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+FieldCustomConstructorsMix smokeFieldcustomconstructorsmixFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeFieldcustomconstructorsmixGetFieldstringField(handle);
+  final _intFieldHandle = _smokeFieldcustomconstructorsmixGetFieldintField(handle);
+  final _boolFieldHandle = _smokeFieldcustomconstructorsmixGetFieldboolField(handle);
+  try {
+    return FieldCustomConstructorsMix._(
+      stringFromFfi(_stringFieldHandle),
+      (_intFieldHandle),
+      booleanFromFfi(_boolFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeFieldcustomconstructorsmixReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldcustomconstructorsmixReleaseHandle(handle);
+// Nullable FieldCustomConstructorsMix
+final _smokeFieldcustomconstructorsmixCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldCustomConstructorsMix_create_handle_nullable'));
+final _smokeFieldcustomconstructorsmixReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldCustomConstructorsMix_release_handle_nullable'));
+final _smokeFieldcustomconstructorsmixGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldCustomConstructorsMix_get_value_nullable'));
+Pointer<Void> smokeFieldcustomconstructorsmixToFfiNullable(FieldCustomConstructorsMix? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldcustomconstructorsmixToFfi(value);
+  final result = _smokeFieldcustomconstructorsmixCreateHandleNullable(_handle);
+  smokeFieldcustomconstructorsmixReleaseFfiHandle(_handle);
+  return result;
+}
+FieldCustomConstructorsMix? smokeFieldcustomconstructorsmixFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldcustomconstructorsmixGetValueNullable(handle);
+  final result = smokeFieldcustomconstructorsmixFromFfi(_handle);
+  smokeFieldcustomconstructorsmixReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldcustomconstructorsmixReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldcustomconstructorsmixReleaseHandleNullable(handle);
+// End of FieldCustomConstructorsMix "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/immutable_struct_no_clash.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/immutable_struct_no_clash.dart
@@ -1,0 +1,89 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+@immutable
+class ImmutableStructNoClash {
+  final String stringField;
+  final int intField;
+  final bool boolField;
+  const ImmutableStructNoClash(this.stringField, this.intField, this.boolField);
+  const ImmutableStructNoClash.withAll()
+      : stringField = "nonsense", intField = 42, boolField = true;
+}
+// ImmutableStructNoClash "private" section, not exported.
+final _smokeImmutablestructnoclashCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_ImmutableStructNoClash_create_handle'));
+final _smokeImmutablestructnoclashReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructNoClash_release_handle'));
+final _smokeImmutablestructnoclashGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructNoClash_get_field_stringField'));
+final _smokeImmutablestructnoclashGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructNoClash_get_field_intField'));
+final _smokeImmutablestructnoclashGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructNoClash_get_field_boolField'));
+Pointer<Void> smokeImmutablestructnoclashToFfi(ImmutableStructNoClash value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeImmutablestructnoclashCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+ImmutableStructNoClash smokeImmutablestructnoclashFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeImmutablestructnoclashGetFieldstringField(handle);
+  final _intFieldHandle = _smokeImmutablestructnoclashGetFieldintField(handle);
+  final _boolFieldHandle = _smokeImmutablestructnoclashGetFieldboolField(handle);
+  try {
+    return ImmutableStructNoClash(
+      stringFromFfi(_stringFieldHandle),
+      (_intFieldHandle),
+      booleanFromFfi(_boolFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeImmutablestructnoclashReleaseFfiHandle(Pointer<Void> handle) => _smokeImmutablestructnoclashReleaseHandle(handle);
+// Nullable ImmutableStructNoClash
+final _smokeImmutablestructnoclashCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructNoClash_create_handle_nullable'));
+final _smokeImmutablestructnoclashReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructNoClash_release_handle_nullable'));
+final _smokeImmutablestructnoclashGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructNoClash_get_value_nullable'));
+Pointer<Void> smokeImmutablestructnoclashToFfiNullable(ImmutableStructNoClash? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeImmutablestructnoclashToFfi(value);
+  final result = _smokeImmutablestructnoclashCreateHandleNullable(_handle);
+  smokeImmutablestructnoclashReleaseFfiHandle(_handle);
+  return result;
+}
+ImmutableStructNoClash? smokeImmutablestructnoclashFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeImmutablestructnoclashGetValueNullable(handle);
+  final result = smokeImmutablestructnoclashFromFfi(_handle);
+  smokeImmutablestructnoclashReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeImmutablestructnoclashReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeImmutablestructnoclashReleaseHandleNullable(handle);
+// End of ImmutableStructNoClash "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/immutable_struct_with_clash.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/immutable_struct_with_clash.dart
@@ -1,0 +1,89 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+@immutable
+class ImmutableStructWithClash {
+  final String stringField;
+  final int intField;
+  final bool boolField;
+  const ImmutableStructWithClash.withAll()
+      : stringField = "nonsense", intField = 42, boolField = true;
+  const ImmutableStructWithClash(this.boolField, this.intField, this.stringField);
+}
+// ImmutableStructWithClash "private" section, not exported.
+final _smokeImmutablestructwithclashCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_ImmutableStructWithClash_create_handle'));
+final _smokeImmutablestructwithclashReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructWithClash_release_handle'));
+final _smokeImmutablestructwithclashGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructWithClash_get_field_stringField'));
+final _smokeImmutablestructwithclashGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructWithClash_get_field_intField'));
+final _smokeImmutablestructwithclashGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructWithClash_get_field_boolField'));
+Pointer<Void> smokeImmutablestructwithclashToFfi(ImmutableStructWithClash value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeImmutablestructwithclashCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+ImmutableStructWithClash smokeImmutablestructwithclashFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeImmutablestructwithclashGetFieldstringField(handle);
+  final _intFieldHandle = _smokeImmutablestructwithclashGetFieldintField(handle);
+  final _boolFieldHandle = _smokeImmutablestructwithclashGetFieldboolField(handle);
+  try {
+    return ImmutableStructWithClash(
+      booleanFromFfi(_boolFieldHandle),
+      (_intFieldHandle),
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeImmutablestructwithclashReleaseFfiHandle(Pointer<Void> handle) => _smokeImmutablestructwithclashReleaseHandle(handle);
+// Nullable ImmutableStructWithClash
+final _smokeImmutablestructwithclashCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructWithClash_create_handle_nullable'));
+final _smokeImmutablestructwithclashReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructWithClash_release_handle_nullable'));
+final _smokeImmutablestructwithclashGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ImmutableStructWithClash_get_value_nullable'));
+Pointer<Void> smokeImmutablestructwithclashToFfiNullable(ImmutableStructWithClash? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeImmutablestructwithclashToFfi(value);
+  final result = _smokeImmutablestructwithclashCreateHandleNullable(_handle);
+  smokeImmutablestructwithclashReleaseFfiHandle(_handle);
+  return result;
+}
+ImmutableStructWithClash? smokeImmutablestructwithclashFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeImmutablestructwithclashGetValueNullable(handle);
+  final result = smokeImmutablestructwithclashFromFfi(_handle);
+  smokeImmutablestructwithclashReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeImmutablestructwithclashReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeImmutablestructwithclashReleaseHandleNullable(handle);
+// End of ImmutableStructWithClash "private" section.


### PR DESCRIPTION
Extracted existing Dart Mustache template for field-based struct constructors
into a standalone template file (to simplify maintanance).

Added support for "field constructors" to the new extracted
template.

Updated Dart and FFI template for struct conversion to make use of a "reordered"
all-fields constructor if one is present.

Updated DartOverloadsValidator to validate against overloading "field
constructors".

Added functional and smoke tests.

Resolves: #1058
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>