### PR TITLE
Fix deadlock in Dart finalizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
 ### Features:
   * In Dart, "from lambdas" factory constructors for interfaces are now generated with a documentation comment.
+### Bug fixes:
+  * Fixed an issue in Dart where an object finalizer could run into a deadlock.
 
 ## 9.5.2
 Release date: 2021-09-23

--- a/gluecodium/src/main/resources/templates/ffi/FfiInstanceCacheImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiInstanceCacheImpl.mustache
@@ -35,6 +35,31 @@ std::unordered_map<InstanceCacheKey, Dart_WeakPersistentHandle> _instance_cache{
 std::mutex _instance_cache_mutex{};
 
 std::unordered_map<int32_t, std::vector<Dart_WeakPersistentHandle>> _deletion_queue{};
+
+std::vector<Dart_WeakPersistentHandle>
+{{libraryName}}_store_handle_and_get_deletion_queue_locked(
+    void* raw_pointer, int32_t isolate_id, Dart_WeakPersistentHandle new_handle
+) {
+    const std::lock_guard<std::mutex> lock(_instance_cache_mutex);
+    _instance_cache[raw_pointer] = new_handle;
+
+    auto iter = _deletion_queue.find(isolate_id);
+    if (iter == _deletion_queue.end()) return {};
+
+    auto result = std::move(iter->second);
+    _deletion_queue.erase(iter);
+    return result;
+}
+
+Dart_WeakPersistentHandle
+{{libraryName}}_get_handle_locked(void* raw_pointer)
+{
+    const std::lock_guard<std::mutex> lock(_instance_cache_mutex);
+    auto iter = _instance_cache.find(raw_pointer);
+    return (iter != _instance_cache.end()) ? iter->second : nullptr;
+}
+
+
 }
 
 #ifdef __cplusplus
@@ -49,23 +74,16 @@ void*
     return reinterpret_cast<std::shared_ptr<void>*>(handle)->get();
 }
 
-// "Private" function, call only when mutex is locked.
-void
-{{libraryName}}_process_deletion_queue(int32_t isolate_id) {
-    auto iter = _deletion_queue.find(isolate_id);
-    if (iter == _deletion_queue.end()) return;
-
-    for (const auto& weak_handle: iter->second) {
-        Dart_DeleteWeakPersistentHandle_DL(weak_handle);
-    }
-    _deletion_queue.erase(iter);
-}
-
 void
 {{libraryName}}_cache_dart_handle_by_raw_pointer(void* raw_pointer, int32_t isolate_id, Dart_Handle dart_handle) {
-    const std::lock_guard<std::mutex> lock(_instance_cache_mutex);
-    _instance_cache[raw_pointer] = Dart_NewWeakPersistentHandle_DL(dart_handle, NULL, 0, &{{libraryName}}_nop_finalizer);
-    {{libraryName}}_process_deletion_queue(isolate_id);
+    auto new_handle = Dart_NewWeakPersistentHandle_DL(dart_handle, NULL, 0, &{{libraryName}}_nop_finalizer);
+    auto pending_for_deletion =
+        {{libraryName}}_store_handle_and_get_deletion_queue_locked(raw_pointer, isolate_id, new_handle);
+
+    // Process deletion queue
+    for (const auto& weak_handle: pending_for_deletion) {
+        Dart_DeleteWeakPersistentHandle_DL(weak_handle);
+    }
 }
 
 void
@@ -84,10 +102,8 @@ void
 Dart_Handle
 {{libraryName}}_get_cached_dart_handle(FfiOpaqueHandle handle, Dart_Handle null_handle) {
     auto raw_pointer = {{libraryName}}_raw_pointer_from_opaque_handle(handle);
-
-    const std::lock_guard<std::mutex> lock(_instance_cache_mutex);
-    auto iter = _instance_cache.find(raw_pointer);
-    return (iter != _instance_cache.end()) ? Dart_HandleFromWeakPersistent_DL(iter->second) : null_handle;
+    auto cached_handle = {{libraryName}}_get_handle_locked(raw_pointer);
+    return (cached_handle != nullptr) ? Dart_HandleFromWeakPersistent_DL(cached_handle) : null_handle;
 }
 
 void


### PR DESCRIPTION
Updated FFI instance cache template to limit mutex lock lifetime to an absolute
minimum. Specifically, the new version avoids calling any Dart_DL API functions
while holding the lock. Some (or all) of these functions may cause a finalizer
to run synchronously, thus creating a double-acquire deadlock. The new version
of the code fixes this issue.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>