### PR TITLE
Fix a line break issue for LimeDoc inline tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Bug fixes:
+  * Fixed an issue where a line break was not allowed in documentation comment inline tags if placed immediately after
+    the `@Platform` tag itself.
 ### Removed:
   * Removed deprecated `release()` methods in Dart.
 

--- a/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
@@ -48,3 +48,10 @@ class PlatformComments {
         nothing: String
     }
 }
+
+// Text {@Java middle
+// line break}{@Swift trailing line break
+// }{@Dart
+// leading line break}
+class PlatformCommentsLineBreaks {
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformCommentsLineBreaks.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/PlatformCommentsLineBreaks.java
@@ -1,0 +1,24 @@
+/*
+ *
+ */
+package com.example.smoke;
+import com.example.NativeBase;
+/**
+ * <p>Text middle
+ * line break
+ */
+public final class PlatformCommentsLineBreaks extends NativeBase {
+    /**
+     * For internal use only.
+     * @hidden
+     */
+    protected PlatformCommentsLineBreaks(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
@@ -1,0 +1,43 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+/// Text leading line break
+abstract class PlatformCommentsLineBreaks {
+}
+// PlatformCommentsLineBreaks "private" section, not exported.
+final _smokePlatformcommentslinebreaksRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_PlatformCommentsLineBreaks_register_finalizer'));
+final _smokePlatformcommentslinebreaksCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PlatformCommentsLineBreaks_copy_handle'));
+final _smokePlatformcommentslinebreaksReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PlatformCommentsLineBreaks_release_handle'));
+class PlatformCommentsLineBreaks$Impl extends __lib.NativeBase implements PlatformCommentsLineBreaks {
+  PlatformCommentsLineBreaks$Impl(Pointer<Void> handle) : super(handle);
+}
+Pointer<Void> smokePlatformcommentslinebreaksToFfi(PlatformCommentsLineBreaks value) =>
+  _smokePlatformcommentslinebreaksCopyHandle((value as __lib.NativeBase).handle);
+PlatformCommentsLineBreaks smokePlatformcommentslinebreaksFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is PlatformCommentsLineBreaks) return instance;
+  final _copiedHandle = _smokePlatformcommentslinebreaksCopyHandle(handle);
+  final result = PlatformCommentsLineBreaks$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokePlatformcommentslinebreaksRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokePlatformcommentslinebreaksReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokePlatformcommentslinebreaksReleaseHandle(handle);
+Pointer<Void> smokePlatformcommentslinebreaksToFfiNullable(PlatformCommentsLineBreaks? value) =>
+  value != null ? smokePlatformcommentslinebreaksToFfi(value) : Pointer<Void>.fromAddress(0);
+PlatformCommentsLineBreaks? smokePlatformcommentslinebreaksFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokePlatformcommentslinebreaksFromFfi(handle) : null;
+void smokePlatformcommentslinebreaksReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePlatformcommentslinebreaksReleaseHandle(handle);
+// End of PlatformCommentsLineBreaks "private" section.

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformCommentsLineBreaks.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/PlatformCommentsLineBreaks.swift
@@ -1,0 +1,83 @@
+//
+//
+import Foundation
+/// Text trailing line break
+public class PlatformCommentsLineBreaks {
+    let c_instance : _baseRef
+    init(cPlatformCommentsLineBreaks: _baseRef) {
+        guard cPlatformCommentsLineBreaks != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cPlatformCommentsLineBreaks
+    }
+    deinit {
+        smoke_PlatformCommentsLineBreaks_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_PlatformCommentsLineBreaks_release_handle(c_instance)
+    }
+}
+internal func getRef(_ ref: PlatformCommentsLineBreaks?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_PlatformCommentsLineBreaks_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_PlatformCommentsLineBreaks_release_handle)
+        : RefHolder(handle_copy)
+}
+extension PlatformCommentsLineBreaks: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+extension PlatformCommentsLineBreaks: Hashable {
+    /// :nodoc:
+    public static func == (lhs: PlatformCommentsLineBreaks, rhs: PlatformCommentsLineBreaks) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+internal func PlatformCommentsLineBreaks_copyFromCType(_ handle: _baseRef) -> PlatformCommentsLineBreaks {
+    if let swift_pointer = smoke_PlatformCommentsLineBreaks_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformCommentsLineBreaks {
+        return re_constructed
+    }
+    let result = PlatformCommentsLineBreaks(cPlatformCommentsLineBreaks: smoke_PlatformCommentsLineBreaks_copy_handle(handle))
+    smoke_PlatformCommentsLineBreaks_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func PlatformCommentsLineBreaks_moveFromCType(_ handle: _baseRef) -> PlatformCommentsLineBreaks {
+    if let swift_pointer = smoke_PlatformCommentsLineBreaks_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? PlatformCommentsLineBreaks {
+        smoke_PlatformCommentsLineBreaks_release_handle(handle)
+        return re_constructed
+    }
+    let result = PlatformCommentsLineBreaks(cPlatformCommentsLineBreaks: handle)
+    smoke_PlatformCommentsLineBreaks_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+internal func PlatformCommentsLineBreaks_copyFromCType(_ handle: _baseRef) -> PlatformCommentsLineBreaks? {
+    guard handle != 0 else {
+        return nil
+    }
+    return PlatformCommentsLineBreaks_moveFromCType(handle) as PlatformCommentsLineBreaks
+}
+internal func PlatformCommentsLineBreaks_moveFromCType(_ handle: _baseRef) -> PlatformCommentsLineBreaks? {
+    guard handle != 0 else {
+        return nil
+    }
+    return PlatformCommentsLineBreaks_moveFromCType(handle) as PlatformCommentsLineBreaks
+}
+internal func copyToCType(_ swiftClass: PlatformCommentsLineBreaks) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: PlatformCommentsLineBreaks) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: PlatformCommentsLineBreaks?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: PlatformCommentsLineBreaks?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}

--- a/lime-loader/src/main/antlr/LimedocParser.g4
+++ b/lime-loader/src/main/antlr/LimedocParser.g4
@@ -76,7 +76,7 @@ blockTagContent
     ;
 
 inlineTag
-      : '{@' tagName (WhiteSpace '@' tagName)* WhiteSpace inlineTagContent* '}'
+      : '{@' tagName (WhiteSpace '@' tagName)* (WhiteSpace | NewLine) inlineTagContent* '}'
       ;
 
 inlineTagContent


### PR DESCRIPTION
Updated LimeDoc grammar to support line breaks in inline tags immediately after
the tag name:
```
// {@Dart
// foo bar}
```

The line breaks at any other position inside the inline tag are already
supported. Added smoke test covering leading/middle/trailing line breaks.

Resolves: #1193
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>