### PR TITLE
Make implicit all-fields constructor private in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * All-fields constructor for a mutable struct in Dart is now private if "fields constructors" are present.
+
 ## 9.5.1
 Release date: 2021-09-14
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/FieldConstructors.lime
+++ b/functional-tests/functional/input/lime/FieldConstructors.lime
@@ -41,6 +41,14 @@ struct FieldConstructorsAllDefaults {
     field constructor(boolField, intField, stringField)
 }
 
+struct MutableStructNoClash {
+    stringField: String = "nonsense"
+    intField: Int = 42
+    boolField: Boolean = true
+    @Dart("withAll")
+    field constructor()
+}
+
 @Immutable
 struct ImmutableStructNoClash {
     stringField: String = "nonsense"

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.dart
+
+import com.here.gluecodium.common.LimeModelSkipPredicates
+import com.here.gluecodium.generator.common.CommonGeneratorPredicates
+import com.here.gluecodium.model.lime.LimeAttributeType.DART
+import com.here.gluecodium.model.lime.LimeAttributeType.IMMUTABLE
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeExternalDescriptor
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeType
+
+/**
+ * List of predicates used by `ifPredicate`/`unlessPredicate` template helpers in Dart generator.
+ */
+internal class DartGeneratorPredicates(limeReferenceMap: Map<String, LimeElement>, activeTags: Set<String>) {
+    val predicates = mapOf(
+        "hasAnyComment" to { CommonGeneratorPredicates.hasAnyComment(it, "Dart") },
+        "hasSingleConstructor" to { limeContainer: Any ->
+            when (limeContainer) {
+                !is LimeContainer -> false
+                is LimeStruct -> limeContainer.constructors.size + limeContainer.fieldConstructors.size == 1
+                else -> limeContainer.constructors.size == 1
+            }
+        },
+        "hasStaticFunctions" to { CommonGeneratorPredicates.hasStaticFunctions(it) },
+        "needsPrivateAllFieldsCtor" to { limeStruct: Any ->
+            when {
+                limeStruct !is LimeStruct -> false
+                limeStruct.constructors.isNotEmpty() -> true
+                limeStruct.fieldConstructors.isEmpty() -> false
+                limeStruct.allFieldsConstructor != null -> false
+                else -> !limeStruct.attributes.have(IMMUTABLE)
+            }
+        },
+        "skipDeclaration" to { limeType: Any ->
+            limeType is LimeType && limeType.external?.dart != null &&
+                limeType.external?.dart?.get(LimeExternalDescriptor.CONVERTER_NAME) == null
+        },
+        "shouldRetain" to { limeElement: Any ->
+            limeElement is LimeNamedElement &&
+                LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, DART, limeReferenceMap)
+        }
+    )
+}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -140,7 +140,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/fields}}{{/set}}
   try {
 {{#if external.dart.converter}}
-    final resultInternal = {{resolveName}}Internal{{#if constructors}}._{{/if}}(
+    final resultInternal = {{resolveName}}Internal{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}(
 {{#set container=this}}{{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}{{/set}}
@@ -149,7 +149,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/if}}{{#unless external.dart.converter}}
     return {{resolveName this "" "ref"}}{{#set container=this}}{{!!
     }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{>dart/DartConstructorName}}{{/allFieldsConstructor}}{{/if}}{{!!
-    }}{{#unless allfieldsConstructor}}{{#if constructors}}._{{/if}}{{/unless}}(
+    }}{{#unless allfieldsConstructor}}{{#ifPredicate container "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{/unless}}(
 {{#if attributes.dart.positionalDefaults initializedFields}}
 {{#each uninitializedFields initializedFields}}
 {{>fromFfiFieldInit}}

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -37,7 +37,8 @@
 
 }}{{#unless constructors}}{{#unless allFieldsConstructor}}{{!!
 }}{{>constructorComment}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}({{>thisDotFields}});
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
+}}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}({{>thisDotFields}});
 {{/unless}}{{/unless}}{{!!
 
 }}{{/unless}}

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
@@ -41,6 +41,14 @@ struct FieldConstructorsAllDefaults {
     field constructor(boolField, intField, stringField)
 }
 
+struct MutableStructNoClash {
+    stringField: String = "nonsense"
+    intField: Int = 42
+    boolField: Boolean = true
+    @Dart("withAll")
+    field constructor()
+}
+
 @Immutable
 struct ImmutableStructNoClash {
     stringField: String = "nonsense"

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/MutableStructNoClash.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/MutableStructNoClash.java
@@ -1,0 +1,16 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class MutableStructNoClash {
+    @NonNull
+    public String stringField;
+    public int intField;
+    public boolean boolField;
+    public MutableStructNoClash() {
+        this.stringField = "nonsense";
+        this.intField = 42;
+        this.boolField = true;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_no_clash.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_no_clash.dart
@@ -1,0 +1,87 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class MutableStructNoClash {
+  String stringField;
+  int intField;
+  bool boolField;
+  MutableStructNoClash._(this.stringField, this.intField, this.boolField);
+  MutableStructNoClash.withAll()
+      : stringField = "nonsense", intField = 42, boolField = true;
+}
+// MutableStructNoClash "private" section, not exported.
+final _smokeMutablestructnoclashCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_MutableStructNoClash_create_handle'));
+final _smokeMutablestructnoclashReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructNoClash_release_handle'));
+final _smokeMutablestructnoclashGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructNoClash_get_field_stringField'));
+final _smokeMutablestructnoclashGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructNoClash_get_field_intField'));
+final _smokeMutablestructnoclashGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructNoClash_get_field_boolField'));
+Pointer<Void> smokeMutablestructnoclashToFfi(MutableStructNoClash value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeMutablestructnoclashCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+MutableStructNoClash smokeMutablestructnoclashFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeMutablestructnoclashGetFieldstringField(handle);
+  final _intFieldHandle = _smokeMutablestructnoclashGetFieldintField(handle);
+  final _boolFieldHandle = _smokeMutablestructnoclashGetFieldboolField(handle);
+  try {
+    return MutableStructNoClash._(
+      stringFromFfi(_stringFieldHandle),
+      (_intFieldHandle),
+      booleanFromFfi(_boolFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeMutablestructnoclashReleaseFfiHandle(Pointer<Void> handle) => _smokeMutablestructnoclashReleaseHandle(handle);
+// Nullable MutableStructNoClash
+final _smokeMutablestructnoclashCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructNoClash_create_handle_nullable'));
+final _smokeMutablestructnoclashReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructNoClash_release_handle_nullable'));
+final _smokeMutablestructnoclashGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructNoClash_get_value_nullable'));
+Pointer<Void> smokeMutablestructnoclashToFfiNullable(MutableStructNoClash? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeMutablestructnoclashToFfi(value);
+  final result = _smokeMutablestructnoclashCreateHandleNullable(_handle);
+  smokeMutablestructnoclashReleaseFfiHandle(_handle);
+  return result;
+}
+MutableStructNoClash? smokeMutablestructnoclashFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeMutablestructnoclashGetValueNullable(handle);
+  final result = smokeMutablestructnoclashFromFfi(_handle);
+  smokeMutablestructnoclashReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeMutablestructnoclashReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeMutablestructnoclashReleaseHandleNullable(handle);
+// End of MutableStructNoClash "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/MutableStructNoClash.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/MutableStructNoClash.swift
@@ -1,0 +1,61 @@
+//
+//
+import Foundation
+public struct MutableStructNoClash {
+    public var stringField: String
+    public var intField: Int32
+    public var boolField: Bool
+    public init() {
+        self.stringField = "nonsense"
+        self.intField = 42
+        self.boolField = true
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_MutableStructNoClash_stringField_get(cHandle))
+        intField = moveFromCType(smoke_MutableStructNoClash_intField_get(cHandle))
+        boolField = moveFromCType(smoke_MutableStructNoClash_boolField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> MutableStructNoClash {
+    return MutableStructNoClash(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> MutableStructNoClash {
+    defer {
+        smoke_MutableStructNoClash_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: MutableStructNoClash) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_MutableStructNoClash_create_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: MutableStructNoClash) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_MutableStructNoClash_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> MutableStructNoClash? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_MutableStructNoClash_unwrap_optional_handle(handle)
+    return MutableStructNoClash(cHandle: unwrappedHandle) as MutableStructNoClash
+}
+internal func moveFromCType(_ handle: _baseRef) -> MutableStructNoClash? {
+    defer {
+        smoke_MutableStructNoClash_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: MutableStructNoClash?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_MutableStructNoClash_create_optional_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: MutableStructNoClash?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_MutableStructNoClash_release_optional_handle)
+}


### PR DESCRIPTION
Extracted Dart generator predicates into a stand-alone file, similarly to what
is already done for predicates in other generators. Added a predicate to check
whether the implicit all-fields constructor of a struct needs to be "private".

Updated Dart templates to make use of this new predicate.

This fixes an issues where a mutable struct with "field constructors" defined
had a public all-fields constructor, even though such constructor is not
required (it is still required and public for `@Immutable` structs).

Added smoke and functional tests.

Resolves: #1090
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>