### PR TITLE
Don't run Android functional tests twice

### DIFF
--- a/functional-tests/scripts/build-android-functional
+++ b/functional-tests/scripts/build-android-functional
@@ -98,9 +98,9 @@ INSTALL_AAR_DIR="${ANDROID_DIR}/app/libs/"
 TMP_DIR=$(mktemp -d)
 
 if $HOST_ONLY; then
-    ./gradlew functional:test -PhostOnly -PgluecodiumVersion=${GLUECODIUM_VERSION}
+    ./gradlew functional:testRelease -PhostOnly -PgluecodiumVersion=${GLUECODIUM_VERSION}
 else
-    ./gradlew functional:test -PgluecodiumVersion=${GLUECODIUM_VERSION}
+    ./gradlew functional:testRelease -PgluecodiumVersion=${GLUECODIUM_VERSION}
 fi
 
 if [ "$GENERATE_DOCS" = true ]; then

--- a/functional-tests/scripts/build-android-namerules
+++ b/functional-tests/scripts/build-android-namerules
@@ -52,4 +52,4 @@ GLUECODIUM_VERSION="${GLUECODIUM_VERSION:-+}"
 # Sanity checks
 [ $ANDROID_HOME ] || die "ANDROID_HOME environment variable is mandatory"
 
-./gradlew namerules:test -PhostOnly -PgluecodiumVersion=${GLUECODIUM_VERSION}
+./gradlew namerules:testRelease -PhostOnly -PgluecodiumVersion=${GLUECODIUM_VERSION}


### PR DESCRIPTION
Updated build scripts for Android functional tests to only run tests in the
"release" configuration, instead of both "release" and "debug" as before. This
speeds up the "Android" CI job by ~1 minute. Makes running these tests locally
faster as well.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>