### PR TITLE
Fix the loss of ref equality for interface inheritance in Java

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -267,7 +267,7 @@ feature(Inheritance cpp android swift dart SOURCES
     input/src/cpp/ChildClassImpl.h
     input/src/cpp/GrandchildClassImpl.cpp
     input/src/cpp/GrandchildClassImpl.h
-    input/src/cpp/Talker.cpp
+    input/src/cpp/ListenerInheritance.cpp
     input/src/cpp/Teacher.cpp
     input/src/cpp/Inheritance.cpp
     input/src/cpp/CrossPackageInheritance.cpp

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerInheritanceTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerInheritanceTest.java
@@ -69,4 +69,24 @@ public class ListenerInheritanceTest {
 
     assertTrue(called);
   }
+
+  @Test
+  public void addRemoveParentListener() {
+    Broadcaster caster = new Broadcaster();
+    caster.addParentListener(fakeParentListener);
+
+    boolean result = caster.removeListener(fakeParentListener);
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void addRemoveChildListener() {
+    Broadcaster caster = new Broadcaster();
+    caster.addChildListener(fakeChildListener);
+
+    boolean result = caster.removeListener(fakeChildListener);
+
+    assertTrue(result);
+  }
 }

--- a/functional-tests/functional/input/lime/ListenerInheritance.lime
+++ b/functional-tests/functional/input/lime/ListenerInheritance.lime
@@ -31,3 +31,10 @@ class Talker {
         listener: ChildListener
     )
 }
+
+class Broadcaster {
+    constructor create()
+    fun addParentListener(listener: ParentListener)
+    fun addChildListener(listener: ChildListener)
+    fun removeListener(listener: ParentListener): Boolean
+}

--- a/functional-tests/functional/input/src/cpp/ListenerInheritance.cpp
+++ b/functional-tests/functional/input/src/cpp/ListenerInheritance.cpp
@@ -18,14 +18,34 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "another/AdditionalErrors.h"
-#include "another/TypeCollectionWithEnums.h"
 #include "test/ChildListener.h"
 #include "test/ParentListener.h"
+#include "test/Broadcaster.h"
 #include "test/Talker.h"
+#include <unordered_set>
 
 namespace test
 {
+namespace {
+class BroadcasterImpl : public Broadcaster {
+public:
+    void add_parent_listener(const std::shared_ptr<ParentListener>& listener) override {
+        m_listeners.insert(listener);
+    }
+
+    void add_child_listener(const std::shared_ptr<ChildListener>& listener) override {
+        m_listeners.insert(listener);
+    }
+
+    bool remove_listener(const std::shared_ptr<ParentListener>& listener) override {
+        return m_listeners.erase(listener) == 1;
+    }
+
+private:
+    std::unordered_set<std::shared_ptr<ParentListener>> m_listeners;
+};
+}
+
 void
 Talker::talk_to_parent( const std::shared_ptr< ParentListener >& listener )
 {
@@ -37,4 +57,10 @@ Talker::talk_to_child( const std::shared_ptr< ChildListener >& listener )
 {
     listener->listen( );
 }
-}  // namespace test
+
+std::shared_ptr<Broadcaster>
+Broadcaster::create() {
+    return std::make_shared<BroadcasterImpl>();
+}
+
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -133,6 +133,7 @@ internal class JavaGenerator : Generator {
             GeneratedFile.SourceSet.COMMON
         )
 
+        val descendantInterfaces = LimeTypeHelper.collectDescendantInterfaces(jniFilteredModel.topElements)
         val jniTemplates = JniTemplates(
             limeReferenceMap = jniFilteredModel.referenceMap,
             javaNameRules = javaNameRules,
@@ -141,7 +142,8 @@ internal class JavaGenerator : Generator {
             internalNamespace = internalNamespace,
             cppNameRules = cppNameRules,
             nameCache = cachingNameResolver,
-            activeTags = activeTags
+            activeTags = activeTags,
+            descendantInterfaces = descendantInterfaces
         )
         for (fileName in UTILS_FILES) {
             resultFiles += jniTemplates.generateConversionUtilsHeaderFile(fileName)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -53,7 +53,8 @@ internal class JniTemplates(
     private val internalNamespace: List<String>,
     cppNameRules: CppNameRules,
     nameCache: CppNameCache,
-    activeTags: Set<String>
+    activeTags: Set<String>,
+    private val descendantInterfaces: Map<String, List<LimeInterface>>
 ) {
     private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, javaNameRules)
     private val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
@@ -252,7 +253,7 @@ internal class JniTemplates(
     private fun generateInstanceConversionFiles(limeElement: LimeNamedElement): List<GeneratedFile> {
         val fileName = fileNameRules.getConversionFileName(limeElement)
         val selfInclude = Include.createInternalInclude("$fileName.h")
-        // Conversion includes need to be be added to the header file instead of the impl file, for unity builds.
+        // Conversion includes need to be added to the header file instead of the impl file, for unity builds.
         val headerIncludes = cppIncludeResolver.resolveElementImports(limeElement).distinct().sorted() +
             jniIncludeCollector.collectImports(limeElement).distinct().minus(selfInclude).sorted()
 
@@ -261,7 +262,8 @@ internal class JniTemplates(
             "includes" to headerIncludes,
             "basePackages" to basePackages,
             "internalPackages" to basePackages + internalPackages,
-            "internalNamespace" to internalNamespace
+            "internalNamespace" to internalNamespace,
+            "descendantInterfaces" to descendantInterfaces
         )
         val headerFile = GeneratedFile(
             TemplateEngine.render(

--- a/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
@@ -43,7 +43,9 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("{{resolveName}}{{#notInstanceOf this "Lime
 {{/ifPredicate}}{{#unlessPredicate "hasTypeRepository"}}
 REGISTER_JNI_CLASS_CACHE("{{resolveName}}{{#notInstanceOf this "LimeClass"}}Impl{{/notInstanceOf}}", {{!!
 }}{{resolveName "mangled"}}, {{resolveName "C++ FQN"}})
-{{/unlessPredicate}}
+{{/unlessPredicate}}{{#unless isNarrow}}{{#instanceOf this "LimeInterface"}}{{#if this.parents}}
+REGISTER_JNI_CLASS_CACHE_INTERFACE("{{resolveName}}", {{resolveName "mangled"}}__interface, {{resolveName "C++ FQN"}})
+{{/if}}{{/instanceOf}}{{/unless}}
 
 {{#notInstanceOf this "LimeClass"}}{{#instanceOf this "LimeLambda"}}
 void {{>conversionPrefix}}createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, {{resolveName "C++ FQN"}}& result)
@@ -62,6 +64,18 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
     }}env, obj, "{{resolveName "mangled"}}", result);
 }
 {{/notInstanceOf}}{{/notInstanceOf}}
+
+{{#unless isNarrow}}{{#instanceOf this "LimeInterface"}}{{#set interface=this}}{{#eval "descendantInterfaces" fullName}}
+{{#interface}}{{>cppTypeName}}{{/interface}} try_descendant_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, {{#interface}}{{>cppTypeName}}{{/interface}}*) {
+{{#this}}{{!! pre-sorted, most distant descendants are prioritized }}
+    if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<{{resolveName "C++ FQN"}}>::java_class.get())) {
+        return {{>conversionPrefix}}convert_from_jni(_env, _jobj, ({{>cppTypeName}}*)nullptr);
+    }
+{{/this}}
+    return {};
+}
+
+{{/eval}}{{/set}}{{/instanceOf}}{{/unless}}
 
 {{>cppTypeName}} {{>conversionPrefix}}convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, {{>cppTypeName}}*)
 {
@@ -84,6 +98,10 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
     }
     else
     {
+{{#instanceOf this "LimeInterface"}}{{#set interface=this}}{{#eval "descendantInterfaces" fullName}}
+        _nresult = try_descendant_from_jni(_env, _jobj, ({{#interface}}{{>cppTypeName}}{{/interface}}*)nullptr);
+        if (_nresult) return _nresult;
+{{/eval}}{{/set}}{{/instanceOf}}
         {{>conversionPrefix}}createCppProxy(_env, _jobj, _nresult);
     }
 {{/unless}}

--- a/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheHeader.mustache
@@ -72,8 +72,27 @@ private:
     }
 };
 
+template <class ... CppTypes>
+class CachedJavaInterface : public CachedJavaClassBase
+{
+public:
+    using CachedJavaClassBase::CachedJavaClassBase;
+
+    static JniReference<jclass> java_class;
+
+private:
+    JniReference<jclass>* set_java_class(JniReference<jclass> java_class_reference) override
+    {
+        java_class = std::move(java_class_reference);
+        return &java_class;
+    }
+};
+
 template<class ... CppTypes>
 JniReference<jclass> CachedJavaClass<CppTypes...>::java_class;
+
+template<class ... CppTypes>
+JniReference<jclass> CachedJavaInterface<CppTypes...>::java_class;
 
 #define REGISTER_JNI_CLASS_CACHE(name, register_name, ...) \
   namespace { \
@@ -84,6 +103,12 @@ JniReference<jclass> CachedJavaClass<CppTypes...>::java_class;
   namespace { \
   CachedJavaClass<__VA_ARGS__> register_name(name, cpp_name); \
   }
+
+#define REGISTER_JNI_CLASS_CACHE_INTERFACE(name, register_name, ...) \
+  namespace { \
+  CachedJavaInterface<__VA_ARGS__> register_name(name); \
+  }
+
 
 JNIEXPORT JniReference<jclass>& get_cached_native_base_class();
 

--- a/gluecodium/src/test/resources/smoke/inheritance/input/Inheritance.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/Inheritance.lime
@@ -26,6 +26,10 @@ interface ChildInterface : ParentInterface {
     fun childMethod()
 }
 
+interface GrandChildInterface : ChildInterface {
+    fun grandChildMethod()
+}
+
 class ChildClassFromInterface : ParentInterface {
     fun childClassMethod()
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterface__Conversion.cpp
@@ -1,0 +1,77 @@
+/*
+ *
+ */
+#include "com_example_smoke_ChildInterface__Conversion.h"
+#include "com_example_smoke_ChildInterfaceImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniWrapperCache.h"
+#include <new>
+namespace gluecodium
+{
+namespace jni
+{
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ChildInterfaceImpl", com_example_smoke_ChildInterface, "smoke_ChildInterface", ::smoke::ChildInterface)
+REGISTER_JNI_CLASS_CACHE_INTERFACE("com/example/smoke/ChildInterface", com_example_smoke_ChildInterface__interface, ::smoke::ChildInterface)
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ChildInterface>& result)
+{
+    CppProxyBase::createProxy<::smoke::ChildInterface, com_example_smoke_ChildInterface_CppProxy>(env, obj, "com_example_smoke_ChildInterface", result);
+}
+std::shared_ptr<::smoke::ChildInterface> try_descendant_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ChildInterface>*) {
+    if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::smoke::GrandChildInterface>::java_class.get())) {
+        return convert_from_jni(_env, _jobj, (std::shared_ptr<::smoke::GrandChildInterface>*)nullptr);
+    }
+    return {};
+}
+std::shared_ptr<::smoke::ChildInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ChildInterface>*)
+{
+    std::shared_ptr<::smoke::ChildInterface> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_field_value(
+                _env,
+                _jobj,
+                "nativeHandle",
+                (int64_t*)nullptr);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::ChildInterface>*>(long_ptr);
+        }
+    }
+    else
+    {
+        _nresult = try_descendant_from_jni(_env, _jobj, (std::shared_ptr<::smoke::ChildInterface>*)nullptr);
+        if (_nresult) return _nresult;
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ChildInterface>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::ChildInterface>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ChildInterface>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        auto exceptionClass = find_class(_jenv, "java/lang/OutOfMemoryError" );
+        _jenv->ThrowNew( exceptionClass.get(), "Cannot allocate native memory." );
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+    return jResult;
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ParentInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ParentInterface__Conversion.cpp
@@ -1,0 +1,82 @@
+/*
+ *
+ */
+#include "com_example_smoke_ParentInterface__Conversion.h"
+#include "com_example_smoke_ParentInterfaceImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniWrapperCache.h"
+#include <new>
+namespace gluecodium
+{
+namespace jni
+{
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ParentInterfaceImpl", com_example_smoke_ParentInterface, "smoke_ParentInterface", ::smoke::ParentInterface)
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ParentInterface>& result)
+{
+    CppProxyBase::createProxy<::smoke::ParentInterface, com_example_smoke_ParentInterface_CppProxy>(env, obj, "com_example_smoke_ParentInterface", result);
+}
+std::shared_ptr<::smoke::ParentInterface> try_descendant_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ParentInterface>*) {
+    if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::smoke::GrandChildInterface>::java_class.get())) {
+        return convert_from_jni(_env, _jobj, (std::shared_ptr<::smoke::GrandChildInterface>*)nullptr);
+    }
+    if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::foobar::CrossPackageChildInterface>::java_class.get())) {
+        return convert_from_jni(_env, _jobj, (std::shared_ptr<::foobar::CrossPackageChildInterface>*)nullptr);
+    }
+    if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::smoke::ChildInterface>::java_class.get())) {
+        return convert_from_jni(_env, _jobj, (std::shared_ptr<::smoke::ChildInterface>*)nullptr);
+    }
+    return {};
+}
+std::shared_ptr<::smoke::ParentInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ParentInterface>*)
+{
+    std::shared_ptr<::smoke::ParentInterface> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_field_value(
+                _env,
+                _jobj,
+                "nativeHandle",
+                (int64_t*)nullptr);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::ParentInterface>*>(long_ptr);
+        }
+    }
+    else
+    {
+        _nresult = try_descendant_from_jni(_env, _jobj, (std::shared_ptr<::smoke::ParentInterface>*)nullptr);
+        if (_nresult) return _nresult;
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ParentInterface>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::ParentInterface>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ParentInterface>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        auto exceptionClass = find_class(_jenv, "java/lang/OutOfMemoryError" );
+        _jenv->ThrowNew( exceptionClass.get(), "Cannot allocate native memory." );
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+    return jResult;
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
@@ -4,6 +4,7 @@ import 'package:library/src/smoke/child_class_with_imports.dart';
 import 'package:library/src/smoke/child_class_with_lambda.dart';
 import 'package:library/src/smoke/child_interface.dart';
 import 'package:library/src/smoke/child_with_parent_class_references.dart';
+import 'package:library/src/smoke/grand_child_interface.dart';
 import 'package:library/src/smoke/interface_with_lambda.dart';
 import 'package:library/src/smoke/internal_child.dart';
 import 'package:library/src/smoke/internal_parent.dart';
@@ -18,6 +19,7 @@ final Map<String, Function> typeRepository = {
   "smoke_ChildClassWithLambda": (handle) => ChildClassWithLambda$Impl(handle),
   "smoke_ChildInterface": (handle) => ChildInterface$Impl(handle),
   "smoke_ChildWithParentClassReferences": (handle) => ChildWithParentClassReferences$Impl(handle),
+  "smoke_GrandChildInterface": (handle) => GrandChildInterface$Impl(handle),
   "smoke_InterfaceWithLambda": (handle) => InterfaceWithLambda$Impl(handle),
   "smoke_InternalChild": (handle) => InternalChild$Impl(handle),
   "smoke_InternalParent": (handle) => InternalParent$Impl(handle),


### PR DESCRIPTION
Added `LimeTypeHelper.collectDescendantIntefaces()` utility function. This
function maps each interface type to a (potentially empty) list of its
descendants (inheritance children and their respective descendants). Class types
are excluded from this analysis. Each list of descendants is sorted by its
inheritance distance to the ancestor type, most distant descendants first.

Updated JNI `convert_from_jni()` functions to try downcasting from the parent
interface type to the child interface types when creating a proxy. This fixes
the issue where upcasting an object and sending it across the language boundary
breaks referential equality (due to a parent-type proxy being created).

This "try downcasting" logic is only ever generated for interfaces that have one
or more child interfaces declared in the IDL, based on the results of
`collectDescendantIntefaces()` analysis. Classes, lambdas, narrow interfaces,
and childless interfaces are not affected by this change.

Added smoke and functional tests.

See: #1134
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
