### PR TITLE
Fix `result` local variable in JNI 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a compilation error in Java when a function parameter is named "result".
+
 ## 9.5.3
 Release date: 2021-09-29
 ### Features:

--- a/functional-tests/functional/input/lime/MethodOverloads.lime
+++ b/functional-tests/functional/input/lime/MethodOverloads.lime
@@ -98,7 +98,7 @@ open class ConstructorOverloads {
         input: List<Double>
     )
 
-    constructor create(input: ULong)
+    constructor create(result: ULong)
 }
 
 struct StructConstructorOverloads {

--- a/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
@@ -74,7 +74,7 @@ namespace jni
     {{resolveName typeRef}} j{{resolveName}} = n{{resolveName}};{{!!
 }}{{/ifPredicate}}{{!!
 }}{{/parameters}}
-    {{#unless returnType.isVoid}}auto result = {{/unless}}callJavaMethod<{{resolveName returnType}}>( {{!!
+    {{#unless returnType.isVoid}}auto _result = {{/unless}}callJavaMethod<{{resolveName returnType}}>( {{!!
     }}"{{#if javaName}}{{javaName}}{{/if}}{{#unless javaName}}{{resolveName}}{{/unless}}", {{!!
     }}"({{#parameters}}{{resolveName typeRef "signature"}}{{/parameters}}){{!!
     }}{{resolveName returnType "signature"}}", jniEnv {{#if parameters}},{{/if}} {{!!
@@ -113,9 +113,9 @@ namespace jni
 {{/unless}}{{!!
 }}{{#unless returnType.isVoid}}
     return {{#unlessPredicate returnType.typeRef "isJniPrimitive"}}{{!!
-    }}{{#returnType}}{{>jni/JniConversionPrefix}}{{/returnType}}convert_from_jni( jniEnv, result, {{!!
+    }}{{#returnType}}{{>jni/JniConversionPrefix}}{{/returnType}}convert_from_jni( jniEnv, _result, {{!!
     }}({{resolveName returnType "C++"}}*)nullptr ){{/unlessPredicate}}{{!!
-    }}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}result{{/ifPredicate}};
+    }}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}_result{{/ifPredicate}};
 {{/unless}}
 {{#if thrownType}}{{#if returnType.isVoid}}{{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}
         return ::std::error_code{};

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -173,12 +173,12 @@ jint
         }}{{#unlessPredicate returnType.typeRef "isJniPrimitive"}}nullptr{{/unlessPredicate}}{{!!
         }}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}nativeCallResult.unsafe_value(){{/ifPredicate}}{{/unlessPredicate}};{{/unless}}
     }{{#unless returnType.isVoid}}
-    auto result = nativeCallResult.unsafe_value();{{/unless}}
+    auto _result = nativeCallResult.unsafe_value();{{/unless}}
 {{/if}}
-{{#unless thrownType}}    {{#unless returnType.isVoid}}auto result = {{/unless}}{{>cppMethodCall}}{{/unless}}{{!!
+{{#unless thrownType}}    {{#unless returnType.isVoid}}auto _result = {{/unless}}{{>cppMethodCall}}{{/unless}}{{!!
 }}{{#unless returnType.isVoid}}
     {{#ifPredicate "returnsOpaqueHandle"}}auto nSharedPtr = new (::std::nothrow) {{!!
-    }}::std::shared_ptr< {{resolveName returnType "C++ FQN"}} >(result);
+    }}::std::shared_ptr< {{resolveName returnType "C++ FQN"}} >(_result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = {{>common/InternalNamespace}}jni::find_class(_jenv, "java/lang/OutOfMemoryError");
@@ -188,12 +188,12 @@ jint
     return reinterpret_cast<jlong>(nSharedPtr);{{/ifPredicate}}{{!!
 }}{{#unlessPredicate "returnsOpaqueHandle"}}return {{#unlessPredicate returnType.typeRef "isJniPrimitive"}}{{!!
 }}{{#if returnType.typeRef.attributes.optimized}}{{!!
-}}{{>common/InternalNamespace}}jni::convert_to_jni_optimized(_jenv, result, {{!!
+}}{{>common/InternalNamespace}}jni::convert_to_jni_optimized(_jenv, _result, {{!!
 }}"{{resolveName container "" "ref"}}${{resolveName returnType.typeRef "" "ref"}}"{{!!
 }}).release(){{/if}}{{!!
 }}{{#unless returnType.typeRef.attributes.optimized}}{{!!
-}}{{>common/InternalNamespace}}jni::{{#returnType}}{{>jni/JniConversionPrefix}}{{/returnType}}convert_to_jni(_jenv, result).release(){{/unless}}{{/unlessPredicate}}{{!!
-}}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}result{{/ifPredicate}};{{/unlessPredicate}}{{/unless}}
+}}{{>common/InternalNamespace}}jni::{{#returnType}}{{>jni/JniConversionPrefix}}{{/returnType}}convert_to_jni(_jenv, _result).release(){{/unless}}{{/unlessPredicate}}{{!!
+}}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}_result{{/ifPredicate}};{{/unlessPredicate}}{{/unless}}
 }
 {{/jniMethodBody}}{{!!
 

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
@@ -14,85 +14,85 @@ Java_com_example_smoke_BasicTypes_stringFunction(JNIEnv* _jenv, jobject _jinstan
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
             (::std::string*)nullptr);
-    auto result = ::smoke::BasicTypes::string_function(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::BasicTypes::string_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jboolean
 Java_com_example_smoke_BasicTypes_boolFunction(JNIEnv* _jenv, jobject _jinstance, jboolean jinput)
 {
     bool input = jinput;
-    auto result = ::smoke::BasicTypes::bool_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::bool_function(input);
+    return _result;
 }
 jfloat
 Java_com_example_smoke_BasicTypes_floatFunction(JNIEnv* _jenv, jobject _jinstance, jfloat jinput)
 {
     float input = jinput;
-    auto result = ::smoke::BasicTypes::float_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::float_function(input);
+    return _result;
 }
 jdouble
 Java_com_example_smoke_BasicTypes_doubleFunction(JNIEnv* _jenv, jobject _jinstance, jdouble jinput)
 {
     double input = jinput;
-    auto result = ::smoke::BasicTypes::double_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::double_function(input);
+    return _result;
 }
 jbyte
 Java_com_example_smoke_BasicTypes_byteFunction(JNIEnv* _jenv, jobject _jinstance, jbyte jinput)
 {
     int8_t input = jinput;
-    auto result = ::smoke::BasicTypes::byte_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::byte_function(input);
+    return _result;
 }
 jshort
 Java_com_example_smoke_BasicTypes_shortFunction(JNIEnv* _jenv, jobject _jinstance, jshort jinput)
 {
     int16_t input = jinput;
-    auto result = ::smoke::BasicTypes::short_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::short_function(input);
+    return _result;
 }
 jint
 Java_com_example_smoke_BasicTypes_intFunction(JNIEnv* _jenv, jobject _jinstance, jint jinput)
 {
     int32_t input = jinput;
-    auto result = ::smoke::BasicTypes::int_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::int_function(input);
+    return _result;
 }
 jlong
 Java_com_example_smoke_BasicTypes_longFunction(JNIEnv* _jenv, jobject _jinstance, jlong jinput)
 {
     int64_t input = jinput;
-    auto result = ::smoke::BasicTypes::long_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::long_function(input);
+    return _result;
 }
 jshort
 Java_com_example_smoke_BasicTypes_ubyteFunction(JNIEnv* _jenv, jobject _jinstance, jshort jinput)
 {
     uint8_t input = jinput;
-    auto result = ::smoke::BasicTypes::ubyte_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::ubyte_function(input);
+    return _result;
 }
 jint
 Java_com_example_smoke_BasicTypes_ushortFunction(JNIEnv* _jenv, jobject _jinstance, jint jinput)
 {
     uint16_t input = jinput;
-    auto result = ::smoke::BasicTypes::ushort_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::ushort_function(input);
+    return _result;
 }
 jlong
 Java_com_example_smoke_BasicTypes_uintFunction(JNIEnv* _jenv, jobject _jinstance, jlong jinput)
 {
     uint32_t input = jinput;
-    auto result = ::smoke::BasicTypes::uint_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::uint_function(input);
+    return _result;
 }
 jlong
 Java_com_example_smoke_BasicTypes_ulongFunction(JNIEnv* _jenv, jobject _jinstance, jlong jinput)
 {
     uint64_t input = jinput;
-    auto result = ::smoke::BasicTypes::ulong_function(input);
-    return result;
+    auto _result = ::smoke::BasicTypes::ulong_function(input);
+    return _result;
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_BasicTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
@@ -13,8 +13,8 @@ extern "C" {
 jlong
 Java_com_example_smoke_Constructors_create__(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::Constructors::create();
-    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(result);
+    auto _result = ::smoke::Constructors::create();
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(_result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "java/lang/OutOfMemoryError");
@@ -29,8 +29,8 @@ Java_com_example_smoke_Constructors_create__Lcom_example_smoke_Constructors_2(JN
     ::std::shared_ptr< ::smoke::Constructors > other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
             (::std::shared_ptr< ::smoke::Constructors >*)nullptr);
-    auto result = ::smoke::Constructors::create(other);
-    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(result);
+    auto _result = ::smoke::Constructors::create(other);
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(_result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "java/lang/OutOfMemoryError");
@@ -46,8 +46,8 @@ Java_com_example_smoke_Constructors_create__Ljava_lang_String_2J(JNIEnv* _jenv, 
             ::gluecodium::jni::make_non_releasing_ref(jfoo),
             (::std::string*)nullptr);
     uint64_t bar = jbar;
-    auto result = ::smoke::Constructors::create(foo,bar);
-    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(result);
+    auto _result = ::smoke::Constructors::create(foo,bar);
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(_result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "java/lang/OutOfMemoryError");
@@ -75,8 +75,8 @@ Java_com_example_smoke_Constructors_create__Ljava_lang_String_2(JNIEnv* _jenv, j
         _throw_exception.register_exception(std::move(exception));
         return 0;
     }
-    auto result = nativeCallResult.unsafe_value();
-    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(result);
+    auto _result = nativeCallResult.unsafe_value();
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(_result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "java/lang/OutOfMemoryError");
@@ -91,8 +91,8 @@ Java_com_example_smoke_Constructors_create__Ljava_util_List_2(JNIEnv* _jenv, job
     ::std::vector< double > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
             (::std::vector< double >*)nullptr);
-    auto result = ::smoke::Constructors::create(input);
-    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(result);
+    auto _result = ::smoke::Constructors::create(input);
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Constructors >(_result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "java/lang/OutOfMemoryError");

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_Dates_dateMethod(JNIEnv* _jenv, jobject _jinstance, jobje
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->date_method(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->date_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Dates_nullableDateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -35,8 +35,8 @@ Java_com_example_smoke_Dates_nullableDateMethod(JNIEnv* _jenv, jobject _jinstanc
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->nullable_date_method(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->nullable_date_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Dates_getDateProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -47,8 +47,8 @@ Java_com_example_smoke_Dates_getDateProperty(JNIEnv* _jenv, jobject _jinstance)
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_date_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_date_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Dates_setDateProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -73,8 +73,8 @@ Java_com_example_smoke_Dates_getDateSet(JNIEnv* _jenv, jobject _jinstance)
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_date_set();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_date_set();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Dates_setDateSet(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_DatesSteady_dateMethod(JNIEnv* _jenv, jobject _jinstance,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->date_method(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->date_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_DatesSteady_nullableDateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -35,8 +35,8 @@ Java_com_example_smoke_DatesSteady_nullableDateMethod(JNIEnv* _jenv, jobject _ji
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->nullable_date_method(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->nullable_date_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_DatesSteady_dateListMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -50,8 +50,8 @@ Java_com_example_smoke_DatesSteady_dateListMethod(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->date_list_method(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->date_list_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_DatesSteady_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationMilliseconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationMilliseconds.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_DurationMilliseconds_durationFunction(JNIEnv* _jenv, jobj
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->duration_function(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_DurationMilliseconds_nullableDurationFunction(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -35,8 +35,8 @@ Java_com_example_smoke_DurationMilliseconds_nullableDurationFunction(JNIEnv* _je
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->nullable_duration_function(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->nullable_duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_DurationMilliseconds_getDurationProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -47,8 +47,8 @@ Java_com_example_smoke_DurationMilliseconds_getDurationProperty(JNIEnv* _jenv, j
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_duration_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_duration_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_DurationMilliseconds_setDurationProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationSeconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationSeconds.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_DurationSeconds_durationFunction(JNIEnv* _jenv, jobject _
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->duration_function(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_DurationSeconds_nullableDurationFunction(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -35,8 +35,8 @@ Java_com_example_smoke_DurationSeconds_nullableDurationFunction(JNIEnv* _jenv, j
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->nullable_duration_function(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->nullable_duration_function(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_DurationSeconds_getDurationProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -47,8 +47,8 @@ Java_com_example_smoke_DurationSeconds_getDurationProperty(JNIEnv* _jenv, jobjec
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_duration_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_duration_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_DurationSeconds_setDurationProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_Errors.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_Errors.cpp
@@ -60,8 +60,8 @@ Java_com_example_smoke_Errors_methodWithErrorsAndReturnValue(JNIEnv* _jenv, jobj
         _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
-    auto result = nativeCallResult.unsafe_value();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = nativeCallResult.unsafe_value();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Errors_methodWithPayloadError(JNIEnv* _jenv, jobject _jinstance)
@@ -91,8 +91,8 @@ Java_com_example_smoke_Errors_methodWithPayloadErrorAndReturnValue(JNIEnv* _jenv
         _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
-    auto result = nativeCallResult.unsafe_value();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = nativeCallResult.unsafe_value();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Errors_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_ErrorsInterfaceImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_ErrorsInterfaceImplCppProxy.cpp
@@ -66,7 +66,7 @@ com_example_smoke_ErrorsInterface_CppProxy::method_with_external_errors(  ) {
 ::gluecodium::Return< ::std::string, ::std::error_code >
 com_example_smoke_ErrorsInterface_CppProxy::method_with_errors_and_return_value(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jstring>( "methodWithErrorsAndReturnValue", "()Ljava/lang/String;", jniEnv  );
+    auto _result = callJavaMethod<jstring>( "methodWithErrorsAndReturnValue", "()Ljava/lang/String;", jniEnv  );
     auto jException = make_local_ref<jobject>(jniEnv, jniEnv->ExceptionOccurred( ));
     if ( jException )
     {
@@ -84,7 +84,7 @@ com_example_smoke_ErrorsInterface_CppProxy::method_with_errors_and_return_value(
     }
     else
     {
-    return convert_from_jni( jniEnv, result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
     }
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass.cpp
@@ -29,8 +29,8 @@ Java_com_example_smoke_ExternalClass_getSomeProperty(JNIEnv* _jenv, jobject _jin
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_Me();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_Me();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_ExternalClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterfaceImpl.cpp
@@ -29,8 +29,8 @@ Java_com_example_smoke_ExternalInterfaceImpl_getSomeProperty(JNIEnv* _jenv, jobj
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_Me();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_Me();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_ExternalInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs.cpp
@@ -13,14 +13,14 @@ extern "C" {
 jobject
 Java_com_example_smoke_Structs_getExternalStruct(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::Structs::get_external_struct();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::Structs::get_external_struct();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Structs_getAnotherExternalStruct(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::Structs::get_another_external_struct();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::Structs::get_another_external_struct();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Structs_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithList(JNIEnv* _jenv, 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_list(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_list(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMap(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -35,8 +35,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMap(JNIEnv* _jenv, j
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_map(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_map(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSet(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -50,8 +50,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSet(JNIEnv* _jenv, j
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_set(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_set(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -65,8 +65,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias(JNIEnv
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_list_type_alias(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_list_type_alias(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -80,8 +80,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias(JNIEnv*
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_map_type_alias(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_map_type_alias(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -95,8 +95,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias(JNIEnv*
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_set_type_alias(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_set_type_alias(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithBasicTypes_getListProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -107,8 +107,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_getListProperty(JNIEnv* _jenv,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_list_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_list_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_GenericTypesWithBasicTypes_setListProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -133,8 +133,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_getMapProperty(JNIEnv* _jenv, 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_map_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_map_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_GenericTypesWithBasicTypes_setMapProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -159,8 +159,8 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_getSetProperty(JNIEnv* _jenv, 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_set_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_set_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_GenericTypesWithBasicTypes_setSetProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithCompoundTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithCompoundTypes.cpp
@@ -26,8 +26,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithStructList(JNIEnv
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_struct_list(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_struct_list(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithStructMap(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -41,8 +41,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithStructMap(JNIEnv*
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_struct_map(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_struct_map(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumList(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -56,8 +56,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumList(JNIEnv* 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_enum_list(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_enum_list(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -71,8 +71,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey(JNIEnv
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_enum_map_key(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_enum_map_key(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -86,8 +86,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue(JNIE
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_enum_map_value(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_enum_map_value(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -101,8 +101,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet(JNIEnv* _
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_enum_set(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_enum_set(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -116,8 +116,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList(JNI
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_instances_list(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_instances_list(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -131,8 +131,8 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap(JNIE
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_instances_map(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_instances_map(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_GenericTypesWithCompoundTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithGenericTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithGenericTypes.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListOfLists(JNIEnv
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_list_of_lists(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_list_of_lists(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -35,8 +35,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps(JNIEnv* 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_map_of_maps(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_map_of_maps(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -50,8 +50,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets(JNIEnv* 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_set_of_sets(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_set_of_sets(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListAndMap(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -65,8 +65,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListAndMap(JNIEnv*
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_list_and_map(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_list_and_map(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListAndSet(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -80,8 +80,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListAndSet(JNIEnv*
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_list_and_set(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_list_and_set(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -95,8 +95,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet(JNIEnv* 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_map_and_set(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_map_and_set(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -110,8 +110,8 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys(JNI
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_map_generic_keys(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_map_generic_keys(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_GenericTypesWithGenericTypes_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_UseOptimizedList.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_UseOptimizedList.cpp
@@ -13,14 +13,14 @@ extern "C" {
 jobject
 Java_com_example_smoke_UseOptimizedList_fetchTheBigOnes(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::UseOptimizedList::fetch_the_big_ones();
-    return ::gluecodium::jni::convert_to_jni_optimized(_jenv, result, "com/example/smoke/UseOptimizedList$VeryBigStructLazyNativeList").release();
+    auto _result = ::smoke::UseOptimizedList::fetch_the_big_ones();
+    return ::gluecodium::jni::convert_to_jni_optimized(_jenv, _result, "com/example/smoke/UseOptimizedList$VeryBigStructLazyNativeList").release();
 }
 jobject
 Java_com_example_smoke_UseOptimizedList_getLazyOnes(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::UseOptimizedList::get_lazy_ones();
-    return ::gluecodium::jni::convert_to_jni_optimized(_jenv, result, "com/example/smoke/UseOptimizedList$UnreasonablyLazyClassLazyNativeList").release();
+    auto _result = ::smoke::UseOptimizedList::get_lazy_ones();
+    return ::gluecodium::jni::convert_to_jni_optimized(_jenv, _result, "com/example/smoke/UseOptimizedList$UnreasonablyLazyClassLazyNativeList").release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_UseOptimizedList_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_foobar_CrossPackageChildInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_foobar_CrossPackageChildInterfaceImpl.cpp
@@ -28,8 +28,8 @@ Java_com_example_foobar_CrossPackageChildInterfaceImpl_getRootProperty(JNIEnv* _
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_root_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_root_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_foobar_CrossPackageChildInterfaceImpl_setRootProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
@@ -39,8 +39,8 @@ Java_com_example_smoke_ChildClassFromInterface_getRootProperty(JNIEnv* _jenv, jo
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_root_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_root_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_ChildClassFromInterface_setRootProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.cpp
@@ -27,8 +27,8 @@ Java_com_example_smoke_ChildClassWithIncludes_rootMethod(JNIEnv* _jenv, jobject 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->root_method(input1,input2);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->root_method(input1,input2);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_ChildClassWithIncludes_getRootProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -39,8 +39,8 @@ Java_com_example_smoke_ChildClassWithIncludes_getRootProperty(JNIEnv* _jenv, job
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_root_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_root_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_ChildClassWithIncludes_setRootProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterfaceImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterfaceImplCppProxy.cpp
@@ -27,7 +27,7 @@ com_example_smoke_ChildInterface_CppProxy::root_method(  ) {
 ::std::string
 com_example_smoke_ChildInterface_CppProxy::get_root_property(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jstring>( "getRootProperty", "()Ljava/lang/String;", jniEnv  );
+    auto _result = callJavaMethod<jstring>( "getRootProperty", "()Ljava/lang/String;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -35,7 +35,7 @@ com_example_smoke_ChildInterface_CppProxy::get_root_property(  ) const {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
 }
 void
 com_example_smoke_ChildInterface_CppProxy::set_root_property( const ::std::string& nvalue ) {

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass.cpp
@@ -17,8 +17,8 @@ Java_com_example_smoke_SimpleClass_getStringValue(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_string_value();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_string_value();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_SimpleClass_useSimpleClass(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -32,8 +32,8 @@ Java_com_example_smoke_SimpleClass_useSimpleClass(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->use_simple_class(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->use_simple_class(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_SimpleClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterfaceImpl.cpp
@@ -17,8 +17,8 @@ Java_com_example_smoke_SimpleInterfaceImpl_getStringValue(JNIEnv* _jenv, jobject
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_string_value();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_string_value();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_SimpleInterfaceImpl_useSimpleInterface(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -32,8 +32,8 @@ Java_com_example_smoke_SimpleInterfaceImpl_useSimpleInterface(JNIEnv* _jenv, job
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->use_simple_interface(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->use_simple_interface(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_SimpleInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas.cpp
@@ -26,8 +26,8 @@ Java_com_example_smoke_Lambdas_deconfuse(JNIEnv* _jenv, jobject _jinstance, jstr
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->deconfuse(value,confuser);
-    return ::gluecodium::jni::com_example_smoke_Lambdas_00024Producer_convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->deconfuse(value,confuser);
+    return ::gluecodium::jni::com_example_smoke_Lambdas_00024Producer_convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Lambdas_fuse(JNIEnv* _jenv, jobject _jinstance, jobject jitems, jobject jcallback)
@@ -38,8 +38,8 @@ Java_com_example_smoke_Lambdas_fuse(JNIEnv* _jenv, jobject _jinstance, jobject j
     ::smoke::Lambdas::Indexer callback = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jcallback),
             (::smoke::Lambdas::Indexer*)nullptr);
-    auto result = ::smoke::Lambdas::fuse(items,callback);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::Lambdas::fuse(items,callback);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Lambdas_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
@@ -21,8 +21,8 @@ Java_com_example_smoke_Lambdas_00024ConfounderImpl_confuse(JNIEnv* _jenv, jobjec
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)(p0);
-    return ::gluecodium::jni::com_example_smoke_Lambdas_00024Producer_convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)(p0);
+    return ::gluecodium::jni::com_example_smoke_Lambdas_00024Producer_convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Lambdas_00024ConfounderImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImplCppProxy.cpp
@@ -17,7 +17,7 @@ com_example_smoke_Lambdas_00024Confounder_CppProxy::com_example_smoke_Lambdas_00
 com_example_smoke_Lambdas_00024Confounder_CppProxy::operator()( const ::std::string& np0 ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jp0 = convert_to_jni( jniEnv, np0 );
-    auto result = callJavaMethod<jobject>( "confuse", "(Ljava/lang/String;)Lcom/example/smoke/Lambdas$Producer;", jniEnv , jp0);
+    auto _result = callJavaMethod<jobject>( "confuse", "(Ljava/lang/String;)Lcom/example/smoke/Lambdas$Producer;", jniEnv , jp0);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -25,7 +25,7 @@ com_example_smoke_Lambdas_00024Confounder_CppProxy::operator()( const ::std::str
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return com_example_smoke_Lambdas_00024Producer_convert_from_jni( jniEnv, result, (::smoke::Lambdas::Producer*)nullptr );
+    return com_example_smoke_Lambdas_00024Producer_convert_from_jni( jniEnv, _result, (::smoke::Lambdas::Producer*)nullptr );
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_IndexerImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_IndexerImplCppProxy.cpp
@@ -17,7 +17,7 @@ com_example_smoke_Lambdas_00024Indexer_CppProxy::operator()( const ::std::string
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jp0 = convert_to_jni( jniEnv, np0 );
     jfloat jindex = nindex;
-    auto result = callJavaMethod<jint>( "apply", "(Ljava/lang/String;F)I", jniEnv , jp0, jindex);
+    auto _result = callJavaMethod<jint>( "apply", "(Ljava/lang/String;F)I", jniEnv , jp0, jindex);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -25,7 +25,7 @@ com_example_smoke_Lambdas_00024Indexer_CppProxy::operator()( const ::std::string
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return result;
+    return _result;
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.cpp
@@ -15,7 +15,7 @@ com_example_smoke_Lambdas_00024Producer_CppProxy::com_example_smoke_Lambdas_0002
 ::std::string
 com_example_smoke_Lambdas_00024Producer_CppProxy::operator()(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jstring>( "apply", "()Ljava/lang/String;", jniEnv  );
+    auto _result = callJavaMethod<jstring>( "apply", "()Ljava/lang/String;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -23,7 +23,7 @@ com_example_smoke_Lambdas_00024Producer_CppProxy::operator()(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImpl.cpp
@@ -17,14 +17,14 @@ Java_com_example_smoke_InterfaceWithStaticImpl_regularFunction(JNIEnv* _jenv, jo
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->regular_function();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->regular_function();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jstring
 Java_com_example_smoke_InterfaceWithStaticImpl_staticFunction(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::InterfaceWithStatic::static_function();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::InterfaceWithStatic::static_function();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jstring
 Java_com_example_smoke_InterfaceWithStaticImpl_getRegularProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -35,8 +35,8 @@ Java_com_example_smoke_InterfaceWithStaticImpl_getRegularProperty(JNIEnv* _jenv,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_regular_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_regular_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_InterfaceWithStaticImpl_setRegularProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)
@@ -55,8 +55,8 @@ Java_com_example_smoke_InterfaceWithStaticImpl_setRegularProperty(JNIEnv* _jenv,
 jstring
 Java_com_example_smoke_InterfaceWithStaticImpl_getStaticProperty(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::InterfaceWithStatic::get_static_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::InterfaceWithStatic::get_static_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_InterfaceWithStaticImpl_setStaticProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.cpp
@@ -15,7 +15,7 @@ com_example_smoke_InterfaceWithStatic_CppProxy::com_example_smoke_InterfaceWithS
 ::std::string
 com_example_smoke_InterfaceWithStatic_CppProxy::regular_function(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jstring>( "regularFunction", "()Ljava/lang/String;", jniEnv  );
+    auto _result = callJavaMethod<jstring>( "regularFunction", "()Ljava/lang/String;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -23,12 +23,12 @@ com_example_smoke_InterfaceWithStatic_CppProxy::regular_function(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
 }
 ::std::string
 com_example_smoke_InterfaceWithStatic_CppProxy::get_regular_property(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jstring>( "getRegularProperty", "()Ljava/lang/String;", jniEnv  );
+    auto _result = callJavaMethod<jstring>( "getRegularProperty", "()Ljava/lang/String;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -36,7 +36,7 @@ com_example_smoke_InterfaceWithStatic_CppProxy::get_regular_property(  ) const {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
 }
 void
 com_example_smoke_InterfaceWithStatic_CppProxy::set_regular_property( const ::std::string& nvalue ) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithNullableImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithNullableImplCppProxy.cpp
@@ -16,7 +16,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::com_example_smoke_ListenerWithN
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_byte( const ::gluecodium::optional< int8_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithByte", "(Ljava/lang/Byte;)Ljava/lang/Byte;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithByte", "(Ljava/lang/Byte;)Ljava/lang/Byte;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -24,13 +24,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_byte( const ::gluec
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< int8_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< int8_t >*)nullptr );
 }
 ::gluecodium::optional< uint8_t >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_byte( const ::gluecodium::optional< uint8_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithUByte", "(Ljava/lang/Short;)Ljava/lang/Short;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithUByte", "(Ljava/lang/Short;)Ljava/lang/Short;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -38,13 +38,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_byte( const ::glu
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< uint8_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< uint8_t >*)nullptr );
 }
 ::gluecodium::optional< int16_t >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_short( const ::gluecodium::optional< int16_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithShort", "(Ljava/lang/Short;)Ljava/lang/Short;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithShort", "(Ljava/lang/Short;)Ljava/lang/Short;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -52,13 +52,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_short( const ::glue
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< int16_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< int16_t >*)nullptr );
 }
 ::gluecodium::optional< uint16_t >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_short( const ::gluecodium::optional< uint16_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithUShort", "(Ljava/lang/Integer;)Ljava/lang/Integer;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithUShort", "(Ljava/lang/Integer;)Ljava/lang/Integer;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -66,13 +66,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_short( const ::gl
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< uint16_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< uint16_t >*)nullptr );
 }
 ::gluecodium::optional< int32_t >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_int( const ::gluecodium::optional< int32_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithInt", "(Ljava/lang/Integer;)Ljava/lang/Integer;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithInt", "(Ljava/lang/Integer;)Ljava/lang/Integer;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -80,13 +80,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_int( const ::glueco
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< int32_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< int32_t >*)nullptr );
 }
 ::gluecodium::optional< uint32_t >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_int( const ::gluecodium::optional< uint32_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithUInt", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithUInt", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -94,13 +94,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_int( const ::glue
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< uint32_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< uint32_t >*)nullptr );
 }
 ::gluecodium::optional< int64_t >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_long( const ::gluecodium::optional< int64_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithLong", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithLong", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -108,13 +108,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_long( const ::gluec
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< int64_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< int64_t >*)nullptr );
 }
 ::gluecodium::optional< uint64_t >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_long( const ::gluecodium::optional< uint64_t >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithULong", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithULong", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -122,13 +122,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_long( const ::glu
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< uint64_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< uint64_t >*)nullptr );
 }
 ::gluecodium::optional< bool >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const ::gluecodium::optional< bool >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithDouble", "(Ljava/lang/Boolean;)Ljava/lang/Boolean;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithDouble", "(Ljava/lang/Boolean;)Ljava/lang/Boolean;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -136,13 +136,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const ::glu
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< bool >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< bool >*)nullptr );
 }
 ::gluecodium::optional< float >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_float( const ::gluecodium::optional< float >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithFloat", "(Ljava/lang/Float;)Ljava/lang/Float;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithFloat", "(Ljava/lang/Float;)Ljava/lang/Float;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -150,13 +150,13 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_float( const ::glue
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< float >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< float >*)nullptr );
 }
 ::gluecodium::optional< double >
 com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const ::gluecodium::optional< double >& ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     auto jinput = convert_to_jni( jniEnv, ninput );
-    auto result = callJavaMethod<jobject>( "methodWithDouble", "(Ljava/lang/Double;)Ljava/lang/Double;", jniEnv , jinput);
+    auto _result = callJavaMethod<jobject>( "methodWithDouble", "(Ljava/lang/Double;)Ljava/lang/Double;", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -164,7 +164,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const ::glu
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::gluecodium::optional< double >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::gluecodium::optional< double >*)nullptr );
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
@@ -18,7 +18,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::com_example_smoke_ListenerWit
 ::std::string
 com_example_smoke_ListenerWithProperties_CppProxy::get_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jstring>( "getMessage", "()Ljava/lang/String;", jniEnv  );
+    auto _result = callJavaMethod<jstring>( "getMessage", "()Ljava/lang/String;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -26,7 +26,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_message(  ) const {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
 }
 void
 com_example_smoke_ListenerWithProperties_CppProxy::set_message( const ::std::string& nvalue ) {
@@ -44,7 +44,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::set_message( const ::std::str
 ::std::shared_ptr< ::smoke::CalculationResult >
 com_example_smoke_ListenerWithProperties_CppProxy::get_packed_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "getPackedMessage", "()Lcom/example/smoke/CalculationResult;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "getPackedMessage", "()Lcom/example/smoke/CalculationResult;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -52,7 +52,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_packed_message(  ) const 
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::shared_ptr< ::smoke::CalculationResult >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::shared_ptr< ::smoke::CalculationResult >*)nullptr );
 }
 void
 com_example_smoke_ListenerWithProperties_CppProxy::set_packed_message( const ::std::shared_ptr< ::smoke::CalculationResult >& nvalue ) {
@@ -70,7 +70,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::set_packed_message( const ::s
 ::smoke::ListenerWithProperties::ResultStruct
 com_example_smoke_ListenerWithProperties_CppProxy::get_structured_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "getStructuredMessage", "()Lcom/example/smoke/ListenerWithProperties$ResultStruct;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "getStructuredMessage", "()Lcom/example/smoke/ListenerWithProperties$ResultStruct;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -78,7 +78,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_structured_message(  ) co
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenerWithProperties::ResultStruct*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::smoke::ListenerWithProperties::ResultStruct*)nullptr );
 }
 void
 com_example_smoke_ListenerWithProperties_CppProxy::set_structured_message( const ::smoke::ListenerWithProperties::ResultStruct& nvalue ) {
@@ -96,7 +96,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::set_structured_message( const
 ::smoke::ListenerWithProperties::ResultEnum
 com_example_smoke_ListenerWithProperties_CppProxy::get_enumerated_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "getEnumeratedMessage", "()Lcom/example/smoke/ListenerWithProperties$ResultEnum;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "getEnumeratedMessage", "()Lcom/example/smoke/ListenerWithProperties$ResultEnum;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -104,7 +104,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_enumerated_message(  ) co
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenerWithProperties::ResultEnum*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::smoke::ListenerWithProperties::ResultEnum*)nullptr );
 }
 void
 com_example_smoke_ListenerWithProperties_CppProxy::set_enumerated_message( const ::smoke::ListenerWithProperties::ResultEnum nvalue ) {
@@ -122,7 +122,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::set_enumerated_message( const
 ::std::vector< ::std::string >
 com_example_smoke_ListenerWithProperties_CppProxy::get_arrayed_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "getArrayedMessage", "()Ljava/util/List;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "getArrayedMessage", "()Ljava/util/List;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -130,7 +130,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_arrayed_message(  ) const
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::vector< ::std::string >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::vector< ::std::string >*)nullptr );
 }
 void
 com_example_smoke_ListenerWithProperties_CppProxy::set_arrayed_message( const ::std::vector< ::std::string >& nvalue ) {
@@ -148,7 +148,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::set_arrayed_message( const ::
 ::smoke::ListenerWithProperties::StringToDouble
 com_example_smoke_ListenerWithProperties_CppProxy::get_mapped_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "getMappedMessage", "()Ljava/util/Map;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "getMappedMessage", "()Ljava/util/Map;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -156,7 +156,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_mapped_message(  ) const 
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenerWithProperties::StringToDouble*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::smoke::ListenerWithProperties::StringToDouble*)nullptr );
 }
 void
 com_example_smoke_ListenerWithProperties_CppProxy::set_mapped_message( const ::smoke::ListenerWithProperties::StringToDouble& nvalue ) {
@@ -174,7 +174,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::set_mapped_message( const ::s
 ::std::shared_ptr< ::std::vector< uint8_t > >
 com_example_smoke_ListenerWithProperties_CppProxy::get_buffered_message(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jbyteArray>( "getBufferedMessage", "()[B", jniEnv  );
+    auto _result = callJavaMethod<jbyteArray>( "getBufferedMessage", "()[B", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -182,7 +182,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_buffered_message(  ) cons
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::shared_ptr< ::std::vector< uint8_t > >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::shared_ptr< ::std::vector< uint8_t > >*)nullptr );
 }
 void
 com_example_smoke_ListenerWithProperties_CppProxy::set_buffered_message( const ::std::shared_ptr< ::std::vector< uint8_t > >& nvalue ) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
@@ -18,7 +18,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::com_example_smoke_Listener
 double
 com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_double(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jdouble>( "fetchDataDouble", "()D", jniEnv  );
+    auto _result = callJavaMethod<jdouble>( "fetchDataDouble", "()D", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -26,12 +26,12 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_double(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return result;
+    return _result;
 }
 ::std::string
 com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_string(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jstring>( "fetchDataString", "()Ljava/lang/String;", jniEnv  );
+    auto _result = callJavaMethod<jstring>( "fetchDataString", "()Ljava/lang/String;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -39,12 +39,12 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_string(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
 }
 ::smoke::ListenersWithReturnValues::ResultStruct
 com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_struct(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "fetchDataStruct", "()Lcom/example/smoke/ListenersWithReturnValues$ResultStruct;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "fetchDataStruct", "()Lcom/example/smoke/ListenersWithReturnValues$ResultStruct;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -52,12 +52,12 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_struct(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenersWithReturnValues::ResultStruct*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::smoke::ListenersWithReturnValues::ResultStruct*)nullptr );
 }
 ::smoke::ListenersWithReturnValues::ResultEnum
 com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_enum(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "fetchDataEnum", "()Lcom/example/smoke/ListenersWithReturnValues$ResultEnum;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "fetchDataEnum", "()Lcom/example/smoke/ListenersWithReturnValues$ResultEnum;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -65,12 +65,12 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_enum(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenersWithReturnValues::ResultEnum*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::smoke::ListenersWithReturnValues::ResultEnum*)nullptr );
 }
 ::std::vector< double >
 com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_array(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "fetchDataArray", "()Ljava/util/List;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "fetchDataArray", "()Ljava/util/List;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -78,12 +78,12 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_array(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::vector< double >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::vector< double >*)nullptr );
 }
 ::smoke::ListenersWithReturnValues::StringToDouble
 com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_map(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "fetchDataMap", "()Ljava/util/Map;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "fetchDataMap", "()Ljava/util/Map;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -91,12 +91,12 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_map(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::smoke::ListenersWithReturnValues::StringToDouble*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::smoke::ListenersWithReturnValues::StringToDouble*)nullptr );
 }
 ::std::shared_ptr< ::smoke::CalculationResult >
 com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_instance(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "fetchDataInstance", "()Lcom/example/smoke/CalculationResult;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "fetchDataInstance", "()Lcom/example/smoke/CalculationResult;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -104,7 +104,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_instance(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::shared_ptr< ::smoke::CalculationResult >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::shared_ptr< ::smoke::CalculationResult >*)nullptr );
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/android/jni/com_example_smoke_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/android/jni/com_example_smoke_Locales.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_Locales_localeMethod(JNIEnv* _jenv, jobject _jinstance, j
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->locale_method(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->locale_method(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Locales_getLocaleProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -32,8 +32,8 @@ Java_com_example_smoke_Locales_getLocaleProperty(JNIEnv* _jenv, jobject _jinstan
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_locale_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_locale_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Locales_setLocaleProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
@@ -61,6 +61,7 @@ class SpecialNames {
     fun release()
     fun createProxy()
     fun _upperCase()
+    constructor make(result: String)
 }
 
 @Java(Skip) @Dart(Skip)

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/SpecialNames.java
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/com/example/smoke/SpecialNames.java
@@ -1,10 +1,14 @@
 /*
  *
-
  */
 package com.example.smoke;
+import android.support.annotation.NonNull;
 import com.example.NativeBase;
 public final class SpecialNames extends NativeBase {
+    public SpecialNames(@NonNull final String result) {
+        this(make(result), (Object)null);
+        cacheThisInstance();
+    }
     /**
      * For internal use only.
      * @exclude
@@ -18,8 +22,10 @@ public final class SpecialNames extends NativeBase {
         });
     }
     private static native void disposeNativeHandle(long nativeHandle);
+    private native void cacheThisInstance();
     public native void create();
     public native void release();
     public native void createProxy();
     public native void Uppercase();
+    private static native long make(@NonNull final String result);
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
@@ -19,8 +19,8 @@ Java_com_example_smoke_MethodOverloads_isBoolean__Z(JNIEnv* _jenv, jobject _jins
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isBoolean__B(JNIEnv* _jenv, jobject _jinstance, jbyte jinput)
@@ -32,8 +32,8 @@ Java_com_example_smoke_MethodOverloads_isBoolean__B(JNIEnv* _jenv, jobject _jins
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isBoolean__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -47,8 +47,8 @@ Java_com_example_smoke_MethodOverloads_isBoolean__Ljava_lang_String_2(JNIEnv* _j
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isBoolean__Lcom_example_smoke_MethodOverloads_00024Point_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -62,8 +62,8 @@ Java_com_example_smoke_MethodOverloads_isBoolean__Lcom_example_smoke_MethodOverl
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isBoolean__ZBLjava_lang_String_2Lcom_example_smoke_MethodOverloads_00024Point_2(JNIEnv* _jenv, jobject _jinstance, jboolean jinput1, jbyte jinput2, jstring jinput3, jobject jinput4)
@@ -82,8 +82,8 @@ Java_com_example_smoke_MethodOverloads_isBoolean__ZBLjava_lang_String_2Lcom_exam
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean(input1,input2,input3,input4);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input1,input2,input3,input4);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isBooleanStringArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -97,8 +97,8 @@ Java_com_example_smoke_MethodOverloads_isBooleanStringArrayOverload(JNIEnv* _jen
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isBooleanIntArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -112,8 +112,8 @@ Java_com_example_smoke_MethodOverloads_isBooleanIntArrayOverload(JNIEnv* _jenv, 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isBoolean__(JNIEnv* _jenv, jobject _jinstance)
@@ -124,8 +124,8 @@ Java_com_example_smoke_MethodOverloads_isBoolean__(JNIEnv* _jenv, jobject _jinst
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean();
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isFloat__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -139,8 +139,8 @@ Java_com_example_smoke_MethodOverloads_isFloat__Ljava_lang_String_2(JNIEnv* _jen
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_float(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_float(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_MethodOverloads_isFloat__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -154,8 +154,8 @@ Java_com_example_smoke_MethodOverloads_isFloat__Ljava_util_List_2(JNIEnv* _jenv,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_float(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_float(input);
+    return _result;
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_MethodOverloads_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_SpecialNames.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_SpecialNames.cpp
@@ -1,0 +1,86 @@
+/*
+ *
+ */
+#include "com_example_smoke_SpecialNames.h"
+#include "com_example_smoke_SpecialNames__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+void
+Java_com_example_smoke_SpecialNames_create(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->create();
+}
+void
+Java_com_example_smoke_SpecialNames_release(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->release();
+}
+void
+Java_com_example_smoke_SpecialNames_createProxy(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->create_proxy();
+}
+void
+Java_com_example_smoke_SpecialNames_Uppercase(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+        ::gluecodium::jni::get_field_value(
+            _jenv,
+            ::gluecodium::jni::make_non_releasing_ref(_jinstance),
+            "nativeHandle",
+            (int64_t*)nullptr));
+    (*pInstanceSharedPointer)->_uppercase();
+}
+jlong
+Java_com_example_smoke_SpecialNames_make(JNIEnv* _jenv, jobject _jinstance, jstring jresult)
+{
+    ::std::string result = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jresult),
+            (::std::string*)nullptr);
+    auto _result = ::smoke::SpecialNames::make(result);
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::SpecialNames >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "java/lang/OutOfMemoryError");
+        _jenv->ThrowNew(exceptionClass.get(), "Cannot allocate native memory.");
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = ::gluecodium::jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = ::gluecodium::jni::get_field_value(_jenv, jobj, "nativeHandle", (int64_t*)nullptr);
+    auto nobj = *reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*>(long_ptr);
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+}
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_SpecialNames.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_SpecialNames.h
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 #pragma once
 #include <jni.h>
@@ -15,6 +14,8 @@ JNIEXPORT void JNICALL
 Java_com_example_smoke_SpecialNames_createProxy(JNIEnv* _jenv, jobject _jinstance);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_SpecialNames_Uppercase(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_SpecialNames_make(JNIEnv* _jenv, jobject _jinstance, jstring jresult);
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_SpecialNames.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_SpecialNames.h
@@ -15,6 +15,7 @@ _GLUECODIUM_C_EXPORT void smoke_SpecialNames_create(_baseRef _instance);
 _GLUECODIUM_C_EXPORT void smoke_SpecialNames_release(_baseRef _instance);
 _GLUECODIUM_C_EXPORT void smoke_SpecialNames_createProxy(_baseRef _instance);
 _GLUECODIUM_C_EXPORT void smoke_SpecialNames_Uppercase(_baseRef _instance);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SpecialNames_make(_baseRef result);
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/src/smoke/cbridge_SpecialNames.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/src/smoke/cbridge_SpecialNames.cpp
@@ -1,0 +1,47 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_SpecialNames.h"
+#include "cbridge/include/StringHandle.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "smoke/SpecialNames.h"
+#include <memory>
+#include <new>
+#include <string>
+void smoke_SpecialNames_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(handle);
+}
+_baseRef smoke_SpecialNames_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(handle)))
+        : 0;
+}
+const void* smoke_SpecialNames_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(handle)->get())
+        : nullptr;
+}
+void smoke_SpecialNames_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(handle)->get(), swift_pointer);
+}
+void smoke_SpecialNames_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(handle)->get());
+}
+void smoke_SpecialNames_create(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(_instance)->get()->create();
+}
+void smoke_SpecialNames_release(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(_instance)->get()->release();
+}
+void smoke_SpecialNames_createProxy(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(_instance)->get()->create_proxy();
+}
+void smoke_SpecialNames_Uppercase(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::SpecialNames >>(_instance)->get()->_uppercase();
+}
+_baseRef smoke_SpecialNames_make(_baseRef result) {
+    return Conversion<::std::shared_ptr< ::smoke::SpecialNames >>::toBaseRef(::smoke::SpecialNames::make(Conversion<::std::string>::toCpp(result)));
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/SpecialNames.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/SpecialNames.h
@@ -4,6 +4,8 @@
 // -------------------------------------------------------------------------------------------------
 #pragma once
 #include "gluecodium/ExportGluecodiumCpp.h"
+#include <memory>
+#include <string>
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SpecialNames {
 public:
@@ -14,5 +16,11 @@ public:
     virtual void release(  ) = 0;
     virtual void create_proxy(  ) = 0;
     virtual void _uppercase(  ) = 0;
+    /**
+     *
+     * \param[in] result
+     * \return @NotNull
+     */
+    static ::std::shared_ptr< ::smoke::SpecialNames > make( const ::std::string& result );
 };
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/ffi/ffi_smoke_SpecialNames.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/ffi/ffi_smoke_SpecialNames.cpp
@@ -1,0 +1,69 @@
+#include "ffi_smoke_SpecialNames.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "smoke/SpecialNames.h"
+#include <memory>
+#include <string>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+library_smoke_SpecialNames_create(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SpecialNames>>::toCpp(_self)).create();
+}
+void
+library_smoke_SpecialNames_release(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SpecialNames>>::toCpp(_self)).release();
+}
+void
+library_smoke_SpecialNames_createProxy(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SpecialNames>>::toCpp(_self)).create_proxy();
+}
+void
+library_smoke_SpecialNames_Uppercase(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SpecialNames>>::toCpp(_self))._uppercase();
+}
+FfiOpaqueHandle
+library_smoke_SpecialNames_make__String(int32_t _isolate_id, FfiOpaqueHandle result) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::SpecialNames>>::toFfi(
+        smoke::SpecialNames::make(
+            gluecodium::ffi::Conversion<std::string>::toCpp(result)
+        )
+    );
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_SpecialNames_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::SpecialNames>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_SpecialNames_release_handle(handle);
+}
+void
+library_smoke_SpecialNames_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_SpecialNames_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_SpecialNames_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::SpecialNames>(
+            *reinterpret_cast<std::shared_ptr<smoke::SpecialNames>*>(handle)
+        )
+    );
+}
+void
+library_smoke_SpecialNames_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::SpecialNames>*>(handle);
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -2,7 +2,10 @@ import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
 abstract class SpecialNames {
+  factory SpecialNames(String result) => $prototype.make(result);
   /// @nodoc
   @Deprecated("Does nothing")
   void release();
@@ -10,6 +13,9 @@ abstract class SpecialNames {
   void reallyRelease();
   void createProxy();
   void Uppercase();
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = SpecialNames$Impl(Pointer<Void>.fromAddress(0));
 }
 // SpecialNames "private" section, not exported.
 final _smokeSpecialnamesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -24,10 +30,19 @@ final _smokeSpecialnamesReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialNames_release_handle'));
+/// @nodoc
+@visibleForTesting
 class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
   SpecialNames$Impl(Pointer<Void> handle) : super(handle);
   @override
   void release() {}
+  SpecialNames make(String result) {
+    final _result_handle = _make(result);
+    final _result = SpecialNames$Impl(_result_handle);
+    __lib.cacheInstance(_result_handle, _result);
+    _smokeSpecialnamesRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
   @override
   void create() {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create'));
@@ -51,6 +66,13 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     final _UppercaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase'));
     final _handle = this.handle;
     _UppercaseFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+  static Pointer<Void> _make(String result) {
+    final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SpecialNames_make__String'));
+    final _resultHandle = stringToFfi(result);
+    final __resultHandle = _makeFfi(__lib.LibraryContext.isolateId, _resultHandle);
+    stringReleaseFfiHandle(_resultHandle);
+    return __resultHandle;
   }
 }
 Pointer<Void> smokeSpecialnamesToFfi(SpecialNames value) =>

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/lime/smoke/SpecialNames.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/lime/smoke/SpecialNames.lime
@@ -5,4 +5,7 @@ class SpecialNames {
     fun release()
     fun createProxy()
     fun _upperCase()
+    constructor make(
+        result: String
+    )
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/SpecialNames.swift
@@ -2,6 +2,14 @@
 //
 import Foundation
 public class SpecialNames {
+    public init(result: String) {
+        let _result = SpecialNames.make(result: result)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_SpecialNames_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+    }
     let c_instance : _baseRef
     init(cSpecialNames: _baseRef) {
         guard cSpecialNames != 0 else {
@@ -24,6 +32,11 @@ public class SpecialNames {
     }
     public func Uppercase() -> Void {
         smoke_SpecialNames_Uppercase(self.c_instance)
+    }
+    private static func make(result: String) -> _baseRef {
+        let c_result = moveToCType(result)
+        let c_result_handle = smoke_SpecialNames_make(c_result.ref)
+        return moveFromCType(c_result_handle)
     }
 }
 internal func getRef(_ ref: SpecialNames?, owning: Bool = true) -> RefHolder {

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
@@ -14,8 +14,8 @@ extern "C" {
 jlong
 Java_com_example_namerules_NAME_1RULES_1DROID_create(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::namerules::NameRules::create();
-    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::namerules::NameRules >(result);
+    auto _result = ::namerules::NameRules::create();
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::namerules::NameRules >(_result);
     if (nSharedPtr == nullptr)
     {
         auto exceptionClass = ::jni::find_class(_jenv, "java/lang/OutOfMemoryError");
@@ -49,8 +49,8 @@ Java_com_example_namerules_NAME_1RULES_1DROID_some_1method(JNIEnv* _jenv, jobjec
         _throw_exception.register_exception(std::move(exception));
         return nativeCallResult.unsafe_value();
     }
-    auto result = nativeCallResult.unsafe_value();
-    return result;
+    auto _result = nativeCallResult.unsafe_value();
+    return _result;
 }
 jlong
 Java_com_example_namerules_NAME_1RULES_1DROID_loadIntProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -61,8 +61,8 @@ Java_com_example_namerules_NAME_1RULES_1DROID_loadIntProperty(JNIEnv* _jenv, job
             ::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->retrieve_int_property();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->retrieve_int_property();
+    return _result;
 }
 void
 Java_com_example_namerules_NAME_1RULES_1DROID_STORE_1INT_1PROPERTY(JNIEnv* _jenv, jobject _jinstance, jlong jvalue)
@@ -85,8 +85,8 @@ Java_com_example_namerules_NAME_1RULES_1DROID_loadBooleanProperty(JNIEnv* _jenv,
             ::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->really_boolean_property();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->really_boolean_property();
+    return _result;
 }
 void
 Java_com_example_namerules_NAME_1RULES_1DROID_STORE_1BOOLEAN_1PROPERTY(JNIEnv* _jenv, jobject _jinstance, jboolean jvalue)
@@ -109,8 +109,8 @@ Java_com_example_namerules_NAME_1RULES_1DROID_loadStructProperty(JNIEnv* _jenv, 
             ::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->retrieve_struct_property();
-    return ::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->retrieve_struct_property();
+    return ::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_namerules_NAME_1RULES_1DROID_STORE_1STRUCT_1PROPERTY(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/android/jni/com_example_smoke_Basic.cpp
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/android/jni/com_example_smoke_Basic.cpp
@@ -14,8 +14,8 @@ Java_com_example_smoke_Basic_basicMethod(JNIEnv* _jenv, jobject _jinstance, jstr
     ::std::string inputString = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinputString),
             (::std::string*)nullptr);
-    auto result = ::root::space::smoke::Basic::basic_method(inputString);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::root::space::smoke::Basic::basic_method(inputString);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Basic_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree.cpp
@@ -23,8 +23,8 @@ Java_com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_foo(JNIEnv* _jenv,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->foo(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->foo(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour.cpp
@@ -11,7 +11,7 @@ extern "C" {
 jobject
 Java_com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_00024LevelFour_fooFactory(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour::foo_factory();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour::foo_factory();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences.cpp
@@ -24,8 +24,8 @@ Java_com_example_smoke_NestedReferences_insideOut(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->inside_out(struct1,struct2);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->inside_out(struct1,struct2);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_NestedReferences_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerClass.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_OuterClass_00024InnerClass_foo(JNIEnv* _jenv, jobject _ji
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->foo(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->foo(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterClass_00024InnerClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImpl.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_OuterClass_00024InnerInterfaceImpl_foo(JNIEnv* _jenv, job
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->foo(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->foo(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterClass_00024InnerInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerClass.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_OuterInterface_00024InnerClass_foo(JNIEnv* _jenv, jobject
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->foo(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->foo(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterInterface_00024InnerClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerInterfaceImpl.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_OuterInterface_00024InnerInterfaceImpl_foo(JNIEnv* _jenv,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->foo(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->foo(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterInterface_00024InnerInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerClass.cpp
@@ -17,8 +17,8 @@ Java_com_example_smoke_OuterStruct_00024InnerClass_fooBar(JNIEnv* _jenv, jobject
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->foo_bar();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->foo_bar();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterStruct_00024InnerClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerInterfaceImpl.cpp
@@ -17,8 +17,8 @@ Java_com_example_smoke_OuterStruct_00024InnerInterfaceImpl_barBaz(JNIEnv* _jenv,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->bar_baz();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->bar_baz();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_OuterStruct_00024InnerInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerInterfaceImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerInterfaceImplCppProxy.cpp
@@ -15,7 +15,7 @@ com_example_smoke_OuterStruct_00024InnerInterface_CppProxy::com_example_smoke_Ou
 ::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > >
 com_example_smoke_OuterStruct_00024InnerInterface_CppProxy::bar_baz(  ) {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jobject>( "barBaz", "()Ljava/util/Map;", jniEnv  );
+    auto _result = callJavaMethod<jobject>( "barBaz", "()Ljava/util/Map;", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -23,7 +23,7 @@ com_example_smoke_OuterStruct_00024InnerInterface_CppProxy::bar_baz(  ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return convert_from_jni( jniEnv, result, (::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > >*)nullptr );
+    return convert_from_jni( jniEnv, _result, (::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > >*)nullptr );
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
@@ -23,8 +23,8 @@ Java_com_example_smoke_Nullable_methodWithString(JNIEnv* _jenv, jobject _jinstan
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_string(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_string(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithBoolean(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -38,8 +38,8 @@ Java_com_example_smoke_Nullable_methodWithBoolean(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_boolean(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_boolean(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithDouble(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -53,8 +53,8 @@ Java_com_example_smoke_Nullable_methodWithDouble(JNIEnv* _jenv, jobject _jinstan
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_double(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_double(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithInt(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -68,8 +68,8 @@ Java_com_example_smoke_Nullable_methodWithInt(JNIEnv* _jenv, jobject _jinstance,
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_int(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_int(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithSomeStruct(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -83,8 +83,8 @@ Java_com_example_smoke_Nullable_methodWithSomeStruct(JNIEnv* _jenv, jobject _jin
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_some_struct(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_some_struct(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithSomeEnum(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -98,8 +98,8 @@ Java_com_example_smoke_Nullable_methodWithSomeEnum(JNIEnv* _jenv, jobject _jinst
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_some_enum(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_some_enum(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithSomeArray(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -113,8 +113,8 @@ Java_com_example_smoke_Nullable_methodWithSomeArray(JNIEnv* _jenv, jobject _jins
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_some_array(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_some_array(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithInlineArray(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -128,8 +128,8 @@ Java_com_example_smoke_Nullable_methodWithInlineArray(JNIEnv* _jenv, jobject _ji
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_inline_array(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_inline_array(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithSomeMap(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -143,8 +143,8 @@ Java_com_example_smoke_Nullable_methodWithSomeMap(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_some_map(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_some_map(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Nullable_methodWithInstance(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
@@ -158,8 +158,8 @@ Java_com_example_smoke_Nullable_methodWithInstance(JNIEnv* _jenv, jobject _jinst
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->method_with_instance(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->method_with_instance(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jstring
 Java_com_example_smoke_Nullable_getStringProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -170,8 +170,8 @@ Java_com_example_smoke_Nullable_getStringProperty(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_string_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_string_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setStringProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)
@@ -196,8 +196,8 @@ Java_com_example_smoke_Nullable_isBoolProperty(JNIEnv* _jenv, jobject _jinstance
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_bool_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->is_bool_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setBoolProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -222,8 +222,8 @@ Java_com_example_smoke_Nullable_getDoubleProperty(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_double_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_double_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setDoubleProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -248,8 +248,8 @@ Java_com_example_smoke_Nullable_getIntProperty(JNIEnv* _jenv, jobject _jinstance
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_int_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_int_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setIntProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -274,8 +274,8 @@ Java_com_example_smoke_Nullable_getStructProperty(JNIEnv* _jenv, jobject _jinsta
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_struct_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_struct_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setStructProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -300,8 +300,8 @@ Java_com_example_smoke_Nullable_getEnumProperty(JNIEnv* _jenv, jobject _jinstanc
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_enum_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_enum_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setEnumProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -326,8 +326,8 @@ Java_com_example_smoke_Nullable_getArrayProperty(JNIEnv* _jenv, jobject _jinstan
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_array_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_array_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setArrayProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -352,8 +352,8 @@ Java_com_example_smoke_Nullable_getInlineArrayProperty(JNIEnv* _jenv, jobject _j
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_inline_array_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_inline_array_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setInlineArrayProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -378,8 +378,8 @@ Java_com_example_smoke_Nullable_getMapProperty(JNIEnv* _jenv, jobject _jinstance
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_map_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_map_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setMapProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -404,8 +404,8 @@ Java_com_example_smoke_Nullable_getInstanceProperty(JNIEnv* _jenv, jobject _jins
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_instance_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_instance_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Nullable_setInstanceProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)

--- a/gluecodium/src/test/resources/smoke/packages/output/android/jni/com_example_smokeoff_UnderscorePackage.cpp
+++ b/gluecodium/src/test/resources/smoke/packages/output/android/jni/com_example_smokeoff_UnderscorePackage.cpp
@@ -14,8 +14,8 @@ Java_com_example_smokeoff_UnderscorePackage_basicMethod(JNIEnv* _jenv, jobject _
     ::std::string inputString = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinputString),
             (::std::string*)nullptr);
-    auto result = ::smoke_off::UnderscorePackage::basic_method(inputString);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke_off::UnderscorePackage::basic_method(inputString);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smokeoff_UnderscorePackage_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/properties/output/android/jni/com_example_smoke_Properties.cpp
+++ b/gluecodium/src/test/resources/smoke/properties/output/android/jni/com_example_smoke_Properties.cpp
@@ -20,8 +20,8 @@ Java_com_example_smoke_Properties_getBuiltInTypeProperty(JNIEnv* _jenv, jobject 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_built_in_type_property();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->get_built_in_type_property();
+    return _result;
 }
 void
 Java_com_example_smoke_Properties_setBuiltInTypeProperty(JNIEnv* _jenv, jobject _jinstance, jlong jvalue)
@@ -44,8 +44,8 @@ Java_com_example_smoke_Properties_getReadonlyProperty(JNIEnv* _jenv, jobject _ji
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_readonly_property();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->get_readonly_property();
+    return _result;
 }
 jobject
 Java_com_example_smoke_Properties_getStructProperty(JNIEnv* _jenv, jobject _jinstance)
@@ -56,8 +56,8 @@ Java_com_example_smoke_Properties_getStructProperty(JNIEnv* _jenv, jobject _jins
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_struct_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_struct_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Properties_setStructProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -82,8 +82,8 @@ Java_com_example_smoke_Properties_getArrayProperty(JNIEnv* _jenv, jobject _jinst
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_array_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_array_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Properties_setArrayProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -108,8 +108,8 @@ Java_com_example_smoke_Properties_getComplexTypeProperty(JNIEnv* _jenv, jobject 
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_complex_type_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_complex_type_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Properties_setComplexTypeProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -134,8 +134,8 @@ Java_com_example_smoke_Properties_getByteBufferProperty(JNIEnv* _jenv, jobject _
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_byte_buffer_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_byte_buffer_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Properties_setByteBufferProperty(JNIEnv* _jenv, jobject _jinstance, jbyteArray jvalue)
@@ -160,8 +160,8 @@ Java_com_example_smoke_Properties_getInstanceProperty(JNIEnv* _jenv, jobject _ji
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_instance_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->get_instance_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Properties_setInstanceProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
@@ -186,8 +186,8 @@ Java_com_example_smoke_Properties_isBooleanProperty(JNIEnv* _jenv, jobject _jins
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_boolean_property();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_boolean_property();
+    return _result;
 }
 void
 Java_com_example_smoke_Properties_setBooleanProperty(JNIEnv* _jenv, jobject _jinstance, jboolean jvalue)
@@ -204,8 +204,8 @@ Java_com_example_smoke_Properties_setBooleanProperty(JNIEnv* _jenv, jobject _jin
 jstring
 Java_com_example_smoke_Properties_getStaticProperty(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::Properties::get_static_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::Properties::get_static_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 void
 Java_com_example_smoke_Properties_setStaticProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)
@@ -218,8 +218,8 @@ Java_com_example_smoke_Properties_setStaticProperty(JNIEnv* _jenv, jobject _jins
 jobject
 Java_com_example_smoke_Properties_getStaticReadonlyProperty(JNIEnv* _jenv, jobject _jinstance)
 {
-    auto result = ::smoke::Properties::get_static_readonly_property();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::Properties::get_static_readonly_property();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Properties_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImpl.cpp
@@ -18,8 +18,8 @@ Java_com_example_smoke_SkipProxyImpl_notInSwift(JNIEnv* _jenv, jobject _jinstanc
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->not_in_swift(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->not_in_swift(input);
+    return _result;
 }
 jfloat
 Java_com_example_smoke_SkipProxyImpl_notInDart(JNIEnv* _jenv, jobject _jinstance, jfloat jinput)
@@ -31,8 +31,8 @@ Java_com_example_smoke_SkipProxyImpl_notInDart(JNIEnv* _jenv, jobject _jinstance
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->not_in_dart(input);
-    return result;
+    auto _result = (*pInstanceSharedPointer)->not_in_dart(input);
+    return _result;
 }
 jboolean
 Java_com_example_smoke_SkipProxyImpl_isSkippedInSwift(JNIEnv* _jenv, jobject _jinstance)
@@ -43,8 +43,8 @@ Java_com_example_smoke_SkipProxyImpl_isSkippedInSwift(JNIEnv* _jenv, jobject _ji
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->is_skipped_in_swift();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->is_skipped_in_swift();
+    return _result;
 }
 void
 Java_com_example_smoke_SkipProxyImpl_setSkippedInSwift(JNIEnv* _jenv, jobject _jinstance, jboolean jvalue)
@@ -67,8 +67,8 @@ Java_com_example_smoke_SkipProxyImpl_getSkippedInDart(JNIEnv* _jenv, jobject _ji
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->get_skipped_in_dart();
-    return result;
+    auto _result = (*pInstanceSharedPointer)->get_skipped_in_dart();
+    return _result;
 }
 void
 Java_com_example_smoke_SkipProxyImpl_setSkippedInDart(JNIEnv* _jenv, jobject _jinstance, jfloat jvalue)

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
@@ -20,7 +20,7 @@ bool
 com_example_smoke_SkipProxy_CppProxy::not_in_swift( const bool ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     jboolean jinput = ninput;
-    auto result = callJavaMethod<jboolean>( "notInSwift", "(Z)Z", jniEnv , jinput);
+    auto _result = callJavaMethod<jboolean>( "notInSwift", "(Z)Z", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -28,13 +28,13 @@ com_example_smoke_SkipProxy_CppProxy::not_in_swift( const bool ninput ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return result;
+    return _result;
 }
 float
 com_example_smoke_SkipProxy_CppProxy::not_in_dart( const float ninput ) {
     JNIEnv* jniEnv = getJniEnvironment( );
     jfloat jinput = ninput;
-    auto result = callJavaMethod<jfloat>( "notInDart", "(F)F", jniEnv , jinput);
+    auto _result = callJavaMethod<jfloat>( "notInDart", "(F)F", jniEnv , jinput);
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -42,7 +42,7 @@ com_example_smoke_SkipProxy_CppProxy::not_in_dart( const float ninput ) {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return result;
+    return _result;
 }
 ::std::string
 com_example_smoke_SkipProxy_CppProxy::get_skipped_in_java(  ) const {
@@ -54,7 +54,7 @@ com_example_smoke_SkipProxy_CppProxy::set_skipped_in_java( const ::std::string& 
 bool
 com_example_smoke_SkipProxy_CppProxy::is_skipped_in_swift(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jboolean>( "isSkippedInSwift", "()Z", jniEnv  );
+    auto _result = callJavaMethod<jboolean>( "isSkippedInSwift", "()Z", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -62,7 +62,7 @@ com_example_smoke_SkipProxy_CppProxy::is_skipped_in_swift(  ) const {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return result;
+    return _result;
 }
 void
 com_example_smoke_SkipProxy_CppProxy::set_skipped_in_swift( const bool nvalue ) {
@@ -80,7 +80,7 @@ com_example_smoke_SkipProxy_CppProxy::set_skipped_in_swift( const bool nvalue ) 
 float
 com_example_smoke_SkipProxy_CppProxy::get_skipped_in_dart(  ) const {
     JNIEnv* jniEnv = getJniEnvironment( );
-    auto result = callJavaMethod<jfloat>( "getSkippedInDart", "()F", jniEnv  );
+    auto _result = callJavaMethod<jfloat>( "getSkippedInDart", "()F", jniEnv  );
     if ( jniEnv->ExceptionCheck( ) )
     {
         jniEnv->ExceptionDescribe( );
@@ -88,7 +88,7 @@ com_example_smoke_SkipProxy_CppProxy::get_skipped_in_dart(  ) const {
         jniEnv->FatalError( "Exception was thrown in Java and it was not handled.\n"
             "See the log for more information about the exception (including Java stack trace)." );
     }
-    return result;
+    return _result;
 }
 void
 com_example_smoke_SkipProxy_CppProxy::set_skipped_in_dart( const float nvalue ) {

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SomeSkippedClass.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SomeSkippedClass.cpp
@@ -18,8 +18,8 @@ Java_com_example_smoke_SomeSkippedClass_doFoo(JNIEnv* _jenv, jobject _jinstance)
             ::gluecodium::jni::make_non_releasing_ref(_jinstance),
             "nativeHandle",
             (int64_t*)nullptr));
-    auto result = (*pInstanceSharedPointer)->do_foo();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = (*pInstanceSharedPointer)->do_foo();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 JNIEXPORT void JNICALL
 Java_com_example_smoke_SomeSkippedClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
@@ -19,8 +19,8 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_distanceTo(JNIEn
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
         (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
-    auto result = _ninstance.distance_to(other);
-    return result;
+    auto _result = _ninstance.distance_to(other);
+    return _result;
 }
 jobject
 Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_add(JNIEnv* _jenv, jobject _jinstance, jobject jother)
@@ -31,8 +31,8 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_add(JNIEnv* _jen
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
         (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
-    auto result = _ninstance.add(other);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = _ninstance.add(other);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jboolean
 Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_validate(JNIEnv* _jenv, jobject _jinstance, jdouble jx, jdouble jy, jdouble jz)
@@ -40,8 +40,8 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_validate(JNIEnv*
     double x = jx;
     double y = jy;
     double z = jz;
-    auto result = ::smoke::StructsWithMethodsInterface::Vector3::validate(x,y,z);
-    return result;
+    auto _result = ::smoke::StructsWithMethodsInterface::Vector3::validate(x,y,z);
+    return _result;
 }
 jobject
 Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
@@ -49,8 +49,8 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Ljava_la
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
             (::std::string*)nullptr);
-    auto result = ::smoke::StructsWithMethodsInterface::Vector3::create(input);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::StructsWithMethodsInterface::Vector3::create(input);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Lcom_example_smoke_StructsWithMethodsInterface_00024Vector3_2(JNIEnv* _jenv, jobject _jinstance, jobject jother)
@@ -71,7 +71,7 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Lcom_exa
         _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
-    auto result = nativeCallResult.unsafe_value();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = nativeCallResult.unsafe_value();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Vector.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Vector.cpp
@@ -19,8 +19,8 @@ Java_com_example_smoke_Vector_distanceTo(JNIEnv* _jenv, jobject _jinstance, jobj
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
         (::smoke::Vector*)nullptr);
-    auto result = _ninstance.distance_to(other);
-    return result;
+    auto _result = _ninstance.distance_to(other);
+    return _result;
 }
 jobject
 Java_com_example_smoke_Vector_add(JNIEnv* _jenv, jobject _jinstance, jobject jother)
@@ -31,24 +31,24 @@ Java_com_example_smoke_Vector_add(JNIEnv* _jenv, jobject _jinstance, jobject jot
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
         (::smoke::Vector*)nullptr);
-    auto result = _ninstance.add(other);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = _ninstance.add(other);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jboolean
 Java_com_example_smoke_Vector_validate(JNIEnv* _jenv, jobject _jinstance, jdouble jx, jdouble jy)
 {
     double x = jx;
     double y = jy;
-    auto result = ::smoke::Vector::validate(x,y);
-    return result;
+    auto _result = ::smoke::Vector::validate(x,y);
+    return _result;
 }
 jobject
 Java_com_example_smoke_Vector_create__DD(JNIEnv* _jenv, jobject _jinstance, jdouble jx, jdouble jy)
 {
     double x = jx;
     double y = jy;
-    auto result = ::smoke::Vector::create(x,y);
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = ::smoke::Vector::create(x,y);
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 jobject
 Java_com_example_smoke_Vector_create__Lcom_example_smoke_Vector_2(JNIEnv* _jenv, jobject _jinstance, jobject jother)
@@ -69,7 +69,7 @@ Java_com_example_smoke_Vector_create__Lcom_example_smoke_Vector_2(JNIEnv* _jenv,
         _throw_exception.register_exception(std::move(exception));
         return nullptr;
     }
-    auto result = nativeCallResult.unsafe_value();
-    return ::gluecodium::jni::convert_to_jni(_jenv, result).release();
+    auto _result = nativeCallResult.unsafe_value();
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
 }
 }


### PR DESCRIPTION
Updated JNI templates to rename `result` local variable to `_result`. This fixes
a compilation error when a function parameter is also named "result". Prefixing
the local name with an underscore avoids this name clash under the default Java
name rules, as well as under any other common naming conventions.

Added smoke and functional tests. Unrelated smoke tests are updated in a
separate commit.

Resolves: #1102
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>