### PR TITLE
Add support for multiple inheritance in Java

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -279,7 +279,7 @@ feature(Inheritance cpp android swift dart SOURCES
     input/lime/ConstructorOverride.lime
 )
 
-feature(MultipleInheritance cpp SOURCES
+feature(MultipleInheritance cpp android SOURCES
     input/src/cpp/MultipleInheritance.cpp
     input/lime/MultipleInheritance.lime
 )

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/MultipleInheritanceTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/MultipleInheritanceTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+import android.os.Build;
+import com.here.android.RobolectricApplication;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.M, application = RobolectricApplication.class)
+public class MultipleInheritanceTest {
+
+  private static class MultiInterfaceImpl implements MultiInterface {
+    @Override
+    public void childFunction() { }
+
+    @Override
+    public String getChildProperty() {
+      return "";
+    }
+
+    @Override
+    public void setChildProperty(final String value) { }
+
+    @Override
+    public void parentFunction() { }
+
+    @Override
+    public String getParentProperty() {
+      return "";
+    }
+
+    @Override
+    public void setParentProperty(final String value) { }
+
+    @Override
+    public String parentFunctionLight() {
+      return "java face faces";
+    }
+
+    @Override
+    public String getParentPropertyLight() {
+      return "";
+    }
+
+    @Override
+    public void setParentPropertyLight(final String value) { }
+  }
+
+  @Test
+  public void fromCppSendUpcastSucceeds() {
+    MultiClass instance = MultipleInheritanceFactory.getMultiClass();
+
+    boolean result = instance instanceof NarrowInterface;
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void fromCppSendDowncastFails() {
+    NarrowInterface instance = MultipleInheritanceFactory.getMultiClassAsNarrow();
+
+    boolean result = instance instanceof MultiClass;
+
+    assertFalse(result);
+  }
+
+  @Test
+  public void fromCppSendTwiceEquals() {
+    NarrowInterface instance1 = MultipleInheritanceFactory.getMultiClassSingleton();
+    NarrowInterface instance2 = MultipleInheritanceFactory.getMultiClassSingleton();
+
+    boolean result = instance1 == instance2;
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void fromCppRoundTripNotEquals() {
+    NarrowInterface instance = MultipleInheritanceFactory.getMultiClassSingleton();
+
+    boolean result = MultipleInheritanceChecker.checkSingletonEquality(instance);
+
+    assertFalse(result);
+  }
+
+  @Test
+  public void fromCppRoundTripWithUpcastNotEquals() {
+    MultiClass uncastInstance = MultipleInheritanceFactory.getMultiClass();
+    NarrowInterface instance = (NarrowInterface)uncastInstance;
+
+    boolean result = MultipleInheritanceChecker.checkSingletonEquality(instance);
+
+    assertFalse(result);
+  }
+
+  @Test
+  public void fromJavaSendUpcastSucceeds() {
+    MultiInterface instance = new MultiInterfaceImpl();
+
+    boolean result = MultipleInheritanceChecker.checkIsNarrow(instance);
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void fromJavaSendDowncastFails() {
+    MultiInterface uncastInstance = new MultiInterfaceImpl();
+    NarrowInterface instance = (NarrowInterface)uncastInstance;
+
+    boolean result = MultipleInheritanceChecker.checkIsMultiInterface(instance);
+
+    assertFalse(result);
+  }
+
+  @Test
+  public void fromJavaSendTwiceEquals() {
+    NarrowInterface instance = new MultiInterfaceImpl();
+
+    boolean result = MultipleInheritanceChecker.checkNarrowEquality(instance, instance);
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void fromJavaRoundTripEquals() {
+    MultiInterface uncastInstance = new MultiInterfaceImpl();
+    NarrowInterface instance = (NarrowInterface)uncastInstance;
+
+    boolean result = uncastInstance == MultipleInheritanceChecker.narrowRoundTrip(instance);
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void fromJavaRoundTripWithUpcastNotEquals() {
+    MultiInterface instance = new MultiInterfaceImpl();
+
+    boolean result =
+        instance == MultipleInheritanceFactory.upcastMultiInterfaceToNarrow(instance);
+
+    assertFalse(result);
+  }
+}

--- a/functional-tests/functional/input/lime/MultipleInheritance.lime
+++ b/functional-tests/functional/input/lime/MultipleInheritance.lime
@@ -29,7 +29,7 @@ open class OpenClass {
 }
 
 narrow interface NarrowInterface {
-    fun parentFunctionLight()
+    fun parentFunctionLight(): String
     property parentPropertyLight: String
 }
 
@@ -46,4 +46,15 @@ interface MultiInterface: RegularInterface, NarrowInterface {
 class MultipleInheritanceFactory {
     static fun getMultiClass(): MultiClass
     static fun getMultiInterface(): MultiInterface
+    static fun getMultiClassAsNarrow(): NarrowInterface
+    static fun getMultiClassSingleton(): NarrowInterface
+    static fun upcastMultiInterfaceToNarrow(instance: MultiInterface): NarrowInterface
+}
+
+class MultipleInheritanceChecker {
+    static fun checkSingletonEquality(instance: NarrowInterface): Boolean
+    static fun checkIsNarrow(instance: MultiInterface): Boolean
+    static fun checkIsMultiInterface(instance: NarrowInterface): Boolean
+    static fun checkNarrowEquality(instance1: NarrowInterface, instance2: NarrowInterface): Boolean
+    static fun narrowRoundTrip(instance: NarrowInterface): NarrowInterface
 }

--- a/functional-tests/functional/input/src/cpp/MultipleInheritance.cpp
+++ b/functional-tests/functional/input/src/cpp/MultipleInheritance.cpp
@@ -21,6 +21,7 @@
 #include "test/NarrowInterface.h"
 #include "test/MultiClass.h"
 #include "test/MultiInterface.h"
+#include "test/MultipleInheritanceChecker.h"
 #include "test/MultipleInheritanceFactory.h"
 #include "test/OpenClass.h"
 #include "test/RegularInterface.h"
@@ -41,7 +42,7 @@ public:
     void parent_function() override {}
     std::string get_parent_property() const override { return {}; }
     void set_parent_property(const std::string& value) override {}
-    void parent_function_light() override {}
+    std::string parent_function_light() override { return "foo class"; }
     std::string get_parent_property_light() const override { return {}; }
     void set_parent_property_light(const std::string& value) override {}
 };
@@ -58,10 +59,12 @@ public:
     void parent_function() override {}
     std::string get_parent_property() const override { return {}; }
     void set_parent_property(const std::string& value) override {}
-    void parent_function_light() override {}
+    std::string parent_function_light() override { return "foo interface"; }
     std::string get_parent_property_light() const override { return {}; }
     void set_parent_property_light(const std::string& value) override {}
 };
+
+std::shared_ptr<MultiClassImpl> s_multi_class = std::make_shared<MultiClassImpl>();
 
 }
 
@@ -75,6 +78,49 @@ MultipleInheritanceFactory::get_multi_class() {
 std::shared_ptr<MultiInterface>
 MultipleInheritanceFactory::get_multi_interface() {
     return std::make_shared<MultiInterfaceImpl>();
+}
+
+std::shared_ptr<NarrowInterface>
+MultipleInheritanceFactory::get_multi_class_as_narrow() {
+    return std::make_shared<MultiClassImpl>();
+}
+
+std::shared_ptr<NarrowInterface>
+MultipleInheritanceFactory::get_multi_class_singleton() {
+    return s_multi_class;
+}
+
+std::shared_ptr<NarrowInterface>
+MultipleInheritanceFactory::upcast_multi_interface_to_narrow(const std::shared_ptr<MultiInterface>& instance) {
+    return instance;
+}
+
+bool
+MultipleInheritanceChecker::check_singleton_equality(const std::shared_ptr<NarrowInterface>& instance) {
+    return instance == s_multi_class;
+}
+
+bool
+MultipleInheritanceChecker::check_is_narrow(const std::shared_ptr<MultiInterface>& instance) {
+    return std::dynamic_pointer_cast<NarrowInterface>(instance).get() != nullptr;
+}
+
+bool
+MultipleInheritanceChecker::check_is_multi_interface(const std::shared_ptr<NarrowInterface>& instance) {
+    return std::dynamic_pointer_cast<MultiInterface>(instance).get() != nullptr;
+}
+
+bool
+MultipleInheritanceChecker::check_narrow_equality(
+    const std::shared_ptr<NarrowInterface>& instance1,
+    const std::shared_ptr<NarrowInterface>& instance2
+) {
+    return instance1.get() == instance2.get();
+}
+
+std::shared_ptr<NarrowInterface>
+MultipleInheritanceChecker::narrow_round_trip(const std::shared_ptr<NarrowInterface>& instance) {
+    return instance;
 }
 
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -71,7 +71,7 @@ internal object CommonGeneratorPredicates {
     fun hasTypeRepository(limeContainer: Any) =
         when {
             limeContainer !is LimeContainerWithInheritance -> false
-            limeContainer is LimeInterface -> true
+            limeContainer is LimeInterface -> !limeContainer.isNarrow
             limeContainer.visibility.isOpen -> true
             else -> limeContainer.parents.isNotEmpty()
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
@@ -61,7 +61,7 @@ internal object JavaGeneratorPredicates {
                 CommonGeneratorPredicates.needsAllFieldsConstructor(limeStruct)
         },
         "needsDisposer" to { limeClass: Any ->
-            limeClass is LimeClass && limeClass.parent?.type?.actualType !is LimeClass
+            limeClass is LimeClass && limeClass.parentClass == null
         },
         "needsNonNullAnnotation" to { limeTypeRef ->
             limeTypeRef is LimeTypeRef && !limeTypeRef.isNullable &&

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
@@ -54,8 +54,8 @@ internal class JavaImportCollector(
     }
 
     fun collectImplImports(limeInterface: LimeInterface, defImports: List<JavaImport>): List<JavaImport> {
-        val parentTypeRef = limeInterface.parent ?: return defImports
-        val parentImport = importsResolver.createTopElementImport(parentTypeRef.type.actualType)
+        if (limeInterface.parents.isEmpty()) return defImports
+        val parentImport = limeInterface.parents.map { importsResolver.createTopElementImport(it.type.actualType) }
         return defImports - parentImport +
             (limeInterface.inheritedFunctions + limeInterface.inheritedProperties).flatMap { collectImports(it) }
     }
@@ -67,7 +67,7 @@ internal class JavaImportCollector(
         val inheritedElements =
             when {
                 limeContainer !is LimeContainerWithInheritance -> emptyList()
-                (limeContainer is LimeClass && limeContainer.parent?.type?.actualType is LimeInterface) ||
+                (limeContainer is LimeClass && limeContainer.parentInterfaces.isNotEmpty()) ||
                     (limeContainer is LimeInterface && limeContainer.path.hasParent) ->
                     limeContainer.inheritedFunctions + limeContainer.inheritedProperties
                 else -> emptyList()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportResolver.kt
@@ -72,9 +72,9 @@ internal class JavaImportResolver(
         }
 
     private fun resolveClassInterfaceImports(limeContainer: LimeContainerWithInheritance) =
-        resolveTypeRefImports(limeContainer.parent, ignoreNullability = true) +
+        limeContainer.parents.flatMap { resolveTypeRefImports(it, ignoreNullability = true) } +
             when {
-                (limeContainer is LimeClass && limeContainer.parent?.type?.actualType !is LimeClass) ||
+                (limeContainer is LimeClass && limeContainer.parentClass == null) ||
                     (limeContainer is LimeInterface && limeContainer.path.hasParent) -> listOf(nativeBaseImport)
                 else -> emptyList()
             }

--- a/gluecodium/src/main/resources/templates/java/JavaClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaClass.mustache
@@ -21,9 +21,9 @@
 {{>java/JavaDocComment}}{{>java/JavaAttributes}}
 {{resolveName visibility}}{{#if forceStatic}}static {{/if}}{{!!
 }}{{#unless visibility.isOpen visibility.isInternal logic="and"}}final {{/unless}}{{!!
-}}class {{resolveName}} extends {{#if this.parent}}{{!!
-}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}NativeBase implements {{/instanceOf}}{{resolveName this.parent}}{{/if}}{{!!
-}}{{#unless this.parent}}NativeBase{{/unless}} {
+}}class {{resolveName}} extends {{#if this.parentClass}}{{resolveName this.parentClass "" "ref"}}{{/if}}{{!!
+}}{{#unless this.parentClass}}NativeBase{{/unless}}{{#if this.parentInterfaces}} implements {{!!
+}}{{#this.parentInterfaces}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/this.parentInterfaces}}{{/if}} {
 {{#constants}}{{prefixPartial "java/JavaConstant" "    "}}
 {{/constants}}
 {{>java/JavaContainerContents}}
@@ -75,19 +75,19 @@
 {{/setter}}{{/set}}
 {{/properties}}
 
-{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}{{#set override=true classElement=this}}
-{{#set isClass=true}}{{#classElement.inheritedFunctions}}
+{{#if this.parentInterfaces}}{{#set override=true classElement=this}}
+{{#set isClass=true}}{{#classElement.interfaceInheritedFunctions}}
 {{prefixPartial "java/JavaFunction" "    "}}
-{{/classElement.inheritedFunctions}}{{/set}}
-{{#classElement.inheritedProperties}}{{#set isCached=attributes.cached property=this}}
+{{/classElement.interfaceInheritedFunctions}}{{/set}}
+{{#classElement.interfaceInheritedProperties}}{{#set isCached=attributes.cached property=this}}
 {{#set isGetter=true}}{{#getter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/getter}}{{/set}}
 {{#setter}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/setter}}{{/set}}
-{{/classElement.inheritedProperties}}
-{{/set}}{{/instanceOf}}{{/if}}
+{{/classElement.interfaceInheritedProperties}}
+{{/set}}{{/if}}
 
 {{#eval "optimizedLists" path}}{{#this}}
 {{#elementType}}{{prefixPartial "java/LazyNativeList" "    "}}{{/elementType}}

--- a/gluecodium/src/main/resources/templates/java/JavaImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaImplClass.mustache
@@ -55,7 +55,7 @@ static {{/if}}class {{resolveName}}Impl extends NativeBase implements {{resolveN
 {{/setter}}
 {{/set}}{{/interface.properties}}
 
-{{#if parent}}{{#set override=true}}
+{{#if interface.parents}}{{#set override=true}}
 {{#interface.inheritedFunctions}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/interface.inheritedFunctions}}

--- a/gluecodium/src/main/resources/templates/java/JavaInterface.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaInterface.mustache
@@ -19,7 +19,8 @@
   !
   !}}
 {{>java/JavaDocComment}}{{>java/JavaAttributes}}
-{{resolveName visibility}}interface {{resolveName}} {{#if this.parent}}extends {{resolveName this.parent "" ref}} {{/if}}{
+{{resolveName visibility}}interface {{resolveName}} {{!!
+}}{{#if this.parents}}extends {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
 {{#constants}}{{prefixPartial "java/JavaConstant" "    "}}
 {{/constants}}
 {{>java/JavaContainerContents}}

--- a/gluecodium/src/main/resources/templates/jni/Header.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Header.mustache
@@ -37,7 +37,7 @@ extern "C" {
 
 {{/ifPredicate}}{{/properties}}
 
-{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
+{{#if this.parentInterfaces}}
 {{#inheritedFunctions}}{{#ifPredicate "shouldRetain"}}
 {{>jniFunctionHeader}}
 
@@ -46,7 +46,7 @@ extern "C" {
 {{>jniPropertyHeader}}
 
 {{/ifPredicate}}{{/inheritedProperties}}
-{{/instanceOf}}{{/if}}
+{{/if}}
 
 {{#if attributes.equatable attributes.pointerEquatable logic="or"}}
 JNIEXPORT jboolean JNICALL

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -38,7 +38,7 @@ extern "C" {
 {{>jniPropertyImpl}}
 {{/ifPredicate}}{{/properties}}
 
-{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
+{{#if this.parentInterfaces}}
 {{#inheritedFunctions}}{{#ifPredicate "shouldRetain"}}
 {{>jniMethodImpl}}
 
@@ -46,7 +46,7 @@ extern "C" {
 {{#inheritedProperties}}{{#ifPredicate "shouldRetain"}}
 {{>jniPropertyImpl}}
 {{/ifPredicate}}{{/inheritedProperties}}
-{{/instanceOf}}{{/if}}
+{{/if}}
 
 {{#notInstanceOf container "LimeStruct"}}
 JNIEXPORT void JNICALL

--- a/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
@@ -66,6 +66,9 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 {{>cppTypeName}} {{>conversionPrefix}}convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, {{>cppTypeName}}*)
 {
     {{>cppTypeName}} _nresult{};
+{{#if isNarrow}}
+    createCppProxy(_env, _jobj, _nresult);
+{{/if}}{{#unless isNarrow}}
     auto& nativeBaseClass = get_cached_native_base_class();
     if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
     {
@@ -83,6 +86,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
     {
         {{>conversionPrefix}}createCppProxy(_env, _jobj, _nresult);
     }
+{{/unless}}
     return _nresult;
 }
 

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/com/example/smoke/FirstParentIsClassClass.java
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/com/example/smoke/FirstParentIsClassClass.java
@@ -1,0 +1,25 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FirstParentIsClassClass extends ParentClass implements ParentNarrowOne {
+    /**
+     * For internal use only.
+     * @exclude
+     */
+    protected FirstParentIsClassClass(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, dummy);
+    }
+    public native void childFunction();
+    @NonNull
+    public native String getChildProperty();
+    public native void setChildProperty(@NonNull final String value);
+    @Override
+    public native void parentFunctionOne();
+    @NonNull
+    @Override
+    public native String getParentPropertyOne();
+    @Override
+    public native void setParentPropertyOne(@NonNull final String value);
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/com/example/smoke/FirstParentIsInterfaceInterface.java
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/com/example/smoke/FirstParentIsInterfaceInterface.java
@@ -1,0 +1,11 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public interface FirstParentIsInterfaceInterface extends ParentInterface, ParentNarrowOne {
+    void childFunction();
+    @NonNull
+    String getChildProperty();
+    void setChildProperty(@NonNull final String value);
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/com/example/smoke/ParentNarrowOne.java
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/com/example/smoke/ParentNarrowOne.java
@@ -1,0 +1,11 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public interface ParentNarrowOne {
+    void parentFunctionOne();
+    @NonNull
+    String getParentPropertyOne();
+    void setParentPropertyOne(@NonNull final String value);
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/jni/com_example_smoke_ParentNarrowOne__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/jni/com_example_smoke_ParentNarrowOne__Conversion.cpp
@@ -1,0 +1,51 @@
+/*
+ *
+ */
+#include "com_example_smoke_ParentNarrowOne__Conversion.h"
+#include "com_example_smoke_ParentNarrowOneImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniWrapperCache.h"
+#include <new>
+namespace gluecodium
+{
+namespace jni
+{
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/ParentNarrowOneImpl", com_example_smoke_ParentNarrowOne, ::smoke::ParentNarrowOne)
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ParentNarrowOne>& result)
+{
+    CppProxyBase::createProxy<::smoke::ParentNarrowOne, com_example_smoke_ParentNarrowOne_CppProxy>(env, obj, "com_example_smoke_ParentNarrowOne", result);
+}
+std::shared_ptr<::smoke::ParentNarrowOne> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ParentNarrowOne>*)
+{
+    std::shared_ptr<::smoke::ParentNarrowOne> _nresult{};
+    createCppProxy(_env, _jobj, _nresult);
+    return _nresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ParentNarrowOne>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+    auto &javaClass = CachedJavaClass<::smoke::ParentNarrowOne>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ParentNarrowOne>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        auto exceptionClass = find_class(_jenv, "java/lang/OutOfMemoryError" );
+        _jenv->ThrowNew( exceptionClass.get(), "Cannot allocate native memory." );
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+    return jResult;
+}
+}
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
@@ -136,7 +136,8 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
                 classes = classes.filter(predicate).map { filterClass(it) },
                 interfaces = interfaces.filter(predicate).map { filterInterface(it) },
                 lambdas = lambdas.filter(predicate),
-                parents = parents.map { LimeDirectTypeRef(filterTopElement(it.type.actualType) as LimeType) }
+                parents = parents.map { LimeDirectTypeRef(filterTopElement(it.type.actualType) as LimeType) },
+                isNarrow = isNarrow
             )
         }.also { remap(it) }
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeClass.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeClass.kt
@@ -61,4 +61,12 @@ class LimeClass(
     @Suppress("unused")
     val hasClassParent
         get() = parentClass != null
+
+    @Suppress("unused")
+    val interfaceInheritedFunctions
+        get() = parentInterfaces.flatMap { it.functions + it.inheritedFunctions }
+
+    @Suppress("unused")
+    val interfaceInheritedProperties
+        get() = parentInterfaces.flatMap { it.properties + it.inheritedProperties }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
@@ -60,12 +60,10 @@ abstract class LimeContainerWithInheritance(
     val parentInterfaces
         get() = parents.map { it.type.actualType }.filterIsInstance<LimeInterface>()
 
-    @Suppress("unused")
     val inheritedFunctions: List<LimeFunction>
         get() = parents.mapNotNull { it.type.actualType as? LimeContainerWithInheritance }
             .flatMap { it.functions + it.inheritedFunctions }
 
-    @Suppress("unused")
     val inheritedProperties: List<LimeProperty>
         get() = parents.mapNotNull { it.type.actualType as? LimeContainerWithInheritance }
             .flatMap { it.properties + it.inheritedProperties }


### PR DESCRIPTION
Updated Java templates for classes and interfaces to support multiple
inheritance.

Updated JNI template for instance conversion to force proxy creation for narrow
interfaces (instead of trying to extract a native handle). This circumvents the
potential issues of invalid reinterpret-casts for second+ parent types. This
behavior is already documented in "lime_idl.md".

Added smoke and functional tests.

Resolves: #1079
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>