### PR TITLE
Remap struct references when filtering "field constructors"

### DIFF
--- a/gluecodium/src/test/resources/smoke/skip/input/SkipNameClash.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipNameClash.lime
@@ -1,0 +1,32 @@
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct SkipFieldConstructorsClash {
+    param: String = ""
+
+    @Swift(Skip)
+    field constructor()
+
+    @Swift(Skip)
+    @Java(Skip)
+    @Cpp(Skip)
+    @Dart("withDefaults")
+    @Deprecated("Use the default constructor instead")
+    field constructor()
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousEnumeratorRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousEnumeratorRef.kt
@@ -27,9 +27,9 @@ package com.here.gluecodium.model.lime
  * stored result is used on subsequent calls instead.
  */
 class LimeAmbiguousEnumeratorRef(
-    relativePath: List<String>,
-    parentPaths: List<LimePath>,
-    imports: List<LimePath>,
+    private val relativePath: List<String>,
+    private val parentPaths: List<LimePath>,
+    private val imports: List<LimePath>,
     referenceMap: Map<String, LimeElement>
 ) : LimeEnumeratorRef() {
 
@@ -38,4 +38,7 @@ class LimeAmbiguousEnumeratorRef(
     override val enumerator by lazy {
         LimeAmbiguityResolver.resolve<LimeEnumerator>(relativePath, parentPaths, imports, referenceMap)
     }
+
+    override fun remap(referenceMap: Map<String, LimeElement>) =
+        LimeAmbiguousEnumeratorRef(relativePath, parentPaths, imports, referenceMap)
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousTypeRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousTypeRef.kt
@@ -44,6 +44,9 @@ class LimeAmbiguousTypeRef(
     override fun asNullable() =
         when {
             isNullable -> this
-            else -> LimeAmbiguousTypeRef(relativePath, parentPaths, imports, referenceMap, true)
+            else -> LimeAmbiguousTypeRef(relativePath, parentPaths, imports, referenceMap, true, attributes)
         }
+
+    override fun remap(referenceMap: Map<String, LimeElement>) =
+        LimeAmbiguousTypeRef(relativePath, parentPaths, imports, referenceMap, isNullable, attributes)
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumeratorRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumeratorRef.kt
@@ -22,4 +22,5 @@ package com.here.gluecodium.model.lime
 abstract class LimeEnumeratorRef : LimeElement() {
     abstract val elementFullName: String
     abstract val enumerator: LimeEnumerator
+    internal open fun remap(referenceMap: Map<String, LimeElement>) = this
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyTypeRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyTypeRef.kt
@@ -38,4 +38,7 @@ class LimeLazyTypeRef(
 
     override fun asNullable() =
         if (isNullable) this else LimeLazyTypeRef(elementFullName, referenceMap, true)
+
+    override fun remap(referenceMap: Map<String, LimeElement>) =
+        LimeLazyTypeRef(elementFullName, referenceMap, isNullable)
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePositionalEnumeratorRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePositionalEnumeratorRef.kt
@@ -39,5 +39,6 @@ class LimePositionalEnumeratorRef(
 
     override val elementFullName by lazy { enumerator.path.toString() }
 
-    internal fun remap(parentTypeRef: LimeTypeRef) = LimePositionalEnumeratorRef(parentTypeRef, index)
+    override fun remap(referenceMap: Map<String, LimeElement>) =
+        LimePositionalEnumeratorRef(parentTypeRef.remap(referenceMap), index)
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePositionalTypeRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePositionalTypeRef.kt
@@ -42,4 +42,7 @@ class LimePositionalTypeRef(
     }
 
     override fun asNullable() = if (isNullable) this else LimePositionalTypeRef(parentTypeRef, index, true)
+
+    override fun remap(referenceMap: Map<String, LimeElement>) =
+        LimePositionalTypeRef(parentTypeRef.remap(referenceMap), index, isNullable)
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeRef.kt
@@ -25,6 +25,7 @@ abstract class LimeTypeRef(attributes: LimeAttributes? = null) : LimeElement(att
     abstract val isNullable: Boolean
 
     abstract fun asNullable(): LimeTypeRef
+    internal open fun remap(referenceMap: Map<String, LimeElement>) = this
 
     override fun toString() = type.name + if (isNullable) "?" else ""
 


### PR DESCRIPTION
Added internal `remap(refMap)` methods to type references and enumerator
references. For references that are "lazy" this creates an updated reference
with an new refmap.

Updated LimeModelFilter to
* use `remap()` when updating parent type reference for classes and interfaces,
* filter field constructors, including a `remap()` of struct type
back-reference,
* apply filtering to types nested inside structs.

Added new smoke test file "SkipNameClash.lime". The definitions in that file
fail validation without the new remapping of field constructor struct
back-references.

See: #1189
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>