### PR TITLE
Use `@code` for JavaDoc parameter references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * JavaDoc comments in the generated Java code now use `@hidden` JDK11 tag instead of `@exclude` custom tag.
+  * JavaDoc comments in the generated Java code now use `@code parameterName` for reference links to parameters.
 
 ## 10.2.6
 Release date: 2021-11-22

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.common.LimeModelFilter
 import com.here.gluecodium.common.LimeModelSkipPredicates
-import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.GeneratorOptions
@@ -59,7 +58,7 @@ internal class JavaGenerator : Generator {
     private lateinit var internalPackage: List<String>
     private lateinit var internalNamespace: List<String>
     private lateinit var rootNamespace: List<String>
-    private lateinit var commentsProcessor: CommentsProcessor
+    private lateinit var werror: Set<String>
     private lateinit var cppNameRules: CppNameRules
     private lateinit var javaNameRules: JavaNameRules
     private lateinit var basePackages: List<String>
@@ -74,7 +73,7 @@ internal class JavaGenerator : Generator {
         internalPackage = options.javaInternalPackages
         internalNamespace = options.cppInternalNamespace
         rootNamespace = options.cppRootNamespace
-        commentsProcessor = JavaDocProcessor(options.werror.contains(GeneratorOptions.WARNING_DOC_LINKS))
+        werror = options.werror
         cppNameRules = CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
         javaNameRules = JavaNameRules(nameRuleSetFromConfig(options.javaNameRules))
         nonNullAnnotation = annotationFromOption(options.javaNonNullAnnotation)
@@ -99,6 +98,8 @@ internal class JavaGenerator : Generator {
             throw GluecodiumExecutionException("Validation errors found, see log for details.")
         }
 
+        val commentsProcessor =
+            JavaDocProcessor(werror.contains(GeneratorOptions.WARNING_DOC_LINKS), javaFilteredModel.referenceMap)
         val nameResolver = JavaNameResolver(
             limeReferenceMap = limeModel.referenceMap,
             basePackages = basePackages,

--- a/gluecodium/src/test/java/com/here/gluecodium/model/common/JavaDocProcessorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/model/common/JavaDocProcessorTest.kt
@@ -31,7 +31,7 @@ import java.util.logging.Logger
 class JavaDocProcessorTest {
     private val limeLogger =
         LimeLogger(Logger.getLogger(JavaDocProcessorTest::class.java.name), emptyMap())
-    private val commentsProcessor = JavaDocProcessor(false)
+    private val commentsProcessor = JavaDocProcessor(false, emptyMap())
 
     @Test
     fun simple() {

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsLinks.java
@@ -55,7 +55,7 @@ public final class CommentsLinks extends NativeBase {
      * <li>method: {@link com.example.smoke.Comments#someMethodWithAllComments}</li>
      * <li>method with signature: {@link com.example.smoke.Comments#oneParameterCommentOnly}</li>
      * <li>method with signature with no spaces: {@link com.example.smoke.Comments#oneParameterCommentOnly}</li>
-     * <li>parameter: {@link com.example.smoke.CommentsLinks#randomMethod#inputParameter}</li>
+     * <li>parameter: {@code inputParameter}</li>
      * <li>top level constant: {@link com.example.smoke.CommentsTypeCollection#TYPE_COLLECTION_CONSTANT}</li>
      * <li>top level struct: {@link com.example.smoke.TypeCollectionStruct}</li>
      * <li>top level struct field: {@link com.example.smoke.TypeCollectionStruct#field}</li>


### PR DESCRIPTION
Resolves: #1173
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>