### PR TITLE
Fix compilation issue for nameless field constructors in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Dart compilation issue when using a struct with a nameless constructor to init a field of another struct.
+
 ## 10.2.5
 Release date: 2021-11-12
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -153,6 +153,7 @@ feature(FieldConstructors cpp android swift dart SOURCES
     input/src/cpp/FieldConstructors.cpp
 
     input/lime/FieldConstructors.lime
+    input/lime/FieldConstructorsInit.lime
     input/lime/FieldConstructorsNesting.lime
 )
 

--- a/functional-tests/functional/cpp/googletest-download.cmake.in
+++ b/functional-tests/functional/cpp/googletest-download.cmake.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/functional-tests/functional/input/lime/FieldConstructors.lime
+++ b/functional-tests/functional/input/lime/FieldConstructors.lime
@@ -69,13 +69,6 @@ struct ImmutableStructWithClash {
     field constructor(boolField, intField, stringField)
 }
 
-struct MutableStructImmutableFields {
-    structField: ImmutableStructNoClash = {}
-    intField: Int = 42
-    boolField: Boolean = true
-    field constructor()
-}
-
 struct FieldCustomConstructorsMix {
     stringField: String = "nonsense"
     intField: Int = 42

--- a/functional-tests/functional/input/lime/FieldConstructorsInit.lime
+++ b/functional-tests/functional/input/lime/FieldConstructorsInit.lime
@@ -1,0 +1,49 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct ImmutableNamelessCtor {
+    stringField: String = ""
+    field constructor()
+}
+
+struct ImmutableDefaultCtor {
+    stringField: String = ""
+    field constructor()
+}
+
+struct MutableStructImmutableFields {
+    structField: ImmutableStructNoClash = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
+}
+
+struct MutableStructImmutableFieldsNameless {
+    structField: ImmutableNamelessCtor = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
+}
+
+struct MutableStructImmutableFieldsDefault {
+    structField: ImmutableDefaultCtor = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -155,10 +155,12 @@ internal class DartNameResolver(
                     throw GluecodiumExecutionException("Unsupported type ${actualType.javaClass.name} for struct initializer")
                 }
                 val useDefaultsConstructor = actualType.fields.isNotEmpty() && limeValue.values.isEmpty()
+                val noFieldsConstructor = actualType.noFieldsConstructor
                 val constructorName = when {
-                    useDefaultsConstructor ->
-                        actualType.noFieldsConstructor?.let { ".${resolveName(it)}" } ?: ".withDefaults"
-                    else -> ""
+                    !useDefaultsConstructor -> ""
+                    noFieldsConstructor != null ->
+                        resolveName(noFieldsConstructor).let { if (it.isEmpty()) "" else ".$it" }
+                    else -> ".withDefaults"
                 }
                 limeValue.values.joinToString(
                     prefix = "${resolveName(limeValue.typeRef)}$constructorName(",

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
@@ -69,13 +69,6 @@ struct ImmutableStructWithClash {
     field constructor(boolField, intField, stringField)
 }
 
-struct MutableStructImmutableFields {
-    structField: ImmutableStructNoClash = {}
-    intField: Int = 42
-    boolField: Boolean = true
-    field constructor()
-}
-
 struct FieldCustomConstructorsMix {
     stringField: String = "nonsense"
     intField: Int = 42

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructorsInit.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructorsInit.lime
@@ -1,0 +1,49 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct ImmutableNamelessCtor {
+    stringField: String = ""
+    field constructor()
+}
+
+struct ImmutableDefaultCtor {
+    stringField: String = ""
+    field constructor()
+}
+
+struct MutableStructImmutableFields {
+    structField: ImmutableStructNoClash = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
+}
+
+struct MutableStructImmutableFieldsNameless {
+    structField: ImmutableNamelessCtor = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
+}
+
+struct MutableStructImmutableFieldsDefault {
+    structField: ImmutableDefaultCtor = {}
+    intField: Int = 42
+    boolField: Boolean = true
+    field constructor()
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_immutable_fields_default.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_immutable_fields_default.dart
@@ -1,0 +1,88 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/immutable_default_ctor.dart';
+class MutableStructImmutableFieldsDefault {
+  ImmutableDefaultCtor structField;
+  int intField;
+  bool boolField;
+  MutableStructImmutableFieldsDefault._(this.structField, this.intField, this.boolField);
+  MutableStructImmutableFieldsDefault()
+      : structField = ImmutableDefaultCtor(), intField = 42, boolField = true;
+}
+// MutableStructImmutableFieldsDefault "private" section, not exported.
+final _smokeMutablestructimmutablefieldsdefaultCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_MutableStructImmutableFieldsDefault_create_handle'));
+final _smokeMutablestructimmutablefieldsdefaultReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsDefault_release_handle'));
+final _smokeMutablestructimmutablefieldsdefaultGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsDefault_get_field_structField'));
+final _smokeMutablestructimmutablefieldsdefaultGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsDefault_get_field_intField'));
+final _smokeMutablestructimmutablefieldsdefaultGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsDefault_get_field_boolField'));
+Pointer<Void> smokeMutablestructimmutablefieldsdefaultToFfi(MutableStructImmutableFieldsDefault value) {
+  final _structFieldHandle = smokeImmutabledefaultctorToFfi(value.structField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeMutablestructimmutablefieldsdefaultCreateHandle(_structFieldHandle, _intFieldHandle, _boolFieldHandle);
+  smokeImmutabledefaultctorReleaseFfiHandle(_structFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+MutableStructImmutableFieldsDefault smokeMutablestructimmutablefieldsdefaultFromFfi(Pointer<Void> handle) {
+  final _structFieldHandle = _smokeMutablestructimmutablefieldsdefaultGetFieldstructField(handle);
+  final _intFieldHandle = _smokeMutablestructimmutablefieldsdefaultGetFieldintField(handle);
+  final _boolFieldHandle = _smokeMutablestructimmutablefieldsdefaultGetFieldboolField(handle);
+  try {
+    return MutableStructImmutableFieldsDefault._(
+      smokeImmutabledefaultctorFromFfi(_structFieldHandle),
+      (_intFieldHandle),
+      booleanFromFfi(_boolFieldHandle)
+    );
+  } finally {
+    smokeImmutabledefaultctorReleaseFfiHandle(_structFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeMutablestructimmutablefieldsdefaultReleaseFfiHandle(Pointer<Void> handle) => _smokeMutablestructimmutablefieldsdefaultReleaseHandle(handle);
+// Nullable MutableStructImmutableFieldsDefault
+final _smokeMutablestructimmutablefieldsdefaultCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsDefault_create_handle_nullable'));
+final _smokeMutablestructimmutablefieldsdefaultReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsDefault_release_handle_nullable'));
+final _smokeMutablestructimmutablefieldsdefaultGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsDefault_get_value_nullable'));
+Pointer<Void> smokeMutablestructimmutablefieldsdefaultToFfiNullable(MutableStructImmutableFieldsDefault? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeMutablestructimmutablefieldsdefaultToFfi(value);
+  final result = _smokeMutablestructimmutablefieldsdefaultCreateHandleNullable(_handle);
+  smokeMutablestructimmutablefieldsdefaultReleaseFfiHandle(_handle);
+  return result;
+}
+MutableStructImmutableFieldsDefault? smokeMutablestructimmutablefieldsdefaultFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeMutablestructimmutablefieldsdefaultGetValueNullable(handle);
+  final result = smokeMutablestructimmutablefieldsdefaultFromFfi(_handle);
+  smokeMutablestructimmutablefieldsdefaultReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeMutablestructimmutablefieldsdefaultReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeMutablestructimmutablefieldsdefaultReleaseHandleNullable(handle);
+// End of MutableStructImmutableFieldsDefault "private" section.

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_immutable_fields_nameless.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/mutable_struct_immutable_fields_nameless.dart
@@ -1,0 +1,88 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/immutable_nameless_ctor.dart';
+class MutableStructImmutableFieldsNameless {
+  ImmutableNamelessCtor structField;
+  int intField;
+  bool boolField;
+  MutableStructImmutableFieldsNameless._(this.structField, this.intField, this.boolField);
+  MutableStructImmutableFieldsNameless()
+      : structField = ImmutableNamelessCtor(), intField = 42, boolField = true;
+}
+// MutableStructImmutableFieldsNameless "private" section, not exported.
+final _smokeMutablestructimmutablefieldsnamelessCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
+    Pointer<Void> Function(Pointer<Void>, int, int)
+  >('library_smoke_MutableStructImmutableFieldsNameless_create_handle'));
+final _smokeMutablestructimmutablefieldsnamelessReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsNameless_release_handle'));
+final _smokeMutablestructimmutablefieldsnamelessGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsNameless_get_field_structField'));
+final _smokeMutablestructimmutablefieldsnamelessGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsNameless_get_field_intField'));
+final _smokeMutablestructimmutablefieldsnamelessGetFieldboolField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsNameless_get_field_boolField'));
+Pointer<Void> smokeMutablestructimmutablefieldsnamelessToFfi(MutableStructImmutableFieldsNameless value) {
+  final _structFieldHandle = smokeImmutablenamelessctorToFfi(value.structField);
+  final _intFieldHandle = (value.intField);
+  final _boolFieldHandle = booleanToFfi(value.boolField);
+  final _result = _smokeMutablestructimmutablefieldsnamelessCreateHandle(_structFieldHandle, _intFieldHandle, _boolFieldHandle);
+  smokeImmutablenamelessctorReleaseFfiHandle(_structFieldHandle);
+  booleanReleaseFfiHandle(_boolFieldHandle);
+  return _result;
+}
+MutableStructImmutableFieldsNameless smokeMutablestructimmutablefieldsnamelessFromFfi(Pointer<Void> handle) {
+  final _structFieldHandle = _smokeMutablestructimmutablefieldsnamelessGetFieldstructField(handle);
+  final _intFieldHandle = _smokeMutablestructimmutablefieldsnamelessGetFieldintField(handle);
+  final _boolFieldHandle = _smokeMutablestructimmutablefieldsnamelessGetFieldboolField(handle);
+  try {
+    return MutableStructImmutableFieldsNameless._(
+      smokeImmutablenamelessctorFromFfi(_structFieldHandle),
+      (_intFieldHandle),
+      booleanFromFfi(_boolFieldHandle)
+    );
+  } finally {
+    smokeImmutablenamelessctorReleaseFfiHandle(_structFieldHandle);
+    booleanReleaseFfiHandle(_boolFieldHandle);
+  }
+}
+void smokeMutablestructimmutablefieldsnamelessReleaseFfiHandle(Pointer<Void> handle) => _smokeMutablestructimmutablefieldsnamelessReleaseHandle(handle);
+// Nullable MutableStructImmutableFieldsNameless
+final _smokeMutablestructimmutablefieldsnamelessCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsNameless_create_handle_nullable'));
+final _smokeMutablestructimmutablefieldsnamelessReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsNameless_release_handle_nullable'));
+final _smokeMutablestructimmutablefieldsnamelessGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_MutableStructImmutableFieldsNameless_get_value_nullable'));
+Pointer<Void> smokeMutablestructimmutablefieldsnamelessToFfiNullable(MutableStructImmutableFieldsNameless? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeMutablestructimmutablefieldsnamelessToFfi(value);
+  final result = _smokeMutablestructimmutablefieldsnamelessCreateHandleNullable(_handle);
+  smokeMutablestructimmutablefieldsnamelessReleaseFfiHandle(_handle);
+  return result;
+}
+MutableStructImmutableFieldsNameless? smokeMutablestructimmutablefieldsnamelessFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeMutablestructimmutablefieldsnamelessGetValueNullable(handle);
+  final result = smokeMutablestructimmutablefieldsnamelessFromFfi(_handle);
+  smokeMutablestructimmutablefieldsnamelessReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeMutablestructimmutablefieldsnamelessReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeMutablestructimmutablefieldsnamelessReleaseHandleNullable(handle);
+// End of MutableStructImmutableFieldsNameless "private" section.


### PR DESCRIPTION
Updated Dart name resolver to correctly stop prepending a dot to a field
constructor name if that name is empty. This fixes an issue where a struct with
such constructor is used to initialize a field of another struct.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>