### PR TITLE
Fix "internal inheritance" issue in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a compilation issue in Java when an `internal` class inherits from an `internal` interface.
+
 ## 10.5.0
 Release date: 2021-12-15
 ### Features:

--- a/gluecodium/src/main/resources/templates/java/JavaClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaClass.mustache
@@ -75,7 +75,7 @@
 {{/setter}}{{/set}}
 {{/properties}}
 
-{{#if this.parentInterfaces}}{{#set override=true classElement=this}}
+{{#if this.parentInterfaces}}{{#set override=true classElement=this forcePublic=true}}
 {{#set isClass=true}}{{#classElement.interfaceInheritedFunctions}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/classElement.interfaceInheritedFunctions}}{{/set}}

--- a/gluecodium/src/main/resources/templates/java/JavaFunction.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaFunction.mustache
@@ -24,7 +24,8 @@ private {{#if isStatic}}static {{/if}}boolean is_cached_{{resolveName}} = false;
 
 {{>java/JavaMethodComment}}
 {{#returnType}}{{>java/NullabilityAnnotations}}{{/returnType}}
-{{resolveName visibility}}{{#if isStatic}}static {{/if}}{{resolveName returnType}} {{resolveName}}({{!!
+{{#if forcePublic}}public {{/if}}{{#unless forcePublic}}{{resolveName visibility}}{{/unless}}{{!!
+}}{{#if isStatic}}static {{/if}}{{resolveName returnType}} {{resolveName}}({{!!
 }}{{joinPartial parameters "java/JavaParameter" ", "}}) {
     if (!is_cached_{{resolveName}}) {
         cache_{{resolveName}} = {{resolveName}}_private({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});

--- a/gluecodium/src/main/resources/templates/java/JavaImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaImplClass.mustache
@@ -43,7 +43,7 @@ static {{/if}}class {{resolveName}}Impl extends NativeBase implements {{resolveN
 
 {{/if}}
 
-{{#set isImpl=true interface=this}}{{#functions}}
+{{#set forcePublic=true interface=this}}{{#functions}}
 {{prefixPartial "java/JavaFunction" "    "}}
 {{/functions}}
 {{#interface.properties}}{{#set isCached=attributes.cached}}

--- a/gluecodium/src/main/resources/templates/java/JavaMethodSignature.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaMethodSignature.mustache
@@ -25,7 +25,7 @@
 }}{{#if override}}
 @Override
 {{/if}}
-{{#unless isInterface}}{{#if isImpl}}public {{/if}}{{#unless isImpl}}{{resolveName visibility}}{{/unless}}{{/unless}}{{!!
+{{#unless isInterface}}{{#if forcePublic}}public {{/if}}{{#unless forcePublic}}{{resolveName visibility}}{{/unless}}{{/unless}}{{!!
 }}{{#if isStatic}}static {{/if}}{{#unless isInterface}}native {{/unless}}{{resolveName returnType}}{{/unless}}{{!!
 }} {{resolveName}}{{#if isCached}}_private{{/if}}{{!!
 }}({{joinPartial parameters "java/JavaParameter" ", "}}){{#thrownType}} throws {{resolveName typeRef}}{{/thrownType}}

--- a/gluecodium/src/test/resources/smoke/visibility/input/VisibilityInheritance.lime
+++ b/gluecodium/src/test/resources/smoke/visibility/input/VisibilityInheritance.lime
@@ -1,42 +1,21 @@
-# Copyright (C) 2016-2020 HERE Europe B.V.
-# 
+# Copyright (C) 2016-2021 HERE Europe B.V.
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-package test
-
-internal class InternalClassWithFunctions {
-    fun fooBar()
-    constructor make()
-    @Dart("remake")
-    constructor make(foo: String)
-}
-
-struct PublicStructWithNonDefaultInternalField {
-    defaultedField: Int = 42
-    internal internalField: String
-    publicField: Boolean
-}
-
-internal class InternalClassWithStaticProperty {
-    static property fooBar: String
-}
-
-interface WithInternalProperty {
-    internal property foo: String
-}
+package smoke
 
 internal interface InternalInterfaceParent {
     fun fooBar()

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalClassInherits.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/InternalClassInherits.java
@@ -1,0 +1,24 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+class InternalClassInherits extends NativeBase implements InternalInterfaceParent {
+    protected InternalClassInherits(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+    private static native void disposeNativeHandle(long nativeHandle);
+    @Override
+    public native void fooBar();
+    @NonNull
+    @Override
+    public native String getProp();
+    @Override
+    public native void setProp(@NonNull final String value);
+}


### PR DESCRIPTION
Updated Java templates to force methods inherited by a class from an interface
to be always public. This fixes a compilation issue when both the class and its
interface parent are `internal`. Java treats all interface methods as "public",
even if the interface itself is not, so overriding interface methods with
lower-visibility class methods is a compilation error.

Added smoke and functional tests.

Resolves: #1222
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>