### PR TITLE
Fix compilation issue for nested structs in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Fixed violation of referential equality invariant for some cases of interface inheritance.
+  * Fixed compilation issue in Dart for some combinations of type nesting and field constructors.
 
 ## 10.2.1
 Release date: 2021-11-01

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -153,6 +153,7 @@ feature(FieldConstructors cpp android swift dart SOURCES
     input/src/cpp/FieldConstructors.cpp
 
     input/lime/FieldConstructors.lime
+    input/lime/FieldConstructorsNesting.lime
 )
 
 feature(TypeDefs cpp android swift dart SOURCES

--- a/functional-tests/functional/input/lime/FieldConstructorsNesting.lime
+++ b/functional-tests/functional/input/lime/FieldConstructorsNesting.lime
@@ -1,0 +1,27 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct OuterStructWithFieldConstructor {
+    field constructor (outerStructField)
+    outerStructField: InnerStructWithDefaults
+
+    struct InnerStructWithDefaults {
+        innerStructField: Double = 1.0
+    }
+}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -148,20 +148,20 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
     return {{external.dart.converter}}.convertFromInternal(resultInternal);
 {{/if}}{{#unless external.dart.converter}}
     return {{resolveName this "" "ref"}}{{#set container=this}}{{!!
-    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{>dart/DartConstructorName}}{{/allFieldsConstructor}}{{/if}}{{!!
-    }}{{#unless allfieldsConstructor}}{{#container}}{{>allFieldsConstructorName}}{{/container}}{{/unless}}(
+    }}{{#if container.allFieldsConstructor}}{{#allFieldsConstructor}}{{>dart/DartConstructorName}}{{/allFieldsConstructor}}{{/if}}{{!!
+    }}{{#unless container.allfieldsConstructor}}{{#container}}{{>allFieldsConstructorName}}{{/container}}{{/unless}}(
 {{#if attributes.dart.positionalDefaults initializedFields}}
 {{#each uninitializedFields initializedFields}}
 {{>fromFfiFieldInit}}
 {{/each}}
 {{/if}}{{!!
 }}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
-}}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}
+}}{{#if container.allFieldsConstructor}}{{#allFieldsConstructor}}
 {{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}
 {{/allFieldsConstructor}}{{/if}}{{!!
-}}{{#unless allFieldsConstructor}}
+}}{{#unless container.allFieldsConstructor}}
 {{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}
@@ -209,7 +209,7 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}{{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle){{/unless}}{{#if iter.hasNext}}, {{/if}}
 {{/fromFfiFieldInit}}{{!!
 
-}}{{+allFieldsConstructorName}}{{#unless allFieldsConstructor}}{{!!
+}}{{+allFieldsConstructorName}}{{#unless this.allFieldsConstructor}}{{!!
 }}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{!!
 }}{{#unlessPredicate "needsPrivateAllFieldsCtor"}}{{#ifPredicate "needsPublicFieldsConstructor"}}.allFields{{/ifPredicate}}{{/unlessPredicate}}{{!!
 }}{{/unless}}{{/allFieldsConstructorName}}

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -42,7 +42,7 @@
 }}{{#internalFields}}{{resolveName visibility}}{{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/internalFields}};
 {{/ifPredicate}}{{/unless}}{{!!
 
-}}{{#unless allFieldsConstructor}}{{!!
+}}{{#unless this.allFieldsConstructor}}{{!!
 }}{{>constructorComment}}{{!!
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
 }}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{!!

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructorsNesting.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructorsNesting.lime
@@ -1,0 +1,27 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct OuterStructWithFieldConstructor {
+    field constructor (outerStructField)
+    outerStructField: InnerStructWithDefaults
+
+    struct InnerStructWithDefaults {
+        innerStructField: Double = 1.0
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/OuterStructWithFieldConstructor.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/OuterStructWithFieldConstructor.java
@@ -1,0 +1,21 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class OuterStructWithFieldConstructor {
+    @NonNull
+    public OuterStructWithFieldConstructor.InnerStructWithDefaults outerStructField;
+    public static final class InnerStructWithDefaults {
+        public double innerStructField;
+        public InnerStructWithDefaults() {
+            this.innerStructField = 1.0;
+        }
+        public InnerStructWithDefaults(final double innerStructField) {
+            this.innerStructField = innerStructField;
+        }
+    }
+    public OuterStructWithFieldConstructor(@NonNull final OuterStructWithFieldConstructor.InnerStructWithDefaults outerStructField) {
+        this.outerStructField = outerStructField;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/OuterStructWithFieldConstructor.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/OuterStructWithFieldConstructor.h
@@ -1,0 +1,18 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT OuterStructWithFieldConstructor {
+    struct _GLUECODIUM_CPP_EXPORT InnerStructWithDefaults {
+        double inner_struct_field = 1.0;
+        InnerStructWithDefaults( );
+        InnerStructWithDefaults( double inner_struct_field );
+    };
+    ::smoke::OuterStructWithFieldConstructor::InnerStructWithDefaults outer_struct_field;
+    OuterStructWithFieldConstructor( );
+    OuterStructWithFieldConstructor( ::smoke::OuterStructWithFieldConstructor::InnerStructWithDefaults outer_struct_field );
+};
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/outer_struct_with_field_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/outer_struct_with_field_constructor.dart
@@ -1,0 +1,130 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+class OuterStructWithFieldConstructor {
+  OuterStructWithFieldConstructor_InnerStructWithDefaults outerStructField;
+  OuterStructWithFieldConstructor(this.outerStructField);
+}
+class OuterStructWithFieldConstructor_InnerStructWithDefaults {
+  double innerStructField;
+  OuterStructWithFieldConstructor_InnerStructWithDefaults(this.innerStructField);
+  OuterStructWithFieldConstructor_InnerStructWithDefaults.withDefaults()
+    : innerStructField = 1.0;
+}
+// OuterStructWithFieldConstructor_InnerStructWithDefaults "private" section, not exported.
+final _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Double),
+    Pointer<Void> Function(double)
+  >('library_smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_create_handle'));
+final _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_release_handle'));
+final _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsGetFieldinnerStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Double Function(Pointer<Void>),
+    double Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_get_field_innerStructField'));
+Pointer<Void> smokeOuterstructwithfieldconstructorInnerstructwithdefaultsToFfi(OuterStructWithFieldConstructor_InnerStructWithDefaults value) {
+  final _innerStructFieldHandle = (value.innerStructField);
+  final _result = _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsCreateHandle(_innerStructFieldHandle);
+  return _result;
+}
+OuterStructWithFieldConstructor_InnerStructWithDefaults smokeOuterstructwithfieldconstructorInnerstructwithdefaultsFromFfi(Pointer<Void> handle) {
+  final _innerStructFieldHandle = _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsGetFieldinnerStructField(handle);
+  try {
+    return OuterStructWithFieldConstructor_InnerStructWithDefaults(
+      (_innerStructFieldHandle)
+    );
+  } finally {
+  }
+}
+void smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseHandle(handle);
+// Nullable OuterStructWithFieldConstructor_InnerStructWithDefaults
+final _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_create_handle_nullable'));
+final _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_release_handle_nullable'));
+final _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_get_value_nullable'));
+Pointer<Void> smokeOuterstructwithfieldconstructorInnerstructwithdefaultsToFfiNullable(OuterStructWithFieldConstructor_InnerStructWithDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuterstructwithfieldconstructorInnerstructwithdefaultsToFfi(value);
+  final result = _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsCreateHandleNullable(_handle);
+  smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+OuterStructWithFieldConstructor_InnerStructWithDefaults? smokeOuterstructwithfieldconstructorInnerstructwithdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsGetValueNullable(handle);
+  final result = smokeOuterstructwithfieldconstructorInnerstructwithdefaultsFromFfi(_handle);
+  smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseHandleNullable(handle);
+// End of OuterStructWithFieldConstructor_InnerStructWithDefaults "private" section.
+// OuterStructWithFieldConstructor "private" section, not exported.
+final _smokeOuterstructwithfieldconstructorCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_create_handle'));
+final _smokeOuterstructwithfieldconstructorReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_release_handle'));
+final _smokeOuterstructwithfieldconstructorGetFieldouterStructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_get_field_outerStructField'));
+Pointer<Void> smokeOuterstructwithfieldconstructorToFfi(OuterStructWithFieldConstructor value) {
+  final _outerStructFieldHandle = smokeOuterstructwithfieldconstructorInnerstructwithdefaultsToFfi(value.outerStructField);
+  final _result = _smokeOuterstructwithfieldconstructorCreateHandle(_outerStructFieldHandle);
+  smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseFfiHandle(_outerStructFieldHandle);
+  return _result;
+}
+OuterStructWithFieldConstructor smokeOuterstructwithfieldconstructorFromFfi(Pointer<Void> handle) {
+  final _outerStructFieldHandle = _smokeOuterstructwithfieldconstructorGetFieldouterStructField(handle);
+  try {
+    return OuterStructWithFieldConstructor(
+      smokeOuterstructwithfieldconstructorInnerstructwithdefaultsFromFfi(_outerStructFieldHandle)
+    );
+  } finally {
+    smokeOuterstructwithfieldconstructorInnerstructwithdefaultsReleaseFfiHandle(_outerStructFieldHandle);
+  }
+}
+void smokeOuterstructwithfieldconstructorReleaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructwithfieldconstructorReleaseHandle(handle);
+// Nullable OuterStructWithFieldConstructor
+final _smokeOuterstructwithfieldconstructorCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_create_handle_nullable'));
+final _smokeOuterstructwithfieldconstructorReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_release_handle_nullable'));
+final _smokeOuterstructwithfieldconstructorGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithFieldConstructor_get_value_nullable'));
+Pointer<Void> smokeOuterstructwithfieldconstructorToFfiNullable(OuterStructWithFieldConstructor? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuterstructwithfieldconstructorToFfi(value);
+  final result = _smokeOuterstructwithfieldconstructorCreateHandleNullable(_handle);
+  smokeOuterstructwithfieldconstructorReleaseFfiHandle(_handle);
+  return result;
+}
+OuterStructWithFieldConstructor? smokeOuterstructwithfieldconstructorFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuterstructwithfieldconstructorGetValueNullable(handle);
+  final result = smokeOuterstructwithfieldconstructorFromFfi(_handle);
+  smokeOuterstructwithfieldconstructorReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeOuterstructwithfieldconstructorReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterstructwithfieldconstructorReleaseHandleNullable(handle);
+// End of OuterStructWithFieldConstructor "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/OuterStructWithFieldConstructor.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/OuterStructWithFieldConstructor.swift
@@ -1,0 +1,99 @@
+//
+//
+import Foundation
+public struct OuterStructWithFieldConstructor {
+    public var outerStructField: OuterStructWithFieldConstructor.InnerStructWithDefaults
+    public init(outerStructField: OuterStructWithFieldConstructor.InnerStructWithDefaults) {
+        self.outerStructField = outerStructField
+    }
+    internal init(cHandle: _baseRef) {
+        outerStructField = moveFromCType(smoke_OuterStructWithFieldConstructor_outerStructField_get(cHandle))
+    }
+    public struct InnerStructWithDefaults {
+        public var innerStructField: Double
+        public init(innerStructField: Double = 1.0) {
+            self.innerStructField = innerStructField
+        }
+        internal init(cHandle: _baseRef) {
+            innerStructField = moveFromCType(smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_innerStructField_get(cHandle))
+        }
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor {
+    return OuterStructWithFieldConstructor(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor {
+    defer {
+        smoke_OuterStructWithFieldConstructor_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStructWithFieldConstructor) -> RefHolder {
+    let c_outerStructField = moveToCType(swiftType.outerStructField)
+    return RefHolder(smoke_OuterStructWithFieldConstructor_create_handle(c_outerStructField.ref))
+}
+internal func moveToCType(_ swiftType: OuterStructWithFieldConstructor) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStructWithFieldConstructor_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_OuterStructWithFieldConstructor_unwrap_optional_handle(handle)
+    return OuterStructWithFieldConstructor(cHandle: unwrappedHandle) as OuterStructWithFieldConstructor
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor? {
+    defer {
+        smoke_OuterStructWithFieldConstructor_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStructWithFieldConstructor?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_outerStructField = moveToCType(swiftType.outerStructField)
+    return RefHolder(smoke_OuterStructWithFieldConstructor_create_optional_handle(c_outerStructField.ref))
+}
+internal func moveToCType(_ swiftType: OuterStructWithFieldConstructor?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStructWithFieldConstructor_release_optional_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor.InnerStructWithDefaults {
+    return OuterStructWithFieldConstructor.InnerStructWithDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor.InnerStructWithDefaults {
+    defer {
+        smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStructWithFieldConstructor.InnerStructWithDefaults) -> RefHolder {
+    let c_innerStructField = moveToCType(swiftType.innerStructField)
+    return RefHolder(smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_create_handle(c_innerStructField.ref))
+}
+internal func moveToCType(_ swiftType: OuterStructWithFieldConstructor.InnerStructWithDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor.InnerStructWithDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_unwrap_optional_handle(handle)
+    return OuterStructWithFieldConstructor.InnerStructWithDefaults(cHandle: unwrappedHandle) as OuterStructWithFieldConstructor.InnerStructWithDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> OuterStructWithFieldConstructor.InnerStructWithDefaults? {
+    defer {
+        smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: OuterStructWithFieldConstructor.InnerStructWithDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_innerStructField = moveToCType(swiftType.innerStructField)
+    return RefHolder(smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_create_optional_handle(c_innerStructField.ref))
+}
+internal func moveToCType(_ swiftType: OuterStructWithFieldConstructor.InnerStructWithDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStructWithFieldConstructor_InnerStructWithDefaults_release_optional_handle)
+}


### PR DESCRIPTION
Updated Dart struct templates to explicitly refer to `allfieldsConstructor`
value with '.' dot notation, instead of trying to fetch it from the current
context.

The way Trimou template engine works, `allfieldsConstructor` being `null` in the
inner of two nested structs results in a fall-through to the same value of the
outer nested struct. Fortunately, this behavior does not apply to empty
collections, only to `null` values, so most parts of the templates are safe with
regard to nesting.

Added smoke and functional tests as regression tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>