### PR TITLE
Move `getAllParentTypes()` utility function

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGenerator.kt
@@ -37,7 +37,6 @@ import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeContainer
-import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumeration
@@ -125,7 +124,7 @@ internal class CBridgeGenerator(
 
     fun generateCollections(limeModel: List<LimeNamedElement>): List<GeneratedFile> {
         val allTypes = limeModel.flatMap { LimeTypeHelper.getAllTypes(it) }
-        val allParentTypes = getAllParentTypes(allTypes)
+        val allParentTypes = LimeTypeHelper.getAllParentTypes(allTypes)
         val genericTypes = genericTypesCollector.getAllGenericTypes(allTypes + allParentTypes)
         val templateData = mutableMapOf<String, Any>(
             "lists" to genericTypes.filterIsInstance<LimeList>(),
@@ -317,12 +316,6 @@ internal class CBridgeGenerator(
                 Generator.copyCommonFile(Paths.get(CBRIDGE_PUBLIC, INCLUDE_DIR, "LocaleHandle.h").toString(), ""),
                 Generator.copyCommonFile(PROXY_CACHE_FILENAME, "")
             )
-        }
-
-        fun getAllParentTypes(allTypes: List<LimeType>): List<LimeType> {
-            if (allTypes.isEmpty()) return emptyList()
-            val parents = allTypes.filterIsInstance<LimeContainerWithInheritance>().flatMap { it.parents }.map { it.type }
-            return parents + getAllParentTypes(parents)
         }
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -24,7 +24,6 @@ import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
 import com.here.gluecodium.common.LimeModelSkipPredicates
 import com.here.gluecodium.generator.cbridge.CBridgeGenerator
-import com.here.gluecodium.generator.cbridge.CBridgeGenerator.Companion.getAllParentTypes
 import com.here.gluecodium.generator.cbridge.CBridgeNameResolver
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.GeneratedFile
@@ -184,7 +183,7 @@ internal class SwiftGenerator : Generator {
     ): List<GeneratedFile> {
 
         val allTypes = limeModel.flatMap { LimeTypeHelper.getAllTypes(it) }
-        val allParentTypes = getAllParentTypes(allTypes)
+        val allParentTypes = LimeTypeHelper.getAllParentTypes(allTypes)
         val genericTypes = genericTypesCollector.getAllGenericTypes(allTypes + allParentTypes)
 
         val listsFile = generateCollectionsFile(

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
@@ -59,6 +59,12 @@ object LimeTypeHelper {
             else -> identifier
         }
 
+    fun getAllParentTypes(allTypes: List<LimeType>): List<LimeType> {
+        if (allTypes.isEmpty()) return emptyList()
+        val parents = allTypes.filterIsInstance<LimeContainerWithInheritance>().flatMap { it.parents }.map { it.type }
+        return parents + getAllParentTypes(parents)
+    }
+
     private val limeKeywords = setOf(
         "class", "const", "constructor", "enum", "exception", "external", "field", "fun",
         "get", "import", "interface", "internal", "lambda", "narrow", "open", "package", "property", "public",


### PR DESCRIPTION
Moved `getAllParentTypes()` utility function from CBridgeGenerator to
LimeTypeHelper to make it available for general usage.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>