### PR TITLE
Add support for multiple inheritance in C++

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -279,6 +279,11 @@ feature(Inheritance cpp android swift dart SOURCES
     input/lime/ConstructorOverride.lime
 )
 
+feature(MultipleInheritance cpp SOURCES
+    input/src/cpp/MultipleInheritance.cpp
+    input/lime/MultipleInheritance.lime
+)
+
 feature(Serialization android swift SOURCES
     input/lime/Serialization.lime
 )

--- a/functional-tests/functional/input/lime/MultipleInheritance.lime
+++ b/functional-tests/functional/input/lime/MultipleInheritance.lime
@@ -1,0 +1,49 @@
+
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface RegularInterface {
+    fun parentFunction()
+    property parentProperty: String
+}
+
+open class OpenClass {
+    fun parentFunction()
+    property parentProperty: String
+}
+
+narrow interface NarrowInterface {
+    fun parentFunctionLight()
+    property parentPropertyLight: String
+}
+
+class MultiClass: OpenClass, NarrowInterface {
+    fun childFunction()
+    property childProperty: String
+}
+
+interface MultiInterface: RegularInterface, NarrowInterface {
+    fun childFunction()
+    property childProperty: String
+}
+
+class MultipleInheritanceFactory {
+    static fun getMultiClass(): MultiClass
+    static fun getMultiInterface(): MultiInterface
+}

--- a/functional-tests/functional/input/src/cpp/MultipleInheritance.cpp
+++ b/functional-tests/functional/input/src/cpp/MultipleInheritance.cpp
@@ -1,0 +1,80 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/NarrowInterface.h"
+#include "test/MultiClass.h"
+#include "test/MultiInterface.h"
+#include "test/MultipleInheritanceFactory.h"
+#include "test/OpenClass.h"
+#include "test/RegularInterface.h"
+
+#include <memory>
+
+namespace
+{
+class MultiClassImpl: public test::MultiClass
+{
+public:
+    MultiClassImpl( ) = default;
+    ~MultiClassImpl( ) = default;
+
+    void child_function() override {}
+    std::string get_child_property() const override { return {}; }
+    void set_child_property(const std::string& value) override {}
+    void parent_function() override {}
+    std::string get_parent_property() const override { return {}; }
+    void set_parent_property(const std::string& value) override {}
+    void parent_function_light() override {}
+    std::string get_parent_property_light() const override { return {}; }
+    void set_parent_property_light(const std::string& value) override {}
+};
+
+class MultiInterfaceImpl: public test::MultiInterface
+{
+public:
+    MultiInterfaceImpl( ) = default;
+    ~MultiInterfaceImpl( ) = default;
+
+    void child_function() override {}
+    std::string get_child_property() const override { return {}; }
+    void set_child_property(const std::string& value) override {}
+    void parent_function() override {}
+    std::string get_parent_property() const override { return {}; }
+    void set_parent_property(const std::string& value) override {}
+    void parent_function_light() override {}
+    std::string get_parent_property_light() const override { return {}; }
+    void set_parent_property_light(const std::string& value) override {}
+};
+
+}
+
+namespace test
+{
+std::shared_ptr<MultiClass>
+MultipleInheritanceFactory::get_multi_class() {
+    return std::make_shared<MultiClassImpl>();
+}
+
+std::shared_ptr<MultiInterface>
+MultipleInheritanceFactory::get_multi_interface() {
+    return std::make_shared<MultiInterfaceImpl>();
+}
+
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -73,7 +73,7 @@ internal object CommonGeneratorPredicates {
             limeContainer !is LimeContainerWithInheritance -> false
             limeContainer is LimeInterface -> true
             limeContainer.visibility.isOpen -> true
-            else -> limeContainer.parent != null
+            else -> limeContainer.parents.isNotEmpty()
         }
 
     fun hasStaticFunctions(limeContainer: Any) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImportsCollector.kt
@@ -41,8 +41,9 @@ internal abstract class CppImportsCollector<T> : ImportsCollector<T> {
         limeElement: LimeNamedElement,
         allTypeRefs: List<LimeTypeRef>
     ): List<LimeContainerWithInheritance> {
-        val filteredPaths = listOf(limeElement.path) +
-            listOfNotNull((limeElement as? LimeContainerWithInheritance)?.parent?.type?.path)
+        val parentPaths =
+            if (limeElement is LimeContainerWithInheritance) limeElement.parents.map { it.type.path } else emptyList()
+        val filteredPaths = setOf(limeElement.path) + parentPaths
         return allTypeRefs.map { it.type }
             .filterIsInstance<LimeContainerWithInheritance>()
             .filter { !it.path.hasParent && it.external?.cpp == null && !filteredPaths.contains(it.path) }

--- a/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
@@ -21,7 +21,7 @@
 {{#unless external.cpp}}{{!!
 }}{{>cpp/CppDocComment}}
 class {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}}{{!!
-}}{{#if this.parent}}: public {{resolveName this.parent.type "FQN"}}{{/if}} {
+}}{{#if this.parents}}: {{#this.parents}}public {{resolveName this.type "FQN"}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}} {
 public:
     {{resolveName}}();
     virtual ~{{resolveName}}() = 0;

--- a/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClassImpl.mustache
@@ -20,12 +20,12 @@
   !}}
 {{#unless external.cpp}}
 {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::{{resolveName}}() {
-{{#if this.parent}}
+{{#if this.parents}}
     {{>common/InternalNamespace}}get_type_repository().add_type(this, "{{#namespace}}{{.}}_{{/namespace}}{{resolveName}}");
 {{/if}}
 }
 {{#parentName}}{{.}}::{{/parentName}}{{resolveName}}::~{{resolveName}}() {
-{{#if this.parent}}
+{{#if this.parents}}
     {{>common/InternalNamespace}}get_type_repository().remove_type(this);
 {{/if}}
 }

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsClassClass.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsClassClass.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentClass.h"
+#include "smoke/ParentNarrowOne.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT FirstParentIsClassClass: public ::smoke::ParentClass, public ::smoke::ParentNarrowOne {
+public:
+    FirstParentIsClassClass();
+    virtual ~FirstParentIsClassClass() = 0;
+public:
+    virtual void child_function(  ) = 0;
+    virtual ::std::string get_child_property(  ) const = 0;
+    virtual void set_child_property( const ::std::string& value ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsInterfaceInterface.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsInterfaceInterface.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentInterface.h"
+#include "smoke/ParentNarrowOne.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT FirstParentIsInterfaceInterface: public ::smoke::ParentInterface, public ::smoke::ParentNarrowOne {
+public:
+    FirstParentIsInterfaceInterface();
+    virtual ~FirstParentIsInterfaceInterface() = 0;
+public:
+    virtual void child_function(  ) = 0;
+    virtual ::std::string get_child_property(  ) const = 0;
+    virtual void set_child_property( const ::std::string& value ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ParentNarrowOne.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ParentNarrowOne.h
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/TypeRepository.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ParentNarrowOne {
+public:
+    ParentNarrowOne();
+    virtual ~ParentNarrowOne() = 0;
+public:
+    virtual void parent_function_one(  ) = 0;
+    virtual ::std::string get_parent_property_one(  ) const = 0;
+    virtual void set_parent_property_one( const ::std::string& value ) = 0;
+};
+}


### PR DESCRIPTION
Updated CppClass Mustache template to support multiple inheritance. No
additional support is required for "narrow interfaces", as they are identical to
regular interfaces in C++ generated code.

Added smoke and functional tests.

Resolves: #1078
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>