### PR TITLE
Resolve the name of `@Dart(Default) field constructor()` correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Bug fixes:
   * Fixed an issue where a line break was not allowed in documentation comment inline tags if placed immediately after
     the `@Platform` tag itself.
+  * Fixed Dart compilation issue when a struct with `@Dart(Default) field constructor()` is used to initialize the value
+    of a field in another struct.
 ### Removed:
   * Removed deprecated `release()` methods in Dart.
 

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -259,6 +259,7 @@ feature(Defaults cpp android swift dart SOURCES
     input/src/cpp/Defaults.cpp
 
     input/lime/Defaults.lime
+    input/lime/DefaultsWithFcStruct.lime
     input/lime/PositionalDefaults.lime
     input/lime/PositionalEnumerators.lime
     input/lime/InternalEnumDefaults.lime

--- a/functional-tests/functional/input/lime/DefaultsWithFcStruct.lime
+++ b/functional-tests/functional/input/lime/DefaultsWithFcStruct.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct DefaultsWithFcStruct {
+    structField: FcStruct = {}
+    field constructor()
+}
+
+struct FcStruct {
+    stringField: String = ""
+    @Dart(Default)
+    field constructor()
+    @Dart("withValues")
+    field constructor(stringField)
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -158,9 +158,9 @@ internal class DartNameResolver(
                 val noFieldsConstructor = actualType.noFieldsConstructor
                 val constructorName = when {
                     !useDefaultsConstructor -> ""
-                    noFieldsConstructor != null ->
-                        resolveName(noFieldsConstructor).let { if (it.isEmpty()) "" else ".$it" }
-                    else -> ".withDefaults"
+                    noFieldsConstructor == null -> ".withDefaults"
+                    noFieldsConstructor.attributes.have(LimeAttributeType.DART, LimeAttributeValueType.DEFAULT) -> ""
+                    else -> resolveName(noFieldsConstructor).let { if (it.isEmpty()) "" else ".$it" }
                 }
                 limeValue.values.joinToString(
                     prefix = "${resolveName(limeValue.typeRef)}$constructorName(",

--- a/gluecodium/src/test/resources/smoke/defaults/input/DefaultsWithFcStruct.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/DefaultsWithFcStruct.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct DefaultsWithFcStruct {
+    structField: FcStruct = {}
+    field constructor()
+}
+
+struct FcStruct {
+    stringField: String = ""
+    @Dart(Default)
+    field constructor()
+    @Dart("withValues")
+    field constructor(stringField)
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/defaults_with_fc_struct.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/defaults_with_fc_struct.dart
@@ -1,0 +1,69 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/fc_struct.dart';
+class DefaultsWithFcStruct {
+  FcStruct structField;
+  DefaultsWithFcStruct._(this.structField);
+  DefaultsWithFcStruct()
+      : structField = FcStruct();
+}
+// DefaultsWithFcStruct "private" section, not exported.
+final _smokeDefaultswithfcstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DefaultsWithFcStruct_create_handle'));
+final _smokeDefaultswithfcstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DefaultsWithFcStruct_release_handle'));
+final _smokeDefaultswithfcstructGetFieldstructField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DefaultsWithFcStruct_get_field_structField'));
+Pointer<Void> smokeDefaultswithfcstructToFfi(DefaultsWithFcStruct value) {
+  final _structFieldHandle = smokeFcstructToFfi(value.structField);
+  final _result = _smokeDefaultswithfcstructCreateHandle(_structFieldHandle);
+  smokeFcstructReleaseFfiHandle(_structFieldHandle);
+  return _result;
+}
+DefaultsWithFcStruct smokeDefaultswithfcstructFromFfi(Pointer<Void> handle) {
+  final _structFieldHandle = _smokeDefaultswithfcstructGetFieldstructField(handle);
+  try {
+    return DefaultsWithFcStruct._(
+      smokeFcstructFromFfi(_structFieldHandle)
+    );
+  } finally {
+    smokeFcstructReleaseFfiHandle(_structFieldHandle);
+  }
+}
+void smokeDefaultswithfcstructReleaseFfiHandle(Pointer<Void> handle) => _smokeDefaultswithfcstructReleaseHandle(handle);
+// Nullable DefaultsWithFcStruct
+final _smokeDefaultswithfcstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DefaultsWithFcStruct_create_handle_nullable'));
+final _smokeDefaultswithfcstructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DefaultsWithFcStruct_release_handle_nullable'));
+final _smokeDefaultswithfcstructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DefaultsWithFcStruct_get_value_nullable'));
+Pointer<Void> smokeDefaultswithfcstructToFfiNullable(DefaultsWithFcStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDefaultswithfcstructToFfi(value);
+  final result = _smokeDefaultswithfcstructCreateHandleNullable(_handle);
+  smokeDefaultswithfcstructReleaseFfiHandle(_handle);
+  return result;
+}
+DefaultsWithFcStruct? smokeDefaultswithfcstructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDefaultswithfcstructGetValueNullable(handle);
+  final result = smokeDefaultswithfcstructFromFfi(_handle);
+  smokeDefaultswithfcstructReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDefaultswithfcstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDefaultswithfcstructReleaseHandleNullable(handle);
+// End of DefaultsWithFcStruct "private" section.


### PR DESCRIPTION
Updated DartNameResolver to correctly use an empty name for `@Dart(Default)
field constructor()` when initializing a field of another struct.

Added smoke and functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>