### PR TITLE
Allow platform skip attributes for fields of mutable structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Platform skip attributes (`@Skip(Java)`, `@Java(Skip)`, same for Swift and Dart) are now supported for fields of
+    mutable structs.
+
 ## 10.1.7
 Release date: 2021-10-27
   * Fixed compilation issue in Dart for fields marked with `@Dart(EnableIf)`.

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -539,8 +539,8 @@ element is skipped (not generated). Custom tags are case-insensitive.
   * **FunctionName** **=** **"**_FunctionName_**"**: marks a lambda type to have a specific function
   name in the generated functional interface in Java (instead of a default name).
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Java. Can be applied to
-  any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
-  was defined (see `@Skip` above).
+  any element except for enumerators and fields of `@Immutable` structs. Optionally, if custom tag is specified, the
+  element is only skipped if that tag was defined (see `@Skip` above).
   * **EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Java only if a custom tag with that
   name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).   
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Java
@@ -562,8 +562,8 @@ element is skipped (not generated). Custom tags are case-insensitive.
   Extending a generated type is also possible, but requires usage of `Name` attribute to avoid name
   clashes on other platforms.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Swift. Can be applied to
-  any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
-  was defined (see `@Skip` above).
+  any element except for enumerators and fields of `@Immutable` structs. Optionally, if custom tag is specified, the
+  element is only skipped if that tag was defined (see `@Skip` above).
   * **EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Swift only if a custom tag with that
   name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).
   * **Weak**: marks a property in an interface as `weak` in Swift. Property should have a nullable type. Please note
@@ -578,8 +578,8 @@ element is skipped (not generated). Custom tags are case-insensitive.
   This is the default specification for this attribute.
   * **Default**: marks a constructor as a "default" (nameless) in Dart.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Dart. Can be applied to
-  any element except for struct fields. Optionally, if custom tag is specified, the element is only skipped if that tag
-  was defined (see `@Skip` above).
+  any element except for enumerators and fields of `@Immutable` structs. Optionally, if custom tag is specified, the
+  element is only skipped if that tag was defined (see `@Skip` above).
   * **EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Dart only if a custom tag with that
   name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).
   * **PositionalDefaults** \[**=** **"**_DeprecationMessage_**"** \]: marks a struct to have a constructor with optional

--- a/functional-tests/functional/input/lime/Skip.lime
+++ b/functional-tests/functional/input/lime/Skip.lime
@@ -78,3 +78,10 @@ enum SkippedEverywhereEnum {
 }
 
 interface InheritFromSkipped: SkipProxy { }
+
+struct SkipFieldInPlatform {
+    intField: Int
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    stringField: String
+    boolField: Boolean
+}

--- a/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
@@ -78,3 +78,10 @@ enum SkippedEverywhereEnum {
 }
 
 interface InheritFromSkipped: SkipProxy { }
+
+struct SkipFieldInPlatform {
+    intField: Int
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    stringField: String
+    boolField: Boolean
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatform__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatform__Conversion.cpp
@@ -1,0 +1,54 @@
+/*
+ *
+ */
+#include "com_example_smoke_SkipFieldInPlatform__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::SkipFieldInPlatform
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::SkipFieldInPlatform*)
+{
+    ::smoke::SkipFieldInPlatform _nout{};
+    int32_t n_int_field = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "intField",
+        (int32_t*)nullptr );
+    _nout.int_field = n_int_field;
+    bool n_bool_field = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "boolField",
+        (bool*)nullptr );
+    _nout.bool_field = n_bool_field;
+    return _nout;
+}
+::gluecodium::optional<::smoke::SkipFieldInPlatform>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::SkipFieldInPlatform>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::SkipFieldInPlatform>(convert_from_jni(_jenv, _jinput, (::smoke::SkipFieldInPlatform*)nullptr))
+        : ::gluecodium::optional<::smoke::SkipFieldInPlatform>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/SkipFieldInPlatform", com_example_smoke_SkipFieldInPlatform, ::smoke::SkipFieldInPlatform)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::SkipFieldInPlatform& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::SkipFieldInPlatform>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::SkipFieldInPlatform> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipFieldInPlatform.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipFieldInPlatform.cpp
@@ -1,0 +1,46 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_SkipFieldInPlatform.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "gluecodium/Optional.h"
+#include "smoke/SkipFieldInPlatform.h"
+#include <cstdint>
+#include <memory>
+#include <new>
+_baseRef
+smoke_SkipFieldInPlatform_create_handle( int32_t intField, bool boolField )
+{
+    ::smoke::SkipFieldInPlatform* _struct = new ( ::std::nothrow ) ::smoke::SkipFieldInPlatform();
+    _struct->int_field = intField;
+    _struct->bool_field = boolField;
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_SkipFieldInPlatform_release_handle( _baseRef handle )
+{
+    delete get_pointer<::smoke::SkipFieldInPlatform>( handle );
+}
+_baseRef
+smoke_SkipFieldInPlatform_create_optional_handle(int32_t intField, bool boolField)
+{
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::SkipFieldInPlatform>( ::smoke::SkipFieldInPlatform( ) );
+    (*_struct)->int_field = intField;
+    (*_struct)->bool_field = boolField;
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_SkipFieldInPlatform_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::smoke::SkipFieldInPlatform>*>( handle ) );
+}
+void smoke_SkipFieldInPlatform_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::smoke::SkipFieldInPlatform>*>( handle );
+}
+int32_t smoke_SkipFieldInPlatform_intField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::SkipFieldInPlatform>(handle);
+    return struct_pointer->int_field;
+}
+bool smoke_SkipFieldInPlatform_boolField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::SkipFieldInPlatform>(handle);
+    return struct_pointer->bool_field;
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFieldInPlatform.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFieldInPlatform.cpp
@@ -1,0 +1,56 @@
+#include "ffi_smoke_SkipFieldInPlatform.h"
+#include "ConversionBase.h"
+#include "smoke/SkipFieldInPlatform.h"
+#include <cstdint>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_SkipFieldInPlatform_create_handle(int32_t intField, bool boolField) {
+    auto _result = new (std::nothrow) smoke::SkipFieldInPlatform();
+    _result->int_field = gluecodium::ffi::Conversion<int32_t>::toCpp(intField);
+    _result->bool_field = gluecodium::ffi::Conversion<bool>::toCpp(boolField);
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_SkipFieldInPlatform_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<smoke::SkipFieldInPlatform*>(handle);
+}
+int32_t
+library_smoke_SkipFieldInPlatform_get_field_intField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<int32_t>::toFfi(
+        reinterpret_cast<smoke::SkipFieldInPlatform*>(handle)->int_field
+    );
+}
+bool
+library_smoke_SkipFieldInPlatform_get_field_boolField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<bool>::toFfi(
+        reinterpret_cast<smoke::SkipFieldInPlatform*>(handle)->bool_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_SkipFieldInPlatform_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<smoke::SkipFieldInPlatform>(
+            gluecodium::ffi::Conversion<smoke::SkipFieldInPlatform>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_SkipFieldInPlatform_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<smoke::SkipFieldInPlatform>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_SkipFieldInPlatform_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<smoke::SkipFieldInPlatform>::toFfi(
+        **reinterpret_cast<gluecodium::optional<smoke::SkipFieldInPlatform>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Updated LimeSkipValidator to allow platform skip attributes on fields when the
struct does not have an `@Immutable` attribute. If that attribute is present,
this skipping is still not allowed.

Updated unit tests for that validator to reflect the change.

Added smoke and functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>