### PR TITLE
Fix the loss of ref equality for interface inheritance in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed violation of referential equality invariant for some cases of interface inheritance.
+
 ## 10.2.1
 Release date: 2021-11-01
 ### Features:

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -41,6 +41,7 @@ import "test/InterfaceWithStatic_test.dart" as InterfaceWithStaticTests;
 import "test/Lambdas_test.dart" as LambdasTests;
 import "test/Lists_test.dart" as ListsTests;
 import "test/Listeners_test.dart" as ListenersTests;
+import "test/ListenerInheritance_test.dart" as ListenerInheritanceTests;
 import "test/ListenersWithAttributes_test.dart" as ListenersWithAttributesTests;
 import "test/ListenersWithErrors_test.dart" as ListenersWithErrorsTests;
 import "test/ListenersWithReturnValues_test.dart" as ListenersWithReturnValuesTests;
@@ -87,6 +88,7 @@ final _allTests = [
   LambdasTests.main,
   ListsTests.main,
   ListenersTests.main,
+  ListenerInheritanceTests.main,
   ListenersWithAttributesTests.main,
   ListenersWithErrorsTests.main,
   ListenersWithReturnValuesTests.main,

--- a/functional-tests/functional/dart/test/ListenerInheritance_test.dart
+++ b/functional-tests/functional/dart/test/ListenerInheritance_test.dart
@@ -1,0 +1,62 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Listener inheritance");
+
+class ParentListenerImpl implements ParentListener {
+  @override
+  void listen() { }
+
+  @override
+  release() {}
+}
+
+class ChildListenerImpl implements ChildListener {
+  @override
+  void listen() { }
+
+  @override
+  release() {}
+}
+
+void main() {
+  _testSuite.test("Add and remove ParentListener", () {
+    final caster = Broadcaster();
+    final listener = ParentListenerImpl();
+    caster.addParentListener(listener);
+
+    final result = caster.removeListener(listener);
+
+    expect(result, isTrue);
+  });
+  _testSuite.test("Add and remove ChildListener", () {
+    final caster = Broadcaster();
+    final listener = ChildListenerImpl();
+    caster.addChildListener(listener);
+
+    final result = caster.removeListener(listener);
+
+    expect(result, isTrue);
+  });
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -39,7 +39,8 @@ import com.here.gluecodium.model.lime.LimeTypesCollection
 internal class DartDeclarationImportResolver(
     limeReferenceMap: Map<String, LimeElement>,
     nameResolver: DartNameResolver,
-    srcPath: String
+    srcPath: String,
+    private val descendantInterfaces: Map<String, List<LimeInterface>>
 ) : DartImportResolverBase(limeReferenceMap, nameResolver, srcPath) {
 
     private val builtInTypesConversionImport = DartImport("$srcPath/${"builtin_types"}__conversion")
@@ -90,6 +91,12 @@ internal class DartDeclarationImportResolver(
         val result = classInterfaceImports.toMutableList()
         if (hasStaticFunctions(limeInterface) || limeInterface.properties.any { it.visibility.isInternal }) {
             result += metaPackageImport
+        }
+        if (!limeInterface.isNarrow) {
+            val descendants = descendantInterfaces[limeInterface.fullName]
+            if (descendants != null) {
+                result += descendants.map { createImport(it) }
+            }
         }
         return result
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -134,12 +134,14 @@ internal class DartGenerator : Generator {
             "C++ return type" to FfiCppReturnTypeNameResolver(internalNamespace, ffiCppNameResolver)
         )
 
+        val descendantInterfaces = LimeTypeHelper.collectDescendantInterfaces(dartFilteredModel.topElements)
         val importResolver =
             DartImportResolver(dartFilteredModel.referenceMap, dartNameResolver, "$libraryName/$SRC_DIR_SUFFIX")
         val declarationImportResolver = DartDeclarationImportResolver(
             dartFilteredModel.referenceMap,
             dartNameResolver,
-            "$libraryName/$SRC_DIR_SUFFIX"
+            "$libraryName/$SRC_DIR_SUFFIX",
+            descendantInterfaces
         )
         val importsCollector = DartImportsCollector(importResolver)
         val declarationImportsCollector = GenericImportsCollector(declarationImportResolver, collectOwnImports = true)
@@ -166,7 +168,7 @@ internal class DartGenerator : Generator {
             listOfNotNull(
                 generateDart(
                     it, dartResolvers, dartNameResolver, listOf(importsCollector, declarationImportsCollector),
-                    exportsCollector, typeRepositoriesCollector, generatorPredicates.predicates
+                    exportsCollector, typeRepositoriesCollector, generatorPredicates.predicates, descendantInterfaces
                 )
             )
         } + ffiFilteredModel.topElements.flatMap {
@@ -191,7 +193,8 @@ internal class DartGenerator : Generator {
         importCollectors: List<ImportsCollector<DartImport>>,
         exportsCollector: MutableMap<List<String>, MutableList<DartExport>>,
         typeRepositoriesCollector: MutableList<LimeContainerWithInheritance>,
-        predicates: Map<String, (Any) -> Boolean>
+        predicates: Map<String, (Any) -> Boolean>,
+        descendantInterfaces: Map<String, List<LimeInterface>>
     ): GeneratedFile? {
         val contentTemplateName = selectTemplate(rootElement) ?: return null
 
@@ -225,7 +228,8 @@ internal class DartGenerator : Generator {
                 "model" to rootElement,
                 "contentTemplate" to contentTemplateName,
                 "libraryName" to libraryName,
-                "optimizedLists" to optimizedLists
+                "optimizedLists" to optimizedLists,
+                "descendantInterfaces" to descendantInterfaces
             ),
             nameResolvers,
             predicates

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -230,6 +230,13 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}SetStatic(Object _obj, {{resolve
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
 {{#unless isNarrow}}
   if (value is __lib.NativeBase) return _{{resolveName "Ffi"}}CopyHandle((value as __lib.NativeBase).handle);
+{{#eval "descendantInterfaces" fullName}}
+
+  final descendantResult = tryDescendantToFfi(value);
+  if (descendantResult != null) {
+    return descendantResult;
+  }
+{{/eval}}
 {{/unless}}
 
   final result = _{{resolveName "Ffi"}}CreateProxy(
@@ -275,6 +282,15 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfiNullable({{resolveName}}? value) =>
 void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _{{resolveName "Ffi"}}ReleaseHandle(handle);
 
+{{#unless isNarrow}}{{#set interface=this}}{{#eval "descendantInterfaces" fullName}}
+Pointer<Void>? tryDescendantToFfi({{resolveName interface}} value) {
+{{#this}}{{!! pre-sorted, most distant descendants are prioritized }}
+  if (value is {{resolveName}}) return {{resolveName "Ffi"}}ToFfi(value);
+{{/this}}
+  return null;
+}
+
+{{/eval}}{{/set}}{{/unless}}
 // End of {{resolveName}} "private" section.{{!!
 
 }}{{+ffiApi}}Uint8 Function(Handle{{#if parameters}}, {{/if}}{{!!

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -4,6 +4,7 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/grand_child_interface.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 abstract class ChildInterface implements ParentInterface {
   factory ChildInterface(
@@ -130,6 +131,10 @@ int _smokeChildinterfacerootPropertySetStatic(Object _obj, Pointer<Void> _value)
 }
 Pointer<Void> smokeChildinterfaceToFfi(ChildInterface value) {
   if (value is __lib.NativeBase) return _smokeChildinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final descendantResult = tryDescendantToFfi(value);
+  if (descendantResult != null) {
+    return descendantResult;
+  }
   final result = _smokeChildinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -163,4 +168,8 @@ ChildInterface? smokeChildinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeChildinterfaceFromFfi(handle) : null;
 void smokeChildinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeChildinterfaceReleaseHandle(handle);
+Pointer<Void>? tryDescendantToFfi(ChildInterface value) {
+  if (value is GrandChildInterface) return smokeGrandchildinterfaceToFfi(value);
+  return null;
+}
 // End of ChildInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -4,6 +4,8 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/child_interface.dart';
+import 'package:library/src/smoke/grand_child_interface.dart';
 abstract class ParentInterface {
   factory ParentInterface(
     void Function() rootMethodLambda,
@@ -111,6 +113,10 @@ int _smokeParentinterfacerootPropertySetStatic(Object _obj, Pointer<Void> _value
 }
 Pointer<Void> smokeParentinterfaceToFfi(ParentInterface value) {
   if (value is __lib.NativeBase) return _smokeParentinterfaceCopyHandle((value as __lib.NativeBase).handle);
+  final descendantResult = tryDescendantToFfi(value);
+  if (descendantResult != null) {
+    return descendantResult;
+  }
   final result = _smokeParentinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -143,4 +149,9 @@ ParentInterface? smokeParentinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeParentinterfaceFromFfi(handle) : null;
 void smokeParentinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeParentinterfaceReleaseHandle(handle);
+Pointer<Void>? tryDescendantToFfi(ParentInterface value) {
+  if (value is GrandChildInterface) return smokeGrandchildinterfaceToFfi(value);
+  if (value is ChildInterface) return smokeChildinterfaceToFfi(value);
+  return null;
+}
 // End of ParentInterface "private" section.

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -4,6 +4,7 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/inherit_from_skipped.dart';
 abstract class SkipProxy {
   factory SkipProxy(
     String Function(String) notInJavaLambda,
@@ -196,6 +197,10 @@ int _smokeSkipproxyisSkippedInSwiftSetStatic(Object _obj, int _value) {
 }
 Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
   if (value is __lib.NativeBase) return _smokeSkipproxyCopyHandle((value as __lib.NativeBase).handle);
+  final descendantResult = tryDescendantToFfi(value);
+  if (descendantResult != null) {
+    return descendantResult;
+  }
   final result = _smokeSkipproxyCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -231,4 +236,8 @@ SkipProxy? smokeSkipproxyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkipproxyFromFfi(handle) : null;
 void smokeSkipproxyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipproxyReleaseHandle(handle);
+Pointer<Void>? tryDescendantToFfi(SkipProxy value) {
+  if (value is InheritFromSkipped) return smokeInheritfromskippedToFfi(value);
+  return null;
+}
 // End of SkipProxy "private" section.


### PR DESCRIPTION
Updated Dart `toFfi()` conversion functions functions to try downcasting from
the parent interface type to the child interface types when creating a proxy,
based on the results of "descendant interfaces" analysis.

Updated DartDeclarationImportResolver to add imports needed for the new code,
but only when necessary.

Added smoke and functional tests.

Resolves: #1134
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>