### PR TITLE
Fix initializers for internal fields in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a compilation issue in Swift when an internal field in a struct has a type that is an enum or a collection of
+    enum values.
+
 ## 10.1.2
 Release date: 2021-10-08
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -259,6 +259,7 @@ feature(Defaults cpp android swift dart SOURCES
     input/lime/Defaults.lime
     input/lime/PositionalDefaults.lime
     input/lime/PositionalEnumerators.lime
+    input/lime/InternalEnumDefaults.lime
 )
 
 feature(Inheritance cpp android swift dart SOURCES

--- a/functional-tests/functional/input/lime/InternalEnumDefaults.lime
+++ b/functional-tests/functional/input/lime/InternalEnumDefaults.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+enum FooBarBazEnum {
+    FOO,
+    BAR,
+    baz
+}
+
+struct InternalEnumDefaults {
+    publicField: FooBarBazEnum = FooBarBazEnum.FOO
+    publicListField: List<FooBarBazEnum> = [FooBarBazEnum.FOO, FooBarBazEnum.BAR, FooBarBazEnum.baz]
+    internal internalField: FooBarBazEnum = FooBarBazEnum.BAR
+    internal internalListField: List<FooBarBazEnum> = [FooBarBazEnum.FOO, FooBarBazEnum.BAR, FooBarBazEnum.baz]
+}

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
@@ -34,7 +34,7 @@
         self.{{resolveName}} = {{resolveName}}
 {{/publicFields}}
 {{#internalFields}}
-        self.{{resolveName}} = {{defaultValue}}
+        self.{{resolveName}} = {{resolveName defaultValue}}
 {{/internalFields}}
     }
 {{/ifPredicate}}{{/unless}}{{!!

--- a/gluecodium/src/test/resources/smoke/defaults/input/InternalEnumDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/InternalEnumDefaults.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+enum FooBarEnum {
+    FOO,
+    BAR,
+    baz
+}
+
+struct InternalEnumDefaults {
+    publicField: FooBarEnum = FooBarEnum.FOO
+    publicListField: List<FooBarEnum> = [FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.baz]
+    internal internalField: FooBarEnum = FooBarEnum.BAR
+    internal internalListField: List<FooBarEnum> = [FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.baz]
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/InternalEnumDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/InternalEnumDefaults.java
@@ -1,0 +1,30 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+public final class InternalEnumDefaults {
+    @NonNull
+    public FooBarEnum publicField;
+    @NonNull
+    public List<FooBarEnum> publicListField;
+    @NonNull
+    FooBarEnum internalField;
+    @NonNull
+    List<FooBarEnum> internalListField;
+    public InternalEnumDefaults() {
+        this.publicField = FooBarEnum.FOO;
+        this.publicListField = new ArrayList<>(Arrays.asList(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ));
+        this.internalField = FooBarEnum.BAR;
+        this.internalListField = new ArrayList<>(Arrays.asList(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ));
+    }
+    InternalEnumDefaults(@NonNull final FooBarEnum publicField, @NonNull final List<FooBarEnum> publicListField, @NonNull final FooBarEnum internalField, @NonNull final List<FooBarEnum> internalListField) {
+        this.publicField = publicField;
+        this.publicListField = publicListField;
+        this.internalField = internalField;
+        this.internalListField = internalListField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/InternalEnumDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/InternalEnumDefaults.h
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/VectorHash.h"
+#include "smoke/FooBarEnum.h"
+#include <vector>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT InternalEnumDefaults {
+    ::smoke::FooBarEnum public_field = ::smoke::FooBarEnum::FOO;
+    ::std::vector< ::smoke::FooBarEnum > public_list_field = {::smoke::FooBarEnum::FOO, ::smoke::FooBarEnum::BAR, ::smoke::FooBarEnum::BAZ};
+    ::smoke::FooBarEnum internal_field = ::smoke::FooBarEnum::BAR;
+    ::std::vector< ::smoke::FooBarEnum > internal_list_field = {::smoke::FooBarEnum::FOO, ::smoke::FooBarEnum::BAR, ::smoke::FooBarEnum::BAZ};
+    InternalEnumDefaults( );
+    InternalEnumDefaults( ::smoke::FooBarEnum public_field, ::std::vector< ::smoke::FooBarEnum > public_list_field, ::smoke::FooBarEnum internal_field, ::std::vector< ::smoke::FooBarEnum > internal_list_field );
+};
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/internal_enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/internal_enum_defaults.dart
@@ -1,0 +1,105 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/generic_types__conversion.dart';
+import 'package:library/src/smoke/foo_bar_enum.dart';
+import 'package:meta/meta.dart';
+class InternalEnumDefaults {
+  FooBarEnum publicField;
+  List<FooBarEnum> publicListField;
+  /// @nodoc
+  @internal
+  FooBarEnum internal_internalField;
+  /// @nodoc
+  @internal
+  List<FooBarEnum> internal_internalListField;
+  InternalEnumDefaults(this.publicField, this.publicListField, this.internal_internalField, this.internal_internalListField);
+  InternalEnumDefaults.withDefaults()
+    : publicField = FooBarEnum.foo, publicListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz], internal_internalField = FooBarEnum.bar, internal_internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz];
+}
+// InternalEnumDefaults "private" section, not exported.
+final _smokeInternalenumdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32, Pointer<Void>, Uint32, Pointer<Void>),
+    Pointer<Void> Function(int, Pointer<Void>, int, Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_create_handle'));
+final _smokeInternalenumdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_release_handle'));
+final _smokeInternalenumdefaultsGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_get_field_publicField'));
+final _smokeInternalenumdefaultsGetFieldpublicListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_get_field_publicListField'));
+final _smokeInternalenumdefaultsGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_get_field_internalField'));
+final _smokeInternalenumdefaultsGetFieldinternalListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_get_field_internalListField'));
+Pointer<Void> smokeInternalenumdefaultsToFfi(InternalEnumDefaults value) {
+  final _publicFieldHandle = smokeFoobarenumToFfi(value.publicField);
+  final _publicListFieldHandle = listofSmokeFoobarenumToFfi(value.publicListField);
+  final _internalFieldHandle = smokeFoobarenumToFfi(value.internal_internalField);
+  final _internalListFieldHandle = listofSmokeFoobarenumToFfi(value.internal_internalListField);
+  final _result = _smokeInternalenumdefaultsCreateHandle(_publicFieldHandle, _publicListFieldHandle, _internalFieldHandle, _internalListFieldHandle);
+  smokeFoobarenumReleaseFfiHandle(_publicFieldHandle);
+  listofSmokeFoobarenumReleaseFfiHandle(_publicListFieldHandle);
+  smokeFoobarenumReleaseFfiHandle(_internalFieldHandle);
+  listofSmokeFoobarenumReleaseFfiHandle(_internalListFieldHandle);
+  return _result;
+}
+InternalEnumDefaults smokeInternalenumdefaultsFromFfi(Pointer<Void> handle) {
+  final _publicFieldHandle = _smokeInternalenumdefaultsGetFieldpublicField(handle);
+  final _publicListFieldHandle = _smokeInternalenumdefaultsGetFieldpublicListField(handle);
+  final _internalFieldHandle = _smokeInternalenumdefaultsGetFieldinternalField(handle);
+  final _internalListFieldHandle = _smokeInternalenumdefaultsGetFieldinternalListField(handle);
+  try {
+    return InternalEnumDefaults(
+      smokeFoobarenumFromFfi(_publicFieldHandle),
+      listofSmokeFoobarenumFromFfi(_publicListFieldHandle),
+      smokeFoobarenumFromFfi(_internalFieldHandle),
+      listofSmokeFoobarenumFromFfi(_internalListFieldHandle)
+    );
+  } finally {
+    smokeFoobarenumReleaseFfiHandle(_publicFieldHandle);
+    listofSmokeFoobarenumReleaseFfiHandle(_publicListFieldHandle);
+    smokeFoobarenumReleaseFfiHandle(_internalFieldHandle);
+    listofSmokeFoobarenumReleaseFfiHandle(_internalListFieldHandle);
+  }
+}
+void smokeInternalenumdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeInternalenumdefaultsReleaseHandle(handle);
+// Nullable InternalEnumDefaults
+final _smokeInternalenumdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_create_handle_nullable'));
+final _smokeInternalenumdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_release_handle_nullable'));
+final _smokeInternalenumdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_InternalEnumDefaults_get_value_nullable'));
+Pointer<Void> smokeInternalenumdefaultsToFfiNullable(InternalEnumDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeInternalenumdefaultsToFfi(value);
+  final result = _smokeInternalenumdefaultsCreateHandleNullable(_handle);
+  smokeInternalenumdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+InternalEnumDefaults? smokeInternalenumdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeInternalenumdefaultsGetValueNullable(handle);
+  final result = smokeInternalenumdefaultsFromFfi(_handle);
+  smokeInternalenumdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeInternalenumdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeInternalenumdefaultsReleaseHandleNullable(handle);
+// End of InternalEnumDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/InternalEnumDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/InternalEnumDefaults.swift
@@ -1,0 +1,72 @@
+//
+//
+import Foundation
+public struct InternalEnumDefaults {
+    public var publicField: FooBarEnum
+    public var publicListField: [FooBarEnum]
+    internal var internalField: FooBarEnum
+    internal var internalListField: [FooBarEnum]
+    public init(publicField: FooBarEnum = FooBarEnum.foo, publicListField: [FooBarEnum] = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz]) {
+        self.publicField = publicField
+        self.publicListField = publicListField
+        self.internalField = FooBarEnum.bar
+        self.internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz]
+    }
+    internal init(publicField: FooBarEnum = FooBarEnum.foo, publicListField: [FooBarEnum] = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz], internalField: FooBarEnum = FooBarEnum.bar, internalListField: [FooBarEnum] = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz]) {
+        self.publicField = publicField
+        self.publicListField = publicListField
+        self.internalField = internalField
+        self.internalListField = internalListField
+    }
+    internal init(cHandle: _baseRef) {
+        publicField = moveFromCType(smoke_InternalEnumDefaults_publicField_get(cHandle))
+        publicListField = moveFromCType(smoke_InternalEnumDefaults_publicListField_get(cHandle))
+        internalField = moveFromCType(smoke_InternalEnumDefaults_internalField_get(cHandle))
+        internalListField = moveFromCType(smoke_InternalEnumDefaults_internalListField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> InternalEnumDefaults {
+    return InternalEnumDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> InternalEnumDefaults {
+    defer {
+        smoke_InternalEnumDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: InternalEnumDefaults) -> RefHolder {
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_publicListField = moveToCType(swiftType.publicListField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    let c_internalListField = moveToCType(swiftType.internalListField)
+    return RefHolder(smoke_InternalEnumDefaults_create_handle(c_publicField.ref, c_publicListField.ref, c_internalField.ref, c_internalListField.ref))
+}
+internal func moveToCType(_ swiftType: InternalEnumDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_InternalEnumDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> InternalEnumDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_InternalEnumDefaults_unwrap_optional_handle(handle)
+    return InternalEnumDefaults(cHandle: unwrappedHandle) as InternalEnumDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> InternalEnumDefaults? {
+    defer {
+        smoke_InternalEnumDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: InternalEnumDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_publicListField = moveToCType(swiftType.publicListField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    let c_internalListField = moveToCType(swiftType.internalListField)
+    return RefHolder(smoke_InternalEnumDefaults_create_optional_handle(c_publicField.ref, c_publicListField.ref, c_internalField.ref, c_internalListField.ref))
+}
+internal func moveToCType(_ swiftType: InternalEnumDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_InternalEnumDefaults_release_optional_handle)
+}


### PR DESCRIPTION
Updated SwiftConstConstructors template to correctly apply name resolution for
field initializers of internal fields. This fixes an issue where enumerator
names were taken verbatim from IDL, instead of being normalized by name rules,
leading to a compilation error.

Added smoke and functional tests, also for other languages (even if the issue
did not exist there).

Resolves: #1115
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>