### PR TITLE
Add support for internal field constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features:
   * Platform skip attributes (`@Skip(Java)`, `@Java(Skip)`, same for Swift and Dart) are now supported for fields of
     mutable structs.
+  * Added support for `internal` visibility of "field constructors".
 
 ## 10.1.7
 Release date: 2021-10-27

--- a/functional-tests/functional/input/lime/FieldConstructors.lime
+++ b/functional-tests/functional/input/lime/FieldConstructors.lime
@@ -88,3 +88,24 @@ struct FieldConstructorsInternalFields {
     @Dart("withTrue")
     field constructor(intField, stringField)
 }
+
+struct FieldConstructorsInternal {
+    publicField: String = "foo"
+    internal internalField: Double = 42
+    @Dart("withAll")
+    internal field constructor()
+    @Dart("withFortyTwo")
+    internal field constructor(publicField)
+    @Dart("withFoo")
+    internal field constructor(internalField)
+    @Dart(Default)
+    internal field constructor(internalField, publicField)
+}
+
+struct FieldConstructorsExposeInternal {
+    internal internalField: String = "bar"
+    @Dart("withAll")
+    internal field constructor()
+    @Dart(Default)
+    field constructor(internalField)
+}

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -74,7 +74,7 @@
 {{/if}}{{!!
 }}{{#if this.attributes.deprecated}}
   @Deprecated("{{#resolveName this.attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
-{{/if}}{{>dart/DartAttributes}}{{!!
+{{/if}}{{prefixPartial "dart/DartAttributes" "  "}}{{!!
 }}  {{#if struct.attributes.immutable}}const {{/if}}{{resolveName struct}}{{#if external.dart.converter}}Internal{{/if}}{{!!
 }}{{>dart/DartConstructorName}}({{>thisDotFields}}){{#if omittedFields}}
       : {{#omittedFields}}{{resolveName visibility}}{{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/omittedFields}}{{/if}};

--- a/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
@@ -94,7 +94,7 @@
     @Deprecated
 {{/if}}{{/ifPredicate}}
 {{prefixPartial "java/JavaAttributes" "    "}}
-    {{#struct}}{{>structVisibility}}{{/struct}}{{resolveName struct}}({{!!
+    {{resolveName visibility}}{{resolveName struct}}({{!!
     }}{{#set noAttributes=true}}{{joinPartial fields "java/JavaParameter" ", "}}{{/set}}) {
 {{#fields}}        this.{{resolveName}} = {{resolveName}};
 {{/fields}}

--- a/gluecodium/src/main/resources/templates/lime/LimeFieldConstructor.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeFieldConstructor.mustache
@@ -22,4 +22,4 @@
 {{/unless}}{{!!
 }}{{#if attributes.toString}}{{attributes}}
 {{/if}}
-field constructor({{#fields}}{{name}}{{/fields}})
+{{visibility}}field constructor({{#fields}}{{name}}{{#if iter.hasNext}}, {{/if}}{{/fields}})

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
@@ -90,3 +90,16 @@ struct FieldConstructorsInternalFields {
     @Dart(Default)
     field constructor(boolField, intField, stringField)
 }
+
+struct FieldConstructorsInternal {
+    publicField: String = "foo"
+    internal internalField: Double = 42
+    @Dart("withAll")
+    internal field constructor()
+    @Dart("withFortyTwo")
+    internal field constructor(publicField)
+    @Dart("withFoo")
+    internal field constructor(internalField)
+    @Dart(Default)
+    internal field constructor(internalField, publicField)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsInternal.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsInternal.java
@@ -1,0 +1,26 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class FieldConstructorsInternal {
+    @NonNull
+    public String publicField;
+    double internalField;
+    FieldConstructorsInternal() {
+        this.publicField = "foo";
+        this.internalField = 42;
+    }
+    FieldConstructorsInternal(@NonNull final String publicField) {
+        this.publicField = publicField;
+        this.internalField = 42;
+    }
+    FieldConstructorsInternal(final double internalField) {
+        this.internalField = internalField;
+        this.publicField = "foo";
+    }
+    FieldConstructorsInternal(final double internalField, @NonNull final String publicField) {
+        this.internalField = internalField;
+        this.publicField = publicField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_internal.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_internal.dart
@@ -1,0 +1,88 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+class FieldConstructorsInternal {
+  String publicField;
+  /// @nodoc
+  @internal
+  double internal_internalField;
+  @internal
+  FieldConstructorsInternal.withAll()
+      : publicField = "foo", internal_internalField = 42;
+  @internal
+  FieldConstructorsInternal.withFortyTwo(this.publicField)
+      : internal_internalField = 42;
+  @internal
+  FieldConstructorsInternal.withFoo(this.internal_internalField)
+      : publicField = "foo";
+  @internal
+  FieldConstructorsInternal(this.internal_internalField, this.publicField);
+}
+// FieldConstructorsInternal "private" section, not exported.
+final _smokeFieldconstructorsinternalCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Double),
+    Pointer<Void> Function(Pointer<Void>, double)
+  >('library_smoke_FieldConstructorsInternal_create_handle'));
+final _smokeFieldconstructorsinternalReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsInternal_release_handle'));
+final _smokeFieldconstructorsinternalGetFieldpublicField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsInternal_get_field_publicField'));
+final _smokeFieldconstructorsinternalGetFieldinternalField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsInternal_get_field_internalField'));
+Pointer<Void> smokeFieldconstructorsinternalToFfi(FieldConstructorsInternal value) {
+  final _publicFieldHandle = stringToFfi(value.publicField);
+  final _internalFieldHandle = (value.internal_internalField);
+  final _result = _smokeFieldconstructorsinternalCreateHandle(_publicFieldHandle, _internalFieldHandle);
+  stringReleaseFfiHandle(_publicFieldHandle);
+  return _result;
+}
+FieldConstructorsInternal smokeFieldconstructorsinternalFromFfi(Pointer<Void> handle) {
+  final _publicFieldHandle = _smokeFieldconstructorsinternalGetFieldpublicField(handle);
+  final _internalFieldHandle = _smokeFieldconstructorsinternalGetFieldinternalField(handle);
+  try {
+    return FieldConstructorsInternal(
+      (_internalFieldHandle),
+      stringFromFfi(_publicFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_publicFieldHandle);
+  }
+}
+void smokeFieldconstructorsinternalReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorsinternalReleaseHandle(handle);
+// Nullable FieldConstructorsInternal
+final _smokeFieldconstructorsinternalCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsInternal_create_handle_nullable'));
+final _smokeFieldconstructorsinternalReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsInternal_release_handle_nullable'));
+final _smokeFieldconstructorsinternalGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_FieldConstructorsInternal_get_value_nullable'));
+Pointer<Void> smokeFieldconstructorsinternalToFfiNullable(FieldConstructorsInternal? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeFieldconstructorsinternalToFfi(value);
+  final result = _smokeFieldconstructorsinternalCreateHandleNullable(_handle);
+  smokeFieldconstructorsinternalReleaseFfiHandle(_handle);
+  return result;
+}
+FieldConstructorsInternal? smokeFieldconstructorsinternalFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeFieldconstructorsinternalGetValueNullable(handle);
+  final result = smokeFieldconstructorsinternalFromFfi(_handle);
+  smokeFieldconstructorsinternalReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeFieldconstructorsinternalReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeFieldconstructorsinternalReleaseHandleNullable(handle);
+// End of FieldConstructorsInternal "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/lime/smoke/FieldConstructorsInternal.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/lime/smoke/FieldConstructorsInternal.lime
@@ -1,0 +1,13 @@
+package smoke
+struct FieldConstructorsInternal {
+    publicField: String = "foo"
+    internal internalField: Double = 42
+    @Dart("withAll")
+    internal field constructor()
+    @Dart("withFortyTwo")
+    internal field constructor(publicField)
+    @Dart("withFoo")
+    internal field constructor(internalField)
+    @Dart(Default)
+    internal field constructor(internalField, publicField)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsInternal.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsInternal.swift
@@ -1,0 +1,68 @@
+//
+//
+import Foundation
+public struct FieldConstructorsInternal {
+    public var publicField: String
+    internal var internalField: Double
+    internal init() {
+        self.publicField = "foo"
+        self.internalField = 42
+    }
+    internal init(publicField: String) {
+        self.publicField = publicField
+        self.internalField = 42
+    }
+    internal init(internalField: Double) {
+        self.internalField = internalField
+        self.publicField = "foo"
+    }
+    internal init(internalField: Double, publicField: String) {
+        self.internalField = internalField
+        self.publicField = publicField
+    }
+    internal init(cHandle: _baseRef) {
+        publicField = moveFromCType(smoke_FieldConstructorsInternal_publicField_get(cHandle))
+        internalField = moveFromCType(smoke_FieldConstructorsInternal_internalField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsInternal {
+    return FieldConstructorsInternal(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsInternal {
+    defer {
+        smoke_FieldConstructorsInternal_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsInternal) -> RefHolder {
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_FieldConstructorsInternal_create_handle(c_publicField.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsInternal) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsInternal_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsInternal? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorsInternal_unwrap_optional_handle(handle)
+    return FieldConstructorsInternal(cHandle: unwrappedHandle) as FieldConstructorsInternal
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsInternal? {
+    defer {
+        smoke_FieldConstructorsInternal_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsInternal?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_publicField = moveToCType(swiftType.publicField)
+    let c_internalField = moveToCType(swiftType.internalField)
+    return RefHolder(smoke_FieldConstructorsInternal_create_optional_handle(c_publicField.ref, c_internalField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsInternal?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsInternal_release_optional_handle)
+}

--- a/lime-loader/src/main/antlr/LimeParser.g4
+++ b/lime-loader/src/main/antlr/LimeParser.g4
@@ -66,7 +66,7 @@ constructor
     ;
 
 fieldConstructor
-    : docComment* annotation* 'field' NewLine* 'constructor' NewLine*
+    : docComment* annotation* visibility? 'field' NewLine* 'constructor' NewLine*
       '(' NewLine* (simpleId NewLine* (',' NewLine* simpleId NewLine*)*)? ')' NewLine*
     ;
 

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -269,7 +269,7 @@ internal class AntlrLimeModelBuilder(
             else -> throw LimeLoadingException("Invalid syntax context: '$ctx'")
         }
         pathStack.push(currentPath.child("", idx.toString()))
-        visibilityStack.push(currentVisibility)
+        visibilityStack.push(convertVisibility(ctx.visibility(), visibilityStack.peek()))
         structuredCommentsStack.push(parseStructuredComment(ctx.docComment(), ctx))
     }
 
@@ -277,6 +277,7 @@ internal class AntlrLimeModelBuilder(
         val structTypeRef = LimeLazyTypeRef(currentPath.parent.toString(), referenceResolver.referenceMap)
         val limeElement = LimeFieldConstructor(
             path = currentPath,
+            visibility = currentVisibility,
             comment = structuredCommentsStack.peek().description,
             attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
             structRef = structTypeRef,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeFieldConstructor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeFieldConstructor.kt
@@ -21,11 +21,12 @@ package com.here.gluecodium.model.lime
 
 class LimeFieldConstructor(
     path: LimePath,
+    visibility: LimeVisibility = LimeVisibility.PUBLIC,
     comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
     val structRef: LimeTypeRef,
     val fieldRefs: List<LimeFieldRef> = emptyList()
-) : LimeNamedElement(path, LimeVisibility.PUBLIC, comment, attributes) {
+) : LimeNamedElement(path, visibility, comment, attributes) {
     val struct
         get() = structRef.type as LimeStruct
     val fields


### PR DESCRIPTION
Updated LIME IDL grammar to support visibility modifiers on field constructors.
Updated language templates with this support.

Added smoke and functional tests.

Resolves: #1127
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>