### PR TITLE
Mark internal elements with annotation in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Internal elements are now marked with `@internal` annotation in Dart generated code.
+
 ## 10.0.0
 Release date: 2021-10-01
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
@@ -47,7 +47,7 @@ internal open class GenericImportsCollector<T>(
             if (collectTypeRefImports) collectTypeRefs(allTypes).flatMap { importsResolver.resolveElementImports(it) }
             else emptyList()
         val ownImports =
-            if (collectOwnImports) allTypes.flatMap { importsResolver.resolveElementImports(it) } else emptyList()
+            if (collectOwnImports) allTypes.flatMap { collectOwnImports(it) } else emptyList()
         val parentImports =
             allTypes.filterIsInstance<LimeContainerWithInheritance>()
                 .filter(parentTypeFilter)
@@ -61,6 +61,11 @@ internal open class GenericImportsCollector<T>(
             .flatMap { importsResolver.resolveElementImports(it) }
 
         return typeRefImports + ownImports + parentImports + typeAliasImports + constantImports
+    }
+
+    private fun collectOwnImports(limeType: LimeType): List<T> {
+        val elements = listOf(limeType) + if (limeType is LimeStruct) limeType.fields else emptyList()
+        return elements.flatMap { importsResolver.resolveElementImports(it) }
     }
 
     private fun shouldRetain(limeElement: LimeNamedElement) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -31,6 +31,7 @@ import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.IMPORT_PA
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypesCollection
@@ -46,7 +47,10 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
     private val classInterfaceImports =
         listOf(builtInTypesConversionImport, typeRepositoryImport, tokenCacheImport, nativeBaseImport)
 
+    // TODO: not collected for fields?
     override fun resolveElementImports(limeElement: LimeElement): List<DartImport> {
+        if (limeElement !is LimeNamedElement) return emptyList()
+
         if (limeElement is LimeTypesCollection || limeElement is LimeException || limeElement is LimeTypeAlias ||
             limeElement is LimeConstant
         ) return emptyList()
@@ -60,7 +64,8 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
         } + listOfNotNull(
             resolveExternalImport(limeElement, IMPORT_PATH_NAME, useAlias = true),
             resolveExternalImport(limeElement, CONVERTER_IMPORT_NAME, useAlias = false)
-        ) + listOf(ffiSystemImport, libraryContextImport)
+        ) + listOf(ffiSystemImport, libraryContextImport) +
+            if (limeElement.visibility.isInternal) listOf(metaPackageImport) else emptyList()
     }
 
     private fun resolveStructImports(limeStruct: LimeStruct): List<DartImport> {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
@@ -34,6 +34,7 @@ import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
@@ -60,6 +61,7 @@ internal class FfiCppIncludeResolver(
             is LimeContainer -> getTypeIncludes(limeElement) + getContainerIncludes(limeElement)
             is LimeLambda -> getTypeIncludes(limeElement) + proxyIncludes + isolateContextInclude
             is LimeType -> getTypeIncludes(limeElement)
+            is LimeField -> emptyList()
             else ->
                 throw GluecodiumExecutionException("Unsupported element type ${limeElement.javaClass.name}")
         }

--- a/gluecodium/src/main/resources/templates/dart/DartAttributes.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartAttributes.mustache
@@ -18,13 +18,16 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#if attributes.dart.attribute}}
-{{#attributes.dart.attribute}}
+{{#if this.attributes.dart.attribute}}
+{{#this.attributes.dart.attribute}}
 @{{this}}
-{{/attributes.dart.attribute}}
+{{/this.attributes.dart.attribute}}
 {{/if}}{{!!
 }}{{#if property.attributes.dart.attribute}}
 {{#property.attributes.dart.attribute}}
 @{{this}}
 {{/property.attributes.dart.attribute}}
+{{/if}}{{!!
+}}{{#if this.visibility.isInternal}}
+@internal
 {{/if}}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -2,8 +2,10 @@ import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:meta/meta.dart';
 /// This looks internal
 /// @nodoc
+@internal
 abstract class InternalClassWithComments {
   /// @nodoc
   @Deprecated("Does nothing")

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -3,15 +3,20 @@ import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
+import 'package:meta/meta.dart';
 class EquatableStructWithInternalFields {
   String publicField;
   /// @nodoc
+  @internal
   String internal_internalField;
   /// @nodoc
+  @internal
   List<String> internal_internalListField;
   /// @nodoc
+  @internal
   Map<String, String> internal_internalMapField;
   /// @nodoc
+  @internal
   Set<String> internal_internalSetField;
   EquatableStructWithInternalFields(this.publicField, this.internal_internalField, this.internal_internalListField, this.internal_internalMapField, this.internal_internalSetField);
   @override

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -14,6 +14,7 @@ abstract class ClassWithInternalLambda {
   static dynamic $prototype = ClassWithInternalLambda$Impl(Pointer<Void>.fromAddress(0));
 }
 /// @nodoc
+@internal
 typedef ClassWithInternalLambda_InternalLambda = bool Function(String);
 // ClassWithInternalLambda_InternalLambda "private" section, not exported.
 final _smokeClasswithinternallambdaInternallambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -2,7 +2,9 @@ import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:meta/meta.dart';
 /// @nodoc
+@internal
 abstract class InternalClass {
   /// @nodoc
   @Deprecated("Does nothing")

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -5,6 +5,7 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// @nodoc
+@internal
 abstract class InternalClassWithFunctions {
   /// @nodoc
   factory InternalClassWithFunctions.make() => $prototype.internal_make();

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -5,13 +5,16 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// @nodoc
+@internal
 abstract class InternalClassWithStaticProperty {
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
   /// @nodoc
+  @internal
   static String get internal_fooBar => $prototype.internal_fooBar;
   /// @nodoc
+  @internal
   static set internal_fooBar(String value) { $prototype.internal_fooBar = value; }
   /// @nodoc
   @visibleForTesting
@@ -36,6 +39,7 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
   InternalClassWithStaticProperty$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {}
+  @internal
   String get internal_fooBar {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));
     final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
@@ -45,6 +49,7 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
       stringReleaseFfiHandle(__resultHandle);
     }
   }
+  @internal
   set internal_fooBar(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String'));
     final _valueHandle = stringToFfi(value);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
 /// @nodoc
+@internal
 abstract class InternalInterface {
   /// @nodoc
   factory InternalInterface(

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -3,6 +3,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
 abstract class PublicClass {
   /// @nodoc
   @Deprecated("Does nothing")
@@ -10,14 +11,18 @@ abstract class PublicClass {
   /// @nodoc
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input);
   /// @nodoc
+  @internal
   PublicClass_InternalStruct get internal_internalStructProperty;
   /// @nodoc
+  @internal
   set internal_internalStructProperty(PublicClass_InternalStruct value);
   String get internalSetterProperty;
   /// @nodoc
+  @internal
   set internal_internalSetterProperty(String value);
 }
 /// @nodoc
+@internal
 enum PublicClass_InternalEnum {
     foo,
     bar
@@ -74,8 +79,10 @@ void smokePublicclassInternalenumReleaseFfiHandleNullable(Pointer<Void> handle) 
   _smokePublicclassInternalenumReleaseHandleNullable(handle);
 // End of PublicClass_InternalEnum "private" section.
 /// @nodoc
+@internal
 class PublicClass_InternalStruct {
   /// @nodoc
+  @internal
   String internal_stringField;
   PublicClass_InternalStruct(this.internal_stringField);
 }
@@ -141,6 +148,7 @@ void smokePublicclassInternalstructReleaseFfiHandleNullable(Pointer<Void> handle
 // End of PublicClass_InternalStruct "private" section.
 class PublicClass_PublicStruct {
   /// @nodoc
+  @internal
   PublicClass_InternalStruct internal_internalField;
   PublicClass_PublicStruct(this.internal_internalField);
 }
@@ -206,6 +214,7 @@ void smokePublicclassPublicstructReleaseFfiHandleNullable(Pointer<Void> handle) 
 // End of PublicClass_PublicStruct "private" section.
 class PublicClass_PublicStructWithInternalDefaults {
   /// @nodoc
+  @internal
   String internal_internalField;
   double publicField;
   PublicClass_PublicStructWithInternalDefaults(this.internal_internalField, this.publicField);
@@ -309,6 +318,7 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
       smokePublicclassInternalstructReleaseFfiHandle(__resultHandle);
     }
   }
+  @internal
   @override
   PublicClass_InternalStruct get internal_internalStructProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalStructProperty_get'));
@@ -320,6 +330,7 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
       smokePublicclassInternalstructReleaseFfiHandle(__resultHandle);
     }
   }
+  @internal
   @override
   set internal_internalStructProperty(PublicClass_InternalStruct value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct'));
@@ -339,6 +350,7 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
       stringReleaseFfiHandle(__resultHandle);
     }
   }
+  @internal
   @override
   set internal_internalSetterProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalSetterProperty_set__String'));

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -5,14 +5,17 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/public_class.dart';
+import 'package:meta/meta.dart';
 abstract class PublicInterface {
   /// @nodoc
   @Deprecated("Does nothing")
   void release() {}
 }
 /// @nodoc
+@internal
 class PublicInterface_InternalStruct {
   /// @nodoc
+  @internal
   PublicClass_InternalStruct internal_fieldOfInternalType;
   PublicInterface_InternalStruct(this.internal_fieldOfInternalType);
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -1,9 +1,11 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
 class PublicStructWithNonDefaultInternalField {
   int defaultedField;
   /// @nodoc
+  @internal
   String internal_internalField;
   bool publicField;
   PublicStructWithNonDefaultInternalField(this.defaultedField, this.internal_internalField, this.publicField);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_type_collection.dart
@@ -3,8 +3,10 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// @nodoc
+@internal
 class InternalStruct {
   /// @nodoc
+  @internal
   String internal_stringField;
   InternalStruct(this.internal_stringField);
   /// @nodoc


### PR DESCRIPTION
Updated Dart templates to mark internal elements with `@internal` annotation
annotation from "dart:meta" package. Updated import resolution and collection
logic for Dart to correctly import "dart:meta" package for this annotation.

Updated affected smoke tests.

Resolves: #992
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>