### PR TITLE
Add support for multiple inheritance in Swift

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -279,7 +279,7 @@ feature(Inheritance cpp android swift dart SOURCES
     input/lime/ConstructorOverride.lime
 )
 
-feature(MultipleInheritance cpp android SOURCES
+feature(MultipleInheritance cpp android swift SOURCES
     input/src/cpp/MultipleInheritance.cpp
     input/lime/MultipleInheritance.lime
 )

--- a/functional-tests/functional/swift/Tests/MultipleInheritanceTests.swift
+++ b/functional-tests/functional/swift/Tests/MultipleInheritanceTests.swift
@@ -1,0 +1,133 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import functional
+
+class MultipleInheritanceTests: XCTestCase {
+
+    class MultiInterfaceImpl: MultiInterface {
+        public func childFunction() { }
+        public var childProperty: String = ""
+
+        public func parentFunction() { }
+        public var parentProperty: String = ""
+
+        public func parentFunctionLight() -> String { return "swift face" }
+        public var parentPropertyLight: String = ""
+    }
+
+    func testFromCppSendUpcastSucceeds() {
+        let instance = MultipleInheritanceFactory.getMultiClass()
+
+        let result = instance is NarrowInterface
+
+        XCTAssertTrue(result)
+    }
+
+    func testFromCppSendDowncastFails() {
+        let instance = MultipleInheritanceFactory.getMultiClassAsNarrow()
+
+        let result = instance is MultiClass
+
+        XCTAssertFalse(result)
+    }
+
+    func testFromCppSendTwiceEquals() {
+        let instance1 = MultipleInheritanceFactory.getMultiClassSingleton()
+        let instance2 = MultipleInheritanceFactory.getMultiClassSingleton()
+
+        let result = instance1 === instance2
+
+        XCTAssertTrue(result)
+    }
+
+    func testFromCppRoundTripNotEquals() {
+        let instance = MultipleInheritanceFactory.getMultiClassSingleton()
+
+        let result = MultipleInheritanceChecker.checkSingletonEquality(instance: instance)
+
+        XCTAssertFalse(result)
+    }
+
+    func testFromCppRoundTripWithUpcastNotEquals() {
+        let uncastInstance = MultipleInheritanceFactory.getMultiClass()
+        let instance = uncastInstance as NarrowInterface
+
+        let result = MultipleInheritanceChecker.checkSingletonEquality(instance: instance)
+
+        XCTAssertFalse(result)
+    }
+
+    func testFromSwiftSendUpcastSucceeds() {
+        let instance = MultiInterfaceImpl()
+
+        let result = MultipleInheritanceChecker.checkIsNarrow(instance: instance)
+
+        XCTAssertTrue(result)
+    }
+
+    func testFromSwiftSendDowncastFails() {
+        let uncastInstance = MultiInterfaceImpl()
+        let instance = uncastInstance as NarrowInterface
+
+        let result = MultipleInheritanceChecker.checkIsMultiInterface(instance: instance)
+
+        XCTAssertFalse(result)
+    }
+
+    func testFromSwiftSendTwiceEquals() {
+        let instance = MultiInterfaceImpl()
+
+        let result = MultipleInheritanceChecker.checkNarrowEquality(instance1: instance, instance2: instance)
+
+        XCTAssertTrue(result)
+    }
+
+    func testFromSwiftRoundTripEquals() {
+        let uncastInstance = MultiInterfaceImpl()
+        let instance = uncastInstance as NarrowInterface
+
+        let result = uncastInstance === MultipleInheritanceChecker.narrowRoundTrip(instance: instance)
+
+        XCTAssertTrue(result)
+    }
+
+    func testFromSwiftRoundTripWithUpcastNotEquals() {
+        let instance = MultiInterfaceImpl()
+
+        let result = instance === MultipleInheritanceFactory.upcastMultiInterfaceToNarrow(instance: instance)
+
+        XCTAssertFalse(result)
+    }
+
+    static var allTests = [
+        ("testFromCppSendUpcastSucceeds", testFromCppSendUpcastSucceeds),
+        ("testFromCppSendDowncastFails", testFromCppSendDowncastFails),
+        ("testFromCppSendTwiceEquals", testFromCppSendTwiceEquals),
+        ("testFromCppRoundTripNotEquals", testFromCppRoundTripNotEquals),
+        ("testFromCppRoundTripWithUpcastNotEquals", testFromCppRoundTripWithUpcastNotEquals),
+        ("testFromSwiftSendUpcastSucceeds", testFromSwiftSendUpcastSucceeds),
+        ("testFromSwiftSendDowncastFails", testFromSwiftSendDowncastFails),
+        ("testFromSwiftSendTwiceEquals", testFromSwiftSendTwiceEquals),
+        ("testFromSwiftRoundTripEquals", testFromSwiftRoundTripEquals),
+        ("testFromSwiftRoundTripWithUpcastNotEquals", testFromSwiftRoundTripWithUpcastNotEquals)
+    ]
+}

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -58,6 +58,7 @@ func getAllTests() -> [XCTestCaseEntry] {
         testCase(MapsTests.allTests),
         testCase(MethodOverloadsTests.allTests),
         testCase(MultiListenerTests.allTests),
+        testCase(MultipleInheritanceTests.allTests),
         testCase(NestingTests.allTests),
         testCase(NullableAttributesTests.allTests),
         testCase(NullableCollectionsTests.allTests),

--- a/functional-tests/scripts/valgrind_suppressions
+++ b/functional-tests/scripts/valgrind_suppressions
@@ -49,6 +49,15 @@
    fun:*
 }
 {
+   allocateGenericValueMetadata
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:swift_allocateGenericValueMetadata
+   fun:*
+}
+{
    getFunctionTypeMetadata
 
    Memcheck:Leak

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -274,12 +274,6 @@ internal class CBridgeGenerator(
             else -> null
         }
 
-    private fun getAllParentTypes(allTypes: List<LimeType>): List<LimeType> {
-        if (allTypes.isEmpty()) return emptyList()
-        val parents = allTypes.filterIsInstance<LimeContainerWithInheritance>().mapNotNull { it.parent?.type }
-        return parents + getAllParentTypes(parents)
-    }
-
     class GenericTypesCollector(private val nameResolver: NameResolver) :
         LimeTypeRefsVisitor<List<LimeGenericType>>() {
 
@@ -328,7 +322,7 @@ internal class CBridgeGenerator(
 
         fun getAllParentTypes(allTypes: List<LimeType>): List<LimeType> {
             if (allTypes.isEmpty()) return emptyList()
-            val parents = allTypes.filterIsInstance<LimeContainerWithInheritance>().mapNotNull { it.parent?.type }
+            val parents = allTypes.filterIsInstance<LimeContainerWithInheritance>().flatMap { it.parents }.map { it.type }
             return parents + getAllParentTypes(parents)
         }
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
@@ -76,10 +76,10 @@ internal class CBridgeImplIncludeResolver(private val cppIncludeResolver: CppInc
         return containerIncludes + ownIncludes + parentIncludes
     }
 
-    private fun resolveParentIncludes(limeContainer: LimeContainerWithInheritance) =
-        ((limeContainer as? LimeInterface)?.parent?.type?.actualType)?.let {
-            cppIncludeResolver.resolveElementImports(it)
-        } ?: emptyList()
+    private fun resolveParentIncludes(limeContainer: LimeContainerWithInheritance): List<Include> {
+        val limeInterface = limeContainer as? LimeInterface ?: return emptyList()
+        return limeInterface.parents.flatMap { cppIncludeResolver.resolveElementImports(it.type.actualType) }
+    }
 
     private fun resolveStructIncludes(limeStruct: LimeStruct) =
         resolveContainerIncludes(limeStruct) + listOf(cppIncludeResolver.optionalInclude)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeBasicType
-import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
@@ -97,9 +96,6 @@ internal class SwiftGeneratorPredicates(
         "needsReducedConstructor" to { limeStruct: Any ->
             limeStruct is LimeStruct && limeStruct.internalFields.isNotEmpty() &&
                 limeStruct.internalFields.all { it.defaultValue != null }
-        },
-        "parentIsClass" to { limeClass: Any ->
-            limeClass is LimeClass && limeClass.parent?.type?.actualType is LimeClass
         },
         "skipDeclaration" to fun(limeType: Any): Boolean {
             if (limeType !is LimeType) return false

--- a/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
+++ b/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
@@ -21,17 +21,23 @@
 {{#constants}}
 {{>swift/SwiftConstant}}
 {{/constants}}
-{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
+{{#if this.parentInterfaces}}
+{{#if this.interfaceInheritedProperties}}
+{{#this.interfaceInheritedProperties}}
+{{>swift/SwiftProperty}}
+{{/this.interfaceInheritedProperties}}
+{{/if}}{{#unless this.interfaceInheritedProperties}}
 {{#inheritedProperties}}
 {{>swift/SwiftProperty}}
 {{/inheritedProperties}}
-{{/instanceOf}}{{/if}}
+{{/unless}}
+{{/if}}
 {{#set container=this}}{{#properties}}
 {{>swift/SwiftProperty}}
 {{/properties}}{{/set}}{{!!
 
 }}
-{{#unlessPredicate "parentIsClass"}}let c_instance : _baseRef
+{{#unless this.parentClass}}let c_instance : _baseRef
 
 init(c{{resolveName}}: _baseRef) {
     guard c{{resolveName}} != 0 else {
@@ -43,11 +49,11 @@ init(c{{resolveName}}: _baseRef) {
 deinit {
     {{resolveName "CBridge"}}_remove_swift_object_from_wrapper_cache(c_instance)
     {{resolveName "CBridge"}}_release_handle(c_instance)
-}{{/unlessPredicate}}{{!!
+}{{/unless}}{{!!
 
-}}{{#ifPredicate "parentIsClass"}}init(c{{resolveName}}: _baseRef) {
-    super.init(c{{resolveName parent.type.actualType}}: c{{resolveName}})
-}{{/ifPredicate}}
+}}{{#if this.parentClass}}init(c{{resolveName}}: _baseRef) {
+    super.init(c{{resolveName this.parentClass}}: c{{resolveName}})
+}{{/if}}
 
 {{#unless isInterface}}{{#classes}}
 {{>swift/SwiftClassDefinition}}
@@ -61,11 +67,17 @@ deinit {
 {{>swift/SwiftStructDefinition}}
 {{/structs}}{{/unless}}{{!!
 
-}}{{#if this.parent}}{{#instanceOf this.parent.type.actualType "LimeInterface"}}
+}}{{#if this.parentInterfaces}}
+{{#if this.interfaceInheritedFunctions}}
+{{#this.interfaceInheritedFunctions}}
+{{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}
+{{/this.interfaceInheritedFunctions}}
+{{/if}}{{#unless this.interfaceInheritedFunctions}}
 {{#inheritedFunctions}}
 {{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}
 {{/inheritedFunctions}}
-{{/instanceOf}}{{/if}}{{!!
+{{/unless}}
+{{/if}}{{!!
 
 }}{{#set container=this}}{{#functions}}
 {{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}

--- a/gluecodium/src/main/resources/templates/swift/GetReference.mustache
+++ b/gluecodium/src/main/resources/templates/swift/GetReference.mustache
@@ -35,12 +35,14 @@
         return RefHolder(0)
     }
 
+{{#unless isNarrow}}
     if let instanceReference = reference as? NativeBase {
         let handle_copy = {{resolveName "CBridge"}}_copy_handle(instanceReference.c_handle)
         return owning
             ? RefHolder(ref: handle_copy, release: {{resolveName "CBridge"}}_release_handle)
             : RefHolder(handle_copy)
     }
+{{/unless}}
 
     var functions = {{resolveName "CBridge"}}_FunctionTable()
 {{#ifPredicate "hasWeakSupport"}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
@@ -39,11 +39,11 @@ internal func _CBridgeInit{{resolveName "CBridge"}}(handle: _baseRef) -> UnsafeM
 }
 {{/notInstanceOf}}
 
-{{#unlessPredicate "parentIsClass"}}
+{{#unless this.parentClass}}
 extension {{>implName}}: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
-}{{/unlessPredicate}}{{!!
+}{{/unless}}{{!!
 
 }}{{#if attributes.equatable attributes.pointerEquatable logic="or"}}
 {{#instanceOf this "LimeInterface"}}
@@ -68,7 +68,7 @@ extension {{>implName}}: Hashable {
 }
 {{/if}}{{!!
 }}{{#unless attributes.equatable attributes.pointerEquatable logic="and"}}
-{{#instanceOf this "LimeClass"}}{{#unlessPredicate "parentIsClass"}}
+{{#instanceOf this "LimeClass"}}{{#unless this.parentClass}}
 
 extension {{>implName}}: Hashable {
     /// :nodoc:
@@ -81,7 +81,7 @@ extension {{>implName}}: Hashable {
         hasher.combine(c_handle)
     }
 }
-{{/unlessPredicate}}{{/instanceOf}}
+{{/unless}}{{/instanceOf}}
 {{/unless}}
 
 {{conversionVisibility}} func {{resolveName this "mangled"}}copyFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -20,7 +20,7 @@
   !}}
 {{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
 }}{{resolveName visibility}} class {{resolveName}}{{!!
-}}{{#if this.parent}}: {{resolveName this.parent}}{{/if}} {
+}}{{#if this.parents}}: {{#this.parents}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}} {
 
 {{#each typeAliases exceptions}}
 {{prefixPartial "swift/SwiftTypeAlias" "    "}}
@@ -36,11 +36,11 @@
 }}{{#if attributes.swift.label}}{{#isNotEq attributes.swift.label "_"}}{{attributes.swift.label}}: {{/isNotEq}}{{/if}}{{!!
 }}{{#unless attributes.swift.label}}{{resolveName}}: {{/unless}}{{!!
 }}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})
-        {{#ifPredicate class "parentIsClass"}}super.init(c{{resolveName parent.type.actualType}}: _result){{/ifPredicate}}{{!!
-        }}{{#unlessPredicate class "parentIsClass"}}guard _result != 0 else {
+        {{#if parentClass}}super.init(c{{resolveName parentClass}}: _result){{/if}}{{!!
+        }}{{#unless parentClass}}guard _result != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
-        c_instance = _result{{/unlessPredicate}}
+        c_instance = _result{{/unless}}
         {{resolveName class "CBridge"}}_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
     }
 

--- a/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftInterfaceDefinition.mustache
@@ -20,7 +20,8 @@
   !}}
 {{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{!!
 }}{{resolveName visibility}} protocol {{resolveName}} : {{!!
-}}{{#if this.parent}}{{resolveName this.parent}}{{/if}}{{#unless this.parent}}AnyObject{{/unless}} {
+}}{{#if this.parents}}{{#this.parents}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}}{{!!
+}}{{#unless this.parents}}AnyObject{{/unless}} {
 {{#set isInterface=true interface=this}}{{#each typeAliases exceptions}}
 {{prefixPartial "swift/SwiftTypeAlias" "    "}}
 {{/each}}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/FirstParentIsClassClass.swift
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/FirstParentIsClassClass.swift
@@ -1,0 +1,97 @@
+//
+//
+import Foundation
+public class FirstParentIsClassClass: ParentClass, ParentNarrowOne {
+    public var parentPropertyOne: String {
+        get {
+            let c_result_handle = smoke_ParentNarrowOne_parentPropertyOne_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_ParentNarrowOne_parentPropertyOne_set(self.c_instance, c_value.ref)
+        }
+    }
+    public var childProperty: String {
+        get {
+            let c_result_handle = smoke_FirstParentIsClassClass_childProperty_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_FirstParentIsClassClass_childProperty_set(self.c_instance, c_value.ref)
+        }
+    }
+    init(cFirstParentIsClassClass: _baseRef) {
+        super.init(cParentClass: cFirstParentIsClassClass)
+    }
+    public func parentFunctionOne() -> Void {
+        smoke_ParentNarrowOne_parentFunctionOne(self.c_instance)
+    }
+    public func childFunction() -> Void {
+        smoke_FirstParentIsClassClass_childFunction(self.c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_FirstParentIsClassClass")
+internal func _CBridgeInitsmoke_FirstParentIsClassClass(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = FirstParentIsClassClass(cFirstParentIsClassClass: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: FirstParentIsClassClass?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_FirstParentIsClassClass_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_FirstParentIsClassClass_release_handle)
+        : RefHolder(handle_copy)
+}
+internal func FirstParentIsClassClass_copyFromCType(_ handle: _baseRef) -> FirstParentIsClassClass {
+    if let swift_pointer = smoke_FirstParentIsClassClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? FirstParentIsClassClass {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_FirstParentIsClassClass_get_typed(smoke_FirstParentIsClassClass_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? FirstParentIsClassClass {
+        smoke_FirstParentIsClassClass_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func FirstParentIsClassClass_moveFromCType(_ handle: _baseRef) -> FirstParentIsClassClass {
+    if let swift_pointer = smoke_FirstParentIsClassClass_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? FirstParentIsClassClass {
+        smoke_FirstParentIsClassClass_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_FirstParentIsClassClass_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? FirstParentIsClassClass {
+        smoke_FirstParentIsClassClass_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func FirstParentIsClassClass_copyFromCType(_ handle: _baseRef) -> FirstParentIsClassClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return FirstParentIsClassClass_moveFromCType(handle) as FirstParentIsClassClass
+}
+internal func FirstParentIsClassClass_moveFromCType(_ handle: _baseRef) -> FirstParentIsClassClass? {
+    guard handle != 0 else {
+        return nil
+    }
+    return FirstParentIsClassClass_moveFromCType(handle) as FirstParentIsClassClass
+}
+internal func copyToCType(_ swiftClass: FirstParentIsClassClass) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: FirstParentIsClassClass) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: FirstParentIsClassClass?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: FirstParentIsClassClass?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/FirstParentIsInterfaceInterface.swift
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/FirstParentIsInterfaceInterface.swift
@@ -1,0 +1,186 @@
+//
+//
+import Foundation
+public protocol FirstParentIsInterfaceInterface : ParentInterface, ParentNarrowOne {
+    var parentProperty: String { get set }
+    var parentPropertyOne: String { get set }
+    var childProperty: String { get set }
+    func parentFunction() -> Void
+    func parentFunctionOne() -> Void
+    func childFunction() -> Void
+}
+internal class _FirstParentIsInterfaceInterface: FirstParentIsInterfaceInterface {
+    var parentProperty: String {
+        get {
+            let c_result_handle = smoke_ParentInterface_parentProperty_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_ParentInterface_parentProperty_set(self.c_instance, c_value.ref)
+        }
+    }
+    var parentPropertyOne: String {
+        get {
+            let c_result_handle = smoke_ParentNarrowOne_parentPropertyOne_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_ParentNarrowOne_parentPropertyOne_set(self.c_instance, c_value.ref)
+        }
+    }
+    var childProperty: String {
+        get {
+            let c_result_handle = smoke_FirstParentIsInterfaceInterface_childProperty_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_FirstParentIsInterfaceInterface_childProperty_set(self.c_instance, c_value.ref)
+        }
+    }
+    let c_instance : _baseRef
+    init(cFirstParentIsInterfaceInterface: _baseRef) {
+        guard cFirstParentIsInterfaceInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cFirstParentIsInterfaceInterface
+    }
+    deinit {
+        smoke_FirstParentIsInterfaceInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_FirstParentIsInterfaceInterface_release_handle(c_instance)
+    }
+    public func parentFunction() -> Void {
+        smoke_ParentInterface_parentFunction(self.c_instance)
+    }
+    public func parentFunctionOne() -> Void {
+        smoke_ParentNarrowOne_parentFunctionOne(self.c_instance)
+    }
+    public func childFunction() -> Void {
+        smoke_FirstParentIsInterfaceInterface_childFunction(self.c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_FirstParentIsInterfaceInterface")
+internal func _CBridgeInitsmoke_FirstParentIsInterfaceInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _FirstParentIsInterfaceInterface(cFirstParentIsInterfaceInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: FirstParentIsInterfaceInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_FirstParentIsInterfaceInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_FirstParentIsInterfaceInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    var functions = smoke_FirstParentIsInterfaceInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_ParentInterface_parentFunction = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        swift_class.parentFunction()
+    }
+    functions.smoke_ParentNarrowOne_parentFunctionOne = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        swift_class.parentFunctionOne()
+    }
+    functions.smoke_FirstParentIsInterfaceInterface_childFunction = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        swift_class.childFunction()
+    }
+    functions.smoke_ParentInterface_parentProperty_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        return copyToCType(swift_class.parentProperty).ref
+    }
+    functions.smoke_ParentInterface_parentProperty_set = {(swift_class_pointer, value) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        swift_class.parentProperty = moveFromCType(value)
+    }
+    functions.smoke_ParentNarrowOne_parentPropertyOne_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        return copyToCType(swift_class.parentPropertyOne).ref
+    }
+    functions.smoke_ParentNarrowOne_parentPropertyOne_set = {(swift_class_pointer, value) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        swift_class.parentPropertyOne = moveFromCType(value)
+    }
+    functions.smoke_FirstParentIsInterfaceInterface_childProperty_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        return copyToCType(swift_class.childProperty).ref
+    }
+    functions.smoke_FirstParentIsInterfaceInterface_childProperty_set = {(swift_class_pointer, value) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! FirstParentIsInterfaceInterface
+        swift_class.childProperty = moveFromCType(value)
+    }
+    let proxy = smoke_FirstParentIsInterfaceInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_FirstParentIsInterfaceInterface_release_handle) : RefHolder(proxy)
+}
+extension _FirstParentIsInterfaceInterface: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+internal func FirstParentIsInterfaceInterface_copyFromCType(_ handle: _baseRef) -> FirstParentIsInterfaceInterface {
+    if let swift_pointer = smoke_FirstParentIsInterfaceInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? FirstParentIsInterfaceInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_FirstParentIsInterfaceInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? FirstParentIsInterfaceInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_FirstParentIsInterfaceInterface_get_typed(smoke_FirstParentIsInterfaceInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? FirstParentIsInterfaceInterface {
+        smoke_FirstParentIsInterfaceInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func FirstParentIsInterfaceInterface_moveFromCType(_ handle: _baseRef) -> FirstParentIsInterfaceInterface {
+    if let swift_pointer = smoke_FirstParentIsInterfaceInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? FirstParentIsInterfaceInterface {
+        smoke_FirstParentIsInterfaceInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_FirstParentIsInterfaceInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? FirstParentIsInterfaceInterface {
+        smoke_FirstParentIsInterfaceInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_FirstParentIsInterfaceInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? FirstParentIsInterfaceInterface {
+        smoke_FirstParentIsInterfaceInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func FirstParentIsInterfaceInterface_copyFromCType(_ handle: _baseRef) -> FirstParentIsInterfaceInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return FirstParentIsInterfaceInterface_moveFromCType(handle) as FirstParentIsInterfaceInterface
+}
+internal func FirstParentIsInterfaceInterface_moveFromCType(_ handle: _baseRef) -> FirstParentIsInterfaceInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return FirstParentIsInterfaceInterface_moveFromCType(handle) as FirstParentIsInterfaceInterface
+}
+internal func copyToCType(_ swiftClass: FirstParentIsInterfaceInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: FirstParentIsInterfaceInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: FirstParentIsInterfaceInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: FirstParentIsInterfaceInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/ParentNarrowOne.swift
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/ParentNarrowOne.swift
@@ -1,0 +1,115 @@
+//
+//
+import Foundation
+public protocol ParentNarrowOne : AnyObject {
+    var parentPropertyOne: String { get set }
+    func parentFunctionOne() -> Void
+}
+internal class _ParentNarrowOne: ParentNarrowOne {
+    var parentPropertyOne: String {
+        get {
+            let c_result_handle = smoke_ParentNarrowOne_parentPropertyOne_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_ParentNarrowOne_parentPropertyOne_set(self.c_instance, c_value.ref)
+        }
+    }
+    let c_instance : _baseRef
+    init(cParentNarrowOne: _baseRef) {
+        guard cParentNarrowOne != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cParentNarrowOne
+    }
+    deinit {
+        smoke_ParentNarrowOne_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_ParentNarrowOne_release_handle(c_instance)
+    }
+    public func parentFunctionOne() -> Void {
+        smoke_ParentNarrowOne_parentFunctionOne(self.c_instance)
+    }
+}
+internal func getRef(_ ref: ParentNarrowOne?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    var functions = smoke_ParentNarrowOne_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_ParentNarrowOne_parentFunctionOne = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ParentNarrowOne
+        swift_class.parentFunctionOne()
+    }
+    functions.smoke_ParentNarrowOne_parentPropertyOne_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ParentNarrowOne
+        return copyToCType(swift_class.parentPropertyOne).ref
+    }
+    functions.smoke_ParentNarrowOne_parentPropertyOne_set = {(swift_class_pointer, value) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ParentNarrowOne
+        swift_class.parentPropertyOne = moveFromCType(value)
+    }
+    let proxy = smoke_ParentNarrowOne_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_ParentNarrowOne_release_handle) : RefHolder(proxy)
+}
+extension _ParentNarrowOne: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+internal func ParentNarrowOne_copyFromCType(_ handle: _baseRef) -> ParentNarrowOne {
+    if let swift_pointer = smoke_ParentNarrowOne_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentNarrowOne {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ParentNarrowOne_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentNarrowOne {
+        return re_constructed
+    }
+    let result = _ParentNarrowOne(cParentNarrowOne: smoke_ParentNarrowOne_copy_handle(handle))
+    smoke_ParentNarrowOne_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func ParentNarrowOne_moveFromCType(_ handle: _baseRef) -> ParentNarrowOne {
+    if let swift_pointer = smoke_ParentNarrowOne_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentNarrowOne {
+        smoke_ParentNarrowOne_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ParentNarrowOne_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentNarrowOne {
+        smoke_ParentNarrowOne_release_handle(handle)
+        return re_constructed
+    }
+    let result = _ParentNarrowOne(cParentNarrowOne: handle)
+    smoke_ParentNarrowOne_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func ParentNarrowOne_copyFromCType(_ handle: _baseRef) -> ParentNarrowOne? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ParentNarrowOne_moveFromCType(handle) as ParentNarrowOne
+}
+internal func ParentNarrowOne_moveFromCType(_ handle: _baseRef) -> ParentNarrowOne? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ParentNarrowOne_moveFromCType(handle) as ParentNarrowOne
+}
+internal func copyToCType(_ swiftClass: ParentNarrowOne) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ParentNarrowOne) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ParentNarrowOne?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ParentNarrowOne?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Updated Swift templates for classes and interfaces to support multiple
inheritance.

Updated GetReference Swift template to force proxy creation for narrow
interfaces (instead of trying to extract a native handle). This circumvents the
potential issues of invalid reinterpret-casts for second+ parent types. This
behavior is already documented in "lime_idl.md".

Added smoke and functional tests.

Resolves: #1080
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>