### PR TITLE
Handle immutable external structs correctly in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed Dart compilation issue for `@Immutable` structs with `external.cpp` descriptor.
+
 ## 10.2.7
 Release date: 2021-11-25
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -302,6 +302,7 @@ feature(ExternalTypes cpp android swift dart SOURCES
     input/src/cpp/UseExternalTypes.cpp
     input/src/cpp/UseMyClass.cpp
 
+    input/lime/ExternalImmutable.lime
     input/lime/ExternalTypes.lime
     input/lime/ExternalClassAsInterface.lime
     input/lime/UseExternalTypes.lime

--- a/functional-tests/functional/input/lime/ExternalImmutable.lime
+++ b/functional-tests/functional/input/lime/ExternalImmutable.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Immutable
+struct DurationExternal {
+    external {
+        cpp include "include/ExternalTypes.h"
+        cpp name "std::chrono::duration<uint64_t, std::ratio<1,1000>>"
+    }
+    value: ULong external {
+        cpp getterName "count"
+    }
+}

--- a/functional-tests/functional/input/src/cpp/include/ExternalTypes.h
+++ b/functional-tests/functional/input/src/cpp/include/ExternalTypes.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <system_error>
 #include <vector>

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -51,7 +51,6 @@ import com.here.gluecodium.model.lime.LimeAttributeType.DART
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeClass
-import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
@@ -258,12 +257,7 @@ internal class DartGenerator : Generator {
         val interfaces = types.filterIsInstance<LimeInterface>()
         val classes = types.filterIsInstance<LimeClass>() + interfaces
         val enums = types.filterIsInstance<LimeEnumeration>()
-
         val structs = types.filterIsInstance<LimeStruct>()
-        val externalTypes = types.filter { it.external?.cpp != null }
-        val externalStructs = externalTypes.filterIsInstance<LimeStruct>() +
-            externalTypes.filterIsInstance<LimeContainer>().flatMap { it.structs }
-        val nonExternalStructs = structs - externalStructs
 
         val packagePath = rootElement.path.head.joinToString(separator = "_")
         val fileName = "ffi_${packagePath}_${nameRules.getName(rootElement)}"
@@ -275,8 +269,7 @@ internal class DartGenerator : Generator {
             "interfaces" to interfaces,
             "lambdas" to lambdas,
             "typeRepositories" to getTypeRepositories(types),
-            "externalStructs" to externalStructs,
-            "nonExternalStructs" to nonExternalStructs,
+            "structs" to structs,
             "internalNamespace" to internalNamespace,
             "headerName" to fileName,
             "includes" to includeCollector.collectImports(limeType).distinct().sorted()

--- a/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
@@ -56,14 +56,14 @@ _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_create_pr
 }}{{#if setter}}, FfiOpaqueHandle p{{iter.position}}s{{/if}}{{/ifPredicate}}{{/unless}}{{/each}});
 {{/each}}
 
-{{#each nonExternalStructs externalStructs}}
+{{#structs}}
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_create_handle({{#fields}}{{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
 _GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_release_handle(FfiOpaqueHandle handle);
 {{#set parent=this}}{{#fields}}
 _GLUECODIUM_FFI_EXPORT {{resolveName typeRef}} {{libraryName}}_{{resolveName parent}}_get_field_{{resolveName}}(FfiOpaqueHandle handle);
 {{/fields}}{{/set}}
 {{#set type=this handleType="FfiOpaqueHandle"}}{{>ffi/FfiNullableDeclaration}}{{/set}}
-{{/each}}
+{{/structs}}
 
 {{#enums}}
 {{#set type=this handleType="uint32_t"}}{{>ffi/FfiNullableDeclaration}}{{/set}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -134,7 +134,7 @@ FfiOpaqueHandle
 
 {{/lambdas}}
 
-{{#nonExternalStructs}}
+{{#structs}}
 FfiOpaqueHandle
 {{libraryName}}_{{resolveName}}_create_handle({{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}) {
 {{#ifPredicate "hasImmutableFields"}}
@@ -150,17 +150,7 @@ FfiOpaqueHandle
 }
 
 {{>ffiStructReleaseAndGetters}}
-{{/nonExternalStructs}}
-{{#externalStructs}}
-FfiOpaqueHandle
-{{libraryName}}_{{resolveName}}_create_handle({{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}) {
-    auto _result = new (std::nothrow) {{resolveName "C++"}}();
-{{#set struct=this}}{{#fields}}{{>ffiSetCppField}}{{/fields}}{{/set}}
-    return reinterpret_cast<FfiOpaqueHandle>(_result);
-}
-
-{{>ffiStructReleaseAndGetters}}
-{{/externalStructs}}
+{{/structs}}
 
 {{#enums}}
 {{#set type=this handleType="uint32_t"}}{{>ffi/FfiNullableImpl}}{{/set}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiNullableImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiNullableImpl.mustache
@@ -23,7 +23,13 @@ FfiOpaqueHandle
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) {{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName type "C++"}}>(
+{{#instanceOf type "LimeStruct"}}{{#if type.external.cpp}}
+            *reinterpret_cast<{{resolveName type "C++"}}*>(value)
+{{/if}}{{#unless type.external.cpp}}
             {{>ffi/FfiInternal}}::Conversion<{{resolveName type "C++"}}>::toCpp(value)
+{{/unless}}{{/instanceOf}}{{#notInstanceOf type "LimeStruct"}}
+            {{>ffi/FfiInternal}}::Conversion<{{resolveName type "C++"}}>::toCpp(value)
+{{/notInstanceOf}}
         )
     );
 }
@@ -37,7 +43,17 @@ void
 {{handleType}}
 {{libraryName}}_{{internalPrefix}}{{resolveName type}}_get_value_nullable(FfiOpaqueHandle handle)
 {
+{{#instanceOf type "LimeStruct"}}{{#if type.external.cpp}}
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) {{resolveName type "C++"}}(
+        **reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName type "C++"}}>*>(handle)
+    ));
+{{/if}}{{#unless type.external.cpp}}
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName type "C++"}}>::toFfi(
         **reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName type "C++"}}>*>(handle)
     );
+{{/unless}}{{/instanceOf}}{{#notInstanceOf type "LimeStruct"}}
+    return {{>ffi/FfiInternal}}::Conversion<{{resolveName type "C++"}}>::toFfi(
+        **reinterpret_cast<{{#internalNamespace}}{{.}}::{{/internalNamespace}}optional<{{resolveName type "C++"}}>*>(handle)
+    );
+{{/notInstanceOf}}
 }

--- a/gluecodium/src/test/resources/smoke/external_types/input/ExternalImmutable.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/ExternalImmutable.lime
@@ -1,0 +1,29 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Immutable
+struct DurationExternal {
+    external {
+        cpp include "core/duration.h"
+        cpp name "std::chrono::duration<uint64_t, std::ratio<1,1000>>"
+    }
+    value: ULong external {
+        cpp getterName "count"
+    }
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_DurationExternal__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_DurationExternal__Conversion.cpp
@@ -1,0 +1,45 @@
+/*
+ *
+ */
+#include "com_example_smoke_DurationExternal__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+std::chrono::duration<uint64_t, std::ratio<1,1000>>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::chrono::duration<uint64_t, std::ratio<1,1000>>*)
+{
+    uint64_t n_value = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "value",
+        (uint64_t*)nullptr );
+    return std::chrono::duration<uint64_t, std::ratio<1,1000>>(std::move(n_value));
+}
+::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>(convert_from_jni(_jenv, _jinput, (std::chrono::duration<uint64_t, std::ratio<1,1000>>*)nullptr))
+        : ::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/DurationExternal", com_example_smoke_DurationExternal, std::chrono::duration<uint64_t, std::ratio<1,1000>>)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::chrono::duration<uint64_t, std::ratio<1,1000>>& _ninput)
+{
+    auto& javaClass = CachedJavaClass<std::chrono::duration<uint64_t, std::ratio<1,1000>>>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "value", _ninput.count());
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_DurationExternal.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cbridge/src/smoke/cbridge_DurationExternal.cpp
@@ -1,0 +1,40 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_DurationExternal.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "core/duration.h"
+#include "gluecodium/Optional.h"
+#include <cstdint>
+#include <memory>
+#include <new>
+_baseRef
+smoke_DurationExternal_create_handle( uint64_t value )
+{
+    auto _value = value;
+    std::chrono::duration<uint64_t, std::ratio<1,1000>>* _struct = new ( ::std::nothrow ) std::chrono::duration<uint64_t, std::ratio<1,1000>>( _value );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_DurationExternal_release_handle( _baseRef handle )
+{
+    delete get_pointer<std::chrono::duration<uint64_t, std::ratio<1,1000>>>( handle );
+}
+_baseRef
+smoke_DurationExternal_create_optional_handle(uint64_t value)
+{
+    auto _value = value;
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>( std::chrono::duration<uint64_t, std::ratio<1,1000>>( _value ) );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_DurationExternal_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>*>( handle ) );
+}
+void smoke_DurationExternal_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>*>( handle );
+}
+uint64_t smoke_DurationExternal_value_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const std::chrono::duration<uint64_t, std::ratio<1,1000>>>(handle);
+    return struct_pointer->count();
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_DurationExternal.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_DurationExternal.cpp
@@ -1,0 +1,48 @@
+#include "ffi_smoke_DurationExternal.h"
+#include "ConversionBase.h"
+#include "core/duration.h"
+#include <cstdint>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_DurationExternal_create_handle(uint64_t value) {
+    auto _result = new (std::nothrow) std::chrono::duration<uint64_t, std::ratio<1,1000>>(gluecodium::ffi::Conversion<uint64_t>::toCpp(value));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_DurationExternal_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::chrono::duration<uint64_t, std::ratio<1,1000>>*>(handle);
+}
+uint64_t
+library_smoke_DurationExternal_get_field_value(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<uint64_t>::toFfi(
+        reinterpret_cast<std::chrono::duration<uint64_t, std::ratio<1,1000>>*>(handle)->count()
+    );
+}
+FfiOpaqueHandle
+library_smoke_DurationExternal_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>(
+            *reinterpret_cast<std::chrono::duration<uint64_t, std::ratio<1,1000>>*>(value)
+        )
+    );
+}
+void
+library_smoke_DurationExternal_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DurationExternal_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::chrono::duration<uint64_t, std::ratio<1,1000>>(
+        **reinterpret_cast<gluecodium::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>*>(handle)
+    ));
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_Structs.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/ffi/ffi_smoke_Structs.cpp
@@ -97,7 +97,7 @@ library_smoke_Structs_ExternalStruct_create_handle_nullable(FfiOpaqueHandle valu
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<smoke::Structs::ExternalStruct>(
-            gluecodium::ffi::Conversion<smoke::Structs::ExternalStruct>::toCpp(value)
+            *reinterpret_cast<smoke::Structs::ExternalStruct*>(value)
         )
     );
 }
@@ -109,9 +109,9 @@ library_smoke_Structs_ExternalStruct_release_handle_nullable(FfiOpaqueHandle han
 FfiOpaqueHandle
 library_smoke_Structs_ExternalStruct_get_value_nullable(FfiOpaqueHandle handle)
 {
-    return gluecodium::ffi::Conversion<smoke::Structs::ExternalStruct>::toFfi(
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) smoke::Structs::ExternalStruct(
         **reinterpret_cast<gluecodium::optional<smoke::Structs::ExternalStruct>*>(handle)
-    );
+    ));
 }
 FfiOpaqueHandle
 library_smoke_Structs_AnotherExternalStruct_create_handle(int8_t intField) {
@@ -134,7 +134,7 @@ library_smoke_Structs_AnotherExternalStruct_create_handle_nullable(FfiOpaqueHand
 {
     return reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) gluecodium::optional<fire::SomeVeryExternalStruct>(
-            gluecodium::ffi::Conversion<fire::SomeVeryExternalStruct>::toCpp(value)
+            *reinterpret_cast<fire::SomeVeryExternalStruct*>(value)
         )
     );
 }
@@ -146,9 +146,9 @@ library_smoke_Structs_AnotherExternalStruct_release_handle_nullable(FfiOpaqueHan
 FfiOpaqueHandle
 library_smoke_Structs_AnotherExternalStruct_get_value_nullable(FfiOpaqueHandle handle)
 {
-    return gluecodium::ffi::Conversion<fire::SomeVeryExternalStruct>::toFfi(
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) fire::SomeVeryExternalStruct(
         **reinterpret_cast<gluecodium::optional<fire::SomeVeryExternalStruct>*>(handle)
-    );
+    ));
 }
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Updated Dart FFI templates to produce correct compilable code for structs that
are both `@Immutable` and have a `external.cpp` descriptor.

Added smoke and functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>