### PR TITLE
Revert "Remove deprecated release() method in Dart  (#1184)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
     the `@Platform` tag itself.
   * Fixed Dart compilation issue when a struct with `@Dart(Default) field constructor()` is used to initialize the value
     of a field in another struct.
-### Removed:
-  * Removed deprecated `release()` methods in Dart.
 
 ## 10.3.0
 Release date: 2021-12-01

--- a/functional-tests/functional/dart/test/CallbacksMultithreaded_test.dart
+++ b/functional-tests/functional/dart/test/CallbacksMultithreaded_test.dart
@@ -42,6 +42,9 @@ class ThreadedListenerImpl implements ThreadedListener {
     // Do nothing, no related Dart functionality.
     return 0;
   }
+
+  @override
+  void release() {}
 }
 
 void main(List<String> args) {

--- a/functional-tests/functional/dart/test/CppConstMethods_test.dart
+++ b/functional-tests/functional/dart/test/CppConstMethods_test.dart
@@ -27,6 +27,9 @@ final _testSuite = TestSuite("CppConstMethods");
 class CppConstCallback implements CppConstInterface {
   @override
   String getFoo() => "FOO";
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/ExternalTypes_test.dart
+++ b/functional-tests/functional/dart/test/ExternalTypes_test.dart
@@ -30,6 +30,9 @@ final _testSuite = TestSuite("ExternalTypes");
 class MyDartClass implements MyClass {
   @override
   int foo() => 77;
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/InterfaceWithStatic_test.dart
+++ b/functional-tests/functional/dart/test/InterfaceWithStatic_test.dart
@@ -30,6 +30,9 @@ class InterfaceWithStaticImpl implements InterfaceWithStatic {
 
   @override
   String regularProperty = "buzz2";
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/ListenerInheritance_test.dart
+++ b/functional-tests/functional/dart/test/ListenerInheritance_test.dart
@@ -27,11 +27,17 @@ final _testSuite = TestSuite("Listener inheritance");
 class ParentListenerImpl implements ParentListener {
   @override
   void listen() { }
+
+  @override
+  release() {}
 }
 
 class ChildListenerImpl implements ChildListener {
   @override
   void listen() { }
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/ListenersWithAttributes_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithAttributes_test.dart
@@ -29,6 +29,9 @@ final _testSuite = TestSuite("ListenersWithAttributes");
 class TestMessagePackage implements MessagePackage {
   @override
   String unpackMessage() => "Works";
+
+  @override
+  release() {}
 }
 
 class TestListener implements ListenerWithAttributes {
@@ -55,6 +58,9 @@ class TestListener implements ListenerWithAttributes {
 
   @override
   Uint8List bufferedMessage = Uint8List.fromList(utf8.encode("Doesn't work"));
+
+  @override
+  void release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/ListenersWithErrors_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithErrors_test.dart
@@ -43,6 +43,9 @@ class TestListener implements ErrorsInInterface {
   void setMessageWithPayload(String value) {
     _message = value;
   }
+
+  @override
+  release() {}
 }
 
 class ThrowingListener implements ErrorsInInterface {
@@ -67,6 +70,9 @@ class ThrowingListener implements ErrorsInInterface {
   void setMessageWithPayload(String value) {
     throw WithPayloadException(Payload(42, "foo"));
   }
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/ListenersWithReturnValues_test.dart
+++ b/functional-tests/functional/dart/test/ListenersWithReturnValues_test.dart
@@ -29,6 +29,9 @@ final _testSuite = TestSuite("ListenersWithReturnValues");
 class TestMessagePackage implements MessagePackage {
   @override
   String unpackMessage() => "Works";
+
+  @override
+  release() {}
 }
 
 class TestListener implements ListenerWithReturn {
@@ -57,6 +60,9 @@ class TestListener implements ListenerWithReturn {
 
   @override
   Uint8List getBufferedMessage() => Uint8List.fromList(utf8.encode("Works"));
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/Listeners_test.dart
+++ b/functional-tests/functional/dart/test/Listeners_test.dart
@@ -35,9 +35,15 @@ class MessageListener implements StringListener {
 
   @override
   void onStructMessage(StringListenerStringStruct message) {}
+
+  @override
+  release() {}
 }
 
-class RouteImpl implements Route {}
+class RouteImpl implements Route {
+  @override
+  release() {}
+}
 
 class RouteProviderImpl implements RouteProvider {
   static bool setRouteWasRun = false;
@@ -48,6 +54,9 @@ class RouteProviderImpl implements RouteProvider {
     setRouteWasRun = true;
     setRouteCouldCast = route is RouteImpl;
   }
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/MultiListener_test.dart
+++ b/functional-tests/functional/dart/test/MultiListener_test.dart
@@ -36,6 +36,9 @@ class MultiReceiver implements ReceiverA, ReceiverB {
   void receiveB(String message) {
     log.add("ReceiverB: received from Sender: " + message);
   }
+
+  @override
+  void release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/MultipleInheritance_test.dart
+++ b/functional-tests/functional/dart/test/MultipleInheritance_test.dart
@@ -41,6 +41,9 @@ class MultiInterfaceImpl implements MultiInterface {
   String parentFunctionLight() => "dart face";
   @override
   String parentPropertyLight = "";
+
+  @override
+  release() {}
 }
 
 void main() {

--- a/functional-tests/functional/dart/test/SkipElement_test.dart
+++ b/functional-tests/functional/dart/test/SkipElement_test.dart
@@ -28,6 +28,9 @@ final _testSuite = TestSuite("SkipElement");
 class SkipTagsInDartImpl implements SkipTagsInDart {
   @override
   void dontSkipTagged() {}
+
+  @override
+  void release() {}
 }
 
 void main() {

--- a/functional-tests/functional/input/lime/MethodOverloads.lime
+++ b/functional-tests/functional/input/lime/MethodOverloads.lime
@@ -72,6 +72,7 @@ class MethodOverloads {
 
 interface SpecialNames {
     fun create()
+    @Dart("reallyRelease")
     fun release()
     fun createProxy()
 }

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -28,6 +28,9 @@ abstract class {{resolveName}}{{!!
   }}) => $prototype.{{resolveName visibility}}{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/constructors}}{{/set}}
 
+{{prefixPartial "dart/DartReleaseDocs" "  "}}
+  void release();
+
 {{#set isInClass=true}}{{#constants}}
 {{prefixPartial "dart/DartConstant" "  "}}
 {{/constants}}{{/set}}
@@ -101,6 +104,9 @@ class {{resolveName}}$Impl extends {{#if this.parentClass}}{{resolveName this.pa
 }}{{#unless this.parentClass}}__lib.NativeBase{{/unless}} implements {{resolveName}} {
 
   {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
+
+  @override
+  void release() {}
 
 {{#set parent=this container=this ignoreStatic=true}}{{#constructors}}
 {{prefixPartial "dartConstructor" "  "}}

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -44,6 +44,9 @@ abstract class {{resolveName}}{{!!
   );
 {{/if}}
 
+{{prefixPartial "dart/DartReleaseDocs" "  "}}
+  void release() {}
+
 {{#set isInClass=true}}{{#constants}}
 {{prefixPartial "dart/DartConstant" "  "}}
 {{/constants}}{{/set}}
@@ -131,6 +134,9 @@ class {{resolveName}}$Lambdas implements {{resolveName}} {
 
   );
 
+  @override
+  void release() {}
+
 {{#each inheritedFunctions functions}}{{#unless isStatic}}
   @override
   {{>dart/DartFunctionSignature}} =>
@@ -154,6 +160,9 @@ class {{resolveName}}$Lambdas implements {{resolveName}} {
 class {{resolveName}}$Impl extends __lib.NativeBase implements {{resolveName}} {
 
   {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
+
+  @override
+  void release() {}
 
 {{#set ignoreStatic=true}}{{#set parent=this}}{{#each inheritedFunctions functions}}
   @override

--- a/gluecodium/src/main/resources/templates/dart/DartReleaseDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartReleaseDocs.mustache
@@ -1,0 +1,22 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+/// @nodoc
+@Deprecated("Does nothing")

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 @OnClass
 abstract class AttributesClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   @OnConstInClass
   static final bool pi = false;
   @OnFunctionInClass
@@ -30,7 +32,8 @@ final _smokeAttributesclassReleaseHandle = __lib.catchArgumentError(() => __lib.
   >('library_smoke_AttributesClass_release_handle'));
 class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
   AttributesClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void veryFun(@OnParameterInClass String param) {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesClass_veryFun__String'));

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -15,7 +15,9 @@ abstract class AttributesInterface {
     propGetLambda,
     propSetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   @OnConstInInterface
   static final bool pi = false;
   @OnFunctionInInterface
@@ -55,7 +57,8 @@ class AttributesInterface$Lambdas implements AttributesInterface {
     this.propGetLambda,
     this.propSetLambda
   );
-
+  @override
+  void release() {}
   @override
   void veryFun(@OnParameterInInterface String param) =>
     veryFunLambda(param);
@@ -66,7 +69,8 @@ class AttributesInterface$Lambdas implements AttributesInterface {
 }
 class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInterface {
   AttributesInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void veryFun(@OnParameterInInterface String param) {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_veryFun__String'));

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 /// Class comment
 @OnClass
 abstract class AttributesWithComments {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// Const comment
   @OnConstInClass
   static final bool pi = false;
@@ -102,7 +104,8 @@ final _smokeAttributeswithcommentsReleaseHandle = __lib.catchArgumentError(() =>
   >('library_smoke_AttributesWithComments_release_handle'));
 class AttributesWithComments$Impl extends __lib.NativeBase implements AttributesWithComments {
   AttributesWithComments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_veryFun'));

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 @Deprecated("")
 @OnClass
 abstract class AttributesWithDeprecated {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   @Deprecated("")
   @OnConstInClass
   static final bool pi = false;
@@ -101,7 +103,8 @@ final _smokeAttributeswithdeprecatedReleaseHandle = __lib.catchArgumentError(() 
   >('library_smoke_AttributesWithDeprecated_release_handle'));
 class AttributesWithDeprecated$Impl extends __lib.NativeBase implements AttributesWithDeprecated {
   AttributesWithDeprecated$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_veryFun'));

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -3,7 +3,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 abstract class MultipleAttributesDart {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   @Foo
   @Bar
   void noLists2();
@@ -40,7 +42,8 @@ final _smokeMultipleattributesdartReleaseHandle = __lib.catchArgumentError(() =>
   >('library_smoke_MultipleAttributesDart_release_handle'));
 class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAttributesDart {
   MultipleAttributesDart$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void noLists2() {
     final _noLists2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists2'));

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -3,7 +3,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 abstract class SpecialAttributes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   @Deprecated("foo\nbar")
   void withEscaping();
   @HackMerm -rf *
@@ -24,7 +26,8 @@ final _smokeSpecialattributesReleaseHandle = __lib.catchArgumentError(() => __li
   >('library_smoke_SpecialAttributes_release_handle'));
 class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttributes {
   SpecialAttributes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void withEscaping() {
     final _withEscapingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withEscaping'));

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class BasicTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static String stringFunction(String input) => $prototype.stringFunction(input);
   static bool boolFunction(bool input) => $prototype.boolFunction(input);
   static double floatFunction(double input) => $prototype.floatFunction(input);
@@ -39,7 +41,8 @@ final _smokeBasictypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
 @visibleForTesting
 class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
   BasicTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   String stringFunction(String input) {
     final _stringFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_BasicTypes_stringFunction__String'));
     final _inputHandle = stringToFfi(input);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// This is some very useful interface.
 abstract class Comments {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// This is some very useful constant.
   static final bool veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
@@ -352,7 +354,8 @@ final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => 
   >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error'));
 class Comments$Impl extends __lib.NativeBase implements Comments {
   Comments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -34,7 +34,9 @@ abstract class CommentsInterface {
     isSomePropertyGetLambda,
     isSomePropertySetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   /// This is some very useful constant.
   static final bool veryUseful = true;
   /// This is some very useful method that measures the usefulness of its input.
@@ -254,7 +256,8 @@ class CommentsInterface$Lambdas implements CommentsInterface {
     this.isSomePropertyGetLambda,
     this.isSomePropertySetLambda
   );
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
@@ -292,7 +295,8 @@ class CommentsInterface$Lambdas implements CommentsInterface {
 }
 class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterface {
   CommentsInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithAllComments__String'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -12,7 +12,9 @@ import 'package:library/src/smoke/comments.dart';
 ///
 /// [example1]: http://example.com/1
 abstract class CommentsLinks {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// Link types:
   /// * constant: [Comments.veryUseful]
   /// * struct: [Comments_SomeStruct]
@@ -158,7 +160,8 @@ final _randomMethodReturnHasError = __lib.catchArgumentError(() => __lib.nativeL
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error'));
 class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
   CommentsLinks$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
     final _randomMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Uint32), Pointer<Void> Function(Pointer<Void>, int, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
@@ -28,7 +28,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 ///
 /// [title](https://www.markdownguide.org/cheat-sheet/)
 abstract class CommentsMarkdown {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 // CommentsMarkdown "private" section, not exported.
 final _smokeCommentsmarkdownRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -45,7 +47,8 @@ final _smokeCommentsmarkdownReleaseHandle = __lib.catchArgumentError(() => __lib
   >('library_smoke_CommentsMarkdown_release_handle'));
 class CommentsMarkdown$Impl extends __lib.NativeBase implements CommentsMarkdown {
   CommentsMarkdown$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeCommentsmarkdownToFfi(CommentsMarkdown value) =>
   _smokeCommentsmarkdownCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -22,7 +22,9 @@ abstract class DeprecationComments {
     propertyButNotAccessorsGetLambda,
     propertyButNotAccessorsSetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   /// This is some very useful constant.
   @Deprecated("Unfortunately, this constant is deprecated. Use [Comments.veryUseful] instead.")
   static final bool veryUseful = true;
@@ -207,7 +209,8 @@ class DeprecationComments$Lambdas implements DeprecationComments {
     this.propertyButNotAccessorsGetLambda,
     this.propertyButNotAccessorsSetLambda
   );
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
@@ -222,7 +225,8 @@ class DeprecationComments$Lambdas implements DeprecationComments {
 }
 class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationComments {
   DeprecationComments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -16,7 +16,9 @@ abstract class DeprecationCommentsOnly {
     isSomePropertyGetLambda,
     isSomePropertySetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   @Deprecated("Unfortunately, this constant is deprecated.")
   static final bool veryUseful = true;
   /// [input] Very useful input parameter
@@ -178,7 +180,8 @@ class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
     this.isSomePropertyGetLambda,
     this.isSomePropertySetLambda
   );
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
@@ -189,7 +192,8 @@ class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
 }
 class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements DeprecationCommentsOnly {
   DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 /// This is some very useful class.
 /// @nodoc
 abstract class ExcludedComments {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// This is some very useful constant.
   /// @nodoc
   static final bool veryUseful = true;
@@ -286,7 +288,8 @@ final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => 
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_has_error'));
 class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments {
   ExcludedComments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedComments_someMethodWithAllComments__String'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -7,7 +7,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 /// This is some very useful interface.
 /// @nodoc
 abstract class ExcludedCommentsInterface {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
 }
 // ExcludedCommentsInterface "private" section, not exported.
 final _smokeExcludedcommentsinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -32,7 +34,8 @@ final _smokeExcludedcommentsinterfaceGetTypeId = __lib.catchArgumentError(() => 
   >('library_smoke_ExcludedCommentsInterface_get_type_id'));
 class ExcludedCommentsInterface$Impl extends __lib.NativeBase implements ExcludedCommentsInterface {
   ExcludedCommentsInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeExcludedcommentsinterfaceToFfi(ExcludedCommentsInterface value) {
   if (value is __lib.NativeBase) return _smokeExcludedcommentsinterfaceCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 /// @nodoc
 abstract class ExcludedCommentsOnly {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   static final bool veryUseful = true;
   /// @nodoc
@@ -262,7 +264,8 @@ final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => 
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_has_error'));
 class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedCommentsOnly {
   ExcludedCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -7,7 +7,9 @@ import 'package:meta/meta.dart';
 /// @nodoc
 @internal
 abstract class InternalClassWithComments {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// This is definitely internal
   ///
   /// @nodoc
@@ -28,7 +30,8 @@ final _smokeInternalclasswithcommentsReleaseHandle = __lib.catchArgumentError(()
   >('library_smoke_InternalClassWithComments_release_handle'));
 class InternalClassWithComments$Impl extends __lib.NativeBase implements InternalClassWithComments {
   InternalClassWithComments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void internal_doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 /// Referencing some type [MapScene.loadSceneWithInt].
 abstract class MapScene {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback);
   void loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback);
 }
@@ -107,7 +109,8 @@ final _smokeMapsceneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
   >('library_smoke_MapScene_release_handle'));
 class MapScene$Impl extends __lib.NativeBase implements MapScene {
   MapScene$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback) {
     final _loadSceneWithIntFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_MapScene_loadScene__Int_LoadSceneCallback_'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -18,7 +18,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 ///
 /// ```Some example code;```
 abstract class MultiLineComments {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// This is very important method.
   ///
   /// It has very important parameters.
@@ -54,7 +56,8 @@ final _smokeMultilinecommentsReleaseHandle = __lib.catchArgumentError(() => __li
   >('library_smoke_MultiLineComments_release_handle'));
 class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineComments {
   MultiLineComments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   double someMethodWithLongComment(String input, double ratio) {
     final _someMethodWithLongCommentFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32, Pointer<Void>, Double), double Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_MultiLineComments_someMethodWithLongComment__String_Double'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class PlatformComments {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// This is some very useless method that cannot have overloads.
   ///
   void doNothing();
@@ -179,7 +181,8 @@ final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => 
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error'));
 class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments {
   PlatformComments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
@@ -4,6 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 /// Text leading line break
 abstract class PlatformCommentsLineBreaks {
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 // PlatformCommentsLineBreaks "private" section, not exported.
 final _smokePlatformcommentslinebreaksRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -20,6 +23,8 @@ final _smokePlatformcommentslinebreaksReleaseHandle = __lib.catchArgumentError((
   >('library_smoke_PlatformCommentsLineBreaks_release_handle'));
 class PlatformCommentsLineBreaks$Impl extends __lib.NativeBase implements PlatformCommentsLineBreaks {
   PlatformCommentsLineBreaks$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  void release() {}
 }
 Pointer<Void> smokePlatformcommentslinebreaksToFfi(PlatformCommentsLineBreaks value) =>
   _smokePlatformcommentslinebreaksCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
 abstract class UnicodeComments {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// Süßölgefäß
   ///
   /// [input] שלום
@@ -47,7 +49,8 @@ final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => 
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error'));
 class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
   UnicodeComments$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -3,7 +3,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 abstract class CollectionConstants {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static final List<String> listConstant = ["foo", "bar"];
   static final Set<String> setConstant = {"foo", "bar"};
   static final Map<String, String> mapConstant = {"foo": "bar"};
@@ -24,7 +26,8 @@ final _smokeCollectionconstantsReleaseHandle = __lib.catchArgumentError(() => __
   >('library_smoke_CollectionConstants_release_handle'));
 class CollectionConstants$Impl extends __lib.NativeBase implements CollectionConstants {
   CollectionConstants$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeCollectionconstantsToFfi(CollectionConstants value) =>
   _smokeCollectionconstantsCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -3,7 +3,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 abstract class ConstantsInterface {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static final bool boolConstant = true;
   static final int intConstant = -11;
   static final int uintConstant = 4294967295;
@@ -82,7 +84,8 @@ final _smokeConstantsinterfaceReleaseHandle = __lib.catchArgumentError(() => __l
   >('library_smoke_ConstantsInterface_release_handle'));
 class ConstantsInterface$Impl extends __lib.NativeBase implements ConstantsInterface {
   ConstantsInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeConstantsinterfaceToFfi(ConstantsInterface value) =>
   _smokeConstantsinterfaceCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class StructConstants {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static final StructConstants_SomeStruct structConstant = StructConstants_SomeStruct("bar Buzz", 1.41);
   static final StructConstants_NestingStruct nestingStructConstant = StructConstants_NestingStruct(StructConstants_SomeStruct("nonsense", -2.82));
 }
@@ -159,7 +161,8 @@ final _smokeStructconstantsReleaseHandle = __lib.catchArgumentError(() => __lib.
   >('library_smoke_StructConstants_release_handle'));
 class StructConstants$Impl extends __lib.NativeBase implements StructConstants {
   StructConstants$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeStructconstantsToFfi(StructConstants value) =>
   _smokeStructconstantsCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -13,7 +13,9 @@ abstract class Constructors {
   factory Constructors.fromString(String input) => $prototype.fromString(input);
   factory Constructors.fromList(List<double> input) => $prototype.fromList(input);
   factory Constructors.create(int input) => $prototype.create(input);
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Constructors$Impl(Pointer<Void>.fromAddress(0));
@@ -114,7 +116,8 @@ final _fromStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLib
 @visibleForTesting
 class Constructors$Impl extends __lib.NativeBase implements Constructors {
   Constructors$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   Constructors $init() {
     final _result_handle = _$init();
     final _result = Constructors$Impl(_result_handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
 abstract class SingleNamedConstructor {
   factory SingleNamedConstructor.fooBar() => $prototype.fooBar();
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = SingleNamedConstructor$Impl(Pointer<Void>.fromAddress(0));
@@ -27,7 +29,8 @@ final _smokeSinglenamedconstructorReleaseHandle = __lib.catchArgumentError(() =>
 @visibleForTesting
 class SingleNamedConstructor$Impl extends __lib.NativeBase implements SingleNamedConstructor {
   SingleNamedConstructor$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   SingleNamedConstructor fooBar() {
     final _result_handle = _fooBar();
     final _result = SingleNamedConstructor$Impl(_result_handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
 abstract class SingleNamelessConstructor {
   factory SingleNamelessConstructor() => $prototype.create();
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = SingleNamelessConstructor$Impl(Pointer<Void>.fromAddress(0));
@@ -27,7 +29,8 @@ final _smokeSinglenamelessconstructorReleaseHandle = __lib.catchArgumentError(()
 @visibleForTesting
 class SingleNamelessConstructor$Impl extends __lib.NativeBase implements SingleNamelessConstructor {
   SingleNamelessConstructor$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   SingleNamelessConstructor create() {
     final _result_handle = _create();
     final _result = SingleNamelessConstructor$Impl(_result_handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 abstract class Dates {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   DateTime dateMethod(DateTime input);
   DateTime? nullableDateMethod(DateTime? input);
   DateTime get dateProperty;
@@ -102,7 +104,8 @@ final _smokeDatesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
   >('library_smoke_Dates_release_handle'));
 class Dates$Impl extends __lib.NativeBase implements Dates {
   Dates$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   DateTime dateMethod(DateTime input) {
     final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateMethod__Date'));

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 abstract class DatesSteady {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   DateTime dateMethod(DateTime input);
   DateTime? nullableDateMethod(DateTime? input);
   List<DateTime> dateListMethod(List<DateTime> input);
@@ -99,7 +101,8 @@ final _smokeDatessteadyReleaseHandle = __lib.catchArgumentError(() => __lib.nati
   >('library_smoke_DatesSteady_release_handle'));
 class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
   DatesSteady$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   DateTime dateMethod(DateTime input) {
     final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DatesSteady_dateMethod__Date'));

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class DefaultValues {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) => $prototype.processStructWithDefaults(input);
   /// @nodoc
   @visibleForTesting
@@ -687,7 +689,8 @@ final _smokeDefaultvaluesReleaseHandle = __lib.catchArgumentError(() => __lib.na
 @visibleForTesting
 class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
   DefaultValues$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
     final _processStructWithDefaultsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults'));
     final _inputHandle = smokeDefaultvaluesStructwithdefaultsToFfi(input);

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class DurationMilliseconds {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   Duration durationFunction(Duration input);
   Duration? nullableDurationFunction(Duration? input);
   Duration get durationProperty;
@@ -89,7 +91,8 @@ final _smokeDurationmillisecondsReleaseHandle = __lib.catchArgumentError(() => _
   >('library_smoke_DurationMilliseconds_release_handle'));
 class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMilliseconds {
   DurationMilliseconds$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Duration durationFunction(Duration input) {
     final _durationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DurationMilliseconds_durationFunction__Duration'));

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class DurationSeconds {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   Duration durationFunction(Duration input);
   Duration? nullableDurationFunction(Duration? input);
   Duration get durationProperty;
@@ -89,7 +91,8 @@ final _smokeDurationsecondsReleaseHandle = __lib.catchArgumentError(() => __lib.
   >('library_smoke_DurationSeconds_release_handle'));
 class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
   DurationSeconds$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Duration durationFunction(Duration input) {
     final _durationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DurationSeconds_durationFunction__Duration'));

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class Enums {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) => $prototype.methodWithEnumeration(input);
   static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) => $prototype.flipEnumValue(input);
   static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) => $prototype.extractEnumFromStruct(input);
@@ -215,7 +217,8 @@ final _smokeEnumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
 @visibleForTesting
 class Enums$Impl extends __lib.NativeBase implements Enums {
   Enums$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) {
     final _methodWithEnumerationFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_methodWithEnumeration__SimpleEnum'));
     final _inputHandle = smokeEnumsSimpleenumToFfi(input);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class EquatableInterface {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
 }
 // EquatableInterface "private" section, not exported.
 final _smokeEquatableinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -33,7 +35,8 @@ final __areEqual = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunc
   >('library_smoke_EquatableInterface_get_type_id'));
 class EquatableInterface$Impl extends __lib.NativeBase implements EquatableInterface {
   EquatableInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -7,7 +7,9 @@ import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'package:meta/meta.dart';
 abstract class Errors {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static void methodWithErrors() => $prototype.methodWithErrors();
   static void methodWithExternalErrors() => $prototype.methodWithExternalErrors();
   static String methodWithErrorsAndReturnValue() => $prototype.methodWithErrorsAndReturnValue();
@@ -225,7 +227,8 @@ final _methodWithPayloadErrorAndReturnValueReturnHasError = __lib.catchArgumentE
 @visibleForTesting
 class Errors$Impl extends __lib.NativeBase implements Errors {
   Errors$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
     final __callResultHandle = _methodWithErrorsFfi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -17,7 +17,9 @@ abstract class ErrorsInterface {
     methodWithExternalErrorsLambda,
     methodWithErrorsAndReturnValueLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void methodWithErrors();
   void methodWithExternalErrors();
   String methodWithErrorsAndReturnValue();
@@ -248,7 +250,8 @@ class ErrorsInterface$Lambdas implements ErrorsInterface {
     this.methodWithExternalErrorsLambda,
     this.methodWithErrorsAndReturnValueLambda,
   );
-
+  @override
+  void release() {}
   @override
   void methodWithErrors() =>
     methodWithErrorsLambda();
@@ -263,7 +266,8 @@ class ErrorsInterface$Lambdas implements ErrorsInterface {
 @visibleForTesting
 class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
   ErrorsInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors'));

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -10,7 +10,9 @@ import 'package:library/src/package/types.dart';
 import 'package:meta/meta.dart';
 abstract class Class implements Interface {
   factory Class() => $prototype.constructor();
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   Struct fun(List<Struct> double);
   Enum get property;
   set property(Enum value);
@@ -55,7 +57,8 @@ final _funReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lo
 @visibleForTesting
 class Class$Impl extends __lib.NativeBase implements Class {
   Class$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   Class constructor() {
     final _result_handle = _constructor();
     final _result = Class$Impl(_result_handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class Interface {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
 }
 // Interface "private" section, not exported.
 final _packageInterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -30,7 +32,8 @@ final _packageInterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLi
   >('library_package_Interface_get_type_id'));
 class Interface$Impl extends __lib.NativeBase implements Interface {
   Interface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> packageInterfaceToFfi(Interface value) {
   if (value is __lib.NativeBase) return _packageInterfaceCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
 abstract class Enums {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static void methodWithExternalEnum(Enums_ExternalEnum input) => $prototype.methodWithExternalEnum(input);
   /// @nodoc
   @visibleForTesting
@@ -137,7 +139,8 @@ final _smokeEnumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
 @visibleForTesting
 class Enums$Impl extends __lib.NativeBase implements Enums {
   Enums$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   void methodWithExternalEnum(Enums_ExternalEnum input) {
     final _methodWithExternalEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Uint32), void Function(int, int)>('library_smoke_Enums_methodWithExternalEnum__External_Enum'));
     final _inputHandle = smokeEnumsExternalenumToFfi(input);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class ExternalClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void someMethod(int someParameter);
   String get someProperty;
 }
@@ -137,7 +139,8 @@ final _smokeExternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.na
   >('library_smoke_ExternalClass_release_handle'));
 class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
   ExternalClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void someMethod(int someParameter) {
     final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalClass_someMethod__Byte'));

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -12,7 +12,9 @@ abstract class ExternalInterface {
     someMethodLambda,
     somePropertyGetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void someMethod(int someParameter);
   String get someProperty;
 }
@@ -158,7 +160,8 @@ class ExternalInterface$Lambdas implements ExternalInterface {
     this.someMethodLambda,
     this.somePropertyGetLambda
   );
-
+  @override
+  void release() {}
   @override
   void someMethod(int someParameter) =>
     someMethodLambda(someParameter);
@@ -167,7 +170,8 @@ class ExternalInterface$Lambdas implements ExternalInterface {
 }
 class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterface {
   ExternalInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void someMethod(int someParameter) {
     final _someMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int8), void Function(Pointer<Void>, int, int)>('library_smoke_ExternalInterface_someMethod__Byte'));

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class Structs {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static Structs_ExternalStruct getExternalStruct() => $prototype.getExternalStruct();
   static Structs_AnotherExternalStruct getAnotherExternalStruct() => $prototype.getAnotherExternalStruct();
   /// @nodoc
@@ -186,7 +188,8 @@ final _smokeStructsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
 @visibleForTesting
 class Structs$Impl extends __lib.NativeBase implements Structs {
   Structs$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   Structs_ExternalStruct getExternalStruct() {
     final _getExternalStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getExternalStruct'));
     final __resultHandle = _getExternalStructFfi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -10,7 +10,9 @@ import 'package:library/src/smoke/rectangle_int_.dart';
 import 'package:library/src/smoke/string.dart';
 import 'package:meta/meta.dart';
 abstract class UseDartExternalTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) => $prototype.rectangleRoundTrip(input);
   static bar.HttpClientResponseCompressionState compressionStateRoundTrip(bar.HttpClientResponseCompressionState input) => $prototype.compressionStateRoundTrip(input);
   static int colorRoundTrip(int input) => $prototype.colorRoundTrip(input);
@@ -36,7 +38,8 @@ final _smokeUsedartexternaltypesReleaseHandle = __lib.catchArgumentError(() => _
 @visibleForTesting
 class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExternalTypes {
   UseDartExternalTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) {
     final _rectangleRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_rectangleRoundTrip__Rectangle'));
     final _inputHandle = smokeRectangleToFfi(input);

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class OuterName {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 class Futhark {
   String stringField;
@@ -85,7 +87,8 @@ final _smokeOuternameReleaseHandle = __lib.catchArgumentError(() => __lib.native
   >('library_smoke_OuterName_release_handle'));
 class OuterName$Impl extends __lib.NativeBase implements OuterName {
   OuterName$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeOuternameToFfi(OuterName value) =>
   _smokeOuternameCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/outer_name.dart';
 abstract class UseInnerName {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   Futhark doFoo();
 }
 // UseInnerName "private" section, not exported.
@@ -22,7 +24,8 @@ final _smokeUseinnernameReleaseHandle = __lib.catchArgumentError(() => __lib.nat
   >('library_smoke_UseInnerName_release_handle'));
 class UseInnerName$Impl extends __lib.NativeBase implements UseInnerName {
   UseInnerName$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Futhark doFoo() {
     final _doFooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_UseInnerName_doFoo'));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
 abstract class GenericTypesWithBasicTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   List<int> methodWithList(List<int> input);
   Map<int, bool> methodWithMap(Map<int, bool> input);
   Set<int> methodWithSet(Set<int> input);
@@ -117,7 +119,8 @@ final _smokeGenerictypeswithbasictypesReleaseHandle = __lib.catchArgumentError((
   >('library_smoke_GenericTypesWithBasicTypes_release_handle'));
 class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements GenericTypesWithBasicTypes {
   GenericTypesWithBasicTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   List<int> methodWithList(List<int> input) {
     final _methodWithListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithList__ListOf_Int'));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -7,7 +7,9 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/dummy_class.dart';
 import 'package:library/src/smoke/dummy_interface.dart';
 abstract class GenericTypesWithCompoundTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input);
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input);
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input);
@@ -268,7 +270,8 @@ final _smokeGenerictypeswithcompoundtypesReleaseHandle = __lib.catchArgumentErro
   >('library_smoke_GenericTypesWithCompoundTypes_release_handle'));
 class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements GenericTypesWithCompoundTypes {
   GenericTypesWithCompoundTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input) {
     final _methodWithStructListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructList__ListOf_smoke_GenericTypesWithCompoundTypes_BasicStruct'));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
 abstract class GenericTypesWithGenericTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   List<List<int>> methodWithListOfLists(List<List<int>> input);
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input);
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input);
@@ -28,7 +30,8 @@ final _smokeGenerictypeswithgenerictypesReleaseHandle = __lib.catchArgumentError
   >('library_smoke_GenericTypesWithGenericTypes_release_handle'));
 class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements GenericTypesWithGenericTypes {
   GenericTypesWithGenericTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   List<List<int>> methodWithListOfLists(List<List<int>> input) {
     final _methodWithListOfListsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListOfLists__ListOf_foobar_ListOf_Int'));

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -8,7 +8,9 @@ import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
 import 'package:meta/meta.dart';
 abstract class UseOptimizedList {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static List<VeryBigStruct> fetchTheBigOnes() => $prototype.fetchTheBigOnes();
   static List<UnreasonablyLazyClass> get lazyOnes => $prototype.lazyOnes;
   /// @nodoc
@@ -56,7 +58,8 @@ final _smokeUseoptimizedlistsmokeVerybigstructLazyListRegisterFinalizer = __lib.
 @visibleForTesting
 class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList {
   UseOptimizedList$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   List<VeryBigStruct> fetchTheBigOnes() {
     final _fetchTheBigOnesFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_UseOptimizedList_fetchTheBigOnes'));
     final __resultHandle = _fetchTheBigOnesFfi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -6,7 +6,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 abstract class ChildClassFromClass implements ParentClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void childClassMethod();
 }
 // ChildClassFromClass "private" section, not exported.
@@ -28,7 +30,8 @@ final _smokeChildclassfromclassGetTypeId = __lib.catchArgumentError(() => __lib.
   >('library_smoke_ChildClassFromClass_get_type_id'));
 class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFromClass {
   ChildClassFromClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod'));

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -6,7 +6,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 abstract class ChildClassFromInterface implements ParentInterface {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void childClassMethod();
 }
 // ChildClassFromInterface "private" section, not exported.
@@ -28,7 +30,8 @@ final _smokeChildclassfrominterfaceGetTypeId = __lib.catchArgumentError(() => __
   >('library_smoke_ChildClassFromInterface_get_type_id'));
 class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClassFromInterface {
   ChildClassFromInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
@@ -6,7 +6,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class_with_imports.dart';
 abstract class ChildClassWithImports implements ParentClassWithImports {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 // ChildClassWithImports "private" section, not exported.
 final _smokeChildclasswithimportsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -27,7 +29,8 @@ final _smokeChildclasswithimportsGetTypeId = __lib.catchArgumentError(() => __li
   >('library_smoke_ChildClassWithImports_get_type_id'));
 class ChildClassWithImports$Impl extends ParentClassWithImports$Impl implements ChildClassWithImports {
   ChildClassWithImports$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeChildclasswithimportsToFfi(ChildClassWithImports value) =>
   _smokeChildclasswithimportsCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -18,7 +18,9 @@ abstract class ChildInterface implements ParentInterface {
     rootPropertyGetLambda,
     rootPropertySetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void childMethod();
 }
 // ChildInterface "private" section, not exported.
@@ -53,7 +55,8 @@ class ChildInterface$Lambdas implements ChildInterface {
     this.rootPropertyGetLambda,
     this.rootPropertySetLambda
   );
-
+  @override
+  void release() {}
   @override
   void rootMethod() =>
     rootMethodLambda();
@@ -67,7 +70,8 @@ class ChildInterface$Lambdas implements ChildInterface {
 }
 class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
   ChildInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -8,7 +8,9 @@ import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
 abstract class ChildWithParentClassReferences implements ParentWithClassReferences {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 // ChildWithParentClassReferences "private" section, not exported.
 final _smokeChildwithparentclassreferencesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -29,7 +31,8 @@ final _smokeChildwithparentclassreferencesGetTypeId = __lib.catchArgumentError((
   >('library_smoke_ChildWithParentClassReferences_get_type_id'));
 class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements ChildWithParentClassReferences {
   ChildWithParentClassReferences$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   ChildClassFromClass classFunction() {
     final _classFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classFunction'));

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class ParentClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void rootMethod();
   String get rootProperty;
   set rootProperty(String value);
@@ -29,7 +31,8 @@ final _smokeParentclassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLi
   >('library_smoke_ParentClass_get_type_id'));
 class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
   ParentClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod'));

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -16,7 +16,9 @@ abstract class ParentInterface {
     rootPropertyGetLambda,
     rootPropertySetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void rootMethod();
   String get rootProperty;
   set rootProperty(String value);
@@ -51,7 +53,8 @@ class ParentInterface$Lambdas implements ParentInterface {
     this.rootPropertyGetLambda,
     this.rootPropertySetLambda
   );
-
+  @override
+  void release() {}
   @override
   void rootMethod() =>
     rootMethodLambda();
@@ -62,7 +65,8 @@ class ParentInterface$Lambdas implements ParentInterface {
 }
 class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
   ParentInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class SimpleClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   String getStringValue();
   SimpleClass useSimpleClass(SimpleClass input);
 }
@@ -23,7 +25,8 @@ final _smokeSimpleclassReleaseHandle = __lib.catchArgumentError(() => __lib.nati
   >('library_smoke_SimpleClass_release_handle'));
 class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
   SimpleClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String getStringValue() {
     final _getStringValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleClass_getStringValue'));

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -12,7 +12,9 @@ abstract class SimpleInterface {
     getStringValueLambda,
     useSimpleInterfaceLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String getStringValue();
   SimpleInterface useSimpleInterface(SimpleInterface input);
 }
@@ -44,7 +46,8 @@ class SimpleInterface$Lambdas implements SimpleInterface {
     this.getStringValueLambda,
     this.useSimpleInterfaceLambda,
   );
-
+  @override
+  void release() {}
   @override
   String getStringValue() =>
     getStringValueLambda();
@@ -54,7 +57,8 @@ class SimpleInterface$Lambdas implements SimpleInterface {
 }
 class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
   SimpleInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String getStringValue() {
     final _getStringValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SimpleInterface_getStringValue'));

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class ClassWithInternalLambda {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static bool invokeInternalLambda(ClassWithInternalLambda_InternalLambda lambda, String value) => $prototype.invokeInternalLambda(lambda, value);
   /// @nodoc
   @visibleForTesting
@@ -120,7 +122,8 @@ final _smokeClasswithinternallambdaReleaseHandle = __lib.catchArgumentError(() =
 @visibleForTesting
 class ClassWithInternalLambda$Impl extends __lib.NativeBase implements ClassWithInternalLambda {
   ClassWithInternalLambda$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   bool invokeInternalLambda(ClassWithInternalLambda_InternalLambda lambda, String value) {
     final _invokeInternalLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Pointer<Void>, Pointer<Void>), int Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_invokeInternalLambda__InternalLambda_String'));
     final _lambdaHandle = smokeClasswithinternallambdaInternallambdaToFfi(lambda);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class Lambdas {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser);
   static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) => $prototype.fuse(items, callback);
   /// @nodoc
@@ -471,7 +473,8 @@ final _smokeLambdasReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
 @visibleForTesting
 class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
   Lambdas$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser) {
     final _deconfuseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_deconfuse__String_Confuser'));

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/lambdas_declaration_order.dart';
 import 'package:library/src/smoke/lambdas_interface.dart';
 abstract class LambdasWithStructuredTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void doClassStuff(LambdasWithStructuredTypes_ClassCallback callback);
   void doStructStuff(LambdasWithStructuredTypes_StructCallback callback);
 }
@@ -190,7 +192,8 @@ final _smokeLambdaswithstructuredtypesReleaseHandle = __lib.catchArgumentError((
   >('library_smoke_LambdasWithStructuredTypes_release_handle'));
 class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements LambdasWithStructuredTypes {
   LambdasWithStructuredTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void doClassStuff(LambdasWithStructuredTypes_ClassCallback callback) {
     final _doClassStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doClassStuff__ClassCallback'));

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -22,7 +22,9 @@ abstract class CalculatorListener {
     onCalculationResultMapLambda,
     onCalculationResultInstanceLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void onCalculationResult(double calculationResult);
   void onCalculationResultConst(double calculationResult);
   void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult);
@@ -128,7 +130,8 @@ class CalculatorListener$Lambdas implements CalculatorListener {
     this.onCalculationResultMapLambda,
     this.onCalculationResultInstanceLambda,
   );
-
+  @override
+  void release() {}
   @override
   void onCalculationResult(double calculationResult) =>
     onCalculationResultLambda(calculationResult);
@@ -150,7 +153,8 @@ class CalculatorListener$Lambdas implements CalculatorListener {
 }
 class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorListener {
   CalculatorListener$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void onCalculationResult(double calculationResult) {
     final _onCalculationResultFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResult__Double'));

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -15,7 +15,9 @@ abstract class InterfaceWithStatic {
     regularPropertyGetLambda,
     regularPropertySetLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String regularFunction();
   static String staticFunction() => $prototype.staticFunction();
   String get regularProperty;
@@ -56,7 +58,8 @@ class InterfaceWithStatic$Lambdas implements InterfaceWithStatic {
     this.regularPropertyGetLambda,
     this.regularPropertySetLambda,
   );
-
+  @override
+  void release() {}
   @override
   String regularFunction() =>
     regularFunctionLambda();
@@ -69,7 +72,8 @@ class InterfaceWithStatic$Lambdas implements InterfaceWithStatic {
 @visibleForTesting
 class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWithStatic {
   InterfaceWithStatic$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String regularFunction() {
     final _regularFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_InterfaceWithStatic_regularFunction'));

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -39,7 +39,9 @@ abstract class ListenerWithProperties {
     bufferedMessageGetLambda,
     bufferedMessageSetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String get message;
   set message(String value);
   CalculationResult get packedMessage;
@@ -224,7 +226,8 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
     this.bufferedMessageGetLambda,
     this.bufferedMessageSetLambda
   );
-
+  @override
+  void release() {}
   @override
   String get message => messageGetLambda();
   @override
@@ -256,7 +259,8 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
 }
 class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWithProperties {
   ListenerWithProperties$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   String get message {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_message_get'));
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -24,7 +24,9 @@ abstract class ListenersWithReturnValues {
     fetchDataMapLambda,
     fetchDataInstanceLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   double fetchDataDouble();
   String fetchDataString();
   ListenersWithReturnValues_ResultStruct fetchDataStruct();
@@ -188,7 +190,8 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
     this.fetchDataMapLambda,
     this.fetchDataInstanceLambda,
   );
-
+  @override
+  void release() {}
   @override
   double fetchDataDouble() =>
     fetchDataDoubleLambda();
@@ -213,7 +216,8 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
 }
 class ListenersWithReturnValues$Impl extends __lib.NativeBase implements ListenersWithReturnValues {
   ListenersWithReturnValues$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   double fetchDataDouble() {
     final _fetchDataDoubleFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataDouble'));

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class Locales {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   Locale localeMethod(Locale input);
   Locale get localeProperty;
   set localeProperty(Locale value);
@@ -89,7 +91,8 @@ final _smokeLocalesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
   >('library_smoke_Locales_release_handle'));
 class Locales$Impl extends __lib.NativeBase implements Locales {
   Locales$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Locale localeMethod(Locale input) {
     final _localeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeMethod__Locale'));

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 abstract class MethodOverloads {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   bool isBoolean(bool input);
   bool isBooleanByte(int input);
   bool isBooleanString(String input);
@@ -102,7 +104,8 @@ final _smokeMethodoverloadsReleaseHandle = __lib.catchArgumentError(() => __lib.
   >('library_smoke_MethodOverloads_release_handle'));
 class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
   MethodOverloads$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   bool isBoolean(bool input) {
     final _isBooleanFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Boolean'));

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class SpecialNames {
   factory SpecialNames(String result) => $prototype.make(result);
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void create();
   void reallyRelease();
   void createProxy();
@@ -32,7 +34,8 @@ final _smokeSpecialnamesReleaseHandle = __lib.catchArgumentError(() => __lib.nat
 @visibleForTesting
 class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
   SpecialNames$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   SpecialNames make(String result) {
     final _result_handle = _make(result);
     final _result = SpecialNames$Impl(_result_handle);

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
@@ -7,7 +7,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_narrow_one.dart';
 abstract class FirstParentIsClassClass implements ParentClass, ParentNarrowOne {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   void childFunction();
   String get childProperty;
   set childProperty(String value);
@@ -31,7 +33,8 @@ final _smokeFirstparentisclassclassGetTypeId = __lib.catchArgumentError(() => __
   >('library_smoke_FirstParentIsClassClass_get_type_id'));
 class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstParentIsClassClass {
   FirstParentIsClassClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void childFunction() {
     final _childFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_childFunction'));

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
@@ -28,7 +28,9 @@ abstract class FirstParentIsInterfaceInterface implements ParentInterface, Paren
     childPropertyGetLambda,
     childPropertySetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void childFunction();
   String get childProperty;
   set childProperty(String value);
@@ -75,7 +77,8 @@ class FirstParentIsInterfaceInterface$Lambdas implements FirstParentIsInterfaceI
     this.childPropertyGetLambda,
     this.childPropertySetLambda
   );
-
+  @override
+  void release() {}
   @override
   void parentFunction() =>
     parentFunctionLambda();
@@ -100,7 +103,8 @@ class FirstParentIsInterfaceInterface$Lambdas implements FirstParentIsInterfaceI
 }
 class FirstParentIsInterfaceInterface$Impl extends __lib.NativeBase implements FirstParentIsInterfaceInterface {
   FirstParentIsInterfaceInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void parentFunction() {
     final _parentFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_parentFunction'));

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
@@ -14,7 +14,9 @@ abstract class ParentNarrowOne {
     parentPropertyOneGetLambda,
     parentPropertyOneSetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void parentFunctionOne();
   String get parentPropertyOne;
   set parentPropertyOne(String value);
@@ -49,7 +51,8 @@ class ParentNarrowOne$Lambdas implements ParentNarrowOne {
     this.parentPropertyOneGetLambda,
     this.parentPropertyOneSetLambda
   );
-
+  @override
+  void release() {}
   @override
   void parentFunctionOne() =>
     parentFunctionOneLambda();
@@ -60,7 +63,8 @@ class ParentNarrowOne$Lambdas implements ParentNarrowOne {
 }
 class ParentNarrowOne$Impl extends __lib.NativeBase implements ParentNarrowOne {
   ParentNarrowOne$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void parentFunctionOne() {
     final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentFunctionOne'));

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -7,13 +7,19 @@ import 'package:library/src/smoke/outer_class.dart';
 import 'package:library/src/smoke/outer_interface.dart';
 import 'package:meta/meta.dart';
 abstract class LevelOne {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 abstract class LevelOne_LevelTwo {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 abstract class LevelOne_LevelTwo_LevelThree {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   OuterInterface_InnerClass foo(OuterClass_InnerInterface input);
 }
 enum LevelOne_LevelTwo_LevelThree_LevelFourEnum {
@@ -163,7 +169,8 @@ final _smokeLeveloneLeveltwoLevelthreeReleaseHandle = __lib.catchArgumentError((
   >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle'));
 class LevelOne_LevelTwo_LevelThree$Impl extends __lib.NativeBase implements LevelOne_LevelTwo_LevelThree {
   LevelOne_LevelTwo_LevelThree$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   OuterInterface_InnerClass foo(OuterClass_InnerInterface input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LevelOne_LevelTwo_LevelThree_foo__InnerInterface'));
@@ -213,7 +220,8 @@ final _smokeLeveloneLeveltwoReleaseHandle = __lib.catchArgumentError(() => __lib
   >('library_smoke_LevelOne_LevelTwo_release_handle'));
 class LevelOne_LevelTwo$Impl extends __lib.NativeBase implements LevelOne_LevelTwo {
   LevelOne_LevelTwo$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeLeveloneLeveltwoToFfi(LevelOne_LevelTwo value) =>
   _smokeLeveloneLeveltwoCopyHandle((value as __lib.NativeBase).handle);
@@ -250,7 +258,8 @@ final _smokeLeveloneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
   >('library_smoke_LevelOne_release_handle'));
 class LevelOne$Impl extends __lib.NativeBase implements LevelOne {
   LevelOne$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeLeveloneToFfi(LevelOne value) =>
   _smokeLeveloneCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -5,11 +5,15 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class OuterClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   String foo(String input);
 }
 abstract class OuterClass_InnerClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   String foo(String input);
 }
 // OuterClass_InnerClass "private" section, not exported.
@@ -27,7 +31,8 @@ final _smokeOuterclassInnerclassReleaseHandle = __lib.catchArgumentError(() => _
   >('library_smoke_OuterClass_InnerClass_release_handle'));
 class OuterClass_InnerClass$Impl extends __lib.NativeBase implements OuterClass_InnerClass {
   OuterClass_InnerClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String foo(String input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerClass_foo__String'));
@@ -68,7 +73,9 @@ abstract class OuterClass_InnerInterface {
   ) => OuterClass_InnerInterface$Lambdas(
     fooLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String foo(String input);
 }
 // OuterClass_InnerInterface "private" section, not exported.
@@ -97,14 +104,16 @@ class OuterClass_InnerInterface$Lambdas implements OuterClass_InnerInterface {
   OuterClass_InnerInterface$Lambdas(
     this.fooLambda,
   );
-
+  @override
+  void release() {}
   @override
   String foo(String input) =>
     fooLambda(input);
 }
 class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterClass_InnerInterface {
   OuterClass_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String foo(String input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_InnerInterface_foo__String'));
@@ -177,7 +186,8 @@ final _smokeOuterclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
   >('library_smoke_OuterClass_release_handle'));
 class OuterClass$Impl extends __lib.NativeBase implements OuterClass {
   OuterClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String foo(String input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClass_foo__String'));

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -6,11 +6,15 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 abstract class OuterClassWithInheritance implements ParentClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   String foo(String input);
 }
 abstract class OuterClassWithInheritance_InnerClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   String bar(String input);
 }
 // OuterClassWithInheritance_InnerClass "private" section, not exported.
@@ -28,7 +32,8 @@ final _smokeOuterclasswithinheritanceInnerclassReleaseHandle = __lib.catchArgume
   >('library_smoke_OuterClassWithInheritance_InnerClass_release_handle'));
 class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerClass {
   OuterClassWithInheritance_InnerClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String bar(String input) {
     final _barFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerClass_bar__String'));
@@ -69,7 +74,9 @@ abstract class OuterClassWithInheritance_InnerInterface {
   ) => OuterClassWithInheritance_InnerInterface$Lambdas(
     bazLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String baz(String input);
 }
 // OuterClassWithInheritance_InnerInterface "private" section, not exported.
@@ -98,14 +105,16 @@ class OuterClassWithInheritance_InnerInterface$Lambdas implements OuterClassWith
   OuterClassWithInheritance_InnerInterface$Lambdas(
     this.bazLambda,
   );
-
+  @override
+  void release() {}
   @override
   String baz(String input) =>
     bazLambda(input);
 }
 class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerInterface {
   OuterClassWithInheritance_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String baz(String input) {
     final _bazFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_InnerInterface_baz__String'));
@@ -182,7 +191,8 @@ final _smokeOuterclasswithinheritanceGetTypeId = __lib.catchArgumentError(() => 
   >('library_smoke_OuterClassWithInheritance_get_type_id'));
 class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterClassWithInheritance {
   OuterClassWithInheritance$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String foo(String input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterClassWithInheritance_foo__String'));

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -10,11 +10,15 @@ abstract class OuterInterface {
   ) => OuterInterface$Lambdas(
     fooLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String foo(String input);
 }
 abstract class OuterInterface_InnerClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   String foo(String input);
 }
 // OuterInterface_InnerClass "private" section, not exported.
@@ -32,7 +36,8 @@ final _smokeOuterinterfaceInnerclassReleaseHandle = __lib.catchArgumentError(() 
   >('library_smoke_OuterInterface_InnerClass_release_handle'));
 class OuterInterface_InnerClass$Impl extends __lib.NativeBase implements OuterInterface_InnerClass {
   OuterInterface_InnerClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String foo(String input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerClass_foo__String'));
@@ -73,7 +78,9 @@ abstract class OuterInterface_InnerInterface {
   ) => OuterInterface_InnerInterface$Lambdas(
     fooLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String foo(String input);
 }
 // OuterInterface_InnerInterface "private" section, not exported.
@@ -102,14 +109,16 @@ class OuterInterface_InnerInterface$Lambdas implements OuterInterface_InnerInter
   OuterInterface_InnerInterface$Lambdas(
     this.fooLambda,
   );
-
+  @override
+  void release() {}
   @override
   String foo(String input) =>
     fooLambda(input);
 }
 class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements OuterInterface_InnerInterface {
   OuterInterface_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String foo(String input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_InnerInterface_foo__String'));
@@ -193,14 +202,16 @@ class OuterInterface$Lambdas implements OuterInterface {
   OuterInterface$Lambdas(
     this.fooLambda,
   );
-
+  @override
+  void release() {}
   @override
   String foo(String input) =>
     fooLambda(input);
 }
 class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
   OuterInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String foo(String input) {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_OuterInterface_foo__String'));

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -166,7 +166,9 @@ void smokeOuterstructInnerstructReleaseFfiHandleNullable(Pointer<Void> handle) =
   _smokeOuterstructInnerstructReleaseHandleNullable(handle);
 // End of OuterStruct_InnerStruct "private" section.
 abstract class OuterStruct_InnerClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   Set<Locale> fooBar();
 }
 // OuterStruct_InnerClass "private" section, not exported.
@@ -184,7 +186,8 @@ final _smokeOuterstructInnerclassReleaseHandle = __lib.catchArgumentError(() => 
   >('library_smoke_OuterStruct_InnerClass_release_handle'));
 class OuterStruct_InnerClass$Impl extends __lib.NativeBase implements OuterStruct_InnerClass {
   OuterStruct_InnerClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Set<Locale> fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerClass_fooBar'));
@@ -223,7 +226,9 @@ abstract class OuterStruct_InnerInterface {
   ) => OuterStruct_InnerInterface$Lambdas(
     barBazLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   Map<String, Uint8List> barBaz();
 }
 // OuterStruct_InnerInterface "private" section, not exported.
@@ -252,14 +257,16 @@ class OuterStruct_InnerInterface$Lambdas implements OuterStruct_InnerInterface {
   OuterStruct_InnerInterface$Lambdas(
     this.barBazLambda,
   );
-
+  @override
+  void release() {}
   @override
   Map<String, Uint8List> barBaz() =>
     barBazLambda();
 }
 class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterStruct_InnerInterface {
   OuterStruct_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   Map<String, Uint8List> barBaz() {
     final _barBazFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerInterface_barBaz'));

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -7,7 +7,9 @@ import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
 abstract class UseFreeTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   DateTime doStuff(FreePoint point, FreeEnum mode);
 }
 // UseFreeTypes "private" section, not exported.
@@ -41,7 +43,8 @@ final _doStuffReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrar
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
 class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
   UseFreeTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   DateTime doStuff(FreePoint point, FreeEnum mode) {
     final _doStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -6,7 +6,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/some_interface.dart';
 abstract class Nullable {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   String? methodWithString(String? input);
   bool? methodWithBoolean(bool? input);
   double? methodWithDouble(double? input);
@@ -450,7 +452,8 @@ final _smokeNullableReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
   >('library_smoke_Nullable_release_handle'));
 class Nullable$Impl extends __lib.NativeBase implements Nullable {
   Nullable$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String? methodWithString(String? input) {
     final _methodWithStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String_'));

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class NestedPackages {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) => $prototype.basicMethod(input);
   /// @nodoc
   @visibleForTesting
@@ -92,7 +94,8 @@ final _smokeOffNestedpackagesReleaseHandle = __lib.catchArgumentError(() => __li
 @visibleForTesting
 class NestedPackages$Impl extends __lib.NativeBase implements NestedPackages {
   NestedPackages$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) {
     final _basicMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_off_NestedPackages_basicMethod__SomeStruct'));
     final _inputHandle = smokeOffNestedpackagesSomestructToFfi(input);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -7,7 +7,9 @@ import 'package:library/src/smoke/wee_types.dart';
 import 'package:meta/meta.dart';
 abstract class weeInterface {
   factory weeInterface.make(String makeParameter) => $prototype.make(makeParameter);
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   weeStruct WeeMethod(String WeeParameter);
   int get WEE_PROPERTY;
   set WEE_PROPERTY(int value);
@@ -32,7 +34,8 @@ final _smokePlatformnamesinterfaceReleaseHandle = __lib.catchArgumentError(() =>
 @visibleForTesting
 class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
   weeInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   weeInterface make(String makeParameter) {
     final _result_handle = _make(makeParameter);
     final _result = weeInterface$Impl(_result_handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -10,7 +10,9 @@ abstract class weeListener {
   ) => weeListener$Lambdas(
     WeeMethodLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void WeeMethod(String WeeParameter);
 }
 // weeListener "private" section, not exported.
@@ -39,14 +41,16 @@ class weeListener$Lambdas implements weeListener {
   weeListener$Lambdas(
     this.WeeMethodLambda,
   );
-
+  @override
+  void release() {}
   @override
   void WeeMethod(String WeeParameter) =>
     WeeMethodLambda(WeeParameter);
 }
 class weeListener$Impl extends __lib.NativeBase implements weeListener {
   weeListener$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void WeeMethod(String WeeParameter) {
     final _WeeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesListener_basicMethod__String'));

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -7,7 +7,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class CachedProperties {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   List<String> get cachedProperty;
   static Uint8List get staticCachedProperty => $prototype.staticCachedProperty;
   /// @nodoc
@@ -31,7 +33,8 @@ final _smokeCachedpropertiesReleaseHandle = __lib.catchArgumentError(() => __lib
 @visibleForTesting
 class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties {
   CachedProperties$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   late List<String> _cachedPropertyCache;
   bool _cachedPropertyIsCached = false;
   @override

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -8,7 +8,9 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/properties_interface.dart';
 import 'package:meta/meta.dart';
 abstract class Properties {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   int get builtInTypeProperty;
   set builtInTypeProperty(int value);
   double get readonlyProperty;
@@ -165,7 +167,8 @@ final _smokePropertiesReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
 @visibleForTesting
 class Properties$Impl extends __lib.NativeBase implements Properties {
   Properties$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   int get builtInTypeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_builtInTypeProperty_get'));

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -12,7 +12,9 @@ abstract class PropertiesInterface {
     structPropertyGetLambda,
     structPropertySetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   PropertiesInterface_ExampleStruct get structProperty;
   set structProperty(PropertiesInterface_ExampleStruct value);
 }
@@ -106,7 +108,8 @@ class PropertiesInterface$Lambdas implements PropertiesInterface {
     this.structPropertyGetLambda,
     this.structPropertySetLambda
   );
-
+  @override
+  void release() {}
   @override
   PropertiesInterface_ExampleStruct get structProperty => structPropertyGetLambda();
   @override
@@ -114,7 +117,8 @@ class PropertiesInterface$Lambdas implements PropertiesInterface {
 }
 class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInterface {
   PropertiesInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   PropertiesInterface_ExampleStruct get structProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PropertiesInterface_structProperty_get'));
     final _handle = this.handle;

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
 abstract class EnableIfEnabled {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static void enableIfUnquoted() => $prototype.enableIfUnquoted();
   static void enableIfUnquotedList() => $prototype.enableIfUnquotedList();
   static void enableIfQuoted() => $prototype.enableIfQuoted();
@@ -33,7 +35,8 @@ final _smokeEnableifenabledReleaseHandle = __lib.catchArgumentError(() => __lib.
 @visibleForTesting
 class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
   EnableIfEnabled$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   void enableIfUnquoted() {
     final _enableIfUnquotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquoted'));
     _enableIfUnquotedFfi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -3,7 +3,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 abstract class EnableIfSkipped {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 // EnableIfSkipped "private" section, not exported.
 final _smokeEnableifskippedRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -20,7 +22,8 @@ final _smokeEnableifskippedReleaseHandle = __lib.catchArgumentError(() => __lib.
   >('library_smoke_EnableIfSkipped_release_handle'));
 class EnableIfSkipped$Impl extends __lib.NativeBase implements EnableIfSkipped {
   EnableIfSkipped$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeEnableifskippedToFfi(EnableIfSkipped value) =>
   _smokeEnableifskippedCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
@@ -12,7 +12,9 @@ abstract class EnableTagsInDart {
     enableTaggedLambda,
     enableTaggedListLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void enableTagged();
   void enableTaggedList();
 }
@@ -44,7 +46,8 @@ class EnableTagsInDart$Lambdas implements EnableTagsInDart {
     this.enableTaggedLambda,
     this.enableTaggedListLambda,
   );
-
+  @override
+  void release() {}
   @override
   void enableTagged() =>
     enableTaggedLambda();
@@ -54,7 +57,8 @@ class EnableTagsInDart$Lambdas implements EnableTagsInDart {
 }
 class EnableTagsInDart$Impl extends __lib.NativeBase implements EnableTagsInDart {
   EnableTagsInDart$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void enableTagged() {
     final _enableTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_EnableTagsInDart_enableTagged'));

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -21,7 +21,9 @@ abstract class InheritFromSkipped implements SkipProxy {
     isSkippedInSwiftGetLambda,
     isSkippedInSwiftSetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
 }
 // InheritFromSkipped "private" section, not exported.
 final _smokeInheritfromskippedRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -59,7 +61,8 @@ class InheritFromSkipped$Lambdas implements InheritFromSkipped {
     this.isSkippedInSwiftGetLambda,
     this.isSkippedInSwiftSetLambda
   );
-
+  @override
+  void release() {}
   @override
   String notInJava(String input) =>
     notInJavaLambda(input);
@@ -77,7 +80,8 @@ class InheritFromSkipped$Lambdas implements InheritFromSkipped {
 }
 class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSkipped {
   InheritFromSkipped$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String notInJava(String input) {
     final _notInJavaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_notInJava__String'));

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class SkipFunctions {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static String notInJava(String input) => $prototype.notInJava(input);
   static bool notInSwift(bool input) => $prototype.notInSwift(input);
   /// @nodoc
@@ -29,7 +31,8 @@ final _smokeSkipfunctionsReleaseHandle = __lib.catchArgumentError(() => __lib.na
 @visibleForTesting
 class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
   SkipFunctions$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   String notInJava(String input) {
     final _notInJavaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SkipFunctions_notInJava__String'));
     final _inputHandle = stringToFfi(input);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -21,7 +21,9 @@ abstract class SkipProxy {
     isSkippedInSwiftGetLambda,
     isSkippedInSwiftSetLambda
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   String notInJava(String input);
   bool notInSwift(bool input);
   String get skippedInJava;
@@ -65,7 +67,8 @@ class SkipProxy$Lambdas implements SkipProxy {
     this.isSkippedInSwiftGetLambda,
     this.isSkippedInSwiftSetLambda
   );
-
+  @override
+  void release() {}
   @override
   String notInJava(String input) =>
     notInJavaLambda(input);
@@ -83,7 +86,8 @@ class SkipProxy$Lambdas implements SkipProxy {
 }
 class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
   SkipProxy$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   String notInJava(String input) {
     final _notInJavaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_notInJava__String'));

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
@@ -10,7 +10,9 @@ abstract class SkipTagsInDart {
   ) => SkipTagsInDart$Lambdas(
     dontSkipTaggedLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   void dontSkipTagged();
 }
 // SkipTagsInDart "private" section, not exported.
@@ -39,14 +41,16 @@ class SkipTagsInDart$Lambdas implements SkipTagsInDart {
   SkipTagsInDart$Lambdas(
     this.dontSkipTaggedLambda,
   );
-
+  @override
+  void release() {}
   @override
   void dontSkipTagged() =>
     dontSkipTaggedLambda();
 }
 class SkipTagsInDart$Impl extends __lib.NativeBase implements SkipTagsInDart {
   SkipTagsInDart$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void dontSkipTagged() {
     final _dontSkipTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SkipTagsInDart_dontSkipTagged'));

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -3,7 +3,9 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 abstract class SkipTagsOnly {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 // SkipTagsOnly "private" section, not exported.
 final _smokeSkiptagsonlyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -20,7 +22,8 @@ final _smokeSkiptagsonlyReleaseHandle = __lib.catchArgumentError(() => __lib.nat
   >('library_smoke_SkipTagsOnly_release_handle'));
 class SkipTagsOnly$Impl extends __lib.NativeBase implements SkipTagsOnly {
   SkipTagsOnly$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeSkiptagsonlyToFfi(SkipTagsOnly value) =>
   _smokeSkiptagsonlyCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -4,7 +4,9 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class SkipTypes {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
 }
 class SkipTypes_NotInJava {
   String fooField;
@@ -149,7 +151,8 @@ final _smokeSkiptypesReleaseHandle = __lib.catchArgumentError(() => __lib.native
   >('library_smoke_SkipTypes_release_handle'));
 class SkipTypes$Impl extends __lib.NativeBase implements SkipTypes {
   SkipTypes$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokeSkiptypesToFfi(SkipTypes value) =>
   _smokeSkiptypesCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -8,7 +8,9 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'package:meta/meta.dart';
 abstract class Structs {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static Structs_Point swapPointCoordinates(Structs_Point input) => $prototype.swapPointCoordinates(input);
   static Structs_AllTypesStruct returnAllTypesStruct(Structs_AllTypesStruct input) => $prototype.returnAllTypesStruct(input);
   static Point createPoint(double x, double y) => $prototype.createPoint(x, y);
@@ -729,7 +731,8 @@ final _smokeStructsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
 @visibleForTesting
 class Structs$Impl extends __lib.NativeBase implements Structs {
   Structs$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   Structs_Point swapPointCoordinates(Structs_Point input) {
     final _swapPointCoordinatesFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Structs_swapPointCoordinates__Point'));
     final _inputHandle = smokeStructsPointToFfi(input);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -7,7 +7,9 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'package:meta/meta.dart';
 abstract class TypeDefs {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   static double methodWithPrimitiveTypeDef(double input) => $prototype.methodWithPrimitiveTypeDef(input);
   static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) => $prototype.methodWithComplexTypeDef(input);
   static double returnNestedIntTypeDef(double input) => $prototype.returnNestedIntTypeDef(input);
@@ -163,7 +165,8 @@ final _smokeTypedefsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
 @visibleForTesting
 class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
   TypeDefs$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   double methodWithPrimitiveTypeDef(double input) {
     final _methodWithPrimitiveTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
     final _inputHandle = (input);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class.dart
@@ -6,7 +6,9 @@ import 'package:meta/meta.dart';
 /// @nodoc
 @internal
 abstract class InternalClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   void internal_fooBar();
 }
@@ -25,7 +27,8 @@ final _smokeInternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.na
   >('library_smoke_InternalClass_release_handle'));
 class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
   InternalClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -11,7 +11,9 @@ abstract class InternalClassWithFunctions {
   factory InternalClassWithFunctions.make() => $prototype.internal_make();
   /// @nodoc
   factory InternalClassWithFunctions.remake(String foo) => $prototype.internal_remake(foo);
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   void internal_fooBar();
   /// @nodoc
@@ -35,7 +37,8 @@ final _smokeInternalclasswithfunctionsReleaseHandle = __lib.catchArgumentError((
 @visibleForTesting
 class InternalClassWithFunctions$Impl extends __lib.NativeBase implements InternalClassWithFunctions {
   InternalClassWithFunctions$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   InternalClassWithFunctions internal_make() {
     final _result_handle = _make();
     final _result = InternalClassWithFunctions$Impl(_result_handle);

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -7,7 +7,9 @@ import 'package:meta/meta.dart';
 /// @nodoc
 @internal
 abstract class InternalClassWithStaticProperty {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   @internal
   static String get internal_fooBar => $prototype.internal_fooBar;
@@ -35,7 +37,8 @@ final _smokeInternalclasswithstaticpropertyReleaseHandle = __lib.catchArgumentEr
 @visibleForTesting
 class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements InternalClassWithStaticProperty {
   InternalClassWithStaticProperty$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @internal
   String get internal_fooBar {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_interface.dart
@@ -14,7 +14,9 @@ abstract class InternalInterface {
   ) => InternalInterface$Lambdas(
     fooBarLambda,
   );
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
   /// @nodoc
   void internal_fooBar();
 }
@@ -44,14 +46,16 @@ class InternalInterface$Lambdas implements InternalInterface {
   InternalInterface$Lambdas(
     this.fooBarLambda,
   );
-
+  @override
+  void release() {}
   @override
   void internal_fooBar() =>
     fooBarLambda();
 }
 class InternalInterface$Impl extends __lib.NativeBase implements InternalInterface {
   InternalInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   void internal_fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_property_only.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/internal_property_only.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class InternalPropertyOnly {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   @internal
   String get internal_foo;
@@ -28,7 +30,8 @@ final _smokeInternalpropertyonlyReleaseHandle = __lib.catchArgumentError(() => _
   >('library_smoke_InternalPropertyOnly_release_handle'));
 class InternalPropertyOnly$Impl extends __lib.NativeBase implements InternalPropertyOnly {
   InternalPropertyOnly$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @internal
   @override
   String get internal_foo {

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -5,7 +5,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class PublicClass {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release();
   /// @nodoc
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input);
   /// @nodoc
@@ -301,7 +303,8 @@ final _smokePublicclassReleaseHandle = __lib.catchArgumentError(() => __lib.nati
   >('library_smoke_PublicClass_release_handle'));
 class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
   PublicClass$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
   @override
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input) {
     final _internalMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct'));

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_interface.dart
@@ -7,7 +7,9 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/public_class.dart';
 import 'package:meta/meta.dart';
 abstract class PublicInterface {
-
+  /// @nodoc
+  @Deprecated("Does nothing")
+  void release() {}
 }
 /// @nodoc
 @internal
@@ -100,7 +102,8 @@ final _smokePublicinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
   >('library_smoke_PublicInterface_get_type_id'));
 class PublicInterface$Impl extends __lib.NativeBase implements PublicInterface {
   PublicInterface$Impl(Pointer<Void> handle) : super(handle);
-
+  @override
+  void release() {}
 }
 Pointer<Void> smokePublicinterfaceToFfi(PublicInterface value) {
   if (value is __lib.NativeBase) return _smokePublicinterfaceCopyHandle((value as __lib.NativeBase).handle);


### PR DESCRIPTION
This reverts commit 9eb331bbd92afad9a780e53e11f333b59fee1883.

Temorarily reverting Dart `release()` removal to have a "safe" bug fix release
for internal needs.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>