### PR TITLE
Fix overloads validation in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed an issue where Dart validation incorrectly considered skipped elements.
+
 ## 9.5.0
 Release date: 2021-09-13
 ### Features:

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipOverloads.lime
@@ -28,3 +28,10 @@ struct SkipOverloads {
     @Skip("Lite")
     fun doFoo()
 }
+
+@Skip(Java, Swift)
+class SkipOverloadsInDart {
+    constructor make()
+    @Skip(Dart)
+    constructor make(input: String)
+}

--- a/gluecodium/src/test/resources/smoke/skip/input/commandlineoptions.txt
+++ b/gluecodium/src/test/resources/smoke/skip/input/commandlineoptions.txt
@@ -5,3 +5,4 @@
 -javanullableannotation android.support.annotation.Nullable
 -tag lite
 -tag ExperimentalFoo
+-werror DartOverloads


### PR DESCRIPTION
Fixed LimeModelFilter to properly update the reference map with the newly
created elements, in addition to removing the skipped elements as before. This
fixes a bug in Dart overloads validation where skipped functions were
incorrectly taken into account when calculating overloads.

Added a new smoke test as a regression test.