### PR TITLE
Use "lime full name" in CommentsProcessor

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommentsProcessor.kt
@@ -65,7 +65,7 @@ abstract class CommentsProcessor(private val renderer: IRender, private val werr
                 val child = (path.take(i) + normalizedReference).joinToString(".")
                 val element = limeToLanguage[child]
                 if (element != null) {
-                    processLink(it, element)
+                    processLink(it, element, child)
                     return@VisitHandler
                 }
             }
@@ -96,7 +96,7 @@ abstract class CommentsProcessor(private val renderer: IRender, private val werr
         return name + "(" + signature.split(",").joinToString(",") { it.split('.').last() }
     }
 
-    abstract fun processLink(linkNode: LinkRef, linkReference: String)
+    abstract fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String)
     open fun processAutoLink(linkNode: AutoLink) {}
     open val nullReference = standardNullReference
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/DoxygenCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/DoxygenCommentsProcessor.kt
@@ -28,7 +28,7 @@ import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 internal class DoxygenCommentsProcessor(werror: Boolean) :
     CommentsProcessor(Formatter.builder().build(), werror) {
 
-    override fun processLink(linkNode: LinkRef, linkReference: String) {
+    override fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String) {
         linkNode.reference = BasedSequenceImpl.of(linkReference)
         // Doxygen documentation claims that \link classname Alternative title \endlink is the
         // correct way to have a link with alternative title, however it only works for a small

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
@@ -28,7 +28,7 @@ import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 internal class DartCommentsProcessor(werror: Boolean) :
     CommentsProcessor(Formatter.builder().build(), werror) {
 
-    override fun processLink(linkNode: LinkRef, linkReference: String) {
+    override fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String) {
         linkNode.reference = BasedSequenceImpl.of(linkReference)
         linkNode.referenceOpeningMarker = BasedSequenceImpl.of("[")
         linkNode.referenceClosingMarker = BasedSequenceImpl.of("]")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaDocProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaDocProcessor.kt
@@ -31,7 +31,7 @@ import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 internal class JavaDocProcessor(werror: Boolean) :
     CommentsProcessor(HtmlRenderer.builder().build(), werror) {
 
-    override fun processLink(linkNode: LinkRef, linkReference: String) {
+    override fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String) {
         linkNode.chars = BasedSequenceImpl.of("{@link $linkReference}")
         linkNode.firstChild?.unlink()
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftCommentsProcessor.kt
@@ -34,7 +34,7 @@ import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
 class SwiftCommentsProcessor(werror: Boolean) :
     CommentsProcessor(Formatter.builder(FORMATTER_OPTIONS).build(), werror) {
 
-    override fun processLink(linkNode: LinkRef, linkReference: String) {
+    override fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String) {
         linkNode.reference = BasedSequenceImpl.of(linkReference)
         linkNode.referenceOpeningMarker = BasedSequenceImpl.of("`")
         linkNode.referenceClosingMarker = BasedSequenceImpl.of("`")


### PR DESCRIPTION
Refactored CommentsProcessor to pass "lime full name" to the `processLink()`
function. This enables diffentiating between LIME element types when processing
links in descendant comment processors.

See: #1173
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>