### PR TITLE
Add missing "public fields only" ctor in Java and Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed an issue where a "public fields only" constructor was sometimes missing for structs with a mix of "public" and
+    "internal" fields in Java and Dart.
+
 ## 10.1.5
 Release date: 2021-10-13
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -423,6 +423,7 @@ feature(Lambdas cpp android swift dart SOURCES
 
 feature(Visibility dart SOURCES
     input/lime/Visibility.lime
+    input/lime/InternalFields.lime
 
     input/src/cpp/Visibility.cpp
 )

--- a/functional-tests/functional/input/lime/InternalFields.lime
+++ b/functional-tests/functional/input/lime/InternalFields.lime
@@ -1,0 +1,46 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct PublicFieldsNone {
+    internal internalField: String = "foo"
+}
+
+struct PublicFieldsNoInit {
+    publicField: String
+    internal internalField: String = "foo"
+}
+
+struct PublicFieldsAllInit {
+    publicField: String = "bar"
+    internal internalField: String = "foo"
+}
+
+struct PublicFieldsMixedInit {
+    publicField1: String = "bar"
+    publicField2: String
+    internal internalField: String = "foo"
+}
+
+@Java(PositionalDefaults)
+@Dart(PositionalDefaults)
+@Swift(Skip)
+struct PublicFieldsAllInitPosDefaults {
+    publicField: String = "bar"
+    internal internalField: String = "foo"
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -20,6 +20,7 @@
 package com.here.gluecodium.generator.common
 
 import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeFieldConstructor
@@ -91,6 +92,12 @@ internal object CommonGeneratorPredicates {
             limeStruct.attributes.have(LimeAttributeType.IMMUTABLE) -> limeStruct.allFieldsConstructor == null
             else -> false
         }
+
+    fun needsPublicFieldsConstructor(limeStruct: Any, platformAttribute: LimeAttributeType) =
+        limeStruct is LimeStruct &&
+            !limeStruct.attributes.have(platformAttribute, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&
+            limeStruct.internalFields.isNotEmpty() && limeStruct.internalFields.all { it.defaultValue != null } &&
+            limeStruct.publicFields.any { it.defaultValue != null }
 
     private fun getAllFieldTypes(limeType: LimeType) = getAllFieldTypesRec(getLeafType(limeType), mutableSetOf())
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
@@ -53,6 +53,7 @@ internal class DartGeneratorPredicates(limeReferenceMap: Map<String, LimeElement
                 else -> !limeStruct.attributes.have(IMMUTABLE)
             }
         },
+        "needsPublicFieldsConstructor" to { CommonGeneratorPredicates.needsPublicFieldsConstructor(it, DART) },
         "skipDeclaration" to { limeType: Any ->
             limeType is LimeType && limeType.external?.dart != null &&
                 limeType.external?.dart?.get(LimeExternalDescriptor.CONVERTER_NAME) == null

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
@@ -20,7 +20,7 @@
 package com.here.gluecodium.generator.java
 
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
-import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeInterface
@@ -57,7 +57,7 @@ internal object JavaGeneratorPredicates {
         },
         "needsAllFieldsConstructor" to { limeStruct: Any ->
             limeStruct is LimeStruct &&
-                !limeStruct.attributes.have(LimeAttributeType.JAVA, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&
+                !limeStruct.attributes.have(JAVA, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&
                 CommonGeneratorPredicates.needsAllFieldsConstructor(limeStruct)
         },
         "needsDisposer" to { limeClass: Any ->
@@ -66,6 +66,7 @@ internal object JavaGeneratorPredicates {
         "needsNonNullAnnotation" to { limeTypeRef ->
             limeTypeRef is LimeTypeRef && !limeTypeRef.isNullable &&
                 JavaImportResolver.needsNonNullAnnotation(limeTypeRef.type.actualType)
-        }
+        },
+        "needsPublicFieldsConstructor" to { CommonGeneratorPredicates.needsPublicFieldsConstructor(it, JAVA) },
     )
 }

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -140,7 +140,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/fields}}{{/set}}
   try {
 {{#if external.dart.converter}}
-    final resultInternal = {{resolveName}}Internal{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}(
+    final resultInternal = {{resolveName}}Internal{{>allFieldsConstructorName}}(
 {{#set container=this}}{{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}{{/set}}
@@ -149,7 +149,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/if}}{{#unless external.dart.converter}}
     return {{resolveName this "" "ref"}}{{#set container=this}}{{!!
     }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{>dart/DartConstructorName}}{{/allFieldsConstructor}}{{/if}}{{!!
-    }}{{#unless allfieldsConstructor}}{{#ifPredicate container "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{/unless}}(
+    }}{{#unless allfieldsConstructor}}{{#container}}{{>allFieldsConstructorName}}{{/container}}{{/unless}}(
 {{#if attributes.dart.positionalDefaults initializedFields}}
 {{#each uninitializedFields initializedFields}}
 {{>fromFfiFieldInit}}
@@ -207,4 +207,9 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}{{prefixPartial "dart/InitLazyList" "      " skipFirstLine=true}}{{/set}}{{/setJoin}}{{/resolveName}}{{/if}}{{!!
 }}{{#unless typeRef.attributes.optimized}}{{!!
 }}{{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle){{/unless}}{{#if iter.hasNext}}, {{/if}}
-{{/fromFfiFieldInit}}
+{{/fromFfiFieldInit}}{{!!
+
+}}{{+allFieldsConstructorName}}{{#unless allFieldsConstructor}}{{!!
+}}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "needsPrivateAllFieldsCtor"}}{{#ifPredicate "needsPublicFieldsConstructor"}}.allFields{{/ifPredicate}}{{/unlessPredicate}}{{!!
+}}{{/unless}}{{/allFieldsConstructorName}}

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -35,10 +35,19 @@
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}._({{>thisDotFields}});
 {{/if}}{{!!
 
-}}{{#unless constructors}}{{#unless allFieldsConstructor}}{{!!
+}}{{#unless constructors}}{{#unless fieldConstructors}}{{#ifPredicate "needsPublicFieldsConstructor"}}{{!!
+}}{{>constructorComment}}{{!!
+}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}({{!!
+}}{{#publicFields}}this.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/publicFields}}) : {{!!
+}}{{#internalFields}}{{resolveName visibility}}{{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/internalFields}};
+{{/ifPredicate}}{{/unless}}{{!!
+
+}}{{#unless allFieldsConstructor}}{{!!
 }}{{>constructorComment}}{{!!
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
-}}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}({{>thisDotFields}});
+}}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "needsPrivateAllFieldsCtor"}}{{#ifPredicate "needsPublicFieldsConstructor"}}.allFields{{/ifPredicate}}{{/unlessPredicate}}{{!!
+}}({{>thisDotFields}});
 {{/unless}}{{/unless}}{{!!
 
 }}{{/unless}}

--- a/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
@@ -36,7 +36,25 @@
                    }}{{#unless defaultValue}}{{resolveName}}{{/unless}};
 {{/fields}}
     }
-{{/if}}{{/unless}}{{!!
+{{/if}}{{!!
+
+}}{{#ifPredicate "needsPublicFieldsConstructor"}}
+
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
+{{#publicFields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/publicFields}}
+     */
+{{/unless}}
+    {{>structVisibility}}{{resolveName}}{{!!
+    }}({{#set noAttributes=true}}{{joinPartial publicFields "java/JavaParameter" ", "}}{{/set}}) {
+{{#fields}}        this.{{resolveName}} = {{#unless visibility.isInternal}}{{resolveName}}{{/unless}}{{!!
+                    }}{{#if visibility.isInternal}}{{resolveName defaultValue}}{{/if}};
+{{/fields}}
+    }
+{{/ifPredicate}}{{/unless}}{{!!
 
 }}{{#ifPredicate "needsAllFieldsConstructor"}}
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/InternalEnumDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/InternalEnumDefaults.java
@@ -21,6 +21,12 @@ public final class InternalEnumDefaults {
         this.internalField = FooBarEnum.BAR;
         this.internalListField = new ArrayList<>(Arrays.asList(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ));
     }
+    public InternalEnumDefaults(@NonNull final FooBarEnum publicField, @NonNull final List<FooBarEnum> publicListField) {
+        this.publicField = publicField;
+        this.publicListField = publicListField;
+        this.internalField = FooBarEnum.BAR;
+        this.internalListField = new ArrayList<>(Arrays.asList(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ));
+    }
     InternalEnumDefaults(@NonNull final FooBarEnum publicField, @NonNull final List<FooBarEnum> publicListField, @NonNull final FooBarEnum internalField, @NonNull final List<FooBarEnum> internalListField) {
         this.publicField = publicField;
         this.publicListField = publicListField;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/internal_enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/internal_enum_defaults.dart
@@ -12,7 +12,8 @@ class InternalEnumDefaults {
   /// @nodoc
   @internal
   List<FooBarEnum> internal_internalListField;
-  InternalEnumDefaults(this.publicField, this.publicListField, this.internal_internalField, this.internal_internalListField);
+  InternalEnumDefaults(this.publicField, this.publicListField) : internal_internalField = FooBarEnum.bar, internal_internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz];
+  InternalEnumDefaults.allFields(this.publicField, this.publicListField, this.internal_internalField, this.internal_internalListField);
   InternalEnumDefaults.withDefaults()
     : publicField = FooBarEnum.foo, publicListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz], internal_internalField = FooBarEnum.bar, internal_internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz];
 }
@@ -59,7 +60,7 @@ InternalEnumDefaults smokeInternalenumdefaultsFromFfi(Pointer<Void> handle) {
   final _internalFieldHandle = _smokeInternalenumdefaultsGetFieldinternalField(handle);
   final _internalListFieldHandle = _smokeInternalenumdefaultsGetFieldinternalListField(handle);
   try {
-    return InternalEnumDefaults(
+    return InternalEnumDefaults.allFields(
       smokeFoobarenumFromFfi(_publicFieldHandle),
       listofSmokeFoobarenumFromFfi(_publicListFieldHandle),
       smokeFoobarenumFromFfi(_internalFieldHandle),

--- a/gluecodium/src/test/resources/smoke/internal_fields/input/InternalFields.lime
+++ b/gluecodium/src/test/resources/smoke/internal_fields/input/InternalFields.lime
@@ -1,0 +1,46 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct PublicFieldsNone {
+    internal internalField: String = "foo"
+}
+
+struct PublicFieldsNoInit {
+    publicField: String
+    internal internalField: String = "foo"
+}
+
+struct PublicFieldsAllInit {
+    publicField: String = "bar"
+    internal internalField: String = "foo"
+}
+
+struct PublicFieldsMixedInit {
+    publicField1: String = "bar"
+    publicField2: String
+    internal internalField: String = "foo"
+}
+
+@Java(PositionalDefaults)
+@Dart(PositionalDefaults)
+@Swift(Skip)
+struct PublicFieldsAllInitPosDefaults {
+    publicField: String = "bar"
+    internal internalField: String = "foo"
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsAllInit.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsAllInit.java
@@ -1,0 +1,23 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class PublicFieldsAllInit {
+    @NonNull
+    public String publicField;
+    @NonNull
+    String internalField;
+    public PublicFieldsAllInit() {
+        this.publicField = "bar";
+        this.internalField = "foo";
+    }
+    public PublicFieldsAllInit(@NonNull final String publicField) {
+        this.publicField = publicField;
+        this.internalField = "foo";
+    }
+    PublicFieldsAllInit(@NonNull final String publicField, @NonNull final String internalField) {
+        this.publicField = publicField;
+        this.internalField = internalField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsAllInitPosDefaults.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsAllInitPosDefaults.java
@@ -1,0 +1,23 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class PublicFieldsAllInitPosDefaults {
+    @NonNull
+    public String publicField;
+    @NonNull
+    String internalField;
+    public PublicFieldsAllInitPosDefaults() {
+        this.publicField = "bar";
+        this.internalField = "foo";
+    }
+    public PublicFieldsAllInitPosDefaults(@NonNull final String publicField) {
+        this.publicField = publicField;
+        this.internalField = "foo";
+    }
+    public PublicFieldsAllInitPosDefaults(@NonNull final String publicField, @NonNull final String internalField) {
+        this.publicField = publicField;
+        this.internalField = internalField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsMixedInit.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsMixedInit.java
@@ -1,0 +1,28 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class PublicFieldsMixedInit {
+    @NonNull
+    public String publicField1;
+    @NonNull
+    public String publicField2;
+    @NonNull
+    String internalField;
+    public PublicFieldsMixedInit(@NonNull final String publicField2) {
+        this.publicField1 = "bar";
+        this.publicField2 = publicField2;
+        this.internalField = "foo";
+    }
+    public PublicFieldsMixedInit(@NonNull final String publicField1, @NonNull final String publicField2) {
+        this.publicField1 = publicField1;
+        this.publicField2 = publicField2;
+        this.internalField = "foo";
+    }
+    PublicFieldsMixedInit(@NonNull final String publicField1, @NonNull final String publicField2, @NonNull final String internalField) {
+        this.publicField1 = publicField1;
+        this.publicField2 = publicField2;
+        this.internalField = internalField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNoInit.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNoInit.java
@@ -1,0 +1,19 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class PublicFieldsNoInit {
+    @NonNull
+    public String publicField;
+    @NonNull
+    String internalField;
+    public PublicFieldsNoInit(@NonNull final String publicField) {
+        this.publicField = publicField;
+        this.internalField = "foo";
+    }
+    PublicFieldsNoInit(@NonNull final String publicField, @NonNull final String internalField) {
+        this.publicField = publicField;
+        this.internalField = internalField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNone.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNone.java
@@ -1,0 +1,15 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class PublicFieldsNone {
+    @NonNull
+    String internalField;
+    public PublicFieldsNone() {
+        this.internalField = "foo";
+    }
+    PublicFieldsNone(@NonNull final String internalField) {
+        this.internalField = internalField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init.dart
@@ -1,0 +1,83 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+class PublicFieldsAllInit {
+  String publicField;
+  /// @nodoc
+  @internal
+  String internal_internalField;
+  PublicFieldsAllInit(this.publicField) : internal_internalField = "foo";
+  PublicFieldsAllInit.allFields(this.publicField, this.internal_internalField);
+  PublicFieldsAllInit.withDefaults()
+    : publicField = "bar", internal_internalField = "foo";
+}
+// PublicFieldsAllInit "private" section, not exported.
+final _smokePublicfieldsallinitCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInit_create_handle'));
+final _smokePublicfieldsallinitReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInit_release_handle'));
+final _smokePublicfieldsallinitGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInit_get_field_publicField'));
+final _smokePublicfieldsallinitGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInit_get_field_internalField'));
+Pointer<Void> smokePublicfieldsallinitToFfi(PublicFieldsAllInit value) {
+  final _publicFieldHandle = stringToFfi(value.publicField);
+  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _result = _smokePublicfieldsallinitCreateHandle(_publicFieldHandle, _internalFieldHandle);
+  stringReleaseFfiHandle(_publicFieldHandle);
+  stringReleaseFfiHandle(_internalFieldHandle);
+  return _result;
+}
+PublicFieldsAllInit smokePublicfieldsallinitFromFfi(Pointer<Void> handle) {
+  final _publicFieldHandle = _smokePublicfieldsallinitGetFieldpublicField(handle);
+  final _internalFieldHandle = _smokePublicfieldsallinitGetFieldinternalField(handle);
+  try {
+    return PublicFieldsAllInit.allFields(
+      stringFromFfi(_publicFieldHandle),
+      stringFromFfi(_internalFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_publicFieldHandle);
+    stringReleaseFfiHandle(_internalFieldHandle);
+  }
+}
+void smokePublicfieldsallinitReleaseFfiHandle(Pointer<Void> handle) => _smokePublicfieldsallinitReleaseHandle(handle);
+// Nullable PublicFieldsAllInit
+final _smokePublicfieldsallinitCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInit_create_handle_nullable'));
+final _smokePublicfieldsallinitReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInit_release_handle_nullable'));
+final _smokePublicfieldsallinitGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInit_get_value_nullable'));
+Pointer<Void> smokePublicfieldsallinitToFfiNullable(PublicFieldsAllInit? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokePublicfieldsallinitToFfi(value);
+  final result = _smokePublicfieldsallinitCreateHandleNullable(_handle);
+  smokePublicfieldsallinitReleaseFfiHandle(_handle);
+  return result;
+}
+PublicFieldsAllInit? smokePublicfieldsallinitFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokePublicfieldsallinitGetValueNullable(handle);
+  final result = smokePublicfieldsallinitFromFfi(_handle);
+  smokePublicfieldsallinitReleaseFfiHandle(_handle);
+  return result;
+}
+void smokePublicfieldsallinitReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePublicfieldsallinitReleaseHandleNullable(handle);
+// End of PublicFieldsAllInit "private" section.

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init_pos_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init_pos_defaults.dart
@@ -1,0 +1,83 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+class PublicFieldsAllInitPosDefaults {
+  String publicField;
+  /// @nodoc
+  @internal
+  String internal_internalField;
+  PublicFieldsAllInitPosDefaults([String publicField = "bar", String internalField = "foo"])
+    : publicField = publicField, internal_internalField = internalField;
+  PublicFieldsAllInitPosDefaults.withDefaults()
+    : publicField = "bar", internal_internalField = "foo";
+}
+// PublicFieldsAllInitPosDefaults "private" section, not exported.
+final _smokePublicfieldsallinitposdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInitPosDefaults_create_handle'));
+final _smokePublicfieldsallinitposdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInitPosDefaults_release_handle'));
+final _smokePublicfieldsallinitposdefaultsGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInitPosDefaults_get_field_publicField'));
+final _smokePublicfieldsallinitposdefaultsGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInitPosDefaults_get_field_internalField'));
+Pointer<Void> smokePublicfieldsallinitposdefaultsToFfi(PublicFieldsAllInitPosDefaults value) {
+  final _publicFieldHandle = stringToFfi(value.publicField);
+  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _result = _smokePublicfieldsallinitposdefaultsCreateHandle(_publicFieldHandle, _internalFieldHandle);
+  stringReleaseFfiHandle(_publicFieldHandle);
+  stringReleaseFfiHandle(_internalFieldHandle);
+  return _result;
+}
+PublicFieldsAllInitPosDefaults smokePublicfieldsallinitposdefaultsFromFfi(Pointer<Void> handle) {
+  final _publicFieldHandle = _smokePublicfieldsallinitposdefaultsGetFieldpublicField(handle);
+  final _internalFieldHandle = _smokePublicfieldsallinitposdefaultsGetFieldinternalField(handle);
+  try {
+    return PublicFieldsAllInitPosDefaults(
+      stringFromFfi(_publicFieldHandle),
+      stringFromFfi(_internalFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_publicFieldHandle);
+    stringReleaseFfiHandle(_internalFieldHandle);
+  }
+}
+void smokePublicfieldsallinitposdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokePublicfieldsallinitposdefaultsReleaseHandle(handle);
+// Nullable PublicFieldsAllInitPosDefaults
+final _smokePublicfieldsallinitposdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInitPosDefaults_create_handle_nullable'));
+final _smokePublicfieldsallinitposdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInitPosDefaults_release_handle_nullable'));
+final _smokePublicfieldsallinitposdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsAllInitPosDefaults_get_value_nullable'));
+Pointer<Void> smokePublicfieldsallinitposdefaultsToFfiNullable(PublicFieldsAllInitPosDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokePublicfieldsallinitposdefaultsToFfi(value);
+  final result = _smokePublicfieldsallinitposdefaultsCreateHandleNullable(_handle);
+  smokePublicfieldsallinitposdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+PublicFieldsAllInitPosDefaults? smokePublicfieldsallinitposdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokePublicfieldsallinitposdefaultsGetValueNullable(handle);
+  final result = smokePublicfieldsallinitposdefaultsFromFfi(_handle);
+  smokePublicfieldsallinitposdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokePublicfieldsallinitposdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePublicfieldsallinitposdefaultsReleaseHandleNullable(handle);
+// End of PublicFieldsAllInitPosDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_mixed_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_mixed_init.dart
@@ -1,0 +1,93 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+class PublicFieldsMixedInit {
+  String publicField1;
+  String publicField2;
+  /// @nodoc
+  @internal
+  String internal_internalField;
+  PublicFieldsMixedInit(this.publicField1, this.publicField2) : internal_internalField = "foo";
+  PublicFieldsMixedInit.allFields(this.publicField1, this.publicField2, this.internal_internalField);
+  PublicFieldsMixedInit.withDefaults(String publicField2)
+    : publicField1 = "bar", publicField2 = publicField2, internal_internalField = "foo";
+}
+// PublicFieldsMixedInit "private" section, not exported.
+final _smokePublicfieldsmixedinitCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_create_handle'));
+final _smokePublicfieldsmixedinitReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_release_handle'));
+final _smokePublicfieldsmixedinitGetFieldpublicField1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_get_field_publicField1'));
+final _smokePublicfieldsmixedinitGetFieldpublicField2 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_get_field_publicField2'));
+final _smokePublicfieldsmixedinitGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_get_field_internalField'));
+Pointer<Void> smokePublicfieldsmixedinitToFfi(PublicFieldsMixedInit value) {
+  final _publicField1Handle = stringToFfi(value.publicField1);
+  final _publicField2Handle = stringToFfi(value.publicField2);
+  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _result = _smokePublicfieldsmixedinitCreateHandle(_publicField1Handle, _publicField2Handle, _internalFieldHandle);
+  stringReleaseFfiHandle(_publicField1Handle);
+  stringReleaseFfiHandle(_publicField2Handle);
+  stringReleaseFfiHandle(_internalFieldHandle);
+  return _result;
+}
+PublicFieldsMixedInit smokePublicfieldsmixedinitFromFfi(Pointer<Void> handle) {
+  final _publicField1Handle = _smokePublicfieldsmixedinitGetFieldpublicField1(handle);
+  final _publicField2Handle = _smokePublicfieldsmixedinitGetFieldpublicField2(handle);
+  final _internalFieldHandle = _smokePublicfieldsmixedinitGetFieldinternalField(handle);
+  try {
+    return PublicFieldsMixedInit.allFields(
+      stringFromFfi(_publicField1Handle),
+      stringFromFfi(_publicField2Handle),
+      stringFromFfi(_internalFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_publicField1Handle);
+    stringReleaseFfiHandle(_publicField2Handle);
+    stringReleaseFfiHandle(_internalFieldHandle);
+  }
+}
+void smokePublicfieldsmixedinitReleaseFfiHandle(Pointer<Void> handle) => _smokePublicfieldsmixedinitReleaseHandle(handle);
+// Nullable PublicFieldsMixedInit
+final _smokePublicfieldsmixedinitCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_create_handle_nullable'));
+final _smokePublicfieldsmixedinitReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_release_handle_nullable'));
+final _smokePublicfieldsmixedinitGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsMixedInit_get_value_nullable'));
+Pointer<Void> smokePublicfieldsmixedinitToFfiNullable(PublicFieldsMixedInit? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokePublicfieldsmixedinitToFfi(value);
+  final result = _smokePublicfieldsmixedinitCreateHandleNullable(_handle);
+  smokePublicfieldsmixedinitReleaseFfiHandle(_handle);
+  return result;
+}
+PublicFieldsMixedInit? smokePublicfieldsmixedinitFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokePublicfieldsmixedinitGetValueNullable(handle);
+  final result = smokePublicfieldsmixedinitFromFfi(_handle);
+  smokePublicfieldsmixedinitReleaseFfiHandle(_handle);
+  return result;
+}
+void smokePublicfieldsmixedinitReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePublicfieldsmixedinitReleaseHandleNullable(handle);
+// End of PublicFieldsMixedInit "private" section.

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_no_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_no_init.dart
@@ -1,0 +1,82 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+class PublicFieldsNoInit {
+  String publicField;
+  /// @nodoc
+  @internal
+  String internal_internalField;
+  PublicFieldsNoInit(this.publicField, this.internal_internalField);
+  PublicFieldsNoInit.withDefaults(String publicField)
+    : publicField = publicField, internal_internalField = "foo";
+}
+// PublicFieldsNoInit "private" section, not exported.
+final _smokePublicfieldsnoinitCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_PublicFieldsNoInit_create_handle'));
+final _smokePublicfieldsnoinitReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNoInit_release_handle'));
+final _smokePublicfieldsnoinitGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNoInit_get_field_publicField'));
+final _smokePublicfieldsnoinitGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNoInit_get_field_internalField'));
+Pointer<Void> smokePublicfieldsnoinitToFfi(PublicFieldsNoInit value) {
+  final _publicFieldHandle = stringToFfi(value.publicField);
+  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _result = _smokePublicfieldsnoinitCreateHandle(_publicFieldHandle, _internalFieldHandle);
+  stringReleaseFfiHandle(_publicFieldHandle);
+  stringReleaseFfiHandle(_internalFieldHandle);
+  return _result;
+}
+PublicFieldsNoInit smokePublicfieldsnoinitFromFfi(Pointer<Void> handle) {
+  final _publicFieldHandle = _smokePublicfieldsnoinitGetFieldpublicField(handle);
+  final _internalFieldHandle = _smokePublicfieldsnoinitGetFieldinternalField(handle);
+  try {
+    return PublicFieldsNoInit(
+      stringFromFfi(_publicFieldHandle),
+      stringFromFfi(_internalFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_publicFieldHandle);
+    stringReleaseFfiHandle(_internalFieldHandle);
+  }
+}
+void smokePublicfieldsnoinitReleaseFfiHandle(Pointer<Void> handle) => _smokePublicfieldsnoinitReleaseHandle(handle);
+// Nullable PublicFieldsNoInit
+final _smokePublicfieldsnoinitCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNoInit_create_handle_nullable'));
+final _smokePublicfieldsnoinitReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNoInit_release_handle_nullable'));
+final _smokePublicfieldsnoinitGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNoInit_get_value_nullable'));
+Pointer<Void> smokePublicfieldsnoinitToFfiNullable(PublicFieldsNoInit? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokePublicfieldsnoinitToFfi(value);
+  final result = _smokePublicfieldsnoinitCreateHandleNullable(_handle);
+  smokePublicfieldsnoinitReleaseFfiHandle(_handle);
+  return result;
+}
+PublicFieldsNoInit? smokePublicfieldsnoinitFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokePublicfieldsnoinitGetValueNullable(handle);
+  final result = smokePublicfieldsnoinitFromFfi(_handle);
+  smokePublicfieldsnoinitReleaseFfiHandle(_handle);
+  return result;
+}
+void smokePublicfieldsnoinitReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePublicfieldsnoinitReleaseHandleNullable(handle);
+// End of PublicFieldsNoInit "private" section.

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_none.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_none.dart
@@ -1,0 +1,72 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+class PublicFieldsNone {
+  /// @nodoc
+  @internal
+  String internal_internalField;
+  PublicFieldsNone(this.internal_internalField);
+  PublicFieldsNone.withDefaults()
+    : internal_internalField = "foo";
+}
+// PublicFieldsNone "private" section, not exported.
+final _smokePublicfieldsnoneCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNone_create_handle'));
+final _smokePublicfieldsnoneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNone_release_handle'));
+final _smokePublicfieldsnoneGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNone_get_field_internalField'));
+Pointer<Void> smokePublicfieldsnoneToFfi(PublicFieldsNone value) {
+  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _result = _smokePublicfieldsnoneCreateHandle(_internalFieldHandle);
+  stringReleaseFfiHandle(_internalFieldHandle);
+  return _result;
+}
+PublicFieldsNone smokePublicfieldsnoneFromFfi(Pointer<Void> handle) {
+  final _internalFieldHandle = _smokePublicfieldsnoneGetFieldinternalField(handle);
+  try {
+    return PublicFieldsNone(
+      stringFromFfi(_internalFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_internalFieldHandle);
+  }
+}
+void smokePublicfieldsnoneReleaseFfiHandle(Pointer<Void> handle) => _smokePublicfieldsnoneReleaseHandle(handle);
+// Nullable PublicFieldsNone
+final _smokePublicfieldsnoneCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNone_create_handle_nullable'));
+final _smokePublicfieldsnoneReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNone_release_handle_nullable'));
+final _smokePublicfieldsnoneGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PublicFieldsNone_get_value_nullable'));
+Pointer<Void> smokePublicfieldsnoneToFfiNullable(PublicFieldsNone? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokePublicfieldsnoneToFfi(value);
+  final result = _smokePublicfieldsnoneCreateHandleNullable(_handle);
+  smokePublicfieldsnoneReleaseFfiHandle(_handle);
+  return result;
+}
+PublicFieldsNone? smokePublicfieldsnoneFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokePublicfieldsnoneGetValueNullable(handle);
+  final result = smokePublicfieldsnoneFromFfi(_handle);
+  smokePublicfieldsnoneReleaseFfiHandle(_handle);
+  return result;
+}
+void smokePublicfieldsnoneReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePublicfieldsnoneReleaseHandleNullable(handle);
+// End of PublicFieldsNone "private" section.

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsAllInit.swift
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsAllInit.swift
@@ -1,0 +1,60 @@
+//
+//
+import Foundation
+public struct PublicFieldsAllInit {
+    public var publicField: String
+    internal var internalField: String
+    public init(publicField: String = "bar") {
+        self.publicField = publicField
+        self.internalField = "foo"
+    }
+    internal init(publicField: String = "bar", internalField: String = "foo") {
+        self.publicField = publicField
+        self.internalField = internalField
+    }
+    internal init(cHandle: _baseRef) {
+        publicField = moveFromCType(smoke_PublicFieldsAllInit_publicField_get(cHandle))
+        internalField = moveFromCType(smoke_PublicFieldsAllInit_internalField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsAllInit {
+    return PublicFieldsAllInit(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsAllInit {
+    defer {
+        smoke_PublicFieldsAllInit_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsAllInit) -> RefHolder {
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsAllInit_create_handle(c_publicField.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsAllInit) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsAllInit_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsAllInit? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_PublicFieldsAllInit_unwrap_optional_handle(handle)
+    return PublicFieldsAllInit(cHandle: unwrappedHandle) as PublicFieldsAllInit
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsAllInit? {
+    defer {
+        smoke_PublicFieldsAllInit_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsAllInit?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsAllInit_create_optional_handle(c_publicField.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsAllInit?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsAllInit_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsMixedInit.swift
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsMixedInit.swift
@@ -1,0 +1,66 @@
+//
+//
+import Foundation
+public struct PublicFieldsMixedInit {
+    public var publicField1: String
+    public var publicField2: String
+    internal var internalField: String
+    public init(publicField1: String = "bar", publicField2: String) {
+        self.publicField1 = publicField1
+        self.publicField2 = publicField2
+        self.internalField = "foo"
+    }
+    internal init(publicField1: String = "bar", publicField2: String, internalField: String = "foo") {
+        self.publicField1 = publicField1
+        self.publicField2 = publicField2
+        self.internalField = internalField
+    }
+    internal init(cHandle: _baseRef) {
+        publicField1 = moveFromCType(smoke_PublicFieldsMixedInit_publicField1_get(cHandle))
+        publicField2 = moveFromCType(smoke_PublicFieldsMixedInit_publicField2_get(cHandle))
+        internalField = moveFromCType(smoke_PublicFieldsMixedInit_internalField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsMixedInit {
+    return PublicFieldsMixedInit(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsMixedInit {
+    defer {
+        smoke_PublicFieldsMixedInit_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsMixedInit) -> RefHolder {
+    let c_publicField1 = moveToCType(swiftType.publicField1)
+    let c_publicField2 = moveToCType(swiftType.publicField2)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsMixedInit_create_handle(c_publicField1.ref, c_publicField2.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsMixedInit) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsMixedInit_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsMixedInit? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_PublicFieldsMixedInit_unwrap_optional_handle(handle)
+    return PublicFieldsMixedInit(cHandle: unwrappedHandle) as PublicFieldsMixedInit
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsMixedInit? {
+    defer {
+        smoke_PublicFieldsMixedInit_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsMixedInit?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_publicField1 = moveToCType(swiftType.publicField1)
+    let c_publicField2 = moveToCType(swiftType.publicField2)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsMixedInit_create_optional_handle(c_publicField1.ref, c_publicField2.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsMixedInit?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsMixedInit_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsNoInit.swift
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsNoInit.swift
@@ -1,0 +1,60 @@
+//
+//
+import Foundation
+public struct PublicFieldsNoInit {
+    public var publicField: String
+    internal var internalField: String
+    public init(publicField: String) {
+        self.publicField = publicField
+        self.internalField = "foo"
+    }
+    internal init(publicField: String, internalField: String = "foo") {
+        self.publicField = publicField
+        self.internalField = internalField
+    }
+    internal init(cHandle: _baseRef) {
+        publicField = moveFromCType(smoke_PublicFieldsNoInit_publicField_get(cHandle))
+        internalField = moveFromCType(smoke_PublicFieldsNoInit_internalField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsNoInit {
+    return PublicFieldsNoInit(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsNoInit {
+    defer {
+        smoke_PublicFieldsNoInit_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsNoInit) -> RefHolder {
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsNoInit_create_handle(c_publicField.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsNoInit) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsNoInit_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsNoInit? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_PublicFieldsNoInit_unwrap_optional_handle(handle)
+    return PublicFieldsNoInit(cHandle: unwrappedHandle) as PublicFieldsNoInit
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsNoInit? {
+    defer {
+        smoke_PublicFieldsNoInit_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsNoInit?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsNoInit_create_optional_handle(c_publicField.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsNoInit?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsNoInit_release_optional_handle)
+}

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsNone.swift
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/swift/smoke/PublicFieldsNone.swift
@@ -1,0 +1,54 @@
+//
+//
+import Foundation
+public struct PublicFieldsNone {
+    internal var internalField: String
+    public init() {
+        self.internalField = "foo"
+    }
+    internal init(internalField: String = "foo") {
+        self.internalField = internalField
+    }
+    internal init(cHandle: _baseRef) {
+        internalField = moveFromCType(smoke_PublicFieldsNone_internalField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsNone {
+    return PublicFieldsNone(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsNone {
+    defer {
+        smoke_PublicFieldsNone_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsNone) -> RefHolder {
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsNone_create_handle(c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsNone) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsNone_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> PublicFieldsNone? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_PublicFieldsNone_unwrap_optional_handle(handle)
+    return PublicFieldsNone(cHandle: unwrappedHandle) as PublicFieldsNone
+}
+internal func moveFromCType(_ handle: _baseRef) -> PublicFieldsNone? {
+    defer {
+        smoke_PublicFieldsNone_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: PublicFieldsNone?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_PublicFieldsNone_create_optional_handle(c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: PublicFieldsNone?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_PublicFieldsNone_release_optional_handle)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
@@ -56,15 +56,12 @@ class LimeStruct(
     val initializedFields
         get() = fields.filter { it.defaultValue != null }
 
-    @Suppress("unused")
     val uninitializedFields
         get() = fields.filter { it.defaultValue == null }
 
-    @Suppress("unused")
     val publicFields
         get() = fields.filter { !it.visibility.isInternal }
 
-    @Suppress("unused")
     val internalFields
         get() = fields.filter { it.visibility.isInternal }
 


### PR DESCRIPTION
Updated Java and Dart templates to generate a dedicated "public fields only"
constructor for structs with a mix of public and internal fields (when all
internal fields were initialized). Previously such constructor was not present,
making it impossible to initialize public fields for such structs.

Add a new smoke test "internal_fields" (also for Swift, where it works with no
changes). Added a functional test.

Resolves: #1122
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>