### PR TITLE
Improve C++ code for field constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Removed unnecessary automatic all-fields constructor for structs with "field constructors" in C++.
+
 ## 10.2.3
 Release date: 2021-11-10
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/FieldConstructors.lime
+++ b/functional-tests/functional/input/lime/FieldConstructors.lime
@@ -54,7 +54,7 @@ struct ImmutableStructNoClash {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
-    @Dart("withAll")
+    @Dart("withDefaults")
     field constructor()
 }
 
@@ -67,6 +67,13 @@ struct ImmutableStructWithClash {
     field constructor()
     @Dart(Default)
     field constructor(boolField, intField, stringField)
+}
+
+struct MutableStructImmutableFields {
+    structField: ImmutableStructNoClash = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
 }
 
 struct FieldCustomConstructorsMix {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
@@ -83,7 +83,12 @@ internal object CppGeneratorPredicates {
             }
         },
         "needsAllFieldsConstructor" to { limeStruct: Any ->
-            limeStruct is LimeStruct && limeStruct.allFieldsConstructor == null
+            when {
+                limeStruct !is LimeStruct -> false
+                limeStruct.fieldConstructors.isEmpty() -> true
+                CommonGeneratorPredicates.hasImmutableFields(limeStruct) -> limeStruct.allFieldsConstructor == null
+                else -> false
+            }
         },
         "needsPointerValueEqual" to fun(limeField: Any): Boolean {
             if (limeField !is LimeField) return false

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
@@ -69,6 +69,13 @@ struct ImmutableStructWithClash {
     field constructor(boolField, intField, stringField)
 }
 
+struct MutableStructImmutableFields {
+    structField: ImmutableStructNoClash = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
+}
+
 struct FieldCustomConstructorsMix {
     stringField: String = "nonsense"
     intField: Int = 42

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipDefault.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipDefault.h
@@ -12,6 +12,5 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorsSkipDefault {
     int32_t int_field = 42;
     FieldConstructorsSkipDefault( );
     FieldConstructorsSkipDefault( ::std::string string_field );
-    FieldConstructorsSkipDefault( ::std::string string_field, int32_t int_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/MutableStructImmutableFields.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/MutableStructImmutableFields.h
@@ -4,15 +4,14 @@
 // -------------------------------------------------------------------------------------------------
 #pragma once
 #include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ImmutableStructNoClash.h"
 #include <cstdint>
-#include <string>
 namespace smoke {
-struct _GLUECODIUM_CPP_EXPORT FieldCustomConstructorsMix {
-    ::std::string string_field = "nonsense";
+struct _GLUECODIUM_CPP_EXPORT MutableStructImmutableFields {
+    ::smoke::ImmutableStructNoClash struct_field = {};
     int32_t int_field = 42;
     bool bool_field = true;
-    FieldCustomConstructorsMix( );
-    FieldCustomConstructorsMix( int32_t int_field );
-    static ::smoke::FieldCustomConstructorsMix create_me( const int32_t int_value, const double dummy );
+    MutableStructImmutableFields(  );
+    MutableStructImmutableFields( ::smoke::ImmutableStructNoClash struct_field, int32_t int_field, bool bool_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/src/smoke/FieldCustomConstructorsMix.cpp
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/src/smoke/FieldCustomConstructorsMix.cpp
@@ -12,8 +12,4 @@ FieldCustomConstructorsMix::FieldCustomConstructorsMix( int32_t int_field )
     : int_field( std::move( int_field ) )
 {
 }
-FieldCustomConstructorsMix::FieldCustomConstructorsMix( ::std::string string_field, int32_t int_field, bool bool_field )
-    : string_field( std::move( string_field ) ), int_field( std::move( int_field ) ), bool_field( std::move( bool_field ) )
-{
-}
 }


### PR DESCRIPTION
Updated C++ generator predicates to skip generating an "all-fields" constructor
for a mutable struct that has any explicit "field constructors" specified.
Previously it was needed due to legacy code in Dart FFI bindings, but that
legacy code is now removed.

This change does *not* affect:
* structs without "field constructors"
* immutable structs

Updated affected smoke tests. The functional tests pass without changes,
confirming that the removed constructor is no longer needed for any bindings
code.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>