### PR TITLE
Validate LIME IDL values for type correctness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features:
   * Internal elements are now marked with `@internal` annotation in Dart generated code.
+  * Values assigned to constants or fields are now validated for type correctness.
 
 ## 10.0.0
 Release date: 2021-10-01

--- a/functional-tests/functional/input/lime/Defaults.lime
+++ b/functional-tests/functional/input/lime/Defaults.lime
@@ -48,11 +48,11 @@ class Defaults {
         doubleNegativeInfinityField: Double = -Infinity
     }
     struct StructWithEmptyDefaults {
-        intsField: List<Int> = {}
-        floatsField: FloatArray = {}
-        mapField: IdToStringMap = {}
+        intsField: List<Int> = []
+        floatsField: FloatArray = []
+        mapField: IdToStringMap = []
         structField: StructWithDefaults = {}
-        setTypeField: StringSet = {}
+        setTypeField: StringSet = []
     }
     struct StructWithTypedefDefaults {
         intField: IntTypedef = 42

--- a/functional-tests/functional/input/lime/Maps.lime
+++ b/functional-tests/functional/input/lime/Maps.lime
@@ -24,7 +24,7 @@ class Maps {
         value: String = ""
     }
     struct StructWithMap {
-        errorMapping: ErrorCodeToMessageMap = {}
+        errorMapping: ErrorCodeToMessageMap = []
     }
     enum SomeEnum {
         FooValue,

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -45,6 +45,7 @@ import com.here.gluecodium.validator.LimeSkipValidator
 import com.here.gluecodium.validator.LimeStructsValidator
 import com.here.gluecodium.validator.LimeTypeRefTargetValidator
 import com.here.gluecodium.validator.LimeTypeRefsValidator
+import com.here.gluecodium.validator.LimeValuesValidator
 import java.io.File
 import java.io.IOException
 import java.util.Properties
@@ -171,7 +172,8 @@ class Gluecodium(
             { LimeInheritanceValidator(limeLogger).validate(it) },
             { LimeFunctionsValidator(limeLogger).validate(it) },
             { LimeOptimizedListsValidator(limeLogger).validate(it) },
-            { LimeFieldConstructorsValidator(limeLogger).validate(it) }
+            { LimeFieldConstructorsValidator(limeLogger).validate(it) },
+            { LimeValuesValidator(limeLogger).validate(it) }
         )
 
     private fun getIndependentValidators(limeLogger: LimeLogger) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -179,8 +179,8 @@ internal class CppNameResolver(
                 "${signPrefix}std::numeric_limits<$typeString>::$valueString()"
             }
             is LimeValue.Null -> "${resolveName(limeValue.typeRef)}()"
-            is LimeValue.InitializerList ->
-                limeValue.values.joinToString(", ", "{", "}") { resolveValue(it) }
+            is LimeValue.InitializerList -> limeValue.values.joinToString(", ", "{", "}") { resolveValue(it) }
+            is LimeValue.StructInitializer -> limeValue.values.joinToString(", ", "{", "}") { resolveValue(it) }
             is LimeValue.KeyValuePair ->
                 "{${resolveValue(limeValue.key)}, ${resolveValue(limeValue.value)}}"
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -129,13 +129,6 @@ internal class DartNameResolver(
                 val prefix: String
                 val postfix: String
                 when (actualType) {
-                    is LimeStruct -> {
-                        val useDefaultsConstructor =
-                            actualType.fields.isNotEmpty() && limeValue.values.isEmpty()
-                        val constructorName = if (useDefaultsConstructor) ".withDefaults" else ""
-                        prefix = "${resolveName(actualType)}$constructorName("
-                        postfix = ")"
-                    }
                     is LimeList -> {
                         prefix = "["
                         postfix = "]"
@@ -148,6 +141,19 @@ internal class DartNameResolver(
                 limeValue.values.joinToString(
                     prefix = prefix,
                     postfix = postfix,
+                    separator = ", "
+                ) { resolveValue(it) }
+            }
+            is LimeValue.StructInitializer -> {
+                val actualType = limeValue.typeRef.type.actualType
+                if (actualType !is LimeStruct) {
+                    throw GluecodiumExecutionException("Unsupported type ${actualType.javaClass.name} for struct initializer")
+                }
+                val useDefaultsConstructor = actualType.fields.isNotEmpty() && limeValue.values.isEmpty()
+                val constructorName = if (useDefaultsConstructor) ".withDefaults" else ""
+                limeValue.values.joinToString(
+                    prefix = "${resolveName(actualType)}$constructorName(",
+                    postfix = ")",
                     separator = ", "
                 ) { resolveValue(it) }
             }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -128,16 +128,21 @@ internal class SwiftNameResolver(
                 val actualType = limeValue.typeRef.type.actualType
                 when {
                     actualType is LimeMap && limeValue.values.isEmpty() -> "[:]"
-                    actualType is LimeStruct ->
-                        limeValue.values
-                            .mapIndexed { index, it -> resolveName(actualType.fields[index]) + ": " + resolveValue(it) }
-                            .joinToString(prefix = "${resolveReferenceName(actualType)}(", postfix = ")", separator = ", ")
                     else -> limeValue.values.joinToString(
                         prefix = "[",
                         postfix = "]",
                         separator = ", "
                     ) { resolveValue(it) }
                 }
+            }
+            is LimeValue.StructInitializer -> {
+                val actualType = limeValue.typeRef.type.actualType
+                if (actualType !is LimeStruct) {
+                    throw GluecodiumExecutionException("Unsupported type ${actualType.javaClass.name} for struct initializer")
+                }
+                limeValue.values
+                    .mapIndexed { index, it -> resolveName(actualType.fields[index]) + ": " + resolveValue(it) }
+                    .joinToString(prefix = "${resolveReferenceName(actualType)}(", postfix = ")", separator = ", ")
             }
             is LimeValue.KeyValuePair -> "${resolveValue(limeValue.key)}: ${resolveValue(limeValue.value)}"
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeConstant
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeGenericType
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypedElement
+import com.here.gluecodium.model.lime.LimeValue
+
+/**
+ * Validates values assigned to constants and fields for correctness.
+ */
+internal class LimeValuesValidator(private val logger: LimeLogger) {
+
+    fun validate(limeModel: LimeModel): Boolean {
+        val allFields = limeModel.referenceMap.values.filterIsInstance<LimeField>()
+        val allConstants = limeModel.referenceMap.values.filterIsInstance<LimeConstant>()
+        val validationResults = allFields.map { validateField(it) } + allConstants.map { validateValue(it, it.value) }
+        return !validationResults.contains(false)
+    }
+
+    private fun validateField(limeField: LimeField) =
+        limeField.defaultValue?.let { validateValue(limeField, it) } ?: true
+
+    private fun validateValue(limeElement: LimeTypedElement, limeValue: LimeValue): Boolean {
+        val actualType = limeElement.typeRef.type.actualType
+        when (limeValue) {
+            is LimeValue.Literal -> if (actualType !is LimeBasicType || !actualType.typeId.isLiteralType) {
+                logger.error(limeElement, "literal values can only be assigned to numeric types, `Boolean`, or `String`")
+                return false
+            }
+            is LimeValue.Enumerator -> if (actualType !is LimeEnumeration) {
+                logger.error(limeElement, "enumerator values can only be assigned to `enum` types")
+                return false
+            }
+            is LimeValue.InitializerList -> if (actualType !is LimeGenericType) {
+                logger.error(limeElement, "initializer list values can only be assigned to collection types")
+                return false
+            }
+            is LimeValue.KeyValuePair -> {
+                logger.error(limeElement, "key-value pair values can only be used inside initializer lists")
+                return false
+            }
+            is LimeValue.Null -> if (!limeElement.typeRef.isNullable) {
+                logger.error(limeElement, "`null` value can only be assigned to a nullable type")
+                return false
+            }
+            is LimeValue.Special -> if (actualType !is LimeBasicType || !actualType.typeId.isNumericType) {
+                logger.error(limeElement, "special numeric values can only be assigned to numeric types")
+                return false
+            }
+            is LimeValue.StructInitializer -> if (actualType !is LimeStruct) {
+                logger.error(limeElement, "struct initializer values can only be assigned to `struct` types")
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeConstant
+import com.here.gluecodium.model.lime.LimeDirectTypeRef
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeEnumerator
+import com.here.gluecodium.model.lime.LimeEnumeratorRef
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeGenericType
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeValue
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class LimeValuesValidatorTest(
+    private val limeTypeRef: LimeTypeRef,
+    private val limeValue: LimeValue,
+    private val expectedResult: Boolean
+) {
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+
+    private val validator = LimeValuesValidator(mockk(relaxed = true))
+
+    @Test
+    fun validateWithField() {
+        allElements[""] = LimeField(EMPTY_PATH, typeRef = limeTypeRef, defaultValue = limeValue)
+
+        assertEquals(validator.validate(limeModel), expectedResult)
+    }
+
+    @Test
+    fun validateWithConstant() {
+        allElements[""] = LimeConstant(EMPTY_PATH, typeRef = limeTypeRef, value = limeValue)
+
+        assertEquals(validator.validate(limeModel), expectedResult)
+    }
+
+    companion object {
+        private val fooTypeRef = LimeDirectTypeRef(object : LimeType(EMPTY_PATH) {})
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun testData() = listOf(
+            arrayOf(LimeBasicTypeRef.INT, LimeValue.Literal(fooTypeRef, ""), true),
+            arrayOf(LimeBasicTypeRef.FLOAT, LimeValue.Literal(fooTypeRef, ""), true),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.BOOLEAN), LimeValue.Literal(fooTypeRef, ""), true),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.STRING), LimeValue.Literal(fooTypeRef, ""), true),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.DATE), LimeValue.Literal(fooTypeRef, ""), false),
+            arrayOf(fooTypeRef, LimeValue.Literal(fooTypeRef, ""), false),
+            arrayOf(
+                LimeDirectTypeRef(LimeEnumeration(EMPTY_PATH)),
+                LimeValue.Enumerator(
+                    fooTypeRef,
+                    object : LimeEnumeratorRef() {
+                        override val elementFullName = ""
+                        override val enumerator = LimeEnumerator(EMPTY_PATH)
+                    }
+                ),
+                true
+            ),
+            arrayOf(
+                fooTypeRef,
+                LimeValue.Enumerator(
+                    fooTypeRef,
+                    object : LimeEnumeratorRef() {
+                        override val elementFullName = ""
+                        override val enumerator = LimeEnumerator(EMPTY_PATH)
+                    }
+                ),
+                false
+            ),
+            arrayOf(
+                LimeDirectTypeRef(object : LimeGenericType() {}),
+                LimeValue.InitializerList(fooTypeRef, emptyList()),
+                true
+            ),
+            arrayOf(fooTypeRef, LimeValue.InitializerList(fooTypeRef, emptyList()), false),
+            arrayOf(fooTypeRef, LimeValue.KeyValuePair(LimeValue.ZERO, LimeValue.ZERO), false),
+            arrayOf(
+                LimeDirectTypeRef(object : LimeType(EMPTY_PATH) {}, isNullable = true),
+                LimeValue.Null(fooTypeRef),
+                true
+            ),
+            arrayOf(fooTypeRef, LimeValue.Null(fooTypeRef), false),
+            arrayOf(LimeBasicTypeRef.INT, LimeValue.Special(fooTypeRef, LimeValue.Special.ValueId.NAN), true),
+            arrayOf(fooTypeRef, LimeValue.Special(fooTypeRef, LimeValue.Special.ValueId.NAN), false),
+            arrayOf(
+                LimeDirectTypeRef(LimeStruct(EMPTY_PATH)),
+                LimeValue.StructInitializer(fooTypeRef, emptyList()),
+                true
+            ),
+            arrayOf(fooTypeRef, LimeValue.StructInitializer(fooTypeRef, emptyList()), false),
+        )
+    }
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -632,7 +632,7 @@ internal class AntlrLimeModelBuilder(
                         val fieldTypeRef = LimePositionalTypeRef(limeTypeRef, idx)
                         convertLiteralConstant(fieldTypeRef, childCtx)
                     }
-                return LimeValue.InitializerList(limeTypeRef, values)
+                return LimeValue.StructInitializer(limeTypeRef, values)
             }
             ctx.listInitializer() != null -> {
                 val values = ctx.listInitializer().literalConstant().map {

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
@@ -22,8 +22,9 @@ package com.here.gluecodium.model.lime
 class LimeBasicType(val typeId: TypeId) : LimeType(path = LimePath.EMPTY_PATH) {
     enum class TypeId(
         private val tag: String,
-        @Suppress("unused") val isIntegerType: Boolean = false,
-        @Suppress("unused") val isNumericType: Boolean = isIntegerType
+        val isIntegerType: Boolean = false,
+        val isNumericType: Boolean = isIntegerType,
+        val isLiteralType: Boolean = isNumericType
     ) {
         VOID("Void"),
         INT8("Byte", true),
@@ -36,8 +37,8 @@ class LimeBasicType(val typeId: TypeId) : LimeType(path = LimePath.EMPTY_PATH) {
         UINT64("ULong", true),
         FLOAT("Float", false, true),
         DOUBLE("Double", false, true),
-        BOOLEAN("Boolean"),
-        STRING("String"),
+        BOOLEAN("Boolean", false, false, true),
+        STRING("String", false, false, true),
         BLOB("Blob"),
         DATE("Date"),
         DURATION("Duration"),

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
@@ -77,12 +77,11 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
     }
 
     class InitializerList(type: LimeTypeRef, val values: List<LimeValue>) : LimeValue(type) {
-        override fun toString(): String {
-            val limeType = typeRef.type.actualType
-            val prefix = if (limeType is LimeGenericType) "[" else "{"
-            val suffix = if (limeType is LimeGenericType) "]" else "}"
-            return values.joinToString(separator = ", ", prefix = prefix, postfix = suffix)
-        }
+        override fun toString() = values.joinToString(separator = ", ", prefix = "[", postfix = "]")
+    }
+
+    class StructInitializer(type: LimeTypeRef, val values: List<LimeValue>) : LimeValue(type) {
+        override fun toString() = values.joinToString(separator = ", ", prefix = "{", postfix = "}")
     }
 
     class KeyValuePair(val key: LimeValue, val value: LimeValue) :


### PR DESCRIPTION
Updated LimeValue class to represent struct initializers with a separate
subclass instead of mixing it with initializer lists before. This enables more
fine-grained validation of type correctness.

Updated generators to handle the new class properly (by splitting existing code
for initializer lists into two separate cases).

Added a new validator LimeValuesValidator that checks values assigned to fields
and constants for type correctness (e.g. struct initializers should not be
assigned to `List<>` fields, etc.). Added unit tests for the new validator.

Updated LIME files for functional tests to fix errors reported by the new
validator (misuse of `{}` empty struct initializer where `[]` empty initializer
list should be used).

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>