### PR TITLE
Add support for `@Dart(FullName)` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Features:
+  * Added support for `@Dart(FullName)` attribute.
 ### Bug fixes:
   * Fixed linking issues in Dart when building it with Xcode.
 

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -574,8 +574,11 @@ element is skipped (not generated). Custom tags are case-insensitive.
   `@Swift(Attribute="available(*, deprecated, message: \"It's deprecated.\")")`. If some of the parameters are string
   literals, their enclosing quotes need to be backslash-escaped, as in the example.
 * **@Dart**: marks an element with Dart-specific behaviors:
-  * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart.
-  This is the default specification for this attribute.
+  * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart. This is the default
+  specification for this attribute.
+  * **FullName** **=** **"**_ElementName_**"**: marks an element to have a distinct full name in Dart. Normally full
+  name is the name of the element itself, prefixed by the name of its nesting parents. But this attribute overrides this
+  name concatenation. This attribute is only meaningful for nested type declarations.
   * **Default**: marks a constructor as a "default" (nameless) in Dart.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Dart. Can be applied to
   any element except for enumerators and fields of `@Immutable` structs. Optionally, if custom tag is specified, the

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -403,6 +403,10 @@ feature(EscapedNames cpp android swift dart SOURCES
     input/lime/KeywordNames.lime
 )
 
+feature(FullName dart SOURCES
+    input/lime/FullName.lime
+)
+
 feature(Nesting cpp android swift dart SOURCES
     input/src/cpp/TopLevelTypes.cpp
     input/src/cpp/NestedContainers.cpp

--- a/functional-tests/functional/input/lime/FullName.lime
+++ b/functional-tests/functional/input/lime/FullName.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+class OuterName {
+    @Dart(FullName = "Futhark")
+    struct InnerName {
+        stringField: String
+    }
+}
+
+class UseInnerName {
+    fun doFoo(): OuterName.InnerName
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -178,6 +178,9 @@ internal class DartNameResolver(
         }
 
     private fun resolveTypeName(limeType: LimeType): String {
+        val enforcedFullName = limeType.attributes.get(LimeAttributeType.DART, LimeAttributeValueType.FULL_NAME)
+        if (enforcedFullName != null) return enforcedFullName
+
         val typeName = getPlatformName(limeType)
         val parentType = if (limeType.path.hasParent) getParentElement(limeType) as? LimeType else null
         return when (parentType) {

--- a/gluecodium/src/test/resources/smoke/full_name/input/FullName.lime
+++ b/gluecodium/src/test/resources/smoke/full_name/input/FullName.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+class OuterName {
+    @Dart(FullName = "Futhark")
+    struct InnerName {
+        stringField: String
+    }
+}
+
+class UseInnerName {
+    fun doFoo(): OuterName.InnerName
+}

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
@@ -1,0 +1,112 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+abstract class OuterName {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
+}
+class Futhark {
+  String stringField;
+  Futhark(this.stringField);
+}
+// Futhark "private" section, not exported.
+final _smokeOuternameInnernameCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterName_InnerName_create_handle'));
+final _smokeOuternameInnernameReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterName_InnerName_release_handle'));
+final _smokeOuternameInnernameGetFieldstringField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterName_InnerName_get_field_stringField'));
+Pointer<Void> smokeOuternameInnernameToFfi(Futhark value) {
+  final _stringFieldHandle = stringToFfi(value.stringField);
+  final _result = _smokeOuternameInnernameCreateHandle(_stringFieldHandle);
+  stringReleaseFfiHandle(_stringFieldHandle);
+  return _result;
+}
+Futhark smokeOuternameInnernameFromFfi(Pointer<Void> handle) {
+  final _stringFieldHandle = _smokeOuternameInnernameGetFieldstringField(handle);
+  try {
+    return Futhark(
+      stringFromFfi(_stringFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_stringFieldHandle);
+  }
+}
+void smokeOuternameInnernameReleaseFfiHandle(Pointer<Void> handle) => _smokeOuternameInnernameReleaseHandle(handle);
+// Nullable Futhark
+final _smokeOuternameInnernameCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterName_InnerName_create_handle_nullable'));
+final _smokeOuternameInnernameReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterName_InnerName_release_handle_nullable'));
+final _smokeOuternameInnernameGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterName_InnerName_get_value_nullable'));
+Pointer<Void> smokeOuternameInnernameToFfiNullable(Futhark? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuternameInnernameToFfi(value);
+  final result = _smokeOuternameInnernameCreateHandleNullable(_handle);
+  smokeOuternameInnernameReleaseFfiHandle(_handle);
+  return result;
+}
+Futhark? smokeOuternameInnernameFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuternameInnernameGetValueNullable(handle);
+  final result = smokeOuternameInnernameFromFfi(_handle);
+  smokeOuternameInnernameReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeOuternameInnernameReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuternameInnernameReleaseHandleNullable(handle);
+// End of Futhark "private" section.
+// OuterName "private" section, not exported.
+final _smokeOuternameRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_OuterName_register_finalizer'));
+final _smokeOuternameCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterName_copy_handle'));
+final _smokeOuternameReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterName_release_handle'));
+class OuterName$Impl extends __lib.NativeBase implements OuterName {
+  OuterName$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+}
+Pointer<Void> smokeOuternameToFfi(OuterName value) =>
+  _smokeOuternameCopyHandle((value as __lib.NativeBase).handle);
+OuterName smokeOuternameFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is OuterName) return instance;
+  final _copiedHandle = _smokeOuternameCopyHandle(handle);
+  final result = OuterName$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeOuternameRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeOuternameReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeOuternameReleaseHandle(handle);
+Pointer<Void> smokeOuternameToFfiNullable(OuterName? value) =>
+  value != null ? smokeOuternameToFfi(value) : Pointer<Void>.fromAddress(0);
+OuterName? smokeOuternameFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeOuternameFromFfi(handle) : null;
+void smokeOuternameReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuternameReleaseHandle(handle);
+// End of OuterName "private" section.

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
@@ -1,0 +1,60 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/smoke/outer_name.dart';
+abstract class UseInnerName {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
+  Futhark doFoo();
+}
+// UseInnerName "private" section, not exported.
+final _smokeUseinnernameRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_UseInnerName_register_finalizer'));
+final _smokeUseinnernameCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_UseInnerName_copy_handle'));
+final _smokeUseinnernameReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_UseInnerName_release_handle'));
+class UseInnerName$Impl extends __lib.NativeBase implements UseInnerName {
+  UseInnerName$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
+  @override
+  Futhark doFoo() {
+    final _doFooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_UseInnerName_doFoo'));
+    final _handle = this.handle;
+    final __resultHandle = _doFooFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return smokeOuternameInnernameFromFfi(__resultHandle);
+    } finally {
+      smokeOuternameInnernameReleaseFfiHandle(__resultHandle);
+    }
+  }
+}
+Pointer<Void> smokeUseinnernameToFfi(UseInnerName value) =>
+  _smokeUseinnernameCopyHandle((value as __lib.NativeBase).handle);
+UseInnerName smokeUseinnernameFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is UseInnerName) return instance;
+  final _copiedHandle = _smokeUseinnernameCopyHandle(handle);
+  final result = UseInnerName$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeUseinnernameRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeUseinnernameReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeUseinnernameReleaseHandle(handle);
+Pointer<Void> smokeUseinnernameToFfiNullable(UseInnerName? value) =>
+  value != null ? smokeUseinnernameToFfi(value) : Pointer<Void>.fromAddress(0);
+UseInnerName? smokeUseinnernameFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeUseinnernameFromFfi(handle) : null;
+void smokeUseinnernameReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeUseinnernameReleaseHandle(handle);
+// End of UseInnerName "private" section.

--- a/gluecodium/src/test/resources/smoke/full_name/output/lime/smoke/OuterName.lime
+++ b/gluecodium/src/test/resources/smoke/full_name/output/lime/smoke/OuterName.lime
@@ -1,0 +1,7 @@
+package smoke
+class OuterName {
+    @Dart(FullName = "Futhark")
+    struct InnerName {
+        stringField: String
+    }
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -189,6 +189,7 @@ internal object AntlrLimeConverter {
             "Default" -> LimeAttributeValueType.DEFAULT
             "EnableIf" -> LimeAttributeValueType.ENABLE_IF
             "Extension" -> LimeAttributeValueType.EXTENSION
+            "FullName" -> LimeAttributeValueType.FULL_NAME
             "FunctionName" -> LimeAttributeValueType.FUNCTION_NAME
             "Label" -> LimeAttributeValueType.LABEL
             "Message" -> LimeAttributeValueType.MESSAGE

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -28,6 +28,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     DEFAULT("Default"),
     ENABLE_IF("EnableIf"),
     EXTENSION("Extension"),
+    FULL_NAME("FullName"),
     FUNCTION_NAME("FunctionName"),
     LABEL("Label"),
     MESSAGE("Message"),


### PR DESCRIPTION
Updated LIME model and Dart name resolver to add support for `@Dart(FullName)`
attribute. This new attribute overrides the name concatenation logic for nested
type declarations in Dart, replacing the compound name with the value of the
attribute instead.

Added smoke and functional tests.

Resolves: #1151
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
