### PR TITLE
Fix the loss of ref equality for interface inheritance in Swift

### DIFF
--- a/functional-tests/functional/swift/Tests/ListenerInheritanceTests.swift
+++ b/functional-tests/functional/swift/Tests/ListenerInheritanceTests.swift
@@ -1,0 +1,58 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import functional
+
+class ListenerInheritanceTests: XCTestCase {
+
+    class ParentListenerImpl: ParentListener {
+        func listen() {}
+    }
+
+    class ChildListenerImpl: ChildListener {
+        func listen() {}
+    }
+
+    func testAddRemoveParentListener() {
+        let listener = ParentListenerImpl()
+        let broadcaster = Broadcaster()
+        broadcaster.addParentListener(listener: listener)
+
+        let result = broadcaster.removeListener(listener: listener)
+
+        XCTAssertTrue(result)
+    }
+
+    func testAddRemoveChildListener() {
+        let listener = ChildListenerImpl()
+        let broadcaster = Broadcaster()
+        broadcaster.addChildListener(listener: listener)
+
+        let result = broadcaster.removeListener(listener: listener)
+
+        XCTAssertTrue(result)
+    }
+
+    static var allTests = [
+        ("testAddRemoveParentListener", testAddRemoveParentListener),
+        ("testAddRemoveChildListener", testAddRemoveChildListener)
+    ]
+}

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -50,6 +50,7 @@ func getAllTests() -> [XCTestCaseEntry] {
         testCase(InterfacesTests.allTests),
         testCase(InterfaceWithStaticTests.allTests),
         testCase(LambdasTests.allTests),
+        testCase(ListenerInheritanceTests.allTests),
         testCase(ListenerRoundtripTests.allTests),
         testCase(ListenerWithAttributesTests.allTests),
         testCase(ListenersReturnValuesTests.allTests),

--- a/gluecodium/src/main/resources/templates/swift/GetReference.mustache
+++ b/gluecodium/src/main/resources/templates/swift/GetReference.mustache
@@ -34,14 +34,20 @@
     guard let reference = ref else {
         return RefHolder(0)
     }
-
 {{#unless isNarrow}}
+
     if let instanceReference = reference as? NativeBase {
         let handle_copy = {{resolveName "CBridge"}}_copy_handle(instanceReference.c_handle)
         return owning
             ? RefHolder(ref: handle_copy, release: {{resolveName "CBridge"}}_release_handle)
             : RefHolder(handle_copy)
     }
+{{#eval "descendantInterfaces" fullName}}
+
+    if let descendantResult = tryDescendantGetRef(reference, owning{{#ifPredicate "hasWeakSupport"}}, isWeak{{/ifPredicate}}) {
+        return descendantResult
+    }
+{{/eval}}
 {{/unless}}
 
     var functions = {{resolveName "CBridge"}}_FunctionTable()
@@ -67,14 +73,26 @@
 {{/unless}}{{/each}}
     let proxy = {{resolveName "CBridge"}}_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: {{resolveName "CBridge"}}_release_handle) : RefHolder(proxy)
-}
 {{/class}}{{/set}}
+}
 {{#ifPredicate "hasWeakSupport"}}
 
 {{>swift/ConversionVisibility}} func weakToCType(_ swiftClass: {{resolveName}}?) -> RefHolder {
     return getRef(swiftClass, owning: true, isWeak: true)
 }
-{{/ifPredicate}}{{!!
+{{/ifPredicate}}
+{{#unless isNarrow}}{{#set interface=this}}{{#eval "descendantInterfaces" fullName}}
+
+func tryDescendantGetRef(_ reference: {{resolveName interface "" "ref"}}, _ owning: Bool{{!!
+}}{{#ifPredicate interface "hasWeakSupport"}}, _ isWeak: Bool{{/ifPredicate}}) -> RefHolder? {
+{{#this}}{{!! pre-sorted, most distant descendants are prioritized }}
+    if reference is {{resolveName}} {
+        return getRef(reference as? {{resolveName}}, owning: owning{{#ifPredicate interface "hasWeakSupport"}}, isWeak: isWeak{{/ifPredicate}})
+    }
+{{/this}}
+    return nil
+}
+{{/eval}}{{/set}}{{/unless}}{{!!
 
 }}{{+functionTableEntry}}
     functions.{{resolveName function "CBridge"}} = {(swift_class_pointer{{#if parameters}}, {{/if}}{{joinPartial parameters "swiftParameter" ", "}}) in

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildInterface.swift
@@ -50,6 +50,9 @@ internal func getRef(_ ref: ChildInterface?, owning: Bool = true) -> RefHolder {
             ? RefHolder(ref: handle_copy, release: smoke_ChildInterface_release_handle)
             : RefHolder(handle_copy)
     }
+    if let descendantResult = tryDescendantGetRef(reference, owning) {
+        return descendantResult
+    }
     var functions = smoke_ChildInterface_FunctionTable()
     functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
     functions.release = {swift_class_pointer in
@@ -75,6 +78,12 @@ internal func getRef(_ ref: ChildInterface?, owning: Bool = true) -> RefHolder {
     }
     let proxy = smoke_ChildInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_ChildInterface_release_handle) : RefHolder(proxy)
+}
+func tryDescendantGetRef(_ reference: ChildInterface, _ owning: Bool) -> RefHolder? {
+    if reference is GrandChildInterface {
+        return getRef(reference as? GrandChildInterface, owning: owning)
+    }
+    return nil
 }
 extension _ChildInterface: NativeBase {
     /// :nodoc:

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ParentInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ParentInterface.swift
@@ -1,0 +1,147 @@
+//
+//
+import Foundation
+public protocol ParentInterface : AnyObject {
+    var rootProperty: String { get set }
+    func rootMethod() -> Void
+}
+internal class _ParentInterface: ParentInterface {
+    var rootProperty: String {
+        get {
+            let c_result_handle = smoke_ParentInterface_rootProperty_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_ParentInterface_rootProperty_set(self.c_instance, c_value.ref)
+        }
+    }
+    let c_instance : _baseRef
+    init(cParentInterface: _baseRef) {
+        guard cParentInterface != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cParentInterface
+    }
+    deinit {
+        smoke_ParentInterface_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_ParentInterface_release_handle(c_instance)
+    }
+    public func rootMethod() -> Void {
+        smoke_ParentInterface_rootMethod(self.c_instance)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_ParentInterface")
+internal func _CBridgeInitsmoke_ParentInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _ParentInterface(cParentInterface: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: ParentInterface?, owning: Bool = true) -> RefHolder {
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_ParentInterface_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_ParentInterface_release_handle)
+            : RefHolder(handle_copy)
+    }
+    if let descendantResult = tryDescendantGetRef(reference, owning) {
+        return descendantResult
+    }
+    var functions = smoke_ParentInterface_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+    functions.smoke_ParentInterface_rootMethod = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ParentInterface
+        swift_class.rootMethod()
+    }
+    functions.smoke_ParentInterface_rootProperty_get = {(swift_class_pointer) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ParentInterface
+        return copyToCType(swift_class.rootProperty).ref
+    }
+    functions.smoke_ParentInterface_rootProperty_set = {(swift_class_pointer, value) in
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ParentInterface
+        swift_class.rootProperty = moveFromCType(value)
+    }
+    let proxy = smoke_ParentInterface_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_ParentInterface_release_handle) : RefHolder(proxy)
+}
+func tryDescendantGetRef(_ reference: ParentInterface, _ owning: Bool) -> RefHolder? {
+    if reference is GrandChildInterface {
+        return getRef(reference as? GrandChildInterface, owning: owning)
+    }
+    if reference is CrossPackageChildInterface {
+        return getRef(reference as? CrossPackageChildInterface, owning: owning)
+    }
+    if reference is ChildInterface {
+        return getRef(reference as? ChildInterface, owning: owning)
+    }
+    return nil
+}
+extension _ParentInterface: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+internal func ParentInterface_copyFromCType(_ handle: _baseRef) -> ParentInterface {
+    if let swift_pointer = smoke_ParentInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ParentInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentInterface {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ParentInterface_get_typed(smoke_ParentInterface_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ParentInterface {
+        smoke_ParentInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ParentInterface_moveFromCType(_ handle: _baseRef) -> ParentInterface {
+    if let swift_pointer = smoke_ParentInterface_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentInterface {
+        smoke_ParentInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ParentInterface_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ParentInterface {
+        smoke_ParentInterface_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ParentInterface_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ParentInterface {
+        smoke_ParentInterface_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ParentInterface_copyFromCType(_ handle: _baseRef) -> ParentInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ParentInterface_moveFromCType(handle) as ParentInterface
+}
+internal func ParentInterface_moveFromCType(_ handle: _baseRef) -> ParentInterface? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ParentInterface_moveFromCType(handle) as ParentInterface
+}
+internal func copyToCType(_ swiftClass: ParentInterface) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ParentInterface) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ParentInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ParentInterface?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipProxy.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipProxy.swift
@@ -65,6 +65,9 @@ internal func getRef(_ ref: SkipProxy?, owning: Bool = true) -> RefHolder {
             ? RefHolder(ref: handle_copy, release: smoke_SkipProxy_release_handle)
             : RefHolder(handle_copy)
     }
+    if let descendantResult = tryDescendantGetRef(reference, owning) {
+        return descendantResult
+    }
     var functions = smoke_SkipProxy_FunctionTable()
     functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
     functions.release = {swift_class_pointer in
@@ -98,6 +101,12 @@ internal func getRef(_ ref: SkipProxy?, owning: Bool = true) -> RefHolder {
     }
     let proxy = smoke_SkipProxy_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_SkipProxy_release_handle) : RefHolder(proxy)
+}
+func tryDescendantGetRef(_ reference: SkipProxy, _ owning: Bool) -> RefHolder? {
+    if reference is InheritFromSkipped {
+        return getRef(reference as? InheritFromSkipped, owning: owning)
+    }
+    return nil
 }
 extension _SkipProxy: NativeBase {
     /// :nodoc:


### PR DESCRIPTION
Updated Swift `getRef()` conversion functions functions to try downcasting from
the parent interface type to the child interface types when creating a proxy,
based on the results of "descendant interfaces" analysis.

Added smoke and functional tests.

See: #1134
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>