### PR TITLE
Add missing conversion includes in JNI for "descendant interfaces"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Removed unnecessary automatic all-fields constructor for structs with "field constructors" in C++.
+  * Fixed missing includes in JNI for some cases of interface inheritance.
 
 ## 10.2.3
 Release date: 2021-11-10

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterface__Conversion.cpp
@@ -3,6 +3,7 @@
  */
 #include "com_example_smoke_ChildInterface__Conversion.h"
 #include "com_example_smoke_ChildInterfaceImplCppProxy.h"
+#include "com_example_smoke_GrandChildInterface__Conversion.h"
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"
 #include "JniClassCache.h"

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ParentInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ParentInterface__Conversion.cpp
@@ -2,6 +2,9 @@
  *
  */
 #include "com_example_smoke_ParentInterface__Conversion.h"
+#include "com_example_foobar_CrossPackageChildInterface__Conversion.h"
+#include "com_example_smoke_ChildInterface__Conversion.h"
+#include "com_example_smoke_GrandChildInterface__Conversion.h"
 #include "com_example_smoke_ParentInterfaceImplCppProxy.h"
 #include "CppProxyBase.h"
 #include "FieldAccessMethods.h"


### PR DESCRIPTION
Updated JniTemplates and JniResolver to add necessary conversion includes when
"descendant interfaces" JNI code is generated for interface conversion.

Updated affected smoke test.

Resolves: #1134
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>