### PR TITLE
Detect parameterless field constructors in Dart name resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Dart compilation issue when using a struct with `field constructor()` to initialize a field of another struct.
+
 ## 10.2.4
 Release date: 2021-11-12
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/FieldConstructors.lime
+++ b/functional-tests/functional/input/lime/FieldConstructors.lime
@@ -54,7 +54,7 @@ struct ImmutableStructNoClash {
     stringField: String = "nonsense"
     intField: Int = 42
     boolField: Boolean = true
-    @Dart("withDefaults")
+    @Dart("withAll")
     field constructor()
 }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -155,7 +155,11 @@ internal class DartNameResolver(
                     throw GluecodiumExecutionException("Unsupported type ${actualType.javaClass.name} for struct initializer")
                 }
                 val useDefaultsConstructor = actualType.fields.isNotEmpty() && limeValue.values.isEmpty()
-                val constructorName = if (useDefaultsConstructor) ".withDefaults" else ""
+                val constructorName = when {
+                    useDefaultsConstructor ->
+                        actualType.noFieldsConstructor?.let { ".${resolveName(it)}" } ?: ".withDefaults"
+                    else -> ""
+                }
                 limeValue.values.joinToString(
                     prefix = "${resolveName(limeValue.typeRef)}$constructorName(",
                     postfix = ")",

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_immutable_fields.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_immutable_fields.dart
@@ -1,0 +1,88 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/immutable_struct_no_clash.dart';
+class MutableStructImmutableFields {
+  ImmutableStructNoClash structField;
+  int intField;
+  bool boolField;
+  MutableStructImmutableFields._(this.structField, this.intField, this.boolField);
+  MutableStructImmutableFields()
+      : structField = ImmutableStructNoClash.withAll(), intField = 42, boolField = true;
+}
+// MutableStructImmutableFields "private" section, not exported.
+final _smokeMutablestructimmutablefieldsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_MutableStructImmutableFields_create_handle'));
+final _smokeMutablestructimmutablefieldsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFields_release_handle'));
+final _smokeMutablestructimmutablefieldsGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFields_get_field_structField'));
+final _smokeMutablestructimmutablefieldsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFields_get_field_intField'));
+final _smokeMutablestructimmutablefieldsGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFields_get_field_boolField'));
+Pointer<Void> smokeMutablestructimmutablefieldsToFfi(MutableStructImmutableFields value) {
+  final _structFieldHandle = smokeImmutablestructnoclashToFfi(value.structField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeMutablestructimmutablefieldsCreateHandle(_structFieldHandle, _intFieldHandle, _boolFieldHandle);
+  smokeImmutablestructnoclashReleaseFfiHandle(_structFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+MutableStructImmutableFields smokeMutablestructimmutablefieldsFromFfi(Pointer<Void> handle) {
+  final _structFieldHandle = _smokeMutablestructimmutablefieldsGetFieldstructField(handle);
+  final _intFieldHandle = _smokeMutablestructimmutablefieldsGetFieldintField(handle);
+  final _boolFieldHandle = _smokeMutablestructimmutablefieldsGetFieldboolField(handle);
+  try {
+    return MutableStructImmutableFields._(
+      smokeImmutablestructnoclashFromFfi(_structFieldHandle),
+      (_intFieldHandle),
+      booleanFromFfi(_boolFieldHandle)
+    );
+  } finally {
+    smokeImmutablestructnoclashReleaseFfiHandle(_structFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeMutablestructimmutablefieldsReleaseFfiHandle(Pointer<Void> handle) => _smokeMutablestructimmutablefieldsReleaseHandle(handle);
+// Nullable MutableStructImmutableFields
+final _smokeMutablestructimmutablefieldsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFields_create_handle_nullable'));
+final _smokeMutablestructimmutablefieldsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFields_release_handle_nullable'));
+final _smokeMutablestructimmutablefieldsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFields_get_value_nullable'));
+Pointer<Void> smokeMutablestructimmutablefieldsToFfiNullable(MutableStructImmutableFields? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeMutablestructimmutablefieldsToFfi(value);
+  final result = _smokeMutablestructimmutablefieldsCreateHandleNullable(_handle);
+  smokeMutablestructimmutablefieldsReleaseFfiHandle(_handle);
+  return result;
+}
+MutableStructImmutableFields? smokeMutablestructimmutablefieldsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeMutablestructimmutablefieldsGetValueNullable(handle);
+  final result = smokeMutablestructimmutablefieldsFromFfi(_handle);
+  smokeMutablestructimmutablefieldsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeMutablestructimmutablefieldsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeMutablestructimmutablefieldsReleaseHandleNullable(handle);
+// End of MutableStructImmutableFields "private" section.

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
@@ -67,4 +67,7 @@ class LimeStruct(
 
     val allFieldsConstructor
         get() = fieldConstructors.firstOrNull { it.fieldRefs.size == fields.size }
+
+    val noFieldsConstructor
+        get() = fieldConstructors.firstOrNull { it.fieldRefs.isEmpty() }
 }


### PR DESCRIPTION
Updated DartNameResolver to detect a parameterless field constructor when
resolving names for field default values of struct type. Previously it was
hard-coded to always use `withDefaults()` constructor name.

This fixes a compilation issue when using a struct with `field constructor()` to
initialize a field of another struct.

Updated existing smoke and functional tests to serve as regression tests for
this issue.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
