### PR TITLE
Use `const` syntax when invoking `Duration()` constructor in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a compilation issue in Dart when combining `Duration` literals with `@Dart(PositionalDefaults)`.
+
 ## 10.5.1
 Release date: 2021-12-16
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/PositionalDefaults.lime
+++ b/functional-tests/functional/input/lime/PositionalDefaults.lime
@@ -51,3 +51,10 @@ struct StructWithCollectionDefaults {
     mapField: Map<String, String> = ["foo": "bar"]
     setField: Set<String> = ["foo", "bar"]
 }
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct PosDefaultsWithDuration {
+    durationField: Duration = 42s
+    nanosField: Duration = 28567ns
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -183,10 +183,11 @@ internal class DartNameResolver(
             TimeUnit.MICROSECOND, TimeUnit.NANOSECOND -> "microseconds"
         }
         val valueLiteral = when (limeValue.timeUnit) {
-            TimeUnit.NANOSECOND -> "(${limeValue.value} / 1000.0).floor()"
+            // Convert to microseconds during generation to have a compile-time constant in Dart.
+            TimeUnit.NANOSECOND -> (limeValue.value.toDouble() / 1000.0).toInt().toString()
             else -> limeValue.value
         }
-        return "Duration($parameterName: $valueLiteral)"
+        return "const Duration($parameterName: $valueLiteral)"
     }
 
     private fun resolveGenericType(limeType: LimeGenericType) =

--- a/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
@@ -60,3 +60,10 @@ struct DartDeprecatedPosDefaultsCustom {
     stringField: String
     constructor custom()
 }
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct PosDefaultsWithDuration {
+    durationField: Duration = 42s
+    nanosField: Duration = 28567ns
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_defaults_with_duration.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_defaults_with_duration.dart
@@ -1,0 +1,80 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class PosDefaultsWithDuration {
+  Duration durationField;
+  Duration nanosField;
+  PosDefaultsWithDuration([Duration durationField = const Duration(seconds: 42), Duration nanosField = const Duration(microseconds: 28)])
+    : durationField = durationField, nanosField = nanosField;
+  PosDefaultsWithDuration.withDefaults()
+    : durationField = const Duration(seconds: 42), nanosField = const Duration(microseconds: 28);
+}
+// PosDefaultsWithDuration "private" section, not exported.
+final _smokePosdefaultswithdurationCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Uint64),
+    Pointer<Void> Function(int, int)
+  >('library_smoke_PosDefaultsWithDuration_create_handle'));
+final _smokePosdefaultswithdurationReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PosDefaultsWithDuration_release_handle'));
+final _smokePosdefaultswithdurationGetFielddurationField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PosDefaultsWithDuration_get_field_durationField'));
+final _smokePosdefaultswithdurationGetFieldnanosField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_PosDefaultsWithDuration_get_field_nanosField'));
+Pointer<Void> smokePosdefaultswithdurationToFfi(PosDefaultsWithDuration value) {
+  final _durationFieldHandle = durationToFfi(value.durationField);
+  final _nanosFieldHandle = durationToFfi(value.nanosField);
+  final _result = _smokePosdefaultswithdurationCreateHandle(_durationFieldHandle, _nanosFieldHandle);
+  durationReleaseFfiHandle(_durationFieldHandle);
+  durationReleaseFfiHandle(_nanosFieldHandle);
+  return _result;
+}
+PosDefaultsWithDuration smokePosdefaultswithdurationFromFfi(Pointer<Void> handle) {
+  final _durationFieldHandle = _smokePosdefaultswithdurationGetFielddurationField(handle);
+  final _nanosFieldHandle = _smokePosdefaultswithdurationGetFieldnanosField(handle);
+  try {
+    return PosDefaultsWithDuration(
+      durationFromFfi(_durationFieldHandle),
+      durationFromFfi(_nanosFieldHandle)
+    );
+  } finally {
+    durationReleaseFfiHandle(_durationFieldHandle);
+    durationReleaseFfiHandle(_nanosFieldHandle);
+  }
+}
+void smokePosdefaultswithdurationReleaseFfiHandle(Pointer<Void> handle) => _smokePosdefaultswithdurationReleaseHandle(handle);
+// Nullable PosDefaultsWithDuration
+final _smokePosdefaultswithdurationCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PosDefaultsWithDuration_create_handle_nullable'));
+final _smokePosdefaultswithdurationReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PosDefaultsWithDuration_release_handle_nullable'));
+final _smokePosdefaultswithdurationGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PosDefaultsWithDuration_get_value_nullable'));
+Pointer<Void> smokePosdefaultswithdurationToFfiNullable(PosDefaultsWithDuration? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokePosdefaultswithdurationToFfi(value);
+  final result = _smokePosdefaultswithdurationCreateHandleNullable(_handle);
+  smokePosdefaultswithdurationReleaseFfiHandle(_handle);
+  return result;
+}
+PosDefaultsWithDuration? smokePosdefaultswithdurationFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokePosdefaultswithdurationGetValueNullable(handle);
+  final result = smokePosdefaultswithdurationFromFfi(_handle);
+  smokePosdefaultswithdurationReleaseFfiHandle(_handle);
+  return result;
+}
+void smokePosdefaultswithdurationReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePosdefaultswithdurationReleaseHandleNullable(handle);
+// End of PosDefaultsWithDuration "private" section.

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_defaults.dart
@@ -11,7 +11,7 @@ class DurationDefaults {
   Duration nanoz;
   DurationDefaults(this.dayz, this.hourz, this.minutez, this.secondz, this.milliz, this.microz, this.nanoz);
   DurationDefaults.withDefaults()
-    : dayz = Duration(days: 28), hourz = Duration(hours: 22), minutez = Duration(minutes: 45), secondz = Duration(seconds: 42), milliz = Duration(milliseconds: 500), microz = Duration(microseconds: 665), nanoz = Duration(microseconds: (314635 / 1000.0).floor());
+    : dayz = const Duration(days: 28), hourz = const Duration(hours: 22), minutez = const Duration(minutes: 45), secondz = const Duration(seconds: 42), milliz = const Duration(milliseconds: 500), microz = const Duration(microseconds: 665), nanoz = const Duration(microseconds: 314);
 }
 // DurationDefaults "private" section, not exported.
 final _smokeDurationdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<


### PR DESCRIPTION
Updated DartNameResolver to prefix the invokation of `Duration` Dart type
constructor with `const` keyword. This resolves the issue where combining a
`Duration` field default value with `@Dart(PositionalDefaults)` attribute lead
to a compilation error in Dart due to additional const-ness requirements for the
pos-defaults constructor syntax.

Also updated DartNameResolver to convert nanoseconds-based `Duration` literals
to microseconds during generation time. This way the converted values are
compile-time constants in Dart. The old approach delayed the convertion to Dart
run-time, thus preventing the `const Duration()` invocation.

Added smoke and functional tests.

Resolves: #1226
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>