### PR TITLE
Fix referential equality for `@Swift(Weak)` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a runtime issue in Swift when a property marked with `@Swift(Weak)` violated referential equality on a round
+    trip.
+
 ## 10.1.3
 Release date: 2021-10-08
 ### Bug fixes:

--- a/functional-tests/functional/swift/Tests/WeakListenersTests.swift
+++ b/functional-tests/functional/swift/Tests/WeakListenersTests.swift
@@ -97,12 +97,23 @@ class WeakListenersTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func testWeakListenerRoundTrip() {
+        let listener = ListenerImpl()
+        let weakling = WeaklingNotifier.createWeakling()
+        weakling.weakListener = listener
+
+        let result = weakling.weakListener
+
+        XCTAssertTrue(result === listener)
+    }
+
     static var allTests = [
         ("testWeaklingIsPushed", testWeaklingIsPushed),
         ("testWeaklingIsIgnored", testWeaklingIsIgnored),
         ("testWeaklingIsPushedStrongly", testWeaklingIsPushedStrongly),
         ("testWeaklingIsNotIgnored", testWeaklingIsNotIgnored),
         ("testWeaklingIsPushedMaybe", testWeaklingIsPushedMaybe),
-        ("testWeaklingIsIgnoredMaybe", testWeaklingIsIgnoredMaybe)
+        ("testWeaklingIsIgnoredMaybe", testWeaklingIsIgnoredMaybe),
+        ("testWeakListenerRoundTrip", testWeakListenerRoundTrip)
     ]
 }

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassConversion.mustache
@@ -110,13 +110,25 @@ extension {{>implName}}: Hashable {
 }
 
 {{conversionVisibility}} func {{resolveName "mangled"}}moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}} {
-{{#instanceOf this "LimeInterface"}}
+{{#instanceOf this "LimeInterface"}}{{#unlessPredicate "hasWeakSupport"}}
     if let swift_pointer = {{resolveName "CBridge"}}_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? {{resolveName this "" "ref"}} {
         {{resolveName "CBridge"}}_release_handle(handle)
         return re_constructed
     }
-{{/instanceOf}}
+{{/unlessPredicate}}{{#ifPredicate "hasWeakSupport"}}
+    if let swift_pointer = {{resolveName "CBridge"}}_get_swift_object_from_cache(handle) {
+        let re_constructed_uncast = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue()
+        if let re_constructed = re_constructed_uncast as? {{resolveName this "" "ref"}} {
+            {{resolveName "CBridge"}}_release_handle(handle)
+            return re_constructed
+        }
+        if let weak_value = (re_constructed_uncast as? {{resolveName this "" "ref"}}_WeakHolder)?.value {
+            {{resolveName "CBridge"}}_release_handle(handle)
+            return weak_value
+        }
+    }
+{{/ifPredicate}}{{/instanceOf}}
     if let swift_pointer = {{resolveName "CBridge"}}_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? {{resolveName this "" "ref"}} {
         {{resolveName "CBridge"}}_release_handle(handle)

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerInterface.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/ListenerInterface.swift
@@ -90,10 +90,16 @@ internal func ListenerInterface_copyFromCType(_ handle: _baseRef) -> ListenerInt
     fatalError("Failed to initialize Swift object")
 }
 internal func ListenerInterface_moveFromCType(_ handle: _baseRef) -> ListenerInterface {
-    if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_cache(handle),
-        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {
-        smoke_ListenerInterface_release_handle(handle)
-        return re_constructed
+    if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_cache(handle) {
+        let re_constructed_uncast = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue()
+        if let re_constructed = re_constructed_uncast as? ListenerInterface {
+            smoke_ListenerInterface_release_handle(handle)
+            return re_constructed
+        }
+        if let weak_value = (re_constructed_uncast as? ListenerInterface_WeakHolder)?.value {
+            smoke_ListenerInterface_release_handle(handle)
+            return weak_value
+        }
     }
     if let swift_pointer = smoke_ListenerInterface_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ListenerInterface {


### PR DESCRIPTION
Updated SwiftClassConversion template to correctly retrieve `*_WeakHolder`
objects from cache. This fixes an issue where a `@Swift(Weak)` property violated
referential equality in a "set, then get" round trip scenario.

Added functional test. Updated smoke test.

Resolves: #1118
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>