### PR TITLE
Cache Swift SDK archive for CI "Swift on Linux" builds

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -133,6 +133,12 @@ jobs:
             !*lime-*
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
+      - name: Cache Swift SDK
+        uses: actions/cache@v2
+        with:
+          path: ~/swift-sdk
+          key: ${{ runner.os }}-swift-5.4.3-release
+          restore-keys: ${{ runner.os }}-swift-5.4.3-release
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.7
         with:
@@ -147,13 +153,17 @@ jobs:
         run: sudo apt install -y libcurl4
       - name: Install Swift SDK
         run: |
-          SWIFT_BRANCH=swift-5.3.3-release
-          SWIFT_VERSION=swift-5.3.3-RELEASE
+          SWIFT_BRANCH=swift-5.4.3-release
+          SWIFT_VERSION=swift-5.4.3-RELEASE
           SWIFT_PLATFORM=ubuntu18.04
-          SWIFT_ARCHIVE_NAME=${SWIFT_VERSION}-${SWIFT_PLATFORM}
-          SWIFT_URL=https://swift.org/builds/${SWIFT_BRANCH}/$(echo "${SWIFT_PLATFORM}" | tr -d .)/${SWIFT_VERSION}/${SWIFT_ARCHIVE_NAME}.tar.gz
-          wget -nv ${SWIFT_URL}
-          sudo tar xf ${SWIFT_ARCHIVE_NAME}.tar.gz --directory / --strip-components=1
+          SWIFT_ARCHIVE_NAME=${SWIFT_VERSION}-${SWIFT_PLATFORM}.tar.gz
+          if [ ! -d "${HOME}/swift-sdk" ]; then
+            mkdir ~/swift-sdk
+            pushd ~/swift-sdk
+            wget -nv https://swift.org/builds/${SWIFT_BRANCH}/$(echo "${SWIFT_PLATFORM}" | tr -d .)/${SWIFT_VERSION}/${SWIFT_ARCHIVE_NAME}
+            popd
+          fi
+          sudo tar xf ~/swift-sdk/${SWIFT_ARCHIVE_NAME} --directory / --strip-components=1
           sudo chmod -R o+r /usr/lib/swift/CoreFoundation
       - name: Build and run functional tests
         run: |
@@ -262,19 +272,18 @@ jobs:
             !*lime-*
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
+      - name: Cache Dart SDK
+        uses: actions/cache@v2
+        with:
+          path: ~/dart_sdk
+          key: ${{ runner.os }}-dart-2.12.0-stable
+          restore-keys: ${{ runner.os }}-dart-2.12.0-stable
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.7
         with:
           cmake-version: '3.19.3'
       - name: Install ninja
         run: sudo apt install -y ninja-build
-      - name: Cache Dart SDK
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/dart_sdk
-          key: ${{ runner.os }}-dart-2.12.0-stable
-          restore-keys: ${{ runner.os }}-dart-2.12.0-stable
       - name: Compile Dart SDK without tcmalloc
         run: |
           export DART_ROOT=${HOME}/dart_sdk

--- a/functional-tests/scripts/valgrind_suppressions
+++ b/functional-tests/scripts/valgrind_suppressions
@@ -31,12 +31,39 @@
    fun:*
 }
 {
-   allocateMetadata
+   instantiateCPGenericMetadata
 
    Memcheck:Leak
    match-leak-kinds: possible
    ...
-   fun:_ZN5swift16allocateMetadataEmm
+   fun:__swift_instantiateCanonicalPrespecializedGenericMetadata
+   fun:*
+}
+{
+   instantiateGenericMetadata
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:__swift_instantiateGenericMetadata
+   fun:*
+}
+{
+   getFunctionTypeMetadata
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:swift_getFunctionTypeMetadata
+   fun:*
+}
+{
+   getMetatypeMetadata
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:swift_getMetatypeMetadata
    fun:*
 }
 {
@@ -44,10 +71,17 @@
 
    Memcheck:Leak
    match-leak-kinds: possible
-   fun:_Znam
    ...
    fun:swift_getTupleTypeMetadata
-   fun:swift_getTupleTypeMetadata2
+   fun:*
+}
+{
+   allocateMetadata
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_ZN5swift16allocateMetadataEmm
    fun:*
 }
 {
@@ -90,6 +124,15 @@
    fun:malloc
    fun:_ZL29_registerProtocolConformancesR16ConformanceStatePKN5swift21RelativeDirectPointerINS1_35TargetProtocolConformanceDescriptorINS1_9InProcessEEELb0EiEES8_
    fun:swift_addNewDSOImage
+   fun:*
+}
+{
+   ConformanceState_cacheResult
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:_ZN16ConformanceState11cacheResultEPKN5swift14TargetMetadataINS0_9InProcessEEEPKNS0_24TargetProtocolDescriptorIS2_EEPKNS0_18TargetWitnessTableIS2_EEm
    fun:*
 }
 {


### PR DESCRIPTION
Updated "functional-tests.yml" workflow file to add caching of the Swift SDK for
Linux distro archive. This speeds up the "Swift on Linux" build by ~1m and also
makes it more reliable by protecting against swift.org server downtime.

Also updated Swift SDK version from 5.3.3 to 5.4.3, and added new valgrind
suppressions for false positives caused by this version updated.

Resolves: #909
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>