### PR TITLE
Resolve potential name clashes in Java by using fully qualified names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a compilation issue in Java when two types in different packages have the same name.
+
 ## 10.1.1
 Release date: 2021-10-08
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -458,6 +458,11 @@ feature(Locales cpp android swift dart SOURCES
     input/lime/Locales.lime
 )
 
+feature(CrossPackageNameClash cpp android swift dart SOURCES
+    input/lime/CrossPackageNameClashA.lime
+    input/lime/CrossPackageNameClashB.lime
+)
+
 # OBJECT suits all test variants except swift for linux,
 # because build system can't mix Swift and C++ code in single target
 if (swift IN_LIST GLUECODIUM_GENERATORS_DEFAULT AND NOT CMAKE_GENERATOR STREQUAL "Xcode")

--- a/functional-tests/functional/input/lime/CrossPackageNameClashA.lime
+++ b/functional-tests/functional/input/lime/CrossPackageNameClashA.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+enum Alphabet {
+    A,
+    B,
+    C
+}
+
+struct LearnToRead {
+    fieldA: test.Alphabet = test.Alphabet.A
+    fieldB: test.foo.Alphabet = test.foo.Alphabet.BETA
+}

--- a/functional-tests/functional/input/lime/CrossPackageNameClashB.lime
+++ b/functional-tests/functional/input/lime/CrossPackageNameClashB.lime
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test.foo
+
+@Swift("Iphabet")
+@Dart("Dartphabet")
+enum Alphabet {
+    ALPHA,
+    BETA,
+    GAMMA
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/Constants.java
+++ b/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/Constants.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 public final class Constants {
@@ -10,5 +9,5 @@ public final class Constants {
     public static final float FLOAT_CONSTANT = 2.71f;
     public static final double DOUBLE_CONSTANT = -3.14;
     public static final String STRING_CONSTANT = "Foo bar";
-    public static final StateEnum ENUM_CONSTANT = StateEnum.ON;
+    public static final com.example.smoke.StateEnum ENUM_CONSTANT = com.example.smoke.StateEnum.ON;
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/ImmutableStructWithDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/ImmutableStructWithDefaults.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
@@ -13,7 +12,7 @@ public final class ImmutableStructWithDefaults {
     @NonNull
     public final String stringField;
     @NonNull
-    public final SomeEnum enumField;
+    public final com.example.smoke.SomeEnum enumField;
     @NonNull
     public final DefaultValues.ExternalEnum externalEnumField;
     public ImmutableStructWithDefaults(final long uintField, final boolean boolField) {
@@ -23,10 +22,10 @@ public final class ImmutableStructWithDefaults {
         this.doubleField = -1.4142;
         this.boolField = boolField;
         this.stringField = "\\Jonny \"Magic\" Smith\n";
-        this.enumField = SomeEnum.BAR_VALUE;
+        this.enumField = com.example.smoke.SomeEnum.BAR_VALUE;
         this.externalEnumField = DefaultValues.ExternalEnum.ANOTHER_VALUE;
     }
-    public ImmutableStructWithDefaults(final int intField, final long uintField, final float floatField, final double doubleField, final boolean boolField, @NonNull final String stringField, @NonNull final SomeEnum enumField, @NonNull final DefaultValues.ExternalEnum externalEnumField) {
+    public ImmutableStructWithDefaults(final int intField, final long uintField, final float floatField, final double doubleField, final boolean boolField, @NonNull final String stringField, @NonNull final com.example.smoke.SomeEnum enumField, @NonNull final DefaultValues.ExternalEnum externalEnumField) {
         this.intField = intField;
         this.uintField = uintField;
         this.floatField = floatField;

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
@@ -26,5 +26,5 @@ public final class NestedReferences extends NativeBase {
     }
     private static native void disposeNativeHandle(long nativeHandle);
     @NonNull
-    public native NestedReferences insideOut(@NonNull final NestedReferences.NestedReferences struct1, @NonNull final NestedReferences.NestedReferences struct2);
+    public native com.example.smoke.NestedReferences insideOut(@NonNull final com.example.smoke.NestedReferences.NestedReferences struct1, @NonNull final com.example.smoke.NestedReferences.NestedReferences struct2);
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/AllTypesStruct.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/AllTypesStruct.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
@@ -21,8 +20,8 @@ public final class AllTypesStruct {
     @NonNull
     public byte[] bytesField;
     @NonNull
-    public Point pointField;
-    public AllTypesStruct(final byte int8Field, final short uint8Field, final short int16Field, final int uint16Field, final int int32Field, final long uint32Field, final long int64Field, final long uint64Field, final float floatField, final double doubleField, @NonNull final String stringField, final boolean booleanField, @NonNull final byte[] bytesField, @NonNull final Point pointField) {
+    public com.example.smoke.Point pointField;
+    public AllTypesStruct(final byte int8Field, final short uint8Field, final short int16Field, final int uint16Field, final int int32Field, final long uint32Field, final long int64Field, final long uint64Field, final float floatField, final double doubleField, @NonNull final String stringField, final boolean booleanField, @NonNull final byte[] bytesField, @NonNull final com.example.smoke.Point pointField) {
         this.int8Field = int8Field;
         this.uint8Field = uint8Field;
         this.int16Field = int16Field;

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Line.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Line.java
@@ -1,15 +1,14 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
 public final class Line {
     @NonNull
-    public Point a;
+    public com.example.smoke.Point a;
     @NonNull
-    public Point b;
-    public Line(@NonNull final Point a, @NonNull final Point b) {
+    public com.example.smoke.Point b;
+    public Line(@NonNull final com.example.smoke.Point a, @NonNull final com.example.smoke.Point b) {
         this.a = a;
         this.b = b;
     }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
@@ -120,7 +120,7 @@ public final class Structs extends NativeBase {
     @NonNull
     public static native Structs.AllTypesStruct returnAllTypesStruct(@NonNull final Structs.AllTypesStruct input);
     @NonNull
-    public static native Point createPoint(final double x, final double y);
+    public static native com.example.smoke.Point createPoint(final double x, final double y);
     @NonNull
-    public static native AllTypesStruct modifyAllTypesStruct(@NonNull final AllTypesStruct input);
+    public static native com.example.smoke.AllTypesStruct modifyAllTypesStruct(@NonNull final com.example.smoke.AllTypesStruct input);
 }


### PR DESCRIPTION
Updated JavaNameResolver to flag the types with potential name clashes and then
resolve the references to these types as fully qualified names (i.e. with all
package names prepended). This fixes potential Java compilation issues when two
such "clashing" types are used together in the same generated Java file.

Updated smoke tests. Added dedicated functional test.

Resolves: #1112
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
