### PR TITLE
Fix compilation issue for intefaces with `Duration` type in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed a compilation issue in Swift for interface function with `Duration` type parameter.
+
 ## 10.5.2
 Release date: 2022-01-04
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/Durations.lime
+++ b/functional-tests/functional/input/lime/Durations.lime
@@ -64,3 +64,7 @@ class DurationOverloads {
     static fun durationFunction(input: Duration): String
     static fun durationFunction(input: String): String
 }
+
+interface DurationInterface {
+    fun durationFunction(input: Duration): String
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeGeneratorPredicates.kt
@@ -63,6 +63,9 @@ internal class CBridgeGeneratorPredicates(
                 else -> true
             }
         },
+        "needsRefSuffix" to { limeTypeRef: Any ->
+            limeTypeRef is LimeTypeRef && CppNameResolver.needsRefSuffix(limeTypeRef)
+        },
         "shouldRetain" to { limeElement: Any ->
             limeElement is LimeNamedElement && shouldRetain(limeElement)
         }

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeCppProxy.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeCppProxy.mustache
@@ -98,7 +98,8 @@ const void* {{resolveName}}_get_swift_object_from_cache(_baseRef handle) {
 }
 
 {{+cppParameter}}{{!!
-}}{{#ifPredicate typeRef "isComplexType"}}const {{resolveName typeRef "C++"}}&{{/ifPredicate}}{{!!
+}}{{#ifPredicate typeRef "isComplexType"}}{{!!
+}}const {{resolveName typeRef "C++"}}{{#ifPredicate typeRef "needsRefSuffix"}}&{{/ifPredicate}}{{/ifPredicate}}{{!!
 }}{{#unlessPredicate typeRef "isComplexType"}}{{!!
 }}{{#instanceOf typeRef.type.actualType "LimeEnumeration"}}const {{resolveName typeRef "C++"}}{{/instanceOf}}{{!!
 }}{{#notInstanceOf typeRef.type.actualType "LimeEnumeration"}}{{resolveName typeRef "C++"}}{{/notInstanceOf}}{{!!

--- a/gluecodium/src/test/resources/smoke/durations/input/Durations.lime
+++ b/gluecodium/src/test/resources/smoke/durations/input/Durations.lime
@@ -56,3 +56,7 @@ class DurationOverloads {
     fun durationFunction(input: Duration): String
     fun durationFunction(input: String): String
 }
+
+interface DurationInterface {
+    fun durationFunction(input: Duration): String
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationInterfaceImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationInterfaceImplCppProxy.h
@@ -1,0 +1,20 @@
+/*
+ *
+ */
+#pragma once
+#include "smoke/DurationInterface.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+namespace gluecodium
+{
+namespace jni
+{
+class com_example_smoke_DurationInterface_CppProxy : public CppProxyBase, public ::smoke::DurationInterface {
+public:
+    com_example_smoke_DurationInterface_CppProxy( JNIEnv* _jenv, JniReference<jobject> globalRef, jint _jHashCode );
+    com_example_smoke_DurationInterface_CppProxy( const com_example_smoke_DurationInterface_CppProxy& ) = delete;
+    com_example_smoke_DurationInterface_CppProxy& operator=( const com_example_smoke_DurationInterface_CppProxy& ) = delete;
+    ::std::string duration_function( const ::std::chrono::seconds ninput ) override;
+};
+}
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/cbridge/src/smoke/cbridge_DurationInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/cbridge/src/smoke/cbridge_DurationInterface.cpp
@@ -1,0 +1,79 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_DurationInterface.h"
+#include "cbridge/include/StringHandle.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "cbridge_internal/include/CachedProxyBase.h"
+#include "cbridge_internal/include/TypeInitRepository.h"
+#include "cbridge_internal/include/WrapperCache.h"
+#include "gluecodium/DurationHash.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/DurationInterface.h"
+#include <chrono>
+#include <memory>
+#include <new>
+#include <string>
+void smoke_DurationInterface_release_handle(_baseRef handle) {
+    delete get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(handle);
+}
+_baseRef smoke_DurationInterface_copy_handle(_baseRef handle) {
+    return handle
+        ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(handle)))
+        : 0;
+}
+const void* smoke_DurationInterface_get_swift_object_from_wrapper_cache(_baseRef handle) {
+    return handle
+        ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(handle)->get())
+        : nullptr;
+}
+void smoke_DurationInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
+    if (!handle) return;
+    ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(handle)->get(), swift_pointer);
+}
+void smoke_DurationInterface_remove_swift_object_from_wrapper_cache(_baseRef handle) {
+    if (!::gluecodium::WrapperCache::is_alive) return;
+    ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(handle)->get());
+}
+extern "C" {
+extern void* _CBridgeInitsmoke_DurationInterface(_baseRef handle);
+}
+namespace {
+struct smoke_DurationInterfaceRegisterInit {
+    smoke_DurationInterfaceRegisterInit() {
+        get_init_repository().add_init("smoke_DurationInterface", &_CBridgeInitsmoke_DurationInterface);
+    }
+} s_smoke_DurationInterface_register_init;
+}
+void* smoke_DurationInterface_get_typed(_baseRef handle) {
+    const auto& real_type_id = ::gluecodium::get_type_repository().get_id(get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(handle)->get());
+    auto init_function = get_init_repository().get_init(real_type_id);
+    return init_function ? init_function(handle) : _CBridgeInitsmoke_DurationInterface(handle);
+}
+_baseRef smoke_DurationInterface_durationFunction(_baseRef _instance, double input) {
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(_instance)->get()->duration_function(Conversion<::std::chrono::seconds>::toCpp(input)));
+}
+class smoke_DurationInterfaceProxy : public ::smoke::DurationInterface, public CachedProxyBase<smoke_DurationInterfaceProxy> {
+public:
+    smoke_DurationInterfaceProxy(smoke_DurationInterface_FunctionTable&& functions)
+     : mFunctions(::std::move(functions))
+    {
+    }
+    virtual ~smoke_DurationInterfaceProxy() {
+        mFunctions.release(mFunctions.swift_pointer);
+    }
+    smoke_DurationInterfaceProxy(const smoke_DurationInterfaceProxy&) = delete;
+    smoke_DurationInterfaceProxy& operator=(const smoke_DurationInterfaceProxy&) = delete;
+    ::std::string duration_function(const ::std::chrono::seconds input) override {
+        auto _call_result = mFunctions.smoke_DurationInterface_durationFunction(mFunctions.swift_pointer, Conversion<::std::chrono::seconds>::toBaseRef(input));
+        return Conversion<::std::string>::toCppReturn(_call_result);
+    }
+private:
+    smoke_DurationInterface_FunctionTable mFunctions;
+};
+_baseRef smoke_DurationInterface_create_proxy(smoke_DurationInterface_FunctionTable functionTable) {
+    auto proxy = smoke_DurationInterfaceProxy::get_proxy(::std::move(functionTable));
+    return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr< ::smoke::DurationInterface >(proxy)) : 0;
+}
+const void* smoke_DurationInterface_get_swift_object_from_cache(_baseRef handle) {
+    return handle ? smoke_DurationInterfaceProxy::get_swift_object(get_pointer<::std::shared_ptr< ::smoke::DurationInterface >>(handle)->get()) : nullptr;
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/ffi/ffi_smoke_DurationInterface.cpp
@@ -1,0 +1,119 @@
+#include "ffi_smoke_DurationInterface.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "CallbacksQueue.h"
+#include "IsolateContext.h"
+#include "ProxyCache.h"
+#include "gluecodium/DurationHash.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/DurationInterface.h"
+#include <chrono>
+#include <memory>
+#include <string>
+#include <memory>
+#include <new>
+class smoke_DurationInterface_Proxy : public smoke::DurationInterface {
+public:
+    smoke_DurationInterface_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
+        : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
+        library_cache_dart_handle_by_raw_pointer(this, isolate_id, dart_handle);
+    }
+    ~smoke_DurationInterface_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_DurationInterface");
+        auto raw_pointer_local = this;
+        auto isolate_id_local = isolate_id;
+        auto dart_persistent_handle_local = dart_persistent_handle;
+        auto deleter = [raw_pointer_local, isolate_id_local, dart_persistent_handle_local]() {
+            library_uncache_dart_handle_by_raw_pointer(raw_pointer_local, isolate_id_local);
+            Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
+        };
+        if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
+            deleter();
+        } else {
+            gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
+        }
+    }
+    smoke_DurationInterface_Proxy(const smoke_DurationInterface_Proxy&) = delete;
+    smoke_DurationInterface_Proxy& operator=(const smoke_DurationInterface_Proxy&) = delete;
+    std::string
+    duration_function(const std::chrono::seconds input) override {
+        FfiOpaqueHandle _result_handle;
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, uint64_t, FfiOpaqueHandle*)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle),
+            gluecodium::ffi::Conversion<std::chrono::seconds>::toFfi(input),
+            &_result_handle
+        ); });
+        auto _result = gluecodium::ffi::Conversion<std::string>::toCpp(_result_handle);
+        delete reinterpret_cast<std::string*>(_result_handle);
+        return _result;
+    }
+private:
+    const uint64_t token;
+    const int32_t isolate_id;
+    const Dart_PersistentHandle dart_persistent_handle;
+    const FfiOpaqueHandle f0;
+    inline void dispatch(std::function<void()>&& callback) const
+    {
+        gluecodium::ffi::IsolateContext::is_current(isolate_id)
+            ? callback()
+            : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
+    }
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_DurationInterface_durationFunction__Duration(FfiOpaqueHandle _self, int32_t _isolate_id, uint64_t input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::DurationInterface>>::toCpp(_self)).duration_function(
+            gluecodium::ffi::Conversion<std::chrono::seconds>::toCpp(input)
+        )
+    );
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_DurationInterface_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::DurationInterface>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_DurationInterface_release_handle(handle);
+}
+void
+library_smoke_DurationInterface_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_DurationInterface_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_DurationInterface_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::DurationInterface>(
+            *reinterpret_cast<std::shared_ptr<smoke::DurationInterface>*>(handle)
+        )
+    );
+}
+void
+library_smoke_DurationInterface_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::DurationInterface>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_DurationInterface_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_DurationInterface_Proxy>(token, isolate_id, "smoke_DurationInterface");
+    std::shared_ptr<smoke_DurationInterface_Proxy>* proxy_ptr;
+    if (cached_proxy) {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_DurationInterface_Proxy>(cached_proxy);
+    } else {
+        proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_DurationInterface_Proxy>(
+            new (std::nothrow) smoke_DurationInterface_Proxy(token, isolate_id, dart_handle, f0)
+        );
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_DurationInterface", *proxy_ptr);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
+}
+FfiOpaqueHandle
+library_smoke_DurationInterface_get_type_id(FfiOpaqueHandle handle) {
+    const auto& type_id = ::gluecodium::get_type_repository().get_id(reinterpret_cast<std::shared_ptr<smoke::DurationInterface>*>(handle)->get());
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::string(type_id));
+}
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Updated CBridge template for interface proxy to correctly omit `&` reference
specifier for `Duration` type parameters.

Resolves: #1230
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>