### PR TITLE
Add "strict" validation mode for immutable structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added `-strict` command line parameter to enable "strict" validation mode for `@Immutable` structs.
+
 ## 10.4.2
 Release date: 2021-12-10
 ### Bug fixes:

--- a/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
@@ -175,6 +175,15 @@ _gluecodium_define_target_property(
 )
 
 _gluecodium_define_target_property(
+  GLUECODIUM_STRICT_VALIDATION
+  BRIEF_DOCS "Enables 'strict' mode for validation"
+  FULL_DOCS
+    "When validated in 'strict' mode, `@Immutable` structs must have at least one explicit constructor defined."
+    "An explicit constructor is either a `field constructor` or a custom `constructor`."
+    "This property is initialized by the value of the GLUECODIUM_SWIFT_EXPOSE_INTERNALS variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
+_gluecodium_define_target_property(
   GLUECODIUM_DART_LIBRARY_NAME
   BRIEF_DOCS "Name of the generated library for Dart"
   FULL_DOCS

--- a/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
@@ -123,6 +123,7 @@ function(_prepare_gluecodium_config_file file_path)
   _append_boolean_value(cache ON)
   _append_boolean_value(validate "${GLUECODIUM_VALIDATE_ONLY}")
   _append_boolean_value(swiftexpose "${GLUECODIUM_SWIFT_EXPOSE_INTERNALS}")
+  _append_boolean_value(strict "${GLUECODIUM_STRICT_VALIDATION}")
 
   _append_list_option(generators GLUECODIUM_GENERATORS)
   _append_list_option(werror GLUECODIUM_WERROR)

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -167,7 +167,7 @@ class Gluecodium(
         listOf<(LimeModel) -> Boolean>(
             { LimeTypeRefTargetValidator(limeLogger).validate(it) },
             { LimeGenericTypesValidator(limeLogger).validate(it) },
-            { LimeStructsValidator(limeLogger).validate(it) },
+            { LimeStructsValidator(limeLogger, gluecodiumOptions.isStrictMode).validate(it) },
             { LimeSerializableStructsValidator(limeLogger).validate(it) },
             { LimeInheritanceValidator(limeLogger).validate(it) },
             { LimeFunctionsValidator(limeLogger).validate(it) },

--- a/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
@@ -26,5 +26,6 @@ data class GluecodiumOptions(
     var commonOutputDir: String = "",
     var generators: Set<String> = setOf(),
     var isValidatingOnly: Boolean = false,
-    var isEnableCaching: Boolean = false
+    var isEnableCaching: Boolean = false,
+    var isStrictMode: Boolean = false
 )

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -128,6 +128,7 @@ object OptionReader {
             false,
             "Expose `internal` Swift generated code as `public` for reuse across several frameworks."
         )
+        addOption("strict", "strict-mode", false, "Use 'strict' validation rules for `struct` declarations.")
         addOption("tag", true, "Add a custom tag for @Skip attributes.")
         addOption("cppnamerules", true, "C++ name rules property file.")
         addOption("javanamerules", true, "Java name rules property file.")
@@ -176,6 +177,7 @@ object OptionReader {
         gluecodiumOptions.generators = getStringListValue("generators")?.toSet() ?: emptySet()
         gluecodiumOptions.isValidatingOnly = getFlagValue("validate")
         gluecodiumOptions.isEnableCaching = getFlagValue("output") && getFlagValue("cache")
+        gluecodiumOptions.isStrictMode = getFlagValue("strict")
 
         val generatorOptions = GeneratorOptions()
 

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.test.NiceErrorCollector
 import io.mockk.every
 import io.mockk.spyk
 import junit.framework.TestCase
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Assume.assumeFalse
@@ -88,6 +89,7 @@ class SmokeTest(
         val inputDirectory = File(featureDirectory, FEATURE_INPUT_FOLDER)
         val auxDirectory = File(featureDirectory, FEATURE_AUX_FOLDER)
         val outputDirectory = File(featureDirectory, FEATURE_OUTPUT_FOLDER)
+        val validationShouldFail = File(inputDirectory, "validationfail.txt").exists()
 
         val generatorDirectories = listOf(generatorName) + (ADDITIONAL_GENERATOR_DIRS[generatorName] ?: emptyList())
         val referenceFiles = generatorDirectories
@@ -98,7 +100,13 @@ class SmokeTest(
         assumeFalse("No reference files were found", referenceFiles.isEmpty())
 
         val limeModel = LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()))
-        assertTrue(gluecodium.validateModel(limeModel))
+        val validationResult = gluecodium.validateModel(limeModel)
+        if (validationShouldFail) {
+            assertFalse(validationResult)
+            return
+        } else {
+            assertTrue(validationResult)
+        }
         assertTrue(gluecodium.executeGenerator(generatorName, limeModel, HashMap()))
 
         val generatedContents = results.associateBy({ it.targetFile.path }, { it.content })

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorStrictTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorStrictTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeFieldConstructor
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeStruct
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LimeStructsValidatorStrictTest {
+
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+
+    private val limeField = LimeField(EMPTY_PATH, typeRef = LimeBasicTypeRef.INT)
+    private val immutableAttributes =
+        LimeAttributes.Builder().addAttribute(LimeAttributeType.IMMUTABLE).build()
+
+    private val validator = LimeStructsValidator(mockk(relaxed = true), strictMode = true)
+
+    @Test
+    fun validateMutableStruct() {
+        allElements[""] = LimeStruct(EMPTY_PATH, fields = listOf(limeField))
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateImmutableStructWithNoConstructors() {
+        allElements[""] = LimeStruct(EMPTY_PATH, fields = listOf(limeField), attributes = immutableAttributes)
+
+        assertFalse(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateImmutableStructWithFieldConstructors() {
+        val fieldConstructor =
+            LimeFieldConstructor(EMPTY_PATH, structRef = LimeBasicTypeRef.INT, fieldRefs = emptyList())
+        allElements[""] = LimeStruct(
+            EMPTY_PATH,
+            fields = listOf(limeField),
+            attributes = immutableAttributes,
+            fieldConstructors = listOf(fieldConstructor)
+        )
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateImmutableStructWithCustomConstructors() {
+        val customConstructor = LimeFunction(EMPTY_PATH, isConstructor = true)
+        allElements[""] = LimeStruct(
+            EMPTY_PATH,
+            fields = listOf(limeField),
+            attributes = immutableAttributes,
+            functions = listOf(customConstructor)
+        )
+
+        assertTrue(validator.validate(limeModel))
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorTest.kt
@@ -48,7 +48,7 @@ class LimeStructsValidatorTest {
     private val equatableAttributes =
         LimeAttributes.Builder().addAttribute(LimeAttributeType.EQUATABLE).build()
 
-    private val validator = LimeStructsValidator(mockk(relaxed = true))
+    private val validator = LimeStructsValidator(mockk(relaxed = true), strictMode = false)
 
     @Test
     fun validateEquatableWithBasicType() {

--- a/gluecodium/src/test/resources/smoke/strict/input/StrictStructs.lime
+++ b/gluecodium/src/test/resources/smoke/strict/input/StrictStructs.lime
@@ -1,0 +1,30 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Immutable
+struct ImmutableWithFieldConstructor {
+    stringField: String = ""
+    field constructor()
+}
+
+@Immutable
+struct ImmutableWithCustomConstructor {
+    stringField: String = ""
+    constructor create()
+}

--- a/gluecodium/src/test/resources/smoke/strict/input/commandlineoptions.txt
+++ b/gluecodium/src/test/resources/smoke/strict/input/commandlineoptions.txt
@@ -1,0 +1,2 @@
+-input $INPUT_FOLDER
+-strict

--- a/gluecodium/src/test/resources/smoke/strict/output/lime/smoke/ImmutableWithCustomConstructor.lime
+++ b/gluecodium/src/test/resources/smoke/strict/output/lime/smoke/ImmutableWithCustomConstructor.lime
@@ -1,0 +1,6 @@
+package smoke
+@Immutable
+struct ImmutableWithCustomConstructor {
+    stringField: String = ""
+    constructor create()
+}

--- a/gluecodium/src/test/resources/smoke/strict/output/lime/smoke/ImmutableWithFieldConstructor.lime
+++ b/gluecodium/src/test/resources/smoke/strict/output/lime/smoke/ImmutableWithFieldConstructor.lime
@@ -1,0 +1,6 @@
+package smoke
+@Immutable
+struct ImmutableWithFieldConstructor {
+    stringField: String = ""
+    field constructor()
+}

--- a/gluecodium/src/test/resources/smoke/strict_fail/input/StrictStructsFail.lime
+++ b/gluecodium/src/test/resources/smoke/strict_fail/input/StrictStructsFail.lime
@@ -1,0 +1,24 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Immutable
+struct ImmutableWithNoConstructors {
+    stringField: String
+}
+

--- a/gluecodium/src/test/resources/smoke/strict_fail/input/commandlineoptions.txt
+++ b/gluecodium/src/test/resources/smoke/strict_fail/input/commandlineoptions.txt
@@ -1,0 +1,2 @@
+-input $INPUT_FOLDER
+-strict

--- a/gluecodium/src/test/resources/smoke/strict_fail/output/lime/smoke/StrictStructsFail.lime
+++ b/gluecodium/src/test/resources/smoke/strict_fail/output/lime/smoke/StrictStructsFail.lime
@@ -1,0 +1,3 @@
+package smoke
+
+# NOP


### PR DESCRIPTION
Added "-strict" command line option to enable strict mode for validation of
`@Immutable` structs. In this mode immutable structs without explicitly defined
constructors (`field constructor` or `constructor`) are considered invalid.

Added new unit and smoke tests.

Resolves: #1185
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>