### PR TITLE
Fix extraneous include in Dart FFI for some skips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   * Fixed an issue where a "public fields only" constructor was sometimes missing for structs with a mix of "public" and
     "internal" fields in Java and Dart.
   * Fixed a compilation issue in Dart when two types in different packages have the same name.
+  * Fixed an extraneous include in Dart FFI caused by a "tag-in-platform" skip.
 
 ## 10.1.5
 Release date: 2021-10-13

--- a/functional-tests/functional/input/lime/SkipTags.lime
+++ b/functional-tests/functional/input/lime/SkipTags.lime
@@ -36,10 +36,22 @@ types SkipTypesTags {
   }
 
   const PlaceHolder: Boolean = true
+
+  @Java(Skip = "Lite")
+  @Swift(Skip = "Lite")
+  @Dart(Skip = "Lite")
+  enum SkipPlatform { N0 }
 }
 
 struct SkipField {
   `field`: String
   @Skip(Lite)
   noField: SkipTypesTags.SkipMe
+}
+
+class SkippedFunctionClass {
+    @Java(Skip = "Lite")
+    @Swift(Skip = "Lite")
+    @Dart(Skip = "Lite")
+    fun doFoo(input: SkipTypesTags.SkipPlatform)
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
@@ -34,8 +34,8 @@ import com.here.gluecodium.model.lime.LimeType
  * List of predicates used by `ifPredicate`/`unlessPredicate` template helpers in Dart generator.
  */
 internal class DartGeneratorPredicates(
-    limeReferenceMap: Map<String, LimeElement>,
-    activeTags: Set<String>,
+    private val limeReferenceMap: Map<String, LimeElement>,
+    private val activeTags: Set<String>,
     dartNameResolver: DartNameResolver? = null
 ) {
     val predicates = mapOf(
@@ -70,8 +70,10 @@ internal class DartGeneratorPredicates(
                 limeType.external?.dart?.get(LimeExternalDescriptor.CONVERTER_NAME) == null
         },
         "shouldRetain" to { limeElement: Any ->
-            limeElement is LimeNamedElement &&
-                LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, DART, limeReferenceMap)
+            limeElement is LimeNamedElement && shouldRetain(limeElement)
         }
     )
+
+    fun shouldRetain(limeElement: LimeNamedElement) =
+        LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, DART, limeReferenceMap)
 }

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTagsIncludes.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTagsIncludes.lime
@@ -33,3 +33,10 @@ struct SomeSkippedStruct {
 class SomeSkippedClass {
     fun doFoo(): dont.smoke.DontSmokeEnum
 }
+
+class SkippedFunctionClass {
+    @Java(Skip = "Lite")
+    @Swift(Skip = "Lite")
+    @Dart(Skip = "Lite")
+    fun doFoo(input: dont.smoke.DontSmokeEnum)
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkippedFunctionClass.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkippedFunctionClass.cpp
@@ -1,0 +1,18 @@
+/*
+ *
+ */
+#include "com_example_smoke_SkippedFunctionClass.h"
+#include "com_example_smoke_SkippedFunctionClass__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniReference.h"
+#include "JniWrapperCache.h"
+extern "C" {
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SkippedFunctionClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SkippedFunctionClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkippedFunctionClass.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkippedFunctionClass.cpp
@@ -1,0 +1,30 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_SkippedFunctionClass.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "smoke/SkippedFunctionClass.h"
+#include <memory>
+#include <new>
+void smoke_SkippedFunctionClass_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::SkippedFunctionClass >>(handle);
+}
+_baseRef smoke_SkippedFunctionClass_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::SkippedFunctionClass >>(handle)))
+        : 0;
+}
+const void* smoke_SkippedFunctionClass_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkippedFunctionClass >>(handle)->get())
+        : nullptr;
+}
+void smoke_SkippedFunctionClass_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkippedFunctionClass >>(handle)->get(), swift_pointer);
+}
+void smoke_SkippedFunctionClass_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkippedFunctionClass >>(handle)->get());
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
@@ -7,7 +7,6 @@
 #include "ProxyCache.h"
 #include "gluecodium/TypeRepository.h"
 #include "smoke/SkipProxy.h"
-#include "smoke/SkippedEverywhere.h"
 #include <memory>
 #include <string>
 #include <memory>

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkippedFunctionClass.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkippedFunctionClass.cpp
@@ -1,0 +1,39 @@
+#include "ffi_smoke_SkippedFunctionClass.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "smoke/SkippedFunctionClass.h"
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_SkippedFunctionClass_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::SkippedFunctionClass>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_SkippedFunctionClass_release_handle(handle);
+}
+void
+library_smoke_SkippedFunctionClass_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_SkippedFunctionClass_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_SkippedFunctionClass_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::SkippedFunctionClass>(
+            *reinterpret_cast<std::shared_ptr<smoke::SkippedFunctionClass>*>(handle)
+        )
+    );
+}
+void
+library_smoke_SkippedFunctionClass_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::SkippedFunctionClass>*>(handle);
+}
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Updated Dart generator to avoid adding FFI includes for elements that are
skipped with a "tag-in-platform" skip attribute.

Added smoke and functional tests.

See: #1126
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>