### PR TITLE
Java FQN usages for nested types

### DIFF
--- a/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/Constants.java
+++ b/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/Constants.java
@@ -9,5 +9,5 @@ public final class Constants {
     public static final float FLOAT_CONSTANT = 2.71f;
     public static final double DOUBLE_CONSTANT = -3.14;
     public static final String STRING_CONSTANT = "Foo bar";
-    public static final com.example.smoke.StateEnum ENUM_CONSTANT = com.example.smoke.StateEnum.ON;
+    public static final StateEnum ENUM_CONSTANT = StateEnum.ON;
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/ImmutableStructWithDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/ImmutableStructWithDefaults.java
@@ -12,7 +12,7 @@ public final class ImmutableStructWithDefaults {
     @NonNull
     public final String stringField;
     @NonNull
-    public final com.example.smoke.SomeEnum enumField;
+    public final SomeEnum enumField;
     @NonNull
     public final DefaultValues.ExternalEnum externalEnumField;
     public ImmutableStructWithDefaults(final long uintField, final boolean boolField) {
@@ -22,10 +22,10 @@ public final class ImmutableStructWithDefaults {
         this.doubleField = -1.4142;
         this.boolField = boolField;
         this.stringField = "\\Jonny \"Magic\" Smith\n";
-        this.enumField = com.example.smoke.SomeEnum.BAR_VALUE;
+        this.enumField = SomeEnum.BAR_VALUE;
         this.externalEnumField = DefaultValues.ExternalEnum.ANOTHER_VALUE;
     }
-    public ImmutableStructWithDefaults(final int intField, final long uintField, final float floatField, final double doubleField, final boolean boolField, @NonNull final String stringField, @NonNull final com.example.smoke.SomeEnum enumField, @NonNull final DefaultValues.ExternalEnum externalEnumField) {
+    public ImmutableStructWithDefaults(final int intField, final long uintField, final float floatField, final double doubleField, final boolean boolField, @NonNull final String stringField, @NonNull final SomeEnum enumField, @NonNull final DefaultValues.ExternalEnum externalEnumField) {
         this.intField = intField;
         this.uintField = uintField;
         this.floatField = floatField;

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/com/example/smoke/NestedReferences.java
@@ -26,5 +26,5 @@ public final class NestedReferences extends NativeBase {
     }
     private static native void disposeNativeHandle(long nativeHandle);
     @NonNull
-    public native com.example.smoke.NestedReferences insideOut(@NonNull final com.example.smoke.NestedReferences.NestedReferences struct1, @NonNull final com.example.smoke.NestedReferences.NestedReferences struct2);
+    public native NestedReferences insideOut(@NonNull final NestedReferences.NestedReferences struct1, @NonNull final NestedReferences.NestedReferences struct2);
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/AllTypesStruct.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/AllTypesStruct.java
@@ -20,8 +20,8 @@ public final class AllTypesStruct {
     @NonNull
     public byte[] bytesField;
     @NonNull
-    public com.example.smoke.Point pointField;
-    public AllTypesStruct(final byte int8Field, final short uint8Field, final short int16Field, final int uint16Field, final int int32Field, final long uint32Field, final long int64Field, final long uint64Field, final float floatField, final double doubleField, @NonNull final String stringField, final boolean booleanField, @NonNull final byte[] bytesField, @NonNull final com.example.smoke.Point pointField) {
+    public Point pointField;
+    public AllTypesStruct(final byte int8Field, final short uint8Field, final short int16Field, final int uint16Field, final int int32Field, final long uint32Field, final long int64Field, final long uint64Field, final float floatField, final double doubleField, @NonNull final String stringField, final boolean booleanField, @NonNull final byte[] bytesField, @NonNull final Point pointField) {
         this.int8Field = int8Field;
         this.uint8Field = uint8Field;
         this.int16Field = int16Field;

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Line.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Line.java
@@ -5,10 +5,10 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 public final class Line {
     @NonNull
-    public com.example.smoke.Point a;
+    public Point a;
     @NonNull
-    public com.example.smoke.Point b;
-    public Line(@NonNull final com.example.smoke.Point a, @NonNull final com.example.smoke.Point b) {
+    public Point b;
+    public Line(@NonNull final Point a, @NonNull final Point b) {
         this.a = a;
         this.b = b;
     }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
@@ -120,7 +120,7 @@ public final class Structs extends NativeBase {
     @NonNull
     public static native Structs.AllTypesStruct returnAllTypesStruct(@NonNull final Structs.AllTypesStruct input);
     @NonNull
-    public static native com.example.smoke.Point createPoint(final double x, final double y);
+    public static native Point createPoint(final double x, final double y);
     @NonNull
-    public static native com.example.smoke.AllTypesStruct modifyAllTypesStruct(@NonNull final com.example.smoke.AllTypesStruct input);
+    public static native AllTypesStruct modifyAllTypesStruct(@NonNull final AllTypesStruct input);
 }


### PR DESCRIPTION
Updated "duplicate names" logic in JavaNameResolver to eliminate false positives
for nested types. Updated smoke tests where these false positives were present.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>