### PR TITLE
Generate type aliases in Dart 

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -248,7 +248,7 @@ jobs:
       - name: Install Dart SDK
         run: |
           DART_RELEASE_CHANNEL=stable
-          DART_VERSION=2.12.0
+          DART_VERSION=2.13.3
           wget -nv https://storage.googleapis.com/dart-archive/channels/${DART_RELEASE_CHANNEL}/release/${DART_VERSION}/linux_packages/dart_${DART_VERSION}-1_amd64.deb
           sudo apt -y install ./dart_${DART_VERSION}-1_amd64.deb
       - name: Build and run functional tests
@@ -365,7 +365,7 @@ jobs:
       - name: Install Dart SDK
         run: |
           DART_RELEASE_CHANNEL=stable
-          DART_VERSION=2.12.0
+          DART_VERSION=2.13.3
           wget -nv https://storage.googleapis.com/dart-archive/channels/${DART_RELEASE_CHANNEL}/release/${DART_VERSION}/linux_packages/dart_${DART_VERSION}-1_amd64.deb
           sudo apt -y install ./dart_${DART_VERSION}-1_amd64.deb
       - name: Build and run functional tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 ### Features:
+  * Added support for type aliases (typedefs) in Dart
+### Breaking changes:
+  * Generated Dart code now requires minimum Dart version 2.13.0.
+
+## Unreleased
+### Features:
   * Added support for per-platform visibility attributes (e.g. `@Java(Internal)`, etc.).
   * Added a `null` check in Dart for non-nullable class and interface usages.
   * Added support for `@Swift(OptionSet)` attribute.

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -69,6 +69,7 @@ import "test/StaticIntMethods_test.dart" as StaticIntMethodsTests;
 import "test/StaticStringMethods_test.dart" as StaticStringMethodsTests;
 import "test/StructsWithConstants_test.dart" as StructsWithConstantsTests;
 import "test/StructsWithMethods_test.dart" as StructsWithMethodsTests;
+import "test/TypeAliases_test.dart" as TypeAliasesTests;
 
 final _allTests = [
   AsyncTests.main,
@@ -117,7 +118,8 @@ final _allTests = [
   StaticIntMethodsTests.main,
   StaticStringMethodsTests.main,
   StructsWithConstantsTests.main,
-  StructsWithMethodsTests.main
+  StructsWithMethodsTests.main,
+  TypeAliasesTests.main
 ];
 
 String _getLibraryPath(String nativeLibraryName) {

--- a/functional-tests/functional/dart/pubspec.yaml.in
+++ b/functional-tests/functional/dart/pubspec.yaml.in
@@ -1,6 +1,6 @@
 name: FunctionalDartTests
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.13.0 <3.0.0'
 dependencies:
   test:
   functional:

--- a/functional-tests/functional/dart/test/TypeAliases_test.dart
+++ b/functional-tests/functional/dart/test/TypeAliases_test.dart
@@ -1,0 +1,55 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2021 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("Type Aliases");
+
+void main() {
+  _testSuite.test("Type alias to struct", () {
+    final result = StaticTypedefExampleStructTypedef("nonsense");
+
+    expect(result is StaticTypedefExampleStruct, isTrue);
+    expect(result.exampleString, "nonsense");
+  });
+  _testSuite.test("Type alias used by a function", () {
+    final result = StaticTypedef.returnIntTypedef(2);
+
+    expect(result is int, isTrue);
+    expect(result, 3);
+  });
+  _testSuite.test("Type alias points to a type alias", () {
+    final result = StaticTypedef.returnNestedIntTypedef(4);
+
+    expect(result is int, isTrue);
+    expect(result, 5);
+  });
+  _testSuite.test("Type alias from type collection", () {
+    final result = StaticTypedef.returnTypedefPointFromTypeCollection(
+        TypeCollectionPointTypedef(1.0, 3.0)
+    );
+
+    expect(result is TypeCollectionPoint, isTrue);
+    expect(result.x, 1.0);
+    expect(result.y, 3.0);
+  });
+}

--- a/functional-tests/functional/input/lime/StaticTypedef.lime
+++ b/functional-tests/functional/input/lime/StaticTypedef.lime
@@ -23,6 +23,9 @@ class StaticTypedef {
     // Example struct
     struct ExampleStruct {
         exampleString: String = ""
+        @Skip(Dart)
+        field constructor()
+        field constructor(exampleString)
     }
     typealias IntTypedef = Int
     typealias NestedIntTypedef = IntTypedef

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -181,7 +181,7 @@ internal class DartGenerator : Generator {
         injectAsyncHelpers(ffiReferenceMap, asyncHelpers)
 
         val generatedFiles = dartFilteredModel.topElements.flatMap {
-            listOfNotNull(
+            listOf(
                 generateDart(
                     it, dartResolvers, dartNameResolver, listOf(importsCollector, declarationImportsCollector),
                     exportsCollector, typeRepositoriesCollector, predicatesMap, descendantInterfaces,
@@ -216,15 +216,15 @@ internal class DartGenerator : Generator {
         predicates: Map<String, (Any) -> Boolean>,
         descendantInterfaces: Map<String, List<LimeInterface>>,
         asyncHelpers: DartAsyncHelpers.AsyncHelpersGroup?
-    ): GeneratedFile? {
-        val contentTemplateName = selectTemplate(rootElement) ?: return null
+    ): GeneratedFile {
+        val contentTemplateName = selectTemplate(rootElement)
 
         val packagePath = rootElement.path.head.joinToString(separator = "/")
         val fileName = dartNameResolver.resolveFileName(rootElement)
         val filePath = "$packagePath/$fileName"
         val relativePath = "$SRC_DIR_SUFFIX/$filePath.dart"
 
-        val allTypes = LimeTypeHelper.getAllTypes(rootElement).filterNot { it is LimeTypeAlias }
+        val allTypes = LimeTypeHelper.getAllTypes(rootElement)
         val nonExternalTypes = allTypes.filter { it.external?.dart == null }
         val allSymbols = nonExternalTypes.filterNot { CommonGeneratorPredicates.isInternal(it, DART) }
         if (allSymbols.isNotEmpty()) {
@@ -529,7 +529,7 @@ internal class DartGenerator : Generator {
             is LimeEnumeration -> "dart/DartEnumeration"
             is LimeException -> "dart/DartException"
             is LimeLambda -> "dart/DartLambda"
-            is LimeTypeAlias -> null
+            is LimeTypeAlias -> "dart/DartTypeAlias"
             else -> throw GluecodiumExecutionException(
                 "Unsupported top-level element: " +
                     limeElement::class.java.name

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -56,17 +56,16 @@ internal class DartImportResolver(
         }
 
     private fun resolveTypeImports(limeType: LimeType, skipHelpers: Boolean = false): List<DartImport> {
-        val actualType = limeType.actualType
-        when (actualType) {
-            is LimeBasicType -> return resolveBasicTypeImports(actualType)
-            is LimeGenericType -> return resolveGenericTypeImports(actualType)
+        when (limeType) {
+            is LimeBasicType -> return resolveBasicTypeImports(limeType)
+            is LimeGenericType -> return resolveGenericTypeImports(limeType)
         }
 
-        val externalImport = resolveExternalImport(actualType, IMPORT_PATH_NAME, useAlias = true)
+        val externalImport = resolveExternalImport(limeType, IMPORT_PATH_NAME, useAlias = true)
         return when {
-            externalImport == null -> listOf(createImport(actualType))
+            externalImport == null -> listOf(createImport(limeType))
             skipHelpers -> listOf(externalImport)
-            else -> listOf(createImport(actualType), externalImport)
+            else -> listOf(createImport(limeType), externalImport)
         }
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportsCollector.kt
@@ -29,7 +29,8 @@ internal class DartImportsCollector(importsResolver: ImportsResolver<DartImport>
         importsResolver,
         collectTypeRefImports = true,
         collectValueImports = true,
-        parentTypeFilter = { true }
+        parentTypeFilter = { true },
+        collectTypeAliasImports = true
     ) {
 
     override fun collectParentTypeRefs(limeContainer: LimeContainerWithInheritance) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -48,7 +48,6 @@ import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
-import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeValue
@@ -83,7 +82,6 @@ internal class DartNameResolver(
             is LimeValue -> resolveValue(element)
             is LimeGenericType -> resolveGenericType(element)
             is LimeTypeRef -> resolveTypeRefName(element)
-            is LimeTypeAlias -> resolveName(element.typeRef)
             is LimeType -> resolveTypeName(element)
             is LimeNamedElement -> getPlatformName(element)
             else ->
@@ -261,11 +259,11 @@ internal class DartNameResolver(
 
     private fun resolveTypeRefName(limeTypeRef: LimeTypeRef, ignoreDuplicates: Boolean = false): String {
         val typeName = resolveName(limeTypeRef.type)
-        val importPath = limeTypeRef.type.actualType.external?.dart?.get(IMPORT_PATH_NAME)
+        val importPath = limeTypeRef.type.external?.dart?.get(IMPORT_PATH_NAME)
         val alias = when {
             importPath != null -> computeAlias(importPath)
             ignoreDuplicates -> null
-            duplicateNames.contains(typeName) -> limeTypeRef.type.actualType.path.head.joinToString("_")
+            duplicateNames.contains(typeName) -> limeTypeRef.type.path.head.joinToString("_")
             else -> null
         }
         val suffix = if (limeTypeRef.isNullable) "?" else ""
@@ -303,7 +301,7 @@ internal class DartNameResolver(
     private fun buildDuplicateNames() =
         limeReferenceMap.values
             .filterIsInstance<LimeType>()
-            .filterNot { it is LimeTypeAlias || it is LimeGenericType || it is LimeBasicType }
+            .filterNot { it is LimeGenericType || it is LimeBasicType }
             .filter { it.external?.dart == null }
             .groupBy { resolveTypeName(it) }
             .filterValues { it.size > 1 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -45,6 +45,9 @@ abstract class {{resolveName}}{{!!
 {{/ifPredicate}}
 }
 
+{{#typeAliases}}
+{{>dart/DartTypeAlias}}
+{{/typeAliases}}
 {{#enumerations}}
 {{>dart/DartEnumeration}}
 {{/enumerations}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -61,6 +61,9 @@ abstract class {{resolveName}}{{!!
 {{/ifPredicate}}
 }
 
+{{#typeAliases}}
+{{>dart/DartTypeAlias}}
+{{/typeAliases}}
 {{#enumerations}}
 {{>dart/DartEnumeration}}
 {{/enumerations}}

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -70,6 +70,9 @@ class {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
 }
 {{/unlessPredicate}}
 
+{{#typeAliases}}
+{{>dart/DartTypeAlias}}
+{{/typeAliases}}
 {{#enumerations}}
 {{>dart/DartEnumeration}}
 {{/enumerations}}

--- a/gluecodium/src/main/resources/templates/dart/DartTypeAlias.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTypeAlias.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2021 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -18,10 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-name: {{libraryName}}
-environment:
-  sdk: '>=2.13.0 <3.0.0'
-dependencies:
-  ffi:
-  intl:
-  meta:
+{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
+typedef {{resolveName "visibility"}}{{resolveName}} = {{resolveName typeRef}};

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -7,29 +7,29 @@ import 'package:meta/meta.dart';
 /// This is some very useful interface.
 abstract class Comments {
   /// This is some very useful constant.
-  static final bool veryUseful = true;
+  static final Comments_Usefulness veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [inputParameter] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [Comments_Usefulness]. Usefulness of the input
   ///
   /// Throws [Comments_SomethingWrongException]. Sometimes it happens.
   ///
-  bool someMethodWithAllComments(String inputParameter);
+  Comments_Usefulness someMethodWithAllComments(String inputParameter);
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  bool someMethodWithInputComments(String input);
+  Comments_Usefulness someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [Comments_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithOutputComments(String input);
+  Comments_Usefulness someMethodWithOutputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  bool someMethodWithNoComments(String input);
+  Comments_Usefulness someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
   /// [input] Very useful input parameter
@@ -40,12 +40,12 @@ abstract class Comments {
   void someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [Comments_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithoutInputParametersWithAllComments();
+  Comments_Usefulness someMethodWithoutInputParametersWithAllComments();
   /// This is some very useful method that measures the usefulness of something.
   ///
-  bool someMethodWithoutInputParametersWithNoComments();
+  Comments_Usefulness someMethodWithoutInputParametersWithNoComments();
   void someMethodWithNothing();
   /// This is some very useful method that does nothing.
   ///
@@ -57,10 +57,12 @@ abstract class Comments {
   ///
   String returnCommentOnly(String undocumented);
   /// Gets some very useful property.
-  bool get isSomeProperty;
+  Comments_Usefulness get isSomeProperty;
   /// Sets some very useful property.
-  set isSomeProperty(bool value);
+  set isSomeProperty(Comments_Usefulness value);
 }
+/// This is some very useful typedef.
+typedef Comments_Usefulness = bool;
 /// This is some very useful enum.
 enum Comments_SomeEnum {
     /// Not quite useful
@@ -128,7 +130,7 @@ class Comments_SomethingWrongException implements Exception {
 class Comments_SomeStruct {
   /// How useful this struct is
   /// remains to be seen
-  bool someField;
+  Comments_Usefulness someField;
   /// Can be `null`
   String? nullableField;
   /// This is how easy it is to construct.
@@ -136,7 +138,7 @@ class Comments_SomeStruct {
   /// remains to be seen
   /// [nullableField] Can be `null`
   Comments_SomeStruct._(this.someField, this.nullableField);
-  Comments_SomeStruct(bool someField)
+  Comments_SomeStruct(Comments_Usefulness someField)
     : someField = someField, nullableField = null;
   /// This is some struct method that does nothing.
   ///
@@ -354,7 +356,7 @@ final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => 
 class Comments$Impl extends __lib.NativeBase implements Comments {
   Comments$Impl(Pointer<Void> handle) : super(handle);
   @override
-  bool someMethodWithAllComments(String inputParameter) {
+  Comments_Usefulness someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
     final _handle = this.handle;
@@ -378,7 +380,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  bool someMethodWithInputComments(String input) {
+  Comments_Usefulness someMethodWithInputComments(String input) {
     final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -391,7 +393,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  bool someMethodWithOutputComments(String input) {
+  Comments_Usefulness someMethodWithOutputComments(String input) {
     final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -404,7 +406,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  bool someMethodWithNoComments(String input) {
+  Comments_Usefulness someMethodWithNoComments(String input) {
     final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -433,7 +435,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     stringReleaseFfiHandle(_inputHandle);
   }
   @override
-  bool someMethodWithoutInputParametersWithAllComments() {
+  Comments_Usefulness someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -444,7 +446,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  bool someMethodWithoutInputParametersWithNoComments() {
+  Comments_Usefulness someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -495,7 +497,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  bool get isSomeProperty {
+  Comments_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -506,7 +508,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     }
   }
   @override
-  set isSomeProperty(bool value) {
+  set isSomeProperty(Comments_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -8,18 +8,18 @@ import 'package:library/src/builtin_types__conversion.dart';
 abstract class CommentsInterface {
   /// This is some very useful interface.
   factory CommentsInterface(
-    bool Function(String) someMethodWithAllCommentsLambda,
-    bool Function(String) someMethodWithInputCommentsLambda,
-    bool Function(String) someMethodWithOutputCommentsLambda,
-    bool Function(String) someMethodWithNoCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithAllCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithInputCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithOutputCommentsLambda,
+    CommentsInterface_Usefulness Function(String) someMethodWithNoCommentsLambda,
     void Function(String) someMethodWithoutReturnTypeWithAllCommentsLambda,
     void Function(String) someMethodWithoutReturnTypeWithNoCommentsLambda,
-    bool Function() someMethodWithoutInputParametersWithAllCommentsLambda,
-    bool Function() someMethodWithoutInputParametersWithNoCommentsLambda,
+    CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithAllCommentsLambda,
+    CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithNoCommentsLambda,
     void Function() someMethodWithNothingLambda,
     void Function() someMethodWithoutReturnTypeOrInputParametersLambda,
-    bool Function() isSomePropertyGetLambda,
-    void Function(bool) isSomePropertySetLambda
+    CommentsInterface_Usefulness Function() isSomePropertyGetLambda,
+    void Function(CommentsInterface_Usefulness) isSomePropertySetLambda
   ) => CommentsInterface$Lambdas(
     someMethodWithAllCommentsLambda,
     someMethodWithInputCommentsLambda,
@@ -36,27 +36,27 @@ abstract class CommentsInterface {
   );
 
   /// This is some very useful constant.
-  static final bool veryUseful = true;
+  static final CommentsInterface_Usefulness veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [CommentsInterface_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithAllComments(String input);
+  CommentsInterface_Usefulness someMethodWithAllComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  bool someMethodWithInputComments(String input);
+  CommentsInterface_Usefulness someMethodWithInputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [CommentsInterface_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithOutputComments(String input);
+  CommentsInterface_Usefulness someMethodWithOutputComments(String input);
   /// This is some very useful method that measures the usefulness of its input.
   ///
-  bool someMethodWithNoComments(String input);
+  CommentsInterface_Usefulness someMethodWithNoComments(String input);
   /// This is some very useful method that does not measure the usefulness of its input.
   ///
   /// [input] Very useful input parameter
@@ -67,21 +67,23 @@ abstract class CommentsInterface {
   void someMethodWithoutReturnTypeWithNoComments(String input);
   /// This is some very useful method that measures the usefulness of something.
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [CommentsInterface_Usefulness]. Usefulness of the input
   ///
-  bool someMethodWithoutInputParametersWithAllComments();
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithAllComments();
   /// This is some very useful method that measures the usefulness of something.
   ///
-  bool someMethodWithoutInputParametersWithNoComments();
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithNoComments();
   void someMethodWithNothing();
   /// This is some very useful method that does nothing.
   ///
   void someMethodWithoutReturnTypeOrInputParameters();
   /// Gets some very useful property.
-  bool get isSomeProperty;
+  CommentsInterface_Usefulness get isSomeProperty;
   /// Sets some very useful property.
-  set isSomeProperty(bool value);
+  set isSomeProperty(CommentsInterface_Usefulness value);
 }
+/// This is some very useful typedef.
+typedef CommentsInterface_Usefulness = bool;
 /// This is some very useful enum.
 enum CommentsInterface_SomeEnum {
     /// Not quite useful
@@ -143,7 +145,7 @@ void smokeCommentsinterfaceSomeenumReleaseFfiHandleNullable(Pointer<Void> handle
 /// This is some very useful struct.
 class CommentsInterface_SomeStruct {
   /// How useful this struct is
-  bool someField;
+  CommentsInterface_Usefulness someField;
   CommentsInterface_SomeStruct(this.someField);
 }
 // CommentsInterface_SomeStruct "private" section, not exported.
@@ -228,18 +230,18 @@ final _smokeCommentsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_get_type_id'));
 class CommentsInterface$Lambdas implements CommentsInterface {
-  bool Function(String) someMethodWithAllCommentsLambda;
-  bool Function(String) someMethodWithInputCommentsLambda;
-  bool Function(String) someMethodWithOutputCommentsLambda;
-  bool Function(String) someMethodWithNoCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithAllCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithInputCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithOutputCommentsLambda;
+  CommentsInterface_Usefulness Function(String) someMethodWithNoCommentsLambda;
   void Function(String) someMethodWithoutReturnTypeWithAllCommentsLambda;
   void Function(String) someMethodWithoutReturnTypeWithNoCommentsLambda;
-  bool Function() someMethodWithoutInputParametersWithAllCommentsLambda;
-  bool Function() someMethodWithoutInputParametersWithNoCommentsLambda;
+  CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithAllCommentsLambda;
+  CommentsInterface_Usefulness Function() someMethodWithoutInputParametersWithNoCommentsLambda;
   void Function() someMethodWithNothingLambda;
   void Function() someMethodWithoutReturnTypeOrInputParametersLambda;
-  bool Function() isSomePropertyGetLambda;
-  void Function(bool) isSomePropertySetLambda;
+  CommentsInterface_Usefulness Function() isSomePropertyGetLambda;
+  void Function(CommentsInterface_Usefulness) isSomePropertySetLambda;
   CommentsInterface$Lambdas(
     this.someMethodWithAllCommentsLambda,
     this.someMethodWithInputCommentsLambda,
@@ -256,16 +258,16 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   );
 
   @override
-  bool someMethodWithAllComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
-  bool someMethodWithInputComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithInputComments(String input) =>
     someMethodWithInputCommentsLambda(input);
   @override
-  bool someMethodWithOutputComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithOutputComments(String input) =>
     someMethodWithOutputCommentsLambda(input);
   @override
-  bool someMethodWithNoComments(String input) =>
+  CommentsInterface_Usefulness someMethodWithNoComments(String input) =>
     someMethodWithNoCommentsLambda(input);
   @override
   void someMethodWithoutReturnTypeWithAllComments(String input) =>
@@ -274,10 +276,10 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   void someMethodWithoutReturnTypeWithNoComments(String input) =>
     someMethodWithoutReturnTypeWithNoCommentsLambda(input);
   @override
-  bool someMethodWithoutInputParametersWithAllComments() =>
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithAllComments() =>
     someMethodWithoutInputParametersWithAllCommentsLambda();
   @override
-  bool someMethodWithoutInputParametersWithNoComments() =>
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithNoComments() =>
     someMethodWithoutInputParametersWithNoCommentsLambda();
   @override
   void someMethodWithNothing() =>
@@ -286,15 +288,15 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   void someMethodWithoutReturnTypeOrInputParameters() =>
     someMethodWithoutReturnTypeOrInputParametersLambda();
   @override
-  bool get isSomeProperty => isSomePropertyGetLambda();
+  CommentsInterface_Usefulness get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
+  set isSomeProperty(CommentsInterface_Usefulness value) => isSomePropertySetLambda(value);
 }
 class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterface {
   CommentsInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String input) {
+  CommentsInterface_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -307,7 +309,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  bool someMethodWithInputComments(String input) {
+  CommentsInterface_Usefulness someMethodWithInputComments(String input) {
     final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -320,7 +322,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  bool someMethodWithOutputComments(String input) {
+  CommentsInterface_Usefulness someMethodWithOutputComments(String input) {
     final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -333,7 +335,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  bool someMethodWithNoComments(String input) {
+  CommentsInterface_Usefulness someMethodWithNoComments(String input) {
     final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -362,7 +364,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     stringReleaseFfiHandle(_inputHandle);
   }
   @override
-  bool someMethodWithoutInputParametersWithAllComments() {
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -373,7 +375,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   @override
-  bool someMethodWithoutInputParametersWithNoComments() {
+  CommentsInterface_Usefulness someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments'));
     final _handle = this.handle;
     final __resultHandle = _someMethodWithoutInputParametersWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId);
@@ -396,7 +398,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
   }
   /// Gets some very useful property.
-  bool get isSomeProperty {
+  CommentsInterface_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -407,7 +409,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     }
   }
   /// Sets some very useful property.
-  set isSomeProperty(bool value) {
+  set isSomeProperty(CommentsInterface_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_CommentsInterface_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
@@ -416,7 +418,7 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
   }
 }
 int _smokeCommentsinterfacesomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as CommentsInterface).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -426,7 +428,7 @@ int _smokeCommentsinterfacesomeMethodWithAllCommentsStatic(Object _obj, Pointer<
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithInputCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as CommentsInterface).someMethodWithInputComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -436,7 +438,7 @@ int _smokeCommentsinterfacesomeMethodWithInputCommentsStatic(Object _obj, Pointe
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithOutputCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as CommentsInterface).someMethodWithOutputComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -446,7 +448,7 @@ int _smokeCommentsinterfacesomeMethodWithOutputCommentsStatic(Object _obj, Point
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithNoCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as CommentsInterface).someMethodWithNoComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);
@@ -472,7 +474,7 @@ int _smokeCommentsinterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic(Objec
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithoutInputParametersWithAllCommentsStatic(Object _obj, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as CommentsInterface).someMethodWithoutInputParametersWithAllComments();
     _result.value = booleanToFfi(_resultObject);
@@ -481,7 +483,7 @@ int _smokeCommentsinterfacesomeMethodWithoutInputParametersWithAllCommentsStatic
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithoutInputParametersWithNoCommentsStatic(Object _obj, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  CommentsInterface_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as CommentsInterface).someMethodWithoutInputParametersWithNoComments();
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -38,8 +38,8 @@ abstract class CommentsLinks {
   ///   * nested lists
   ///
   /// Not working for Java:
-  /// * typedef: [bool]
-  /// * top level typedef: [bool]
+  /// * typedef: [Comments_Usefulness]
+  /// * top level typedef: [CommentsTypeCollection_TypeCollectionTypedef]
   ///
   /// Not working for Swift:
   /// * named comment: [][Comments.veryUseful]

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -10,9 +10,9 @@ abstract class DeprecationComments {
   /// This is some very useful interface.
   @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
   factory DeprecationComments(
-    bool Function(String) someMethodWithAllCommentsLambda,
-    bool Function() isSomePropertyGetLambda,
-    void Function(bool) isSomePropertySetLambda,
+    DeprecationComments_Usefulness Function(String) someMethodWithAllCommentsLambda,
+    DeprecationComments_Usefulness Function() isSomePropertyGetLambda,
+    void Function(DeprecationComments_Usefulness) isSomePropertySetLambda,
     String Function() propertyButNotAccessorsGetLambda,
     void Function(String) propertyButNotAccessorsSetLambda
   ) => DeprecationComments$Lambdas(
@@ -24,27 +24,30 @@ abstract class DeprecationComments {
   );
   /// This is some very useful constant.
   @Deprecated("Unfortunately, this constant is deprecated. Use [Comments.veryUseful] instead.")
-  static final bool veryUseful = true;
+  static final DeprecationComments_Usefulness veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [DeprecationComments_Usefulness]. Usefulness of the input
   ///
   @Deprecated("Unfortunately, this method is deprecated.\nUse [Comments.someMethodWithAllComments] instead.")
-  bool someMethodWithAllComments(String input);
+  DeprecationComments_Usefulness someMethodWithAllComments(String input);
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
-  bool get isSomeProperty;
+  DeprecationComments_Usefulness get isSomeProperty;
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
-  set isSomeProperty(bool value);
+  set isSomeProperty(DeprecationComments_Usefulness value);
   /// Gets the property but not accessors.
   @Deprecated("Will be removed in v3.2.1.")
   String get propertyButNotAccessors;
   @Deprecated("Will be removed in v3.2.1.")
   set propertyButNotAccessors(String value);
 }
+/// This is some very useful typedef.
+@Deprecated("Unfortunately, this typedef is deprecated. Use [Comments_Usefulness] instead.")
+typedef DeprecationComments_Usefulness = bool;
 /// This is some very useful enum.
 @Deprecated("Unfortunately, this enum is deprecated. Use [Comments_SomeEnum] instead.")
 enum DeprecationComments_SomeEnum {
@@ -109,7 +112,7 @@ class DeprecationComments_SomethingWrongException implements Exception {
 class DeprecationComments_SomeStruct {
   /// How useful this struct is.
   @Deprecated("Unfortunately, this field is deprecated.\nUse [Comments_SomeStruct.someField] instead.")
-  bool someField;
+  DeprecationComments_Usefulness someField;
   DeprecationComments_SomeStruct._(this.someField);
   DeprecationComments_SomeStruct()
     : someField = false;
@@ -196,9 +199,9 @@ final _smokeDeprecationcommentsGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_get_type_id'));
 class DeprecationComments$Lambdas implements DeprecationComments {
-  bool Function(String) someMethodWithAllCommentsLambda;
-  bool Function() isSomePropertyGetLambda;
-  void Function(bool) isSomePropertySetLambda;
+  DeprecationComments_Usefulness Function(String) someMethodWithAllCommentsLambda;
+  DeprecationComments_Usefulness Function() isSomePropertyGetLambda;
+  void Function(DeprecationComments_Usefulness) isSomePropertySetLambda;
   String Function() propertyButNotAccessorsGetLambda;
   void Function(String) propertyButNotAccessorsSetLambda;
   DeprecationComments$Lambdas(
@@ -209,12 +212,12 @@ class DeprecationComments$Lambdas implements DeprecationComments {
     this.propertyButNotAccessorsSetLambda
   );
   @override
-  bool someMethodWithAllComments(String input) =>
+  DeprecationComments_Usefulness someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
-  bool get isSomeProperty => isSomePropertyGetLambda();
+  DeprecationComments_Usefulness get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
+  set isSomeProperty(DeprecationComments_Usefulness value) => isSomePropertySetLambda(value);
   @override
   String get propertyButNotAccessors => propertyButNotAccessorsGetLambda();
   @override
@@ -223,7 +226,7 @@ class DeprecationComments$Lambdas implements DeprecationComments {
 class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationComments {
   DeprecationComments$Impl(Pointer<Void> handle) : super(handle);
   @override
-  bool someMethodWithAllComments(String input) {
+  DeprecationComments_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -237,7 +240,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   }
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
-  bool get isSomeProperty {
+  DeprecationComments_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationComments_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -249,7 +252,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   }
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
-  set isSomeProperty(bool value) {
+  set isSomeProperty(DeprecationComments_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
@@ -278,7 +281,7 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
   }
 }
 int _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  DeprecationComments_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as DeprecationComments).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -8,27 +8,29 @@ import 'package:library/src/builtin_types__conversion.dart';
 abstract class DeprecationCommentsOnly {
   @Deprecated("Unfortunately, this interface is deprecated.")
   factory DeprecationCommentsOnly(
-    bool Function(String) someMethodWithAllCommentsLambda,
-    bool Function() isSomePropertyGetLambda,
-    void Function(bool) isSomePropertySetLambda
+    DeprecationCommentsOnly_Usefulness Function(String) someMethodWithAllCommentsLambda,
+    DeprecationCommentsOnly_Usefulness Function() isSomePropertyGetLambda,
+    void Function(DeprecationCommentsOnly_Usefulness) isSomePropertySetLambda
   ) => DeprecationCommentsOnly$Lambdas(
     someMethodWithAllCommentsLambda,
     isSomePropertyGetLambda,
     isSomePropertySetLambda
   );
   @Deprecated("Unfortunately, this constant is deprecated.")
-  static final bool veryUseful = true;
+  static final DeprecationCommentsOnly_Usefulness veryUseful = true;
   /// [input] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [DeprecationCommentsOnly_Usefulness]. Usefulness of the input
   ///
   @Deprecated("Unfortunately, this method is deprecated.")
-  bool someMethodWithAllComments(String input);
+  DeprecationCommentsOnly_Usefulness someMethodWithAllComments(String input);
   @Deprecated("Unfortunately, this property's getter is deprecated.")
-  bool get isSomeProperty;
+  DeprecationCommentsOnly_Usefulness get isSomeProperty;
   @Deprecated("Unfortunately, this property's setter is deprecated.")
-  set isSomeProperty(bool value);
+  set isSomeProperty(DeprecationCommentsOnly_Usefulness value);
 }
+@Deprecated("Unfortunately, this typedef is deprecated.")
+typedef DeprecationCommentsOnly_Usefulness = bool;
 @Deprecated("Unfortunately, this enum is deprecated.")
 enum DeprecationCommentsOnly_SomeEnum {
     @Deprecated("Unfortunately, this item is deprecated.")
@@ -84,7 +86,7 @@ void smokeDeprecationcommentsonlySomeenumReleaseFfiHandleNullable(Pointer<Void> 
 @Deprecated("Unfortunately, this struct is deprecated.")
 class DeprecationCommentsOnly_SomeStruct {
   @Deprecated("Unfortunately, this field is deprecated.")
-  bool someField;
+  DeprecationCommentsOnly_Usefulness someField;
   DeprecationCommentsOnly_SomeStruct._(this.someField);
   DeprecationCommentsOnly_SomeStruct()
     : someField = false;
@@ -171,26 +173,26 @@ final _smokeDeprecationcommentsonlyGetTypeId = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_get_type_id'));
 class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
-  bool Function(String) someMethodWithAllCommentsLambda;
-  bool Function() isSomePropertyGetLambda;
-  void Function(bool) isSomePropertySetLambda;
+  DeprecationCommentsOnly_Usefulness Function(String) someMethodWithAllCommentsLambda;
+  DeprecationCommentsOnly_Usefulness Function() isSomePropertyGetLambda;
+  void Function(DeprecationCommentsOnly_Usefulness) isSomePropertySetLambda;
   DeprecationCommentsOnly$Lambdas(
     this.someMethodWithAllCommentsLambda,
     this.isSomePropertyGetLambda,
     this.isSomePropertySetLambda
   );
   @override
-  bool someMethodWithAllComments(String input) =>
+  DeprecationCommentsOnly_Usefulness someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
   @override
-  bool get isSomeProperty => isSomePropertyGetLambda();
+  DeprecationCommentsOnly_Usefulness get isSomeProperty => isSomePropertyGetLambda();
   @override
-  set isSomeProperty(bool value) => isSomePropertySetLambda(value);
+  set isSomeProperty(DeprecationCommentsOnly_Usefulness value) => isSomePropertySetLambda(value);
 }
 class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements DeprecationCommentsOnly {
   DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
   @override
-  bool someMethodWithAllComments(String input) {
+  DeprecationCommentsOnly_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;
@@ -203,7 +205,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
     }
   }
   @Deprecated("Unfortunately, this property's getter is deprecated.")
-  bool get isSomeProperty {
+  DeprecationCommentsOnly_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -214,7 +216,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
     }
   }
   @Deprecated("Unfortunately, this property's setter is deprecated.")
-  set isSomeProperty(bool value) {
+  set isSomeProperty(DeprecationCommentsOnly_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
@@ -223,7 +225,7 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
   }
 }
 int _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
-  bool? _resultObject;
+  DeprecationCommentsOnly_Usefulness? _resultObject;
   try {
     _resultObject = (_obj as DeprecationCommentsOnly).someMethodWithAllComments(stringFromFfi(input));
     _result.value = booleanToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -9,28 +9,31 @@ abstract class ExcludedComments {
 
   /// This is some very useful constant.
   /// @nodoc
-  static final bool veryUseful = true;
+  static final ExcludedComments_Usefulness veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [inputParameter] Very useful input parameter
   ///
-  /// Returns [bool]. Usefulness of the input
+  /// Returns [ExcludedComments_Usefulness]. Usefulness of the input
   ///
   /// Throws [ExcludedComments_SomethingWrongException]. Sometimes it happens.
   ///
   /// @nodoc
-  bool someMethodWithAllComments(String inputParameter);
+  ExcludedComments_Usefulness someMethodWithAllComments(String inputParameter);
   /// This is some very useful method that does nothing.
   ///
   /// @nodoc
   void someMethodWithoutReturnTypeOrInputParameters();
   /// Gets some very useful property.
   /// @nodoc
-  bool get isSomeProperty;
+  ExcludedComments_Usefulness get isSomeProperty;
   /// Sets some very useful property.
   /// @nodoc
-  set isSomeProperty(bool value);
+  set isSomeProperty(ExcludedComments_Usefulness value);
 }
+/// This is some very useful typealias.
+/// @nodoc
+typedef ExcludedComments_Usefulness = bool;
 /// This is some very useful enum.
 /// @nodoc
 enum ExcludedComments_SomeEnum {
@@ -97,7 +100,7 @@ class ExcludedComments_SomeStruct {
   /// How useful this struct is
   /// remains to be seen
   /// @nodoc
-  bool someField;
+  ExcludedComments_Usefulness someField;
   /// This is how easy it is to construct.
   /// [someField] How useful this struct is
   /// remains to be seen
@@ -288,7 +291,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
   ExcludedComments$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String inputParameter) {
+  ExcludedComments_Usefulness someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedComments_someMethodWithAllComments__String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
     final _handle = this.handle;
@@ -318,7 +321,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
-  bool get isSomeProperty {
+  ExcludedComments_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -329,7 +332,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     }
   }
   @override
-  set isSomeProperty(bool value) {
+  set isSomeProperty(ExcludedComments_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedComments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -7,16 +7,18 @@ import 'package:library/src/builtin_types__conversion.dart';
 abstract class ExcludedCommentsOnly {
 
   /// @nodoc
-  static final bool veryUseful = true;
+  static final ExcludedCommentsOnly_Usefulness veryUseful = true;
   /// @nodoc
-  bool someMethodWithAllComments(String inputParameter);
+  ExcludedCommentsOnly_Usefulness someMethodWithAllComments(String inputParameter);
   /// @nodoc
   void someMethodWithoutReturnTypeOrInputParameters();
   /// @nodoc
-  bool get isSomeProperty;
+  ExcludedCommentsOnly_Usefulness get isSomeProperty;
   /// @nodoc
-  set isSomeProperty(bool value);
+  set isSomeProperty(ExcludedCommentsOnly_Usefulness value);
 }
+/// @nodoc
+typedef ExcludedCommentsOnly_Usefulness = bool;
 /// @nodoc
 enum ExcludedCommentsOnly_SomeEnum {
     /// @nodoc
@@ -77,7 +79,7 @@ class ExcludedCommentsOnly_SomethingWrongException implements Exception {
 /// @nodoc
 class ExcludedCommentsOnly_SomeStruct {
   /// @nodoc
-  bool someField;
+  ExcludedCommentsOnly_Usefulness someField;
   ExcludedCommentsOnly_SomeStruct(this.someField);
 }
 // ExcludedCommentsOnly_SomeStruct "private" section, not exported.
@@ -264,7 +266,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
   ExcludedCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String inputParameter) {
+  ExcludedCommentsOnly_Usefulness someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
     final _handle = this.handle;
@@ -294,7 +296,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
-  bool get isSomeProperty {
+  ExcludedCommentsOnly_Usefulness get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -305,7 +307,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     }
   }
   @override
-  set isSomeProperty(bool value) {
+  set isSomeProperty(ExcludedCommentsOnly_Usefulness value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -10,11 +10,11 @@ abstract class UnicodeComments {
   ///
   /// [input] שלום
   ///
-  /// Returns [bool]. товарищ
+  /// Returns [Comments_Usefulness]. товарищ
   ///
   /// Throws [Comments_SomethingWrongException]. ネコ
   ///
-  bool someMethodWithAllComments(String input);
+  Comments_Usefulness someMethodWithAllComments(String input);
 }
 // UnicodeComments "private" section, not exported.
 final _smokeUnicodecommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -49,7 +49,7 @@ class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
   UnicodeComments$Impl(Pointer<Void> handle) : super(handle);
 
   @override
-  bool someMethodWithAllComments(String input) {
+  Comments_Usefulness someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));
     final _inputHandle = stringToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/generic_types__conversion.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/generic_types__conversion.dart
@@ -1,4 +1,5 @@
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/dates_steady.dart';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 final _foobarListofDateCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -118,7 +119,7 @@ final _foobarListofDateStd2chrono2steady1clock2time1pointIteratorGet = __lib.cat
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
 >('library_foobar_ListOf_Date_std_2chrono_2steady_1clock_2time_1point_iterator_get'));
-Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfi(List<DateTime> value) {
+Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfi(List<DatesSteady_MonotonicDate> value) {
   final _result = _foobarListofDateStd2chrono2steady1clock2time1pointCreateHandle();
   for (final element in value) {
     final _elementHandle = dateToFfi(element);
@@ -127,8 +128,8 @@ Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfi(List<DateT
   }
   return _result;
 }
-List<DateTime> foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(Pointer<Void> handle) {
-  final result = List<DateTime>.empty(growable: true);
+List<DatesSteady_MonotonicDate> foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(Pointer<Void> handle) {
+  final result = List<DatesSteady_MonotonicDate>.empty(growable: true);
   final _iteratorHandle = _foobarListofDateStd2chrono2steady1clock2time1pointIterator(handle);
   while (_foobarListofDateStd2chrono2steady1clock2time1pointIteratorIsValid(handle, _iteratorHandle) != 0) {
     final _elementHandle = _foobarListofDateStd2chrono2steady1clock2time1pointIteratorGet(_iteratorHandle);
@@ -155,14 +156,14 @@ final _foobarListofDateStd2chrono2steady1clock2time1pointGetValueNullable = __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_ListOf_Date_std_2chrono_2steady_1clock_2time_1point_get_value_nullable'));
-Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfiNullable(List<DateTime>? value) {
+Pointer<Void> foobarListofDateStd2chrono2steady1clock2time1pointToFfiNullable(List<DatesSteady_MonotonicDate>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobarListofDateStd2chrono2steady1clock2time1pointToFfi(value);
   final result = _foobarListofDateStd2chrono2steady1clock2time1pointCreateHandleNullable(_handle);
   foobarListofDateStd2chrono2steady1clock2time1pointReleaseFfiHandle(_handle);
   return result;
 }
-List<DateTime>? foobarListofDateStd2chrono2steady1clock2time1pointFromFfiNullable(Pointer<Void> handle) {
+List<DatesSteady_MonotonicDate>? foobarListofDateStd2chrono2steady1clock2time1pointFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobarListofDateStd2chrono2steady1clock2time1pointGetValueNullable(handle);
   final result = foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(_handle);
@@ -207,7 +208,7 @@ final _foobarMapofDateStd2chrono2steady1clock2time1pointToStringIteratorGetValue
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
 >('library_foobar_MapOf_Date_std_2chrono_2steady_1clock_2time_1point_to_String_iterator_get_value'));
-Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(Map<DateTime, String> value) {
+Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(Map<DatesSteady_MonotonicDate, String> value) {
   final _result = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringCreateHandle();
   for (final entry in value.entries) {
     final _keyHandle = dateToFfi(entry.key);
@@ -218,8 +219,8 @@ Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(Map
   }
   return _result;
 }
-Map<DateTime, String> foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfi(Pointer<Void> handle) {
-  final result = Map<DateTime, String>();
+Map<DatesSteady_MonotonicDate, String> foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfi(Pointer<Void> handle) {
+  final result = Map<DatesSteady_MonotonicDate, String>();
   final _iteratorHandle = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringIterator(handle);
   while (_foobarMapofDateStd2chrono2steady1clock2time1pointToStringIteratorIsValid(handle, _iteratorHandle) != 0) {
     final _keyHandle = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringIteratorGetKey(_iteratorHandle);
@@ -249,14 +250,14 @@ final _foobarMapofDateStd2chrono2steady1clock2time1pointToStringGetValueNullable
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_foobar_MapOf_Date_std_2chrono_2steady_1clock_2time_1point_to_String_get_value_nullable'));
-Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfiNullable(Map<DateTime, String>? value) {
+Pointer<Void> foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfiNullable(Map<DatesSteady_MonotonicDate, String>? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = foobarMapofDateStd2chrono2steady1clock2time1pointToStringToFfi(value);
   final result = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringCreateHandleNullable(_handle);
   foobarMapofDateStd2chrono2steady1clock2time1pointToStringReleaseFfiHandle(_handle);
   return result;
 }
-Map<DateTime, String>? foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfiNullable(Pointer<Void> handle) {
+Map<DatesSteady_MonotonicDate, String>? foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _foobarMapofDateStd2chrono2steady1clock2time1pointToStringGetValueNullable(handle);
   final result = foobarMapofDateStd2chrono2steady1clock2time1pointToStringFromFfi(_handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults_aliased.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults_aliased.dart
@@ -1,11 +1,12 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/date_alias.dart';
 class DateDefaultsAliased {
-  DateTime dateTime;
-  DateTime dateTimeUtc;
-  DateTime beforeEpoch;
-  DateTime exactlyEpoch;
+  DateAlias dateTime;
+  DateAlias dateTimeUtc;
+  DateAlias beforeEpoch;
+  DateAlias exactlyEpoch;
   DateDefaultsAliased._(this.dateTime, this.dateTimeUtc, this.beforeEpoch, this.exactlyEpoch);
   DateDefaultsAliased()
     : dateTime = DateTime.fromMillisecondsSinceEpoch(1643966117000), dateTimeUtc = DateTime.fromMillisecondsSinceEpoch(1643966117000), beforeEpoch = DateTime.fromMillisecondsSinceEpoch(-1511793883000), exactlyEpoch = DateTime.fromMillisecondsSinceEpoch(0);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -12,6 +12,9 @@ abstract class Dates {
   Set<DateTime> get dateSet;
   set dateSet(Set<DateTime> value);
 }
+typedef Dates_DateTypeDef = DateTime;
+typedef Dates_DateArray = List<DateTime>;
+typedef Dates_DateMap = Map<String, DateTime>;
 class Dates_DateStruct {
   DateTime dateField;
   DateTime? nullableDateField;

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
@@ -5,15 +5,18 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 abstract class DatesSteady {
-  DateTime dateMethod(DateTime input);
-  DateTime? nullableDateMethod(DateTime? input);
-  List<DateTime> dateListMethod(List<DateTime> input);
+  DatesSteady_MonotonicDate dateMethod(DatesSteady_MonotonicDate input);
+  DatesSteady_MonotonicDate? nullableDateMethod(DatesSteady_MonotonicDate? input);
+  DatesSteady_DateList dateListMethod(DatesSteady_DateList input);
 }
+typedef DatesSteady_MonotonicDate = DateTime;
+typedef DatesSteady_DateList = List<DatesSteady_MonotonicDate>;
+typedef DatesSteady_DateMap = Map<DatesSteady_MonotonicDate, String>;
 class DatesSteady_DateStruct {
-  DateTime dateField;
-  DateTime? nullableDateField;
+  DatesSteady_MonotonicDate dateField;
+  DatesSteady_MonotonicDate? nullableDateField;
   DatesSteady_DateStruct._(this.dateField, this.nullableDateField);
-  DatesSteady_DateStruct(DateTime dateField)
+  DatesSteady_DateStruct(DatesSteady_MonotonicDate dateField)
     : dateField = dateField, nullableDateField = null;
 }
 // DatesSteady_DateStruct "private" section, not exported.
@@ -101,7 +104,7 @@ final _smokeDatessteadyReleaseHandle = __lib.catchArgumentError(() => __lib.nati
 class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
   DatesSteady$Impl(Pointer<Void> handle) : super(handle);
   @override
-  DateTime dateMethod(DateTime input) {
+  DatesSteady_MonotonicDate dateMethod(DatesSteady_MonotonicDate input) {
     final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DatesSteady_dateMethod__Date'));
     final _inputHandle = dateToFfi(input);
     final _handle = this.handle;
@@ -114,7 +117,7 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
     }
   }
   @override
-  DateTime? nullableDateMethod(DateTime? input) {
+  DatesSteady_MonotonicDate? nullableDateMethod(DatesSteady_MonotonicDate? input) {
     final _nullableDateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_nullableDateMethod__Date_'));
     final _inputHandle = dateToFfiNullable(input);
     final _handle = this.handle;
@@ -127,7 +130,7 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
     }
   }
   @override
-  List<DateTime> dateListMethod(List<DateTime> input) {
+  DatesSteady_DateList dateListMethod(DatesSteady_DateList input) {
     final _dateListMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_dateListMethod__ListOf_Date_std_2chrono_2steady_1clock_2time_1point'));
     final _inputHandle = foobarListofDateStd2chrono2steady1clock2time1pointToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -11,6 +11,12 @@ abstract class DefaultValues {
   @visibleForTesting
   static dynamic $prototype = DefaultValues$Impl(Pointer<Void>.fromAddress(0));
 }
+typedef DefaultValues_LongTypedef = int;
+typedef DefaultValues_BooleanTypedef = bool;
+typedef DefaultValues_StringTypedef = String;
+typedef DefaultValues_FloatArray = List<double>;
+typedef DefaultValues_IdToStringMap = Map<int, String>;
+typedef DefaultValues_StringSet = Set<String>;
 class DefaultValues_StructWithDefaults {
   int intField;
   int uintField;
@@ -331,10 +337,10 @@ void smokeDefaultvaluesStructwithspecialdefaultsReleaseFfiHandleNullable(Pointer
 // End of DefaultValues_StructWithSpecialDefaults "private" section.
 class DefaultValues_StructWithEmptyDefaults {
   List<int> intsField;
-  List<double> floatsField;
-  Map<int, String> mapField;
+  DefaultValues_FloatArray floatsField;
+  DefaultValues_IdToStringMap mapField;
   DefaultValues_StructWithDefaults structField;
-  Set<String> setTypeField;
+  DefaultValues_StringSet setTypeField;
   DefaultValues_StructWithEmptyDefaults._(this.intsField, this.floatsField, this.mapField, this.structField, this.setTypeField);
   DefaultValues_StructWithEmptyDefaults()
     : intsField = [], floatsField = [], mapField = {}, structField = DefaultValues_StructWithDefaults(), setTypeField = {};
@@ -436,9 +442,9 @@ void smokeDefaultvaluesStructwithemptydefaultsReleaseFfiHandleNullable(Pointer<V
   _smokeDefaultvaluesStructwithemptydefaultsReleaseHandleNullable(handle);
 // End of DefaultValues_StructWithEmptyDefaults "private" section.
 class DefaultValues_StructWithTypedefDefaults {
-  int longField;
-  bool boolField;
-  String stringField;
+  DefaultValues_LongTypedef longField;
+  DefaultValues_BooleanTypedef boolField;
+  DefaultValues_StringTypedef stringField;
   DefaultValues_StructWithTypedefDefaults._(this.longField, this.boolField, this.stringField);
   DefaultValues_StructWithTypedefDefaults()
     : longField = 42, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n";

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -1,11 +1,12 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
+import 'package:library/src/smoke/default_values.dart';
 class StructWithInitializerDefaults {
   List<int> intsField;
-  List<double> floatsField;
-  Set<String> setTypeField;
-  Map<int, String> mapField;
+  DefaultValues_FloatArray floatsField;
+  DefaultValues_StringSet setTypeField;
+  DefaultValues_IdToStringMap mapField;
   StructWithInitializerDefaults._(this.intsField, this.floatsField, this.setTypeField, this.mapField);
   StructWithInitializerDefaults()
     : intsField = [4, -2, 42], floatsField = [3.14, double.negativeInfinity], setTypeField = {"foo", "bar"}, mapField = {1: "foo", 42: "bar"};

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
@@ -9,6 +9,7 @@ import 'package:library/src/fire/enum4.dart';
 import 'package:library/src/smoke/enum_wrapper.dart';
 abstract class EnumDefaults {
 }
+typedef EnumDefaults_EnumAlias = Enum3;
 class EnumDefaults_SimpleEnum {
   Enum1 enumField;
   EnumDefaults_SimpleEnum._(this.enumField);
@@ -152,7 +153,7 @@ void smokeEnumdefaultsNullableenumReleaseFfiHandleNullable(Pointer<Void> handle)
   _smokeEnumdefaultsNullableenumReleaseHandleNullable(handle);
 // End of EnumDefaults_NullableEnum "private" section.
 class EnumDefaults_AliasEnum {
-  Enum3 enumField;
+  EnumDefaults_EnumAlias enumField;
   EnumDefaults_AliasEnum._(this.enumField);
   EnumDefaults_AliasEnum()
     : enumField = Enum3.disabled;

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
@@ -12,6 +12,7 @@ import 'package:library/src/fire/external_enum3.dart';
 import 'package:library/src/smoke/enum_wrapper.dart';
 abstract class EnumDefaultsExternal {
 }
+typedef EnumDefaultsExternal_EnumAlias = alien_enum3.ExternalEnum3;
 class EnumDefaultsExternal_SimpleEnum {
   alien_enum1.ExternalEnum1 enumField;
   EnumDefaultsExternal_SimpleEnum._(this.enumField);
@@ -155,7 +156,7 @@ void smokeEnumdefaultsexternalNullableenumReleaseFfiHandleNullable(Pointer<Void>
   _smokeEnumdefaultsexternalNullableenumReleaseHandleNullable(handle);
 // End of EnumDefaultsExternal_NullableEnum "private" section.
 class EnumDefaultsExternal_AliasEnum {
-  alien_enum3.alien_enum3.ExternalEnum3 enumField;
+  EnumDefaultsExternal_EnumAlias enumField;
   EnumDefaultsExternal_AliasEnum._(this.enumField);
   EnumDefaultsExternal_AliasEnum()
     : enumField = alien_enum3.ExternalEnum3.disabled;

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
@@ -3,6 +3,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 abstract class DurationMilliseconds {
 
   Duration durationFunction(Duration input);
@@ -10,6 +11,11 @@ abstract class DurationMilliseconds {
   Duration get durationProperty;
   set durationProperty(Duration value);
 }
+typedef DurationMilliseconds_DurationTypeAlias = Duration;
+typedef DurationMilliseconds_DurationList = List<Duration>;
+typedef DurationMilliseconds_DurationSet = Set<Duration>;
+typedef DurationMilliseconds_DurationMap = Map<String, Duration>;
+typedef DurationMilliseconds_DurationKeyMap = Map<Duration, String>;
 class DurationMilliseconds_DurationStruct {
   Duration durationField;
   DurationMilliseconds_DurationStruct(this.durationField);

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
@@ -3,6 +3,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 abstract class DurationSeconds {
 
   Duration durationFunction(Duration input);
@@ -10,6 +11,11 @@ abstract class DurationSeconds {
   Duration get durationProperty;
   set durationProperty(Duration value);
 }
+typedef DurationSeconds_DurationTypeAlias = Duration;
+typedef DurationSeconds_DurationList = List<Duration>;
+typedef DurationSeconds_DurationSet = Set<Duration>;
+typedef DurationSeconds_DurationMap = Map<String, Duration>;
+typedef DurationSeconds_DurationKeyMap = Map<Duration, String>;
 class DurationSeconds_DurationStruct {
   Duration durationField;
   DurationSeconds_DurationStruct(this.durationField);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -3,6 +3,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class Enums {
 
@@ -14,6 +15,7 @@ abstract class Enums {
   @visibleForTesting
   static dynamic $prototype = Enums$Impl(Pointer<Void>.fromAddress(0));
 }
+typedef Enums_ExampleMap = Map<Enums_SimpleEnum, int>;
 enum Enums_SimpleEnum {
     first,
     second

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -5,6 +5,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 class Equatable {
 }
+typedef Equatable_ErrorCodeToMessageMap = Map<int, String>;
 enum Equatable_SomeEnum {
     foo,
     bar
@@ -70,7 +71,7 @@ class Equatable_EquatableStruct {
   Equatable_NestedEquatableStruct structField;
   Equatable_SomeEnum enumField;
   List<String> arrayField;
-  Map<int, String> mapField;
+  Equatable_ErrorCodeToMessageMap mapField;
   Equatable_EquatableStruct(this.boolField, this.intField, this.longField, this.floatField, this.doubleField, this.stringField, this.structField, this.enumField, this.arrayField, this.mapField);
   @override
   bool operator ==(Object other) {
@@ -246,7 +247,7 @@ class Equatable_EquatableNullableStruct {
   Equatable_NestedEquatableStruct? structField;
   Equatable_SomeEnum? enumField;
   List<String>? arrayField;
-  Map<int, String>? mapField;
+  Equatable_ErrorCodeToMessageMap? mapField;
   Equatable_EquatableNullableStruct._(this.boolField, this.intField, this.uintField, this.floatField, this.stringField, this.structField, this.enumField, this.arrayField, this.mapField);
   Equatable_EquatableNullableStruct()
     : boolField = null, intField = null, uintField = null, floatField = null, stringField = null, structField = null, enumField = null, arrayField = null, mapField = null;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -10,7 +10,7 @@ import 'package:library/src/package/types.dart';
 import 'package:meta/meta.dart';
 abstract class Class implements Interface {
   factory Class() => $prototype.constructor();
-  Types_Struct fun(List<Types_Struct> double);
+  Types_Struct fun(Types_ULong double);
   Types_Enum get property;
   set property(Types_Enum value);
   /// @nodoc
@@ -67,7 +67,7 @@ class Class$Impl extends __lib.NativeBase implements Class {
     return __resultHandle;
   }
   @override
-  Types_Struct fun(List<Types_Struct> double) {
+  Types_Struct fun(Types_ULong double) {
     final _funFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_package_Class_fun__ListOf_package_Types_Struct'));
     final _doubleHandle = foobarListofPackageTypesStructToFfi(double);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -1,8 +1,10 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/generic_types__conversion.dart';
 class Types {
   static final Types_Enum Const = Types_Enum.naN;
 }
+typedef Types_ULong = List<Types_Struct>;
 enum Types_Enum {
     naN
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -8,9 +8,9 @@ abstract class GenericTypesWithBasicTypes {
   List<int> methodWithList(List<int> input);
   Map<int, bool> methodWithMap(Map<int, bool> input);
   Set<int> methodWithSet(Set<int> input);
-  List<String> methodWithListTypeAlias(List<String> input);
-  Map<String, String> methodWithMapTypeAlias(Map<String, String> input);
-  Set<String> methodWithSetTypeAlias(Set<String> input);
+  GenericTypesWithBasicTypes_BasicList methodWithListTypeAlias(GenericTypesWithBasicTypes_BasicList input);
+  GenericTypesWithBasicTypes_BasicMap methodWithMapTypeAlias(GenericTypesWithBasicTypes_BasicMap input);
+  GenericTypesWithBasicTypes_BasicSet methodWithSetTypeAlias(GenericTypesWithBasicTypes_BasicSet input);
   List<double> get listProperty;
   set listProperty(List<double> value);
   Map<double, double> get mapProperty;
@@ -18,6 +18,9 @@ abstract class GenericTypesWithBasicTypes {
   Set<double> get setProperty;
   set setProperty(Set<double> value);
 }
+typedef GenericTypesWithBasicTypes_BasicList = List<String>;
+typedef GenericTypesWithBasicTypes_BasicMap = Map<String, String>;
+typedef GenericTypesWithBasicTypes_BasicSet = Set<String>;
 class GenericTypesWithBasicTypes_StructWithGenerics {
   List<int> numbersList;
   Map<int, String> numbersMap;
@@ -158,7 +161,7 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     }
   }
   @override
-  List<String> methodWithListTypeAlias(List<String> input) {
+  GenericTypesWithBasicTypes_BasicList methodWithListTypeAlias(GenericTypesWithBasicTypes_BasicList input) {
     final _methodWithListTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_String'));
     final _inputHandle = foobarListofStringToFfi(input);
     final _handle = this.handle;
@@ -171,7 +174,7 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     }
   }
   @override
-  Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
+  GenericTypesWithBasicTypes_BasicMap methodWithMapTypeAlias(GenericTypesWithBasicTypes_BasicMap input) {
     final _methodWithMapTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_String_to_String'));
     final _inputHandle = foobarMapofStringToStringToFfi(input);
     final _handle = this.handle;
@@ -184,7 +187,7 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     }
   }
   @override
-  Set<String> methodWithSetTypeAlias(Set<String> input) {
+  GenericTypesWithBasicTypes_BasicSet methodWithSetTypeAlias(GenericTypesWithBasicTypes_BasicSet input) {
     final _methodWithSetTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_String'));
     final _inputHandle = foobarSetofStringToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -12,7 +12,7 @@ abstract class CalculatorListener {
     void Function(double) onCalculationResultConstLambda,
     void Function(CalculatorListener_ResultStruct) onCalculationResultStructLambda,
     void Function(List<double>) onCalculationResultArrayLambda,
-    void Function(Map<String, double>) onCalculationResultMapLambda,
+    void Function(CalculatorListener_NamedCalculationResults) onCalculationResultMapLambda,
     void Function(CalculationResult) onCalculationResultInstanceLambda,
   ) => CalculatorListener$Lambdas(
     onCalculationResultLambda,
@@ -27,9 +27,10 @@ abstract class CalculatorListener {
   void onCalculationResultConst(double calculationResult);
   void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult);
   void onCalculationResultArray(List<double> calculationResult);
-  void onCalculationResultMap(Map<String, double> calculationResults);
+  void onCalculationResultMap(CalculatorListener_NamedCalculationResults calculationResults);
   void onCalculationResultInstance(CalculationResult calculationResult);
 }
+typedef CalculatorListener_NamedCalculationResults = Map<String, double>;
 class CalculatorListener_ResultStruct {
   double result;
   CalculatorListener_ResultStruct(this.result);
@@ -118,7 +119,7 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   void Function(double) onCalculationResultConstLambda;
   void Function(CalculatorListener_ResultStruct) onCalculationResultStructLambda;
   void Function(List<double>) onCalculationResultArrayLambda;
-  void Function(Map<String, double>) onCalculationResultMapLambda;
+  void Function(CalculatorListener_NamedCalculationResults) onCalculationResultMapLambda;
   void Function(CalculationResult) onCalculationResultInstanceLambda;
   CalculatorListener$Lambdas(
     this.onCalculationResultLambda,
@@ -142,7 +143,7 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   void onCalculationResultArray(List<double> calculationResult) =>
     onCalculationResultArrayLambda(calculationResult);
   @override
-  void onCalculationResultMap(Map<String, double> calculationResults) =>
+  void onCalculationResultMap(CalculatorListener_NamedCalculationResults calculationResults) =>
     onCalculationResultMapLambda(calculationResults);
   @override
   void onCalculationResultInstance(CalculationResult calculationResult) =>
@@ -182,7 +183,7 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     foobarListofDoubleReleaseFfiHandle(_calculationResultHandle);
   }
   @override
-  void onCalculationResultMap(Map<String, double> calculationResults) {
+  void onCalculationResultMap(CalculatorListener_NamedCalculationResults calculationResults) {
     final _onCalculationResultMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_String_to_Double'));
     final _calculationResultsHandle = foobarMapofStringToDoubleToFfi(calculationResults);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -19,8 +19,8 @@ abstract class ListenerWithProperties {
     void Function(ListenerWithProperties_ResultEnum) enumeratedMessageSetLambda,
     List<String> Function() arrayedMessageGetLambda,
     void Function(List<String>) arrayedMessageSetLambda,
-    Map<String, double> Function() mappedMessageGetLambda,
-    void Function(Map<String, double>) mappedMessageSetLambda,
+    ListenerWithProperties_StringToDouble Function() mappedMessageGetLambda,
+    void Function(ListenerWithProperties_StringToDouble) mappedMessageSetLambda,
     Uint8List Function() bufferedMessageGetLambda,
     void Function(Uint8List) bufferedMessageSetLambda
   ) => ListenerWithProperties$Lambdas(
@@ -50,11 +50,12 @@ abstract class ListenerWithProperties {
   set enumeratedMessage(ListenerWithProperties_ResultEnum value);
   List<String> get arrayedMessage;
   set arrayedMessage(List<String> value);
-  Map<String, double> get mappedMessage;
-  set mappedMessage(Map<String, double> value);
+  ListenerWithProperties_StringToDouble get mappedMessage;
+  set mappedMessage(ListenerWithProperties_StringToDouble value);
   Uint8List get bufferedMessage;
   set bufferedMessage(Uint8List value);
 }
+typedef ListenerWithProperties_StringToDouble = Map<String, double>;
 enum ListenerWithProperties_ResultEnum {
     none,
     result
@@ -204,8 +205,8 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   void Function(ListenerWithProperties_ResultEnum) enumeratedMessageSetLambda;
   List<String> Function() arrayedMessageGetLambda;
   void Function(List<String>) arrayedMessageSetLambda;
-  Map<String, double> Function() mappedMessageGetLambda;
-  void Function(Map<String, double>) mappedMessageSetLambda;
+  ListenerWithProperties_StringToDouble Function() mappedMessageGetLambda;
+  void Function(ListenerWithProperties_StringToDouble) mappedMessageSetLambda;
   Uint8List Function() bufferedMessageGetLambda;
   void Function(Uint8List) bufferedMessageSetLambda;
   ListenerWithProperties$Lambdas(
@@ -246,9 +247,9 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   @override
   set arrayedMessage(List<String> value) => arrayedMessageSetLambda(value);
   @override
-  Map<String, double> get mappedMessage => mappedMessageGetLambda();
+  ListenerWithProperties_StringToDouble get mappedMessage => mappedMessageGetLambda();
   @override
-  set mappedMessage(Map<String, double> value) => mappedMessageSetLambda(value);
+  set mappedMessage(ListenerWithProperties_StringToDouble value) => mappedMessageSetLambda(value);
   @override
   Uint8List get bufferedMessage => bufferedMessageGetLambda();
   @override
@@ -342,7 +343,7 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandle(_valueHandle);
   }
-  Map<String, double> get mappedMessage {
+  ListenerWithProperties_StringToDouble get mappedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -352,7 +353,7 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       foobarMapofStringToDoubleReleaseFfiHandle(__resultHandle);
     }
   }
-  set mappedMessage(Map<String, double> value) {
+  set mappedMessage(ListenerWithProperties_StringToDouble value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_String_to_Double'));
     final _valueHandle = foobarMapofStringToDoubleToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -13,7 +13,7 @@ abstract class ListenersWithReturnValues {
     ListenersWithReturnValues_ResultStruct Function() fetchDataStructLambda,
     ListenersWithReturnValues_ResultEnum Function() fetchDataEnumLambda,
     List<double> Function() fetchDataArrayLambda,
-    Map<String, double> Function() fetchDataMapLambda,
+    ListenersWithReturnValues_StringToDouble Function() fetchDataMapLambda,
     CalculationResult Function() fetchDataInstanceLambda,
   ) => ListenersWithReturnValues$Lambdas(
     fetchDataDoubleLambda,
@@ -30,9 +30,10 @@ abstract class ListenersWithReturnValues {
   ListenersWithReturnValues_ResultStruct fetchDataStruct();
   ListenersWithReturnValues_ResultEnum fetchDataEnum();
   List<double> fetchDataArray();
-  Map<String, double> fetchDataMap();
+  ListenersWithReturnValues_StringToDouble fetchDataMap();
   CalculationResult fetchDataInstance();
 }
+typedef ListenersWithReturnValues_StringToDouble = Map<String, double>;
 enum ListenersWithReturnValues_ResultEnum {
     none,
     result
@@ -177,7 +178,7 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   ListenersWithReturnValues_ResultStruct Function() fetchDataStructLambda;
   ListenersWithReturnValues_ResultEnum Function() fetchDataEnumLambda;
   List<double> Function() fetchDataArrayLambda;
-  Map<String, double> Function() fetchDataMapLambda;
+  ListenersWithReturnValues_StringToDouble Function() fetchDataMapLambda;
   CalculationResult Function() fetchDataInstanceLambda;
   ListenersWithReturnValues$Lambdas(
     this.fetchDataDoubleLambda,
@@ -205,7 +206,7 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   List<double> fetchDataArray() =>
     fetchDataArrayLambda();
   @override
-  Map<String, double> fetchDataMap() =>
+  ListenersWithReturnValues_StringToDouble fetchDataMap() =>
     fetchDataMapLambda();
   @override
   CalculationResult fetchDataInstance() =>
@@ -269,7 +270,7 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
     }
   }
   @override
-  Map<String, double> fetchDataMap() {
+  ListenersWithReturnValues_StringToDouble fetchDataMap() {
     final _fetchDataMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap'));
     final _handle = this.handle;
     final __resultHandle = _fetchDataMapFfi(_handle, __lib.LibraryContext.isolateId);
@@ -337,7 +338,7 @@ int _smokeListenerswithreturnvaluesfetchDataArrayStatic(Object _obj, Pointer<Poi
   return 0;
 }
 int _smokeListenerswithreturnvaluesfetchDataMapStatic(Object _obj, Pointer<Pointer<Void>> _result) {
-  Map<String, double>? _resultObject;
+  ListenersWithReturnValues_StringToDouble? _resultObject;
   try {
     _resultObject = (_obj as ListenersWithReturnValues).fetchDataMap();
     _result.value = foobarMapofStringToDoubleToFfi(_resultObject);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -4,12 +4,18 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 abstract class Locales {
 
   Locale localeMethod(Locale input);
   Locale get localeProperty;
   set localeProperty(Locale value);
 }
+typedef Locales_LocaleTypeDef = Locale;
+typedef Locales_LocaleArray = List<Locale>;
+typedef Locales_LocaleMap = Map<String, Locale>;
+typedef Locales_LocaleSet = Set<Locale>;
+typedef Locales_LocaleKeyMap = Map<Locale, String>;
 class Locales_LocaleStruct {
   Locale localeField;
   Locales_LocaleStruct(this.localeField);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -11,12 +11,14 @@ abstract class MethodOverloads {
   bool isBooleanString(String input);
   bool isBooleanPoint(MethodOverloads_Point input);
   bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4);
-  bool isBooleanStringArray(List<String> input);
-  bool isBooleanIntArray(List<int> input);
+  bool isBooleanStringArray(MethodOverloads_StringArray input);
+  bool isBooleanIntArray(MethodOverloads_IntArray input);
   bool isBooleanConst();
   bool isFloatString(String input);
-  bool isFloatList(List<int> input);
+  bool isFloatList(MethodOverloads_IntArray input);
 }
+typedef MethodOverloads_StringArray = List<String>;
+typedef MethodOverloads_IntArray = List<int>;
 class MethodOverloads_Point {
   double x;
   double y;
@@ -173,7 +175,7 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
     }
   }
   @override
-  bool isBooleanStringArray(List<String> input) {
+  bool isBooleanStringArray(MethodOverloads_StringArray input) {
     final _isBooleanStringArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_String'));
     final _inputHandle = foobarListofStringToFfi(input);
     final _handle = this.handle;
@@ -186,7 +188,7 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
     }
   }
   @override
-  bool isBooleanIntArray(List<int> input) {
+  bool isBooleanIntArray(MethodOverloads_IntArray input) {
     final _isBooleanIntArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_Byte'));
     final _inputHandle = foobarListofByteToFfi(input);
     final _handle = this.handle;
@@ -223,7 +225,7 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
     }
   }
   @override
-  bool isFloatList(List<int> input) {
+  bool isFloatList(MethodOverloads_IntArray input) {
     final _isFloatListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_Byte'));
     final _inputHandle = foobarListofByteToFfi(input);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -28,6 +28,7 @@ class OuterStruct {
   @visibleForTesting
   static dynamic $prototype = OuterStruct$Impl();
 }
+typedef OuterStruct_TypeAlias = OuterStruct_InnerEnum;
 enum OuterStruct_InnerEnum {
     foo,
     bar
@@ -84,7 +85,7 @@ void smokeOuterstructInnerenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerenumReleaseHandleNullable(handle);
 // End of OuterStruct_InnerEnum "private" section.
 class OuterStruct_InstantiationException implements Exception {
-  final OuterStruct_InnerEnum error;
+  final OuterStruct_TypeAlias error;
   OuterStruct_InstantiationException(this.error);
 }
 class OuterStruct_InnerStruct {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -6,9 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
+import 'package:library/src/smoke/free_type_def.dart';
 abstract class UseFreeTypes {
-
-  DateTime doStuff(FreePoint point, FreeEnum mode);
+  FreeTypeDef doStuff(FreePoint point, FreeEnum mode);
 }
 // UseFreeTypes "private" section, not exported.
 final _smokeUsefreetypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -41,9 +41,8 @@ final _doStuffReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrar
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
 class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
   UseFreeTypes$Impl(Pointer<Void> handle) : super(handle);
-
   @override
-  DateTime doStuff(FreePoint point, FreeEnum mode) {
+  FreeTypeDef doStuff(FreePoint point, FreeEnum mode) {
     final _doStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));
     final _pointHandle = smokeFreepointToFfi(point);
     final _modeHandle = smokeFreeenumToFfi(mode);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -12,9 +12,9 @@ abstract class Nullable {
   int? methodWithInt(int? input);
   Nullable_SomeStruct? methodWithSomeStruct(Nullable_SomeStruct? input);
   Nullable_SomeEnum? methodWithSomeEnum(Nullable_SomeEnum? input);
-  List<String>? methodWithSomeArray(List<String>? input);
+  Nullable_SomeArray? methodWithSomeArray(Nullable_SomeArray? input);
   List<String>? methodWithInlineArray(List<String>? input);
-  Map<int, String>? methodWithSomeMap(Map<int, String>? input);
+  Nullable_SomeMap? methodWithSomeMap(Nullable_SomeMap? input);
   SomeInterface? methodWithInstance(SomeInterface? input);
   String? get stringProperty;
   set stringProperty(String? value);
@@ -28,15 +28,17 @@ abstract class Nullable {
   set structProperty(Nullable_SomeStruct? value);
   Nullable_SomeEnum? get enumProperty;
   set enumProperty(Nullable_SomeEnum? value);
-  List<String>? get arrayProperty;
-  set arrayProperty(List<String>? value);
+  Nullable_SomeArray? get arrayProperty;
+  set arrayProperty(Nullable_SomeArray? value);
   List<String>? get inlineArrayProperty;
   set inlineArrayProperty(List<String>? value);
-  Map<int, String>? get mapProperty;
-  set mapProperty(Map<int, String>? value);
+  Nullable_SomeMap? get mapProperty;
+  set mapProperty(Nullable_SomeMap? value);
   SomeInterface? get instanceProperty;
   set instanceProperty(SomeInterface? value);
 }
+typedef Nullable_SomeArray = List<String>;
+typedef Nullable_SomeMap = Map<int, String>;
 enum Nullable_SomeEnum {
     on,
     off
@@ -162,9 +164,9 @@ class Nullable_NullableStruct {
   double? doubleField;
   Nullable_SomeStruct? structField;
   Nullable_SomeEnum? enumField;
-  List<String>? arrayField;
+  Nullable_SomeArray? arrayField;
   List<String>? inlineArrayField;
-  Map<int, String>? mapField;
+  Nullable_SomeMap? mapField;
   SomeInterface? instanceField;
   Nullable_NullableStruct._(this.stringField, this.boolField, this.doubleField, this.structField, this.enumField, this.arrayField, this.inlineArrayField, this.mapField, this.instanceField);
   Nullable_NullableStruct()
@@ -532,7 +534,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  List<String>? methodWithSomeArray(List<String>? input) {
+  Nullable_SomeArray? methodWithSomeArray(Nullable_SomeArray? input) {
     final _methodWithSomeArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_String_'));
     final _inputHandle = foobarListofStringToFfiNullable(input);
     final _handle = this.handle;
@@ -558,7 +560,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  Map<int, String>? methodWithSomeMap(Map<int, String>? input) {
+  Nullable_SomeMap? methodWithSomeMap(Nullable_SomeMap? input) {
     final _methodWithSomeMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_Long_to_String_'));
     final _inputHandle = foobarMapofLongToStringToFfiNullable(input);
     final _handle = this.handle;
@@ -698,7 +700,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     smokeNullableSomeenumReleaseFfiHandleNullable(_valueHandle);
   }
   @override
-  List<String>? get arrayProperty {
+  Nullable_SomeArray? get arrayProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -709,7 +711,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set arrayProperty(List<String>? value) {
+  set arrayProperty(Nullable_SomeArray? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_String_'));
     final _valueHandle = foobarListofStringToFfiNullable(value);
     final _handle = this.handle;
@@ -736,7 +738,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     foobarListofStringReleaseFfiHandleNullable(_valueHandle);
   }
   @override
-  Map<int, String>? get mapProperty {
+  Nullable_SomeMap? get mapProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -747,7 +749,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     }
   }
   @override
-  set mapProperty(Map<int, String>? value) {
+  set mapProperty(Nullable_SomeMap? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_Long_to_String_'));
     final _valueHandle = foobarMapofLongToStringToFfiNullable(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -4,6 +4,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 class weeTypes {
 }
+typedef weeTypes_BasicTypedef = double;
 enum weeTypes_werrEnum {
     WEE_ITEM
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -16,6 +16,7 @@ abstract class Structs {
   @visibleForTesting
   static dynamic $prototype = Structs$Impl(Pointer<Void>.fromAddress(0));
 }
+typedef Structs_ArrayOfImmutable = List<Structs_AllTypesStruct>;
 enum Structs_FooBar {
     foo,
     bar
@@ -519,7 +520,7 @@ void smokeStructsDoublenestingimmutablestructReleaseFfiHandleNullable(Pointer<Vo
   _smokeStructsDoublenestingimmutablestructReleaseHandleNullable(handle);
 // End of Structs_DoubleNestingImmutableStruct "private" section.
 class Structs_StructWithArrayOfImmutable {
-  List<Structs_AllTypesStruct> arrayField;
+  Structs_ArrayOfImmutable arrayField;
   Structs_StructWithArrayOfImmutable(this.arrayField);
 }
 // Structs_StructWithArrayOfImmutable "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -12,7 +12,7 @@ abstract class TypeDefs {
   static TypeDefs_NestedIntTypeDef returnNestedIntTypeDef(TypeDefs_NestedIntTypeDef input) => $prototype.returnNestedIntTypeDef(input);
   static TypeDefs_TestStructTypeDef returnTestStructTypeDef(TypeDefs_TestStructTypeDef input) => $prototype.returnTestStructTypeDef(input);
   static TypeDefs_NestedStructTypeDef returnNestedStructTypeDef(TypeDefs_NestedStructTypeDef input) => $prototype.returnNestedStructTypeDef(input);
-  static PointTypeDef returnTypeDefPointFromTypeCollection(PointTypeDef input) => $prototype.returnTypeDefPointFromTypeCollection(input);
+  static TypeCollection_PointTypeDef returnTypeDefPointFromTypeCollection(TypeCollection_PointTypeDef input) => $prototype.returnTypeDefPointFromTypeCollection(input);
   List<TypeDefs_PrimitiveTypeDef> get primitiveTypeProperty;
   set primitiveTypeProperty(List<TypeDefs_PrimitiveTypeDef> value);
   /// @nodoc
@@ -219,7 +219,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       smokeTypedefsTeststructReleaseFfiHandle(__resultHandle);
     }
   }
-  PointTypeDef returnTypeDefPointFromTypeCollection(PointTypeDef input) {
+  TypeCollection_PointTypeDef returnTypeDefPointFromTypeCollection(TypeCollection_PointTypeDef input) {
     final _returnTypeDefPointFromTypeCollectionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point'));
     final _inputHandle = smokeTypecollectionPointToFfi(input);
     final __resultHandle = _returnTypeDefPointFromTypeCollectionFfi(__lib.LibraryContext.isolateId, _inputHandle);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -7,20 +7,26 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'package:meta/meta.dart';
 abstract class TypeDefs {
-  static double methodWithPrimitiveTypeDef(double input) => $prototype.methodWithPrimitiveTypeDef(input);
-  static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) => $prototype.methodWithComplexTypeDef(input);
-  static double returnNestedIntTypeDef(double input) => $prototype.returnNestedIntTypeDef(input);
-  static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) => $prototype.returnTestStructTypeDef(input);
-  static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) => $prototype.returnNestedStructTypeDef(input);
-  static TypeCollection_Point returnTypeDefPointFromTypeCollection(TypeCollection_Point input) => $prototype.returnTypeDefPointFromTypeCollection(input);
-  List<double> get primitiveTypeProperty;
-  set primitiveTypeProperty(List<double> value);
+  static TypeDefs_PrimitiveTypeDef methodWithPrimitiveTypeDef(TypeDefs_PrimitiveTypeDef input) => $prototype.methodWithPrimitiveTypeDef(input);
+  static TypeDefs_ComplexTypeDef methodWithComplexTypeDef(TypeDefs_ComplexTypeDef input) => $prototype.methodWithComplexTypeDef(input);
+  static TypeDefs_NestedIntTypeDef returnNestedIntTypeDef(TypeDefs_NestedIntTypeDef input) => $prototype.returnNestedIntTypeDef(input);
+  static TypeDefs_TestStructTypeDef returnTestStructTypeDef(TypeDefs_TestStructTypeDef input) => $prototype.returnTestStructTypeDef(input);
+  static TypeDefs_NestedStructTypeDef returnNestedStructTypeDef(TypeDefs_NestedStructTypeDef input) => $prototype.returnNestedStructTypeDef(input);
+  static PointTypeDef returnTypeDefPointFromTypeCollection(PointTypeDef input) => $prototype.returnTypeDefPointFromTypeCollection(input);
+  List<TypeDefs_PrimitiveTypeDef> get primitiveTypeProperty;
+  set primitiveTypeProperty(List<TypeDefs_PrimitiveTypeDef> value);
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = TypeDefs$Impl(Pointer<Void>.fromAddress(0));
 }
+typedef TypeDefs_NestedIntTypeDef = TypeDefs_PrimitiveTypeDef;
+typedef TypeDefs_PrimitiveTypeDef = double;
+typedef TypeDefs_StructArray = List<TypeDefs_TestStruct>;
+typedef TypeDefs_ComplexTypeDef = TypeDefs_StructArray;
+typedef TypeDefs_TestStructTypeDef = TypeDefs_TestStruct;
+typedef TypeDefs_NestedStructTypeDef = TypeDefs_TestStructTypeDef;
 class TypeDefs_StructHavingAliasFieldDefinedBelow {
-  double field;
+  TypeDefs_PrimitiveTypeDef field;
   TypeDefs_StructHavingAliasFieldDefinedBelow(this.field);
 }
 // TypeDefs_StructHavingAliasFieldDefinedBelow "private" section, not exported.
@@ -162,7 +168,7 @@ final _smokeTypedefsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
 @visibleForTesting
 class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
   TypeDefs$Impl(Pointer<Void> handle) : super(handle);
-  double methodWithPrimitiveTypeDef(double input) {
+  TypeDefs_PrimitiveTypeDef methodWithPrimitiveTypeDef(TypeDefs_PrimitiveTypeDef input) {
     final _methodWithPrimitiveTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _methodWithPrimitiveTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -171,7 +177,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     } finally {
     }
   }
-  List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
+  TypeDefs_ComplexTypeDef methodWithComplexTypeDef(TypeDefs_ComplexTypeDef input) {
     final _methodWithComplexTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_smoke_TypeDefs_TestStruct'));
     final _inputHandle = foobarListofSmokeTypedefsTeststructToFfi(input);
     final __resultHandle = _methodWithComplexTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -182,7 +188,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       foobarListofSmokeTypedefsTeststructReleaseFfiHandle(__resultHandle);
     }
   }
-  double returnNestedIntTypeDef(double input) {
+  TypeDefs_NestedIntTypeDef returnNestedIntTypeDef(TypeDefs_NestedIntTypeDef input) {
     final _returnNestedIntTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _returnNestedIntTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -191,7 +197,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     } finally {
     }
   }
-  TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
+  TypeDefs_TestStructTypeDef returnTestStructTypeDef(TypeDefs_TestStructTypeDef input) {
     final _returnTestStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct'));
     final _inputHandle = smokeTypedefsTeststructToFfi(input);
     final __resultHandle = _returnTestStructTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -202,7 +208,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       smokeTypedefsTeststructReleaseFfiHandle(__resultHandle);
     }
   }
-  TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
+  TypeDefs_NestedStructTypeDef returnNestedStructTypeDef(TypeDefs_NestedStructTypeDef input) {
     final _returnNestedStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct'));
     final _inputHandle = smokeTypedefsTeststructToFfi(input);
     final __resultHandle = _returnNestedStructTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -213,7 +219,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       smokeTypedefsTeststructReleaseFfiHandle(__resultHandle);
     }
   }
-  TypeCollection_Point returnTypeDefPointFromTypeCollection(TypeCollection_Point input) {
+  PointTypeDef returnTypeDefPointFromTypeCollection(PointTypeDef input) {
     final _returnTypeDefPointFromTypeCollectionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point'));
     final _inputHandle = smokeTypecollectionPointToFfi(input);
     final __resultHandle = _returnTypeDefPointFromTypeCollectionFfi(__lib.LibraryContext.isolateId, _inputHandle);
@@ -225,7 +231,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     }
   }
   @override
-  List<double> get primitiveTypeProperty {
+  List<TypeDefs_PrimitiveTypeDef> get primitiveTypeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
@@ -236,7 +242,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     }
   }
   @override
-  set primitiveTypeProperty(List<double> value) {
+  set primitiveTypeProperty(List<TypeDefs_PrimitiveTypeDef> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_Double'));
     final _valueHandle = foobarListofDoubleToFfi(value);
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
@@ -3,8 +3,15 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 abstract class PublicClass {
 }
+/// @nodoc
+typedef _PublicClass_InternalArray = List<PublicClass_InternalStruct>;
+/// @nodoc
+typedef _PublicClass_InternalStructTypeDef = PublicClass_InternalStruct;
+/// @nodoc
+typedef _PublicClass_StringToInternalStructMap = Map<String, PublicClass_InternalStruct>;
 /// @nodoc
 enum PublicClass_InternalEnum {
     foo,


### PR DESCRIPTION
Added dedicated DartTypeAlias template, as type aliases (typedefs) are now
supported in Dart language (since Dart version 2.13). Updated other Dart
tempates and resolvers to treat type aliases as a normal type, instead of
skipping it through to the target type.

Added/updated related smoke and functional tests.

Unrelated smoke tests are updated in a separate commit.

Resolves: #907
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>