### PR TITLE
Stores JAVA_HOME which was specified during configuration

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/AddGenerateCommand.cmake
+++ b/cmake/modules/gluecodium/gluecodium/AddGenerateCommand.cmake
@@ -211,6 +211,10 @@ function(gluecodium_add_generate_command _target)
     set(_command_dependencies $<TARGET_PROPERTY:${_target},LINK_LIBRARIES>)
   endif()
 
+  # Make live of devs easier and pick up JAVA_HOME during CMake configuration because Xcode doesn't
+  # process neither ~/.bash_profile nor ~/.zshrc
+  string(APPEND _configuration_content "set(JAVA_HOME \"$ENV{JAVA_HOME}\")\n")
+
   # Files with CMake options must not be in folder with generated sources to be able to remove
   # generated sources.
   _gluecodium_get_default_generator_folder(_default_generator_folder ${_args_GENERATORS})

--- a/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
@@ -214,6 +214,10 @@ function(_generate)
   file(REMOVE_RECURSE ${GLUECODIUM_OUTPUT_MAIN})
   file(REMOVE_RECURSE ${GLUECODIUM_OUTPUT_COMMON})
 
+  if(JAVA_HOME)
+    set(ENV{JAVA_HOME} "${JAVA_HOME}")
+  endif()
+
   # Create output directories first, otherwise java.io.File won't have permissions to create files
   # at configure time. Those directories are not created with file(MAKE_DIRECTORY ...) because
   # gradle hangs by some reason at exit when it is ran from Xcode. TODO: Find the reason of hanging.


### PR DESCRIPTION
This is important for MacOS because Xcode has other than
bash's environment and JAVA_HOMOE can be different. To
avoid such inconsistency CMake stores JAVA_HOME and uses
the stored path when Gluecodium is ran.

Signed-off-by: Yauheni Khnykin <yauheni.khnykin@here.com>
