### PR TITLE
Add support for multiple inheritance in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for multiple inheritance in LIME IDL.
+
 ## 9.5.4
 Release date: 2021-10-01
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -279,7 +279,7 @@ feature(Inheritance cpp android swift dart SOURCES
     input/lime/ConstructorOverride.lime
 )
 
-feature(MultipleInheritance cpp android swift SOURCES
+feature(MultipleInheritance cpp android swift dart SOURCES
     input/src/cpp/MultipleInheritance.cpp
     input/lime/MultipleInheritance.lime
 )

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -48,6 +48,7 @@ import "test/Locales_test.dart" as LocalesTests;
 import "test/Maps_test.dart" as MapsTests;
 import "test/MethodOverloads_test.dart" as MethodOverloadsTests;
 import "test/MultiListener_test.dart" as MultiListenerTests;
+import "test/MultipleInheritance_test.dart" as MultipleInheritanceTests;
 import "test/Nesting_test.dart" as NestingTests;
 import "test/Nullable_test.dart" as NullableTests;
 import "test/OptimizedLists_test.dart" as OptimizedListsTests;
@@ -93,6 +94,7 @@ final _allTests = [
   MapsTests.main,
   MethodOverloadsTests.main,
   MultiListenerTests.main,
+  MultipleInheritanceTests.main,
   NestingTests.main,
   NullableTests.main,
   OptimizedListsTests.main,

--- a/functional-tests/functional/dart/test/MultipleInheritance_test.dart
+++ b/functional-tests/functional/dart/test/MultipleInheritance_test.dart
@@ -1,0 +1,124 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "dart:typed_data";
+import "package:test/test.dart";
+import "package:functional/another.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Multiple inheritance");
+
+class MultiInterfaceImpl implements MultiInterface {
+  @override
+  void childFunction() { }
+  @override
+  String childProperty = "";
+
+  @override
+  void parentFunction() { }
+  @override
+  String parentProperty = "";
+
+  @override
+  String parentFunctionLight() => "dart face";
+  @override
+  String parentPropertyLight = "";
+
+  @override
+  release() {}
+}
+
+void main() {
+  _testSuite.test("from C++ send upcast succeeds", () {
+    final instance = MultipleInheritanceFactory.getMultiClass();
+
+    final result = instance is NarrowInterface;
+
+    expect(result, isTrue);
+  });
+  _testSuite.test("from C++ send downcast fails", () {
+    final instance = MultipleInheritanceFactory.getMultiClassAsNarrow();
+
+    final result = instance is MultiClass;
+
+    expect(result, isFalse);
+  });
+  _testSuite.test("from C++ send twice equals", () {
+    final instance1 = MultipleInheritanceFactory.getMultiClassSingleton();
+    final instance2 = MultipleInheritanceFactory.getMultiClassSingleton();
+
+    final result = instance1 == instance2;
+
+    expect(result, isTrue);
+  });
+  _testSuite.test("from C++ round trip not equals", () {
+    final instance = MultipleInheritanceFactory.getMultiClassSingleton();
+
+    final result = MultipleInheritanceChecker.checkSingletonEquality(instance);
+
+    expect(result, isFalse);
+  });
+  _testSuite.test("from C++ round trip with upcast not equals", () {
+    final uncastInstance = MultipleInheritanceFactory.getMultiClass();
+    final instance = uncastInstance as NarrowInterface;
+
+    final result = MultipleInheritanceChecker.checkSingletonEquality(instance);
+
+    expect(result, isFalse);
+  });
+  _testSuite.test("from Dart send upcast succeeds", () {
+    final instance = MultiInterfaceImpl();
+
+    final result = MultipleInheritanceChecker.checkIsNarrow(instance);
+
+    expect(result, isTrue);
+  });
+  _testSuite.test("from Dart send downcast fails", () {
+    final uncastInstance = MultiInterfaceImpl();
+    final instance = uncastInstance as NarrowInterface;
+
+    final result = MultipleInheritanceChecker.checkIsMultiInterface(instance);
+
+    expect(result, isFalse);
+  });
+  _testSuite.test("from Dart send twice equals", () {
+    final instance = MultiInterfaceImpl();
+
+    final result = MultipleInheritanceChecker.checkNarrowEquality(instance, instance);
+
+    expect(result, isTrue);
+  });
+  _testSuite.test("from Dart round trip equals", () {
+    final uncastInstance = MultiInterfaceImpl();
+    final instance = uncastInstance as NarrowInterface;
+
+    final result = uncastInstance == MultipleInheritanceChecker.narrowRoundTrip(instance);
+
+    expect(result, isTrue);
+  });
+  _testSuite.test("from Dart round trip with upcast not equals", () {
+    final instance = MultiInterfaceImpl();
+
+    final result = instance == MultipleInheritanceFactory.upcastMultiInterfaceToNarrow(instance);
+
+    expect(result, isFalse);
+  });
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
@@ -79,7 +79,7 @@ internal open class GenericImportsCollector<T>(
             exceptions.map { it.errorType }
     }
 
-    private fun collectTypeRefs(limeFunction: LimeFunction) =
+    protected fun collectTypeRefs(limeFunction: LimeFunction) =
         limeFunction.parameters.map { it.typeRef } +
             limeFunction.returnType.typeRef +
             listOfNotNull(limeFunction.thrownType?.typeRef) +

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -81,7 +81,7 @@ internal class DartDeclarationImportResolver(srcPath: String) : DartImportResolv
 
     private fun resolveClassImports(limeClass: LimeClass) =
         when {
-            limeClass.parent != null || limeClass.visibility.isOpen -> classInterfaceImports
+            limeClass.parents.isNotEmpty() || limeClass.visibility.isOpen -> classInterfaceImports
             else -> listOf(tokenCacheImport, nativeBaseImport)
         } + if (hasStaticFunctions(limeClass)) listOf(metaPackageImport) else emptyList()
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -228,7 +228,7 @@ internal class DartGenerator : Generator {
 
     private fun getTypeRepositories(allTypes: List<LimeType>) =
         allTypes.filterIsInstance<LimeInterface>() +
-            allTypes.filterIsInstance<LimeClass>().filter { it.parent != null || it.visibility.isOpen }
+            allTypes.filterIsInstance<LimeClass>().filter { it.parents.isNotEmpty() || it.visibility.isOpen }
 
     private fun generateFfi(
         rootElement: LimeNamedElement,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
@@ -21,18 +21,16 @@ package com.here.gluecodium.generator.dart
 
 import com.here.gluecodium.generator.common.GenericImportsCollector
 import com.here.gluecodium.generator.common.ImportsResolver
+import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
-import com.here.gluecodium.model.lime.LimeInterface
-import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal class DartImportsCollector(importsResolver: ImportsResolver<DartImport>) :
     GenericImportsCollector<DartImport>(importsResolver, collectTypeRefImports = true, parentTypeFilter = { true }) {
 
-    override fun collectParentTypeRefs(limeContainer: LimeContainerWithInheritance): List<LimeTypeRef> {
-        val parentTypeRef = limeContainer.parent
-        return when (parentTypeRef?.type?.actualType) {
-            is LimeInterface -> super.collectParentTypeRefs(limeContainer)
-            else -> listOfNotNull(parentTypeRef)
+    override fun collectParentTypeRefs(limeContainer: LimeContainerWithInheritance) =
+        when (limeContainer) {
+            is LimeClass -> limeContainer.interfaceInheritedFunctions.flatMap { collectTypeRefs(it) } +
+                limeContainer.interfaceInheritedProperties.map { it.typeRef } + limeContainer.parents
+            else -> super.collectParentTypeRefs(limeContainer)
         }
-    }
 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -19,7 +19,8 @@
   !
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
+abstract class {{resolveName}}{{!!
+}}{{#if this.parents}} implements {{#this.parents}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}} {
 {{#set parent=this container=this}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
   factory {{resolveName parent}}{{>dart/DartConstructorName}}({{!!
@@ -82,7 +83,7 @@ final _{{resolveName "Ffi"}}ReleaseHandle = __lib.catchArgumentError(() => __lib
   >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_release_handle'));
 {{#if attributes.equatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{>dart/DartFfiEqualityFunction}}{{/if}}
-{{#if this.parent visibility.isOpen logic="or"}}
+{{#if this.parents visibility.isOpen logic="or"}}
 final _{{resolveName "Ffi"}}GetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -99,37 +100,37 @@ final _{{resolveName "Ffi"}}GetTypeId = __lib.catchArgumentError(() => __lib.nat
 /// @nodoc
 @visibleForTesting
 {{/ifPredicate}}
-class {{resolveName}}$Impl extends {{#if hasClassParent}}{{resolveName parent}}$Impl{{/if}}{{!!
-}}{{#unless hasClassParent}}__lib.NativeBase{{/unless}} implements {{resolveName}} {
+class {{resolveName}}$Impl extends {{#if this.parentClass}}{{resolveName this.parentClass}}$Impl{{/if}}{{!!
+}}{{#unless this.parentClass}}__lib.NativeBase{{/unless}} implements {{resolveName}} {
 
   {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
 
   @override
   void release() {}
 
-{{#set inheritanceParent=this.parent parent=this container=this ignoreStatic=true}}{{#constructors}}
+{{#set parent=this container=this ignoreStatic=true}}{{#constructors}}
 {{prefixPartial "dartConstructor" "  "}}
 {{/constructors}}
 {{#functions}}
 {{#unless isStatic}}  @override
 {{/unless}}
 {{prefixPartial "dart/DartFunction" "  "}}
-{{/functions}}{{#if inheritanceParent}}{{#instanceOf inheritanceParent.type.actualType "LimeInterface"}}
+{{/functions}}{{#if container.parentInterfaces}}
 {{#inheritedFunctions}}
 {{#unless isStatic}}  @override
 {{/unless}}
 {{prefixPartial "dart/DartFunction" "  "}}
-{{/inheritedFunctions}}{{/instanceOf}}{{/if}}
+{{/inheritedFunctions}}{{/if}}
 {{#set override=true skipDocs=true}}{{#properties}}{{#if attributes.cached}}
 {{prefixPartial "dartCachedProperty" "  "}}
 {{/if}}{{#unless attributes.cached}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/unless}}{{/properties}}
-{{#if inheritanceParent}}{{#instanceOf inheritanceParent.type.actualType "LimeInterface"}}
+{{#if container.parentInterfaces}}
 {{#inheritedProperties}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/inheritedProperties}}
-{{/instanceOf}}{{/if}}{{/set}}{{/set}}
+{{/if}}{{/set}}{{/set}}
 {{#if attributes.equatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}
 }
@@ -141,14 +142,14 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is {{resolveName}}) return instance;
 
-{{#if this.parent visibility.isOpen logic="or"}}
+{{#if this.parents visibility.isOpen logic="or"}}
   final _typeIdHandle = _{{resolveName "Ffi"}}GetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
 
 {{/if}}
   final _copiedHandle = _{{resolveName "Ffi"}}CopyHandle(handle);
-  final result = {{#if this.parent visibility.isOpen logic="or"}}factoryConstructor != null
+  final result = {{#if this.parents visibility.isOpen logic="or"}}factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
     : {{/if}}{{resolveName}}$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -19,7 +19,8 @@
   !
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-abstract class {{resolveName}} {{#if this.parent}}implements {{resolveName this.parent}} {{/if}}{
+abstract class {{resolveName}}{{!!
+}}{{#if this.parents}} implements {{#this.parents}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}} {
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
 {{prefixPartial "dart/DartDocumentation" "  "}}
   factory {{resolveName}}(
@@ -227,7 +228,9 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}SetStatic(Object _obj, {{resolve
 {{/unless}}{{/each}}{{/set}}
 
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
+{{#unless isNarrow}}
   if (value is __lib.NativeBase) return _{{resolveName "Ffi"}}CopyHandle((value as __lib.NativeBase).handle);
+{{/unless}}
 
   final result = _{{resolveName "Ffi"}}CreateProxy(
     __lib.getObjectToken(value),

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
@@ -1,0 +1,138 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/parent_class.dart';
+import 'package:library/src/smoke/parent_narrow_one.dart';
+abstract class FirstParentIsClassClass implements ParentClass, ParentNarrowOne {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
+  void childFunction();
+  String get childProperty;
+  set childProperty(String value);
+}
+// FirstParentIsClassClass "private" section, not exported.
+final _smokeFirstparentisclassclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_FirstParentIsClassClass_register_finalizer'));
+final _smokeFirstparentisclassclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FirstParentIsClassClass_copy_handle'));
+final _smokeFirstparentisclassclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FirstParentIsClassClass_release_handle'));
+final _smokeFirstparentisclassclassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FirstParentIsClassClass_get_type_id'));
+class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstParentIsClassClass {
+  FirstParentIsClassClass$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  void childFunction() {
+    final _childFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_childFunction'));
+    final _handle = this.handle;
+    _childFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  @override
+  void parentFunction() {
+    final _parentFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_parentFunction'));
+    final _handle = this.handle;
+    _parentFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  @override
+  void parentFunctionOne() {
+    final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentFunctionOne'));
+    final _handle = this.handle;
+    _parentFunctionOneFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  @override
+  String get childProperty {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_childProperty_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  set childProperty(String value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_FirstParentIsClassClass_childProperty_set__String'));
+    final _valueHandle = stringToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+  @override
+  String get parentProperty {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentClass_parentProperty_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  set parentProperty(String value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentClass_parentProperty_set__String'));
+    final _valueHandle = stringToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+  @override
+  String get parentPropertyOne {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentPropertyOne_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
+    }
+  }
+  @override
+  set parentPropertyOne(String value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentNarrowOne_parentPropertyOne_set__String'));
+    final _valueHandle = stringToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+}
+Pointer<Void> smokeFirstparentisclassclassToFfi(FirstParentIsClassClass value) =>
+  _smokeFirstparentisclassclassCopyHandle((value as __lib.NativeBase).handle);
+FirstParentIsClassClass smokeFirstparentisclassclassFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is FirstParentIsClassClass) return instance;
+  final _typeIdHandle = _smokeFirstparentisclassclassGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeFirstparentisclassclassCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : FirstParentIsClassClass$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeFirstparentisclassclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeFirstparentisclassclassReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeFirstparentisclassclassReleaseHandle(handle);
+Pointer<Void> smokeFirstparentisclassclassToFfiNullable(FirstParentIsClassClass? value) =>
+  value != null ? smokeFirstparentisclassclassToFfi(value) : Pointer<Void>.fromAddress(0);
+FirstParentIsClassClass? smokeFirstparentisclassclassFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeFirstparentisclassclassFromFfi(handle) : null;
+void smokeFirstparentisclassclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFirstparentisclassclassReleaseHandle(handle);
+// End of FirstParentIsClassClass "private" section.

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
@@ -1,0 +1,278 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/parent_interface.dart';
+import 'package:library/src/smoke/parent_narrow_one.dart';
+abstract class FirstParentIsInterfaceInterface implements ParentInterface, ParentNarrowOne {
+  factory FirstParentIsInterfaceInterface(
+    void Function() parentFunctionLambda,
+    void Function() parentFunctionOneLambda,
+    void Function() childFunctionLambda,
+    String Function() parentPropertyGetLambda,
+    void Function(String) parentPropertySetLambda,
+    String Function() parentPropertyOneGetLambda,
+    void Function(String) parentPropertyOneSetLambda,
+    String Function() childPropertyGetLambda,
+    void Function(String) childPropertySetLambda
+  ) => FirstParentIsInterfaceInterface$Lambdas(
+    parentFunctionLambda,
+    parentFunctionOneLambda,
+    childFunctionLambda,
+    parentPropertyGetLambda,
+    parentPropertySetLambda,
+    parentPropertyOneGetLambda,
+    parentPropertyOneSetLambda,
+    childPropertyGetLambda,
+    childPropertySetLambda
+  );
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
+  void childFunction();
+  String get childProperty;
+  set childProperty(String value);
+}
+// FirstParentIsInterfaceInterface "private" section, not exported.
+final _smokeFirstparentisinterfaceinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_FirstParentIsInterfaceInterface_register_finalizer'));
+final _smokeFirstparentisinterfaceinterfaceCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FirstParentIsInterfaceInterface_copy_handle'));
+final _smokeFirstparentisinterfaceinterfaceReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FirstParentIsInterfaceInterface_release_handle'));
+final _smokeFirstparentisinterfaceinterfaceCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
+  >('library_smoke_FirstParentIsInterfaceInterface_create_proxy'));
+final _smokeFirstparentisinterfaceinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FirstParentIsInterfaceInterface_get_type_id'));
+class FirstParentIsInterfaceInterface$Lambdas implements FirstParentIsInterfaceInterface {
+  void Function() parentFunctionLambda;
+  void Function() parentFunctionOneLambda;
+  void Function() childFunctionLambda;
+  String Function() parentPropertyGetLambda;
+  void Function(String) parentPropertySetLambda;
+  String Function() parentPropertyOneGetLambda;
+  void Function(String) parentPropertyOneSetLambda;
+  String Function() childPropertyGetLambda;
+  void Function(String) childPropertySetLambda;
+  FirstParentIsInterfaceInterface$Lambdas(
+    this.parentFunctionLambda,
+    this.parentFunctionOneLambda,
+    this.childFunctionLambda,
+    this.parentPropertyGetLambda,
+    this.parentPropertySetLambda,
+    this.parentPropertyOneGetLambda,
+    this.parentPropertyOneSetLambda,
+    this.childPropertyGetLambda,
+    this.childPropertySetLambda
+  );
+  @override
+  void release() {}
+  @override
+  void parentFunction() =>
+    parentFunctionLambda();
+  @override
+  void parentFunctionOne() =>
+    parentFunctionOneLambda();
+  @override
+  void childFunction() =>
+    childFunctionLambda();
+  @override
+  String get parentProperty => parentPropertyGetLambda();
+  @override
+  set parentProperty(String value) => parentPropertySetLambda(value);
+  @override
+  String get parentPropertyOne => parentPropertyOneGetLambda();
+  @override
+  set parentPropertyOne(String value) => parentPropertyOneSetLambda(value);
+  @override
+  String get childProperty => childPropertyGetLambda();
+  @override
+  set childProperty(String value) => childPropertySetLambda(value);
+}
+class FirstParentIsInterfaceInterface$Impl extends __lib.NativeBase implements FirstParentIsInterfaceInterface {
+  FirstParentIsInterfaceInterface$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  void parentFunction() {
+    final _parentFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_parentFunction'));
+    final _handle = this.handle;
+    _parentFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  @override
+  void parentFunctionOne() {
+    final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentFunctionOne'));
+    final _handle = this.handle;
+    _parentFunctionOneFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  @override
+  void childFunction() {
+    final _childFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsInterfaceInterface_childFunction'));
+    final _handle = this.handle;
+    _childFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  String get parentProperty {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_parentProperty_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
+    }
+  }
+  set parentProperty(String value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_parentProperty_set__String'));
+    final _valueHandle = stringToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+  String get parentPropertyOne {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentPropertyOne_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
+    }
+  }
+  set parentPropertyOne(String value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentNarrowOne_parentPropertyOne_set__String'));
+    final _valueHandle = stringToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+  String get childProperty {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FirstParentIsInterfaceInterface_childProperty_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
+    }
+  }
+  set childProperty(String value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_FirstParentIsInterfaceInterface_childProperty_set__String'));
+    final _valueHandle = stringToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+}
+int _smokeFirstparentisinterfaceinterfaceparentFunctionStatic(Object _obj) {
+  try {
+    (_obj as FirstParentIsInterfaceInterface).parentFunction();
+  } finally {
+  }
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfaceparentFunctionOneStatic(Object _obj) {
+  try {
+    (_obj as FirstParentIsInterfaceInterface).parentFunctionOne();
+  } finally {
+  }
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfacechildFunctionStatic(Object _obj) {
+  try {
+    (_obj as FirstParentIsInterfaceInterface).childFunction();
+  } finally {
+  }
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfaceparentPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
+  _result.value = stringToFfi((_obj as FirstParentIsInterfaceInterface).parentProperty);
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfaceparentPropertySetStatic(Object _obj, Pointer<Void> _value) {
+  try {
+    (_obj as FirstParentIsInterfaceInterface).parentProperty =
+      stringFromFfi(_value);
+  } finally {
+    stringReleaseFfiHandle(_value);
+  }
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfaceparentPropertyOneGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
+  _result.value = stringToFfi((_obj as FirstParentIsInterfaceInterface).parentPropertyOne);
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfaceparentPropertyOneSetStatic(Object _obj, Pointer<Void> _value) {
+  try {
+    (_obj as FirstParentIsInterfaceInterface).parentPropertyOne =
+      stringFromFfi(_value);
+  } finally {
+    stringReleaseFfiHandle(_value);
+  }
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfacechildPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
+  _result.value = stringToFfi((_obj as FirstParentIsInterfaceInterface).childProperty);
+  return 0;
+}
+int _smokeFirstparentisinterfaceinterfacechildPropertySetStatic(Object _obj, Pointer<Void> _value) {
+  try {
+    (_obj as FirstParentIsInterfaceInterface).childProperty =
+      stringFromFfi(_value);
+  } finally {
+    stringReleaseFfiHandle(_value);
+  }
+  return 0;
+}
+Pointer<Void> smokeFirstparentisinterfaceinterfaceToFfi(FirstParentIsInterfaceInterface value) {
+  if (value is __lib.NativeBase) return _smokeFirstparentisinterfaceinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final result = _smokeFirstparentisinterfaceinterfaceCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Uint8 Function(Handle)>(_smokeFirstparentisinterfaceinterfaceparentFunctionStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle)>(_smokeFirstparentisinterfaceinterfaceparentFunctionOneStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle)>(_smokeFirstparentisinterfaceinterfacechildFunctionStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeFirstparentisinterfaceinterfaceparentPropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeFirstparentisinterfaceinterfaceparentPropertySetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeFirstparentisinterfaceinterfaceparentPropertyOneGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeFirstparentisinterfaceinterfaceparentPropertyOneSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeFirstparentisinterfaceinterfacechildPropertyGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeFirstparentisinterfaceinterfacechildPropertySetStatic, __lib.unknownError)
+  );
+  return result;
+}
+FirstParentIsInterfaceInterface smokeFirstparentisinterfaceinterfaceFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is FirstParentIsInterfaceInterface) return instance;
+  final _typeIdHandle = _smokeFirstparentisinterfaceinterfaceGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeFirstparentisinterfaceinterfaceCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : FirstParentIsInterfaceInterface$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeFirstparentisinterfaceinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeFirstparentisinterfaceinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeFirstparentisinterfaceinterfaceReleaseHandle(handle);
+Pointer<Void> smokeFirstparentisinterfaceinterfaceToFfiNullable(FirstParentIsInterfaceInterface? value) =>
+  value != null ? smokeFirstparentisinterfaceinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+FirstParentIsInterfaceInterface? smokeFirstparentisinterfaceinterfaceFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeFirstparentisinterfaceinterfaceFromFfi(handle) : null;
+void smokeFirstparentisinterfaceinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFirstparentisinterfaceinterfaceReleaseHandle(handle);
+// End of FirstParentIsInterfaceInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
@@ -1,0 +1,145 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+abstract class ParentNarrowOne {
+  factory ParentNarrowOne(
+    void Function() parentFunctionOneLambda,
+    String Function() parentPropertyOneGetLambda,
+    void Function(String) parentPropertyOneSetLambda
+  ) => ParentNarrowOne$Lambdas(
+    parentFunctionOneLambda,
+    parentPropertyOneGetLambda,
+    parentPropertyOneSetLambda
+  );
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
+  void parentFunctionOne();
+  String get parentPropertyOne;
+  set parentPropertyOne(String value);
+}
+// ParentNarrowOne "private" section, not exported.
+final _smokeParentnarrowoneRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_ParentNarrowOne_register_finalizer'));
+final _smokeParentnarrowoneCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ParentNarrowOne_copy_handle'));
+final _smokeParentnarrowoneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ParentNarrowOne_release_handle'));
+final _smokeParentnarrowoneCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer, Pointer, Pointer)
+  >('library_smoke_ParentNarrowOne_create_proxy'));
+final _smokeParentnarrowoneGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ParentNarrowOne_get_type_id'));
+class ParentNarrowOne$Lambdas implements ParentNarrowOne {
+  void Function() parentFunctionOneLambda;
+  String Function() parentPropertyOneGetLambda;
+  void Function(String) parentPropertyOneSetLambda;
+  ParentNarrowOne$Lambdas(
+    this.parentFunctionOneLambda,
+    this.parentPropertyOneGetLambda,
+    this.parentPropertyOneSetLambda
+  );
+  @override
+  void release() {}
+  @override
+  void parentFunctionOne() =>
+    parentFunctionOneLambda();
+  @override
+  String get parentPropertyOne => parentPropertyOneGetLambda();
+  @override
+  set parentPropertyOne(String value) => parentPropertyOneSetLambda(value);
+}
+class ParentNarrowOne$Impl extends __lib.NativeBase implements ParentNarrowOne {
+  ParentNarrowOne$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  void parentFunctionOne() {
+    final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentFunctionOne'));
+    final _handle = this.handle;
+    _parentFunctionOneFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  String get parentPropertyOne {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentPropertyOne_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
+    }
+  }
+  set parentPropertyOne(String value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentNarrowOne_parentPropertyOne_set__String'));
+    final _valueHandle = stringToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    stringReleaseFfiHandle(_valueHandle);
+  }
+}
+int _smokeParentnarrowoneparentFunctionOneStatic(Object _obj) {
+  try {
+    (_obj as ParentNarrowOne).parentFunctionOne();
+  } finally {
+  }
+  return 0;
+}
+int _smokeParentnarrowoneparentPropertyOneGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
+  _result.value = stringToFfi((_obj as ParentNarrowOne).parentPropertyOne);
+  return 0;
+}
+int _smokeParentnarrowoneparentPropertyOneSetStatic(Object _obj, Pointer<Void> _value) {
+  try {
+    (_obj as ParentNarrowOne).parentPropertyOne =
+      stringFromFfi(_value);
+  } finally {
+    stringReleaseFfiHandle(_value);
+  }
+  return 0;
+}
+Pointer<Void> smokeParentnarrowoneToFfi(ParentNarrowOne value) {
+  final result = _smokeParentnarrowoneCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Uint8 Function(Handle)>(_smokeParentnarrowoneparentFunctionOneStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeParentnarrowoneparentPropertyOneGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeParentnarrowoneparentPropertyOneSetStatic, __lib.unknownError)
+  );
+  return result;
+}
+ParentNarrowOne smokeParentnarrowoneFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is ParentNarrowOne) return instance;
+  final _typeIdHandle = _smokeParentnarrowoneGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeParentnarrowoneCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : ParentNarrowOne$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeParentnarrowoneRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeParentnarrowoneReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeParentnarrowoneReleaseHandle(handle);
+Pointer<Void> smokeParentnarrowoneToFfiNullable(ParentNarrowOne? value) =>
+  value != null ? smokeParentnarrowoneToFfi(value) : Pointer<Void>.fromAddress(0);
+ParentNarrowOne? smokeParentnarrowoneFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeParentnarrowoneFromFfi(handle) : null;
+void smokeParentnarrowoneReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeParentnarrowoneReleaseHandle(handle);
+// End of ParentNarrowOne "private" section.

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeClass.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeClass.kt
@@ -57,16 +57,9 @@ class LimeClass(
     val parentClass
         get() = parents.map { it.type.actualType }.firstOrNull { it is LimeClass }
 
-    // TODO: #1077: remove after all generators are updated
-    @Suppress("unused")
-    val hasClassParent
-        get() = parentClass != null
-
-    @Suppress("unused")
     val interfaceInheritedFunctions
         get() = parentInterfaces.flatMap { it.functions + it.inheritedFunctions }
 
-    @Suppress("unused")
     val interfaceInheritedProperties
         get() = parentInterfaces.flatMap { it.properties + it.inheritedProperties }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeContainerWithInheritance.kt
@@ -53,10 +53,6 @@ abstract class LimeContainerWithInheritance(
     interfaces = interfaces,
     lambdas = lambdas
 ) {
-    // TODO: #1077: remove after all generators are updated
-    val parent
-        get() = parents.firstOrNull()
-
     val parentInterfaces
         get() = parents.map { it.type.actualType }.filterIsInstance<LimeInterface>()
 


### PR DESCRIPTION
Updated Dart templates for classes and interfaces to support multiple
inheritance.

Updated DartInterface Dart template to force proxy creation for narrow
interfaces (instead of trying to extract a native handle). This circumvents the
potential issues of invalid reinterpret-casts for second+ parent types. This
behavior is already documented in "lime_idl.md".

Added smoke and functional tests.

Removed unused computed properties from LIME model classes.

Resolves: #1081
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>