### PR TITLE
Add support for `@Cpp(Skip)` on field constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features:
   * Added support for defining "field constructors" for structs in IDL.
+  * Added support for `@Cpp(Skip)` attribute on "field constructors".
 
 ## 9.4.5
 Release date: 2021-09-10

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -591,6 +591,12 @@ element is skipped (not generated). Custom tags are case-insensitive.
   generated code. For example, `@Cpp(Type="std::chrono::steady_clock::time_point") Date` will use monotonic clock time
   point type, instead of the system clock time point type which is used by default.
   * **ToString**: marks an enumeration to have a helper `to_string()` function generated, mapping the enum to string.
+  * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in C++. Can be applied to
+  a `field constuctor` element only. Optionally, if custom tag is specified, the element is only skipped if that tag
+  was defined (see `@Skip` above).
+  * **EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in C++ only if a custom tag with that
+  name was defined through command-line parameters. Can be applied to a `field constuctor` element only. If the tag is
+  not present, the element is skipped (not generated).
   * ~~**ExternalType** **=** **"**_HeaderPaths_**"**~~: legacy attribute, superseded by `cpp
   include` in the `External Descriptor` (see above).
   * ~~**ExternalName** **=** **"**_FullyQualifiedName_**"**~~: legacy attribute, superseded by `cpp

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSkipAttributesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSkipAttributesValidator.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.cpp
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeFieldConstructor
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
+
+/**
+ * Validate that `@Cpp(Skip)` attribute is only used on field constructors of structs.
+ */
+internal class CppSkipAttributesValidator(private val logger: LimeLogger) {
+
+    fun validate(limeModel: LimeModel): Boolean {
+        val allElements = limeModel.referenceMap.values
+        val validationResults = allElements.filterIsInstance<LimeNamedElement>().map { validateElement(it) }
+
+        return !validationResults.contains(false)
+    }
+
+    private fun validateElement(limeElement: LimeNamedElement) =
+        when {
+            limeElement is LimeFieldConstructor -> true
+            limeElement.attributes.have(LimeAttributeType.CPP, LimeAttributeValueType.SKIP) -> {
+                logger.error(limeElement, "`@Cpp(Skip)` attribute can only be used on a field constructor")
+                false
+            }
+            else -> true
+        }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/CppSkipAttributesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/CppSkipAttributesValidatorTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.cpp
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFieldConstructor
+import com.here.gluecodium.model.lime.LimeLazyTypeRef
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class CppSkipAttributesValidatorTest(private val limeElement: LimeNamedElement, private val expectedResult: Boolean) {
+
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+
+    private val validator = CppSkipAttributesValidator(mockk(relaxed = true))
+
+    @Test
+    fun validateWithElement() {
+        allElements[""] = limeElement
+
+        assertEquals(expectedResult, validator.validate(limeModel))
+    }
+
+    companion object {
+        private val cppSkipAttributes =
+            LimeAttributes.Builder().addAttribute(LimeAttributeType.CPP, LimeAttributeValueType.SKIP).build()
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun testData() = listOf(
+            arrayOf(
+                LimeFieldConstructor(
+                    EMPTY_PATH,
+                    structRef = LimeLazyTypeRef("", emptyMap()),
+                    attributes = cppSkipAttributes
+                ),
+                true
+            ),
+            arrayOf(object : LimeNamedElement(EMPTY_PATH) {}, true),
+            arrayOf(object : LimeNamedElement(EMPTY_PATH, attributes = cppSkipAttributes) {}, false),
+        )
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/SkipCpp.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/SkipCpp.lime
@@ -1,0 +1,52 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Skip(Java, Swift, Dart)
+struct FieldConstructorsSkipCpp {
+    stringField: String = ""
+    intField: Int = 42
+    @Skip(Cpp)
+    field constructor(stringField)
+}
+
+@Skip(Java, Swift, Dart)
+struct FieldConstructorsCppSkip {
+    stringField: String = ""
+    intField: Int = 42
+    @Cpp(Skip)
+    field constructor(stringField)
+}
+
+@Skip(Java, Swift, Dart)
+struct FieldConstructorsSkipDefault {
+    stringField: String = ""
+    intField: Int = 42
+    @Cpp(Skip)
+    field constructor()
+    field constructor(stringField)
+}
+
+@Skip(Java, Swift, Dart)
+@Immutable
+struct FieldConstructorsSkipAllFields {
+    stringField: String
+    intField: Int
+    @Cpp(Skip)
+    field constructor(intField, stringField)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsCppSkip.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsCppSkip.h
@@ -1,0 +1,16 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT FieldConstructorsCppSkip {
+    ::std::string string_field = "";
+    int32_t int_field = 42;
+    FieldConstructorsCppSkip( );
+    FieldConstructorsCppSkip( ::std::string string_field, int32_t int_field );
+};
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipAllFields.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipAllFields.h
@@ -1,0 +1,15 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT FieldConstructorsSkipAllFields {
+    const ::std::string string_field;
+    const int32_t int_field;
+    FieldConstructorsSkipAllFields( ::std::string string_field, int32_t int_field );
+};
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipCpp.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipCpp.h
@@ -1,0 +1,16 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT FieldConstructorsSkipCpp {
+    ::std::string string_field = "";
+    int32_t int_field = 42;
+    FieldConstructorsSkipCpp( );
+    FieldConstructorsSkipCpp( ::std::string string_field, int32_t int_field );
+};
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipDefault.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipDefault.h
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+#include <string>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT FieldConstructorsSkipDefault {
+    ::std::string string_field = "";
+    int32_t int_field = 42;
+    FieldConstructorsSkipDefault( );
+    FieldConstructorsSkipDefault( ::std::string string_field );
+    FieldConstructorsSkipDefault( ::std::string string_field, int32_t int_field );
+};
+}


### PR DESCRIPTION
Added support for `@Cpp(Skip)` attribute to C++ generator by enabling it in
`shouldRetainElement()` predicate parameters.

Added a new validator CppSkipAttributesValidator that checks against using
`@Cpp(Skip)` on any element that is not a "field constructor". Added unit tests
for the new validator. Added usage of this new validator to C++ generator.

Added smoke tests for `@Cpp(Skip)` on field constructors.

Resolves: #1059
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>