### PR TITLE
Fix function/property skipping in interface in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
   * Fixed compilation issue in Dart for fields marked with `@Dart(EnableIf)`.
+  * Fixed compilation issue in Swift when a function/property referring to an enum is skipped in an interface.
 
 ## 10.1.6
 Release date: 2021-10-15

--- a/functional-tests/functional/input/lime/Skip.lime
+++ b/functional-tests/functional/input/lime/Skip.lime
@@ -61,6 +61,8 @@ interface SkipProxy {
 
     @Java(Skip) @Swift(Skip) @Dart(Skip)
     property skippedEverywhere: SkippedEverywhere
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    property skippedEverywhereToo: SkippedEverywhereEnum
 }
 
 @Java(Skip) @Swift(Skip) @Dart(Skip)
@@ -68,6 +70,11 @@ struct SkippedEverywhere {
     nothingToSeeHere: String
 
     fun useMapInDart(foo: Map<Int, SkipTypes.NotInDart>)
+}
+
+@Java(Skip) @Swift(Skip) @Dart(Skip)
+enum SkippedEverywhereEnum {
+    nothingToSeeHere
 }
 
 interface InheritFromSkipped: SkipProxy { }

--- a/gluecodium/src/main/resources/templates/cbridge/FunctionTable.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/FunctionTable.mustache
@@ -21,17 +21,17 @@
 typedef struct {
     void* swift_pointer;
     void(*release)(void* swift_pointer);
-{{#each inheritedFunctions functions}}{{#unless isStatic}}
+{{#each inheritedFunctions functions}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}
     {{#if thrownType}}{{resolveName}}_result{{/if}}{{#unless thrownType}}{{resolveName returnType}}{{/unless}}{{!!
     }}(*{{resolveName}})(void* swift_pointer{{#if parameters}}, {{/if}}{{!!
     }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
-{{/unless}}{{/each}}
-{{#each inheritedProperties properties}}{{#unless isStatic}}
+{{/ifPredicate}}{{/unless}}{{/each}}
+{{#each inheritedProperties properties}}{{#unless isStatic}}{{#ifPredicate "shouldRetain"}}
 {{#getter}}
     {{resolveName typeRef}}(*{{resolveName}})(void* swift_pointer);
 {{/getter}}
 {{#setter}}
     void(*{{resolveName}})(void* swift_pointer, {{resolveName typeRef}} value);
 {{/setter}}
-{{/unless}}{{/each}}
+{{/ifPredicate}}{{/unless}}{{/each}}
 } {{resolveName}}_FunctionTable;

--- a/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
@@ -61,6 +61,8 @@ interface SkipProxy {
 
     @Java(Skip) @Swift(Skip) @Dart(Skip)
     property skippedEverywhere: SkippedEverywhere
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    property skippedEverywhereToo: SkippedEverywhereEnum
 }
 
 @Java(Skip) @Swift(Skip) @Dart(Skip)
@@ -68,6 +70,11 @@ struct SkippedEverywhere {
     nothingToSeeHere: String
 
     fun useMapInDart(foo: Map<Int, SkipTypes.NotInDart>)
+}
+
+@Java(Skip) @Swift(Skip) @Dart(Skip)
+enum SkippedEverywhereEnum {
+    nothingToSeeHere
 }
 
 interface InheritFromSkipped: SkipProxy { }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
@@ -110,5 +110,12 @@ com_example_smoke_SkipProxy_CppProxy::get_skipped_everywhere(  ) const {
 void
 com_example_smoke_SkipProxy_CppProxy::set_skipped_everywhere( const ::smoke::SkippedEverywhere& nvalue ) {
 }
+::smoke::SkippedEverywhereEnum
+com_example_smoke_SkipProxy_CppProxy::get_skipped_everywhere_too(  ) const {
+    return {};
+}
+void
+com_example_smoke_SkipProxy_CppProxy::set_skipped_everywhere_too( const ::smoke::SkippedEverywhereEnum nvalue ) {
+}
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipProxy.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipProxy.h
@@ -1,0 +1,35 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+_GLUECODIUM_C_EXPORT void smoke_SkipProxy_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_SkipProxy_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_SkipProxy_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_SkipProxy_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void* smoke_SkipProxy_get_typed(_baseRef handle);
+typedef struct {
+    void* swift_pointer;
+    void(*release)(void* swift_pointer);
+    _baseRef(*smoke_SkipProxy_notInJava)(void* swift_pointer, _baseRef input);
+    float(*smoke_SkipProxy_notInDart)(void* swift_pointer, float input);
+    _baseRef(*smoke_SkipProxy_skippedInJava_get)(void* swift_pointer);
+    void(*smoke_SkipProxy_skippedInJava_set)(void* swift_pointer, _baseRef value);
+    float(*smoke_SkipProxy_skippedInDart_get)(void* swift_pointer);
+    void(*smoke_SkipProxy_skippedInDart_set)(void* swift_pointer, float value);
+} smoke_SkipProxy_FunctionTable;
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_create_proxy(smoke_SkipProxy_FunctionTable functionTable);
+_GLUECODIUM_C_EXPORT const void* smoke_SkipProxy_get_swift_object_from_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_notInJava(_baseRef _instance, _baseRef input);
+_GLUECODIUM_C_EXPORT float smoke_SkipProxy_notInDart(_baseRef _instance, float input);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_skippedInJava_get(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_SkipProxy_skippedInJava_set(_baseRef _instance, _baseRef value);
+_GLUECODIUM_C_EXPORT float smoke_SkipProxy_skippedInDart_get(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_SkipProxy_skippedInDart_set(_baseRef _instance, float value);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
@@ -111,6 +111,11 @@ public:
     }
     void set_skipped_everywhere(const ::smoke::SkippedEverywhere& value) override {
     }
+    ::smoke::SkippedEverywhereEnum get_skipped_everywhere_too() const override {
+        return {};
+    }
+    void set_skipped_everywhere_too(const ::smoke::SkippedEverywhereEnum value) override {
+    }
 private:
     smoke_SkipProxy_FunctionTable mFunctions;
 };

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
@@ -104,6 +104,13 @@ public:
     void
     set_skipped_everywhere(const smoke::SkippedEverywhere& value) override {
     }
+    smoke::SkippedEverywhereEnum
+    get_skipped_everywhere_too() const override {
+        return {};
+    }
+    void
+    set_skipped_everywhere_too(const smoke::SkippedEverywhereEnum value) override {
+    }
 private:
     const uint64_t token;
     const int32_t isolate_id;


### PR DESCRIPTION
Updated FunctionTable.mustache template to properly skip functions and
properties if they are marked with `@Skip(Swift)` or some other applicable skip
attribute. This fixes a compilation issue when such skipped element refers to an
also-skipped enum type.

Added smoke and functional tests.

Resolves: #1135
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>