### PR TITLE
Mark single-parameter struct constructors as `explicit` in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Deprecation message strings in Swift generated code are now properly escaped.
+  * Single-parameter struct constructors are now marked as `explicit` in C++.
 
 ## 10.5.3
 Release date: 2022-01-05

--- a/functional-tests/functional/input/src/cpp/Arrays.cpp
+++ b/functional-tests/functional/input/src/cpp/Arrays.cpp
@@ -216,7 +216,7 @@ Arrays::create_fancy_struct( )
 std::vector< ArrayNameClash::StringArray >
 ArrayNameClash::double_speak( const std::vector< ArrayNameClash::CakeArray >& input )
 {
-    return std::vector< ArrayNameClash::StringArray >{input.size( ), {true}};
+    return std::vector< ArrayNameClash::StringArray >{input.size( ), ArrayNameClash::StringArray{true}};
 }
 
 std::vector<CountDispenser::Holder> CountDispenser::count_characters(const std::vector<NameDispenser::Holder>& input) {

--- a/functional-tests/functional/input/src/cpp/InstanceInStruct.cpp
+++ b/functional-tests/functional/input/src/cpp/InstanceInStruct.cpp
@@ -56,25 +56,25 @@ InstanceInStruct::create( )
 InstanceInStruct::SelfHolder
 InstanceInStruct::create_in_struct( )
 {
-    return {std::make_shared< InstanceInStructImpl >( "foo" )};
+    return InstanceInStruct::SelfHolder{std::make_shared< InstanceInStructImpl >( "foo" )};
 }
 
 InstanceInStruct::SelfHolder
 InstanceInStruct::create_null_in_struct( )
 {
-    return {std::shared_ptr< InstanceInStructImpl >( )};
+    return InstanceInStruct::SelfHolder{std::shared_ptr< InstanceInStructImpl >( )};
 }
 
 InstanceInStruct::NotNullSelfHolder
 InstanceInStruct::create_in_not_null_struct( )
 {
-    return {std::make_shared< InstanceInStructImpl >( "foo" )};
+    return InstanceInStruct::NotNullSelfHolder{std::make_shared< InstanceInStructImpl >( "foo" )};
 }
 
 InstanceInStruct::NotNullSelfHolder
 InstanceInStruct::create_in_empty_not_null_struct( )
 {
-    return {std::shared_ptr< InstanceInStructImpl >( )};
+    return InstanceInStruct::NotNullSelfHolder{std::shared_ptr< InstanceInStructImpl >( )};
 }
 
 }  // namespace test

--- a/functional-tests/functional/input/src/cpp/Lambdas.cpp
+++ b/functional-tests/functional/input/src/cpp/Lambdas.cpp
@@ -66,8 +66,8 @@ Lambdas::concatenate_list(const std::vector<std::string>& strings,
 Lambdas::LambdaHolder
 Lambdas::get_concatenator_in_struct(const std::string& delimiter)
 {
-    return {[delimiter](const std::string& string1,
-                        const std::string& string2){ return string1 + delimiter + string2; }};
+    return Lambdas::LambdaHolder{[delimiter](const std::string& string1,
+                                             const std::string& string2){ return string1 + delimiter + string2; }};
 }
 
 std::string

--- a/functional-tests/functional/input/src/cpp/PlatformNames.cpp
+++ b/functional-tests/functional/input/src/cpp/PlatformNames.cpp
@@ -25,7 +25,7 @@ namespace test
 fooStruct
 fooInterface::FooMethod( const std::string& FooParameter )
 {
-    return {FooParameter};
+    return fooStruct{FooParameter};
 }
 
 std::shared_ptr< fooInterface >

--- a/functional-tests/functional/input/src/cpp/StaticByteArrayMethods.cpp
+++ b/functional-tests/functional/input/src/cpp/StaticByteArrayMethods.cpp
@@ -61,7 +61,7 @@ StaticByteArrayMethods::StructWithBlob
 StaticByteArrayMethods::reverse_blob_in_struct(
     const StaticByteArrayMethods::StructWithBlob& input )
 {
-    return { std::make_shared<std::vector<uint8_t>>( input.blob->rbegin( ), input.blob->rend( ) ) };
+    return StaticByteArrayMethods::StructWithBlob{ std::make_shared<std::vector<uint8_t>>( input.blob->rbegin( ), input.blob->rend( ) ) };
 }
 
 }  // namespace test

--- a/functional-tests/functional/input/src/cpp/StringListeners.cpp
+++ b/functional-tests/functional/input/src/cpp/StringListeners.cpp
@@ -41,7 +41,7 @@ void
 DummyLogger::relay_message_as_struct( const ::std::shared_ptr<::test::StringListener >& listener,
                                       const ::std::string& message )
 {
-    listener->on_struct_message( {message} );
+    listener->on_struct_message( StringListener::StringStruct{message} );
 }
 
 void

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -181,7 +181,8 @@ internal class CppNameResolver(
             }
             is LimeValue.Null -> "${resolveName(limeValue.typeRef)}()"
             is LimeValue.InitializerList -> limeValue.values.joinToString(", ", "{", "}") { resolveValue(it) }
-            is LimeValue.StructInitializer -> limeValue.values.joinToString(", ", "{", "}") { resolveValue(it) }
+            is LimeValue.StructInitializer ->
+                limeValue.values.joinToString(", ", "${resolveName(limeValue.typeRef)}{", "}") { resolveValue(it) }
             is LimeValue.KeyValuePair -> "{${resolveValue(limeValue.key)}, ${resolveValue(limeValue.value)}}"
             is LimeValue.Duration -> resolveDurationValue(limeValue)
         }

--- a/gluecodium/src/main/resources/templates/cpp/CppStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStructConstructors.mustache
@@ -38,7 +38,7 @@
 {{/uninitializedFields}}
      */
 {{/unless}}{{/resolveName}}
-    {{resolveName}}( {{#uninitializedFields}}{{!!
+    {{#isEq uninitializedFields.size 1}}explicit {{/isEq}}{{resolveName}}( {{#uninitializedFields}}{{!!
     }}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}} );{{!!
 }}{{/ifPredicate}}{{!!
 
@@ -61,7 +61,7 @@
      */
 {{/ifPredicate}}
 {{prefixPartial "cpp/CppAttributes" "    "}}
-    {{resolveName struct}}( {{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} );
+    {{#isEq fields.size 1}}explicit {{/isEq}}{{resolveName struct}}( {{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} );
 {{/fieldConstructors}}{{/set}}{{!!
 
 }}{{#ifPredicate "needsAllFieldsConstructor"}}
@@ -74,7 +74,7 @@
 {{/fields}}
      */
 {{/unless}}{{/resolveName}}
-    {{resolveName}}( {{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} );{{!!
+    {{#isEq fields.size 1}}explicit {{/isEq}}{{resolveName}}( {{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} );{{!!
 }}{{/ifPredicate}}
 
 {{/if}}{{!!

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesStruct.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesStruct.h
@@ -12,7 +12,7 @@ struct _GLUECODIUM_CPP_EXPORT [[OnStruct]] AttributesStruct {
     [[OnField]]
     ::std::string field;
     AttributesStruct( );
-    AttributesStruct( ::std::string field );
+    explicit AttributesStruct( ::std::string field );
     [[OnFunctionInStruct]]
     void very_fun( [[OnParameterInStruct]] const ::std::string& param ) const;
 };

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithComments.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithComments.h
@@ -21,7 +21,7 @@ public:
         [[OnField]]
         ::std::string field;
         SomeStruct( );
-        SomeStruct( ::std::string field );
+        explicit SomeStruct( ::std::string field );
     };
     /**
      * Const comment

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
@@ -21,7 +21,7 @@ public:
         [[OnField]]
         ::std::string field;
         SomeStruct( );
-        SomeStruct( ::std::string field );
+        explicit SomeStruct( ::std::string field );
     };
     /**
      * \deprecated

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
@@ -23,7 +23,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string field;
         SomeStruct( );
-        SomeStruct( ::std::string field );
+        explicit SomeStruct( ::std::string field );
     };
 public:
     static void void_ref(  );

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -39,7 +39,7 @@ public:
          * constructor comments ::smoke::Comments::SomeStruct
          * \param random_field Some random field ::smoke::Comments::SomeStruct
          */
-        RandomStruct( ::smoke::Comments::SomeStruct random_field );
+        explicit RandomStruct( ::smoke::Comments::SomeStruct random_field );
     };
 public:
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecatedWithNoMessage.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecatedWithNoMessage.h
@@ -12,6 +12,6 @@ namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT DeprecatedWithNoMessage {
     ::std::string field;
     DeprecatedWithNoMessage( );
-    DeprecatedWithNoMessage( ::std::string field );
+    explicit DeprecatedWithNoMessage( ::std::string field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
@@ -47,7 +47,7 @@ public:
          */
         ::smoke::DeprecationComments::Usefulness some_field;
         SomeStruct( );
-        SomeStruct( ::smoke::DeprecationComments::Usefulness some_field );
+        explicit SomeStruct( ::smoke::DeprecationComments::Usefulness some_field );
     };
     /**
      * This is some very useful constant.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
@@ -38,7 +38,7 @@ public:
          */
         ::smoke::DeprecationCommentsOnly::Usefulness some_field;
         SomeStruct( );
-        SomeStruct( ::smoke::DeprecationCommentsOnly::Usefulness some_field );
+        explicit SomeStruct( ::smoke::DeprecationCommentsOnly::Usefulness some_field );
     };
     /**
      * \deprecated Unfortunately, this constant is deprecated.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
@@ -60,7 +60,7 @@ public:
          * \param some_field How useful this struct is
          * remains to be seen
          */
-        SomeStruct( ::smoke::ExcludedComments::Usefulness some_field );
+        explicit SomeStruct( ::smoke::ExcludedComments::Usefulness some_field );
     };
     /**
      * This is some very useful constant.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
@@ -44,7 +44,7 @@ public:
          */
         ::smoke::ExcludedCommentsOnly::Usefulness some_field;
         SomeStruct( );
-        SomeStruct( ::smoke::ExcludedCommentsOnly::Usefulness some_field );
+        explicit SomeStruct( ::smoke::ExcludedCommentsOnly::Usefulness some_field );
     };
     /**
      * \private

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
@@ -27,7 +27,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT Something {
         ::std::string nothing;
         Something( );
-        Something( ::std::string nothing );
+        explicit Something( ::std::string nothing );
     };
 public:
     /**

--- a/gluecodium/src/test/resources/smoke/constants/output/cpp/src/smoke/StructConstants.cpp
+++ b/gluecodium/src/test/resources/smoke/constants/output/cpp/src/smoke/StructConstants.cpp
@@ -25,6 +25,6 @@ StructConstants::NestingStruct::NestingStruct( ::smoke::StructConstants::SomeStr
     : struct_field( std::move( struct_field ) )
 {
 }
-const ::smoke::StructConstants::SomeStruct StructConstants::STRUCT_CONSTANT = {"bar Buzz", 1.41f};
-const ::smoke::StructConstants::NestingStruct StructConstants::NESTING_STRUCT_CONSTANT = {{"nonsense", -2.82f}};
+const ::smoke::StructConstants::SomeStruct StructConstants::STRUCT_CONSTANT = ::smoke::StructConstants::SomeStruct{"bar Buzz", 1.41f};
+const ::smoke::StructConstants::NestingStruct StructConstants::NESTING_STRUCT_CONSTANT = ::smoke::StructConstants::NestingStruct{::smoke::StructConstants::SomeStruct{"nonsense", -2.82f}};
 }

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrder.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrder.h
@@ -19,7 +19,7 @@ using SomeTypeDef = int32_t;
 struct _GLUECODIUM_CPP_EXPORT NestedStruct {
     ::std::string some_field;
     NestedStruct( );
-    NestedStruct( ::std::string some_field );
+    explicit NestedStruct( ::std::string some_field );
 };
 using NestedStructArray = ::std::vector< ::smoke::NestedStruct >;
 using ErrorCodeToMessageMap = ::std::unordered_map< int32_t, ::smoke::NestedStructArray >;

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrderWithFunctions.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrderWithFunctions.h
@@ -10,27 +10,27 @@ namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT FieldStruct {
     ::std::string some_field;
     FieldStruct( );
-    FieldStruct( ::std::string some_field );
+    explicit FieldStruct( ::std::string some_field );
 };
 struct _GLUECODIUM_CPP_EXPORT ParameterStruct {
     ::std::string some_field;
     ParameterStruct( );
-    ParameterStruct( ::std::string some_field );
+    explicit ParameterStruct( ::std::string some_field );
 };
 struct _GLUECODIUM_CPP_EXPORT ReturnStruct {
     ::std::string some_field;
     ReturnStruct( );
-    ReturnStruct( ::std::string some_field );
+    explicit ReturnStruct( ::std::string some_field );
 };
 struct _GLUECODIUM_CPP_EXPORT ThrownStruct {
     ::std::string some_field;
     ThrownStruct( );
-    ThrownStruct( ::std::string some_field );
+    explicit ThrownStruct( ::std::string some_field );
 };
 struct _GLUECODIUM_CPP_EXPORT MainStructWithFunctions {
     ::smoke::FieldStruct struct_field;
     MainStructWithFunctions( );
-    MainStructWithFunctions( ::smoke::FieldStruct struct_field );
+    explicit MainStructWithFunctions( ::smoke::FieldStruct struct_field );
     void with_parameter( const ::smoke::ParameterStruct& input ) const;
     ::smoke::ReturnStruct with_return(  ) const;
     ::gluecodium::Return< void, ::smoke::ThrownStruct > with_thrown(  ) const;

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInClass.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInClass.h
@@ -24,7 +24,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT NestedStruct {
         ::std::string some_field;
         NestedStruct( );
-        NestedStruct( ::std::string some_field );
+        explicit NestedStruct( ::std::string some_field );
     };
     using NestedStructArray = ::std::vector< ::smoke::OrderInClass::NestedStruct >;
     using ErrorCodeToMessageMap = ::std::unordered_map< int32_t, ::smoke::OrderInClass::NestedStructArray >;

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStruct.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStruct.h
@@ -11,7 +11,7 @@ struct _GLUECODIUM_CPP_EXPORT OrderInStruct {
     struct _GLUECODIUM_CPP_EXPORT NestedStruct {
         ::std::string some_field;
         NestedStruct( );
-        NestedStruct( ::std::string some_field );
+        explicit NestedStruct( ::std::string some_field );
     };
     enum class SomeEnum {
         FOO,

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStructWithFunctions.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStructWithFunctions.h
@@ -11,7 +11,7 @@ struct _GLUECODIUM_CPP_EXPORT OrderInStructWithFunctions {
     struct _GLUECODIUM_CPP_EXPORT NestedStruct {
         ::std::string some_field;
         NestedStruct( );
-        NestedStruct( ::std::string some_field );
+        explicit NestedStruct( ::std::string some_field );
     };
     enum class SomeEnum {
         FOO,
@@ -19,7 +19,7 @@ struct _GLUECODIUM_CPP_EXPORT OrderInStructWithFunctions {
     };
     ::std::string some_field;
     OrderInStructWithFunctions( );
-    OrderInStructWithFunctions( ::std::string some_field );
+    explicit OrderInStructWithFunctions( ::std::string some_field );
     ::smoke::OrderInStructWithFunctions::SomeEnum do_stuff( const ::smoke::OrderInStructWithFunctions::NestedStruct& struct_foo ) const;
 };
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/DefaultValues.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/DefaultValues.h
@@ -68,7 +68,7 @@ public:
         ::std::vector< int32_t > ints_field = {};
         ::smoke::DefaultValues::FloatArray floats_field = {};
         ::smoke::DefaultValues::IdToStringMap map_field = {};
-        ::smoke::DefaultValues::StructWithDefaults struct_field = {};
+        ::smoke::DefaultValues::StructWithDefaults struct_field = ::smoke::DefaultValues::StructWithDefaults{};
         ::smoke::DefaultValues::StringSet set_type_field = {};
         StructWithEmptyDefaults( );
         StructWithEmptyDefaults( ::std::vector< int32_t > ints_field, ::smoke::DefaultValues::FloatArray floats_field, ::smoke::DefaultValues::IdToStringMap map_field, ::smoke::DefaultValues::StructWithDefaults struct_field, ::smoke::DefaultValues::StringSet set_type_field );

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/StructWithInitializerDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/StructWithInitializerDefaults.h
@@ -14,7 +14,7 @@ namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT StructWithInitializerDefaults {
     ::std::vector< int32_t > ints_field = {4, -2, 42};
     ::smoke::DefaultValues::FloatArray floats_field = {3.14f, -std::numeric_limits<float>::infinity()};
-    ::smoke::StructWithAnEnum struct_field = {::smoke::AnEnum::DISABLED};
+    ::smoke::StructWithAnEnum struct_field = ::smoke::StructWithAnEnum{::smoke::AnEnum::DISABLED};
     ::smoke::DefaultValues::StringSet set_type_field = {"foo", "bar"};
     ::smoke::DefaultValues::IdToStringMap map_field = {{1, "foo"}, {42, "bar"}};
     StructWithInitializerDefaults( );

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
@@ -39,6 +39,6 @@ struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithDefaults {
 struct _GLUECODIUM_CPP_EXPORT StructWithAnEnum {
     ::smoke::AnEnum config = ::smoke::AnEnum::ENABLED;
     StructWithAnEnum( );
-    StructWithAnEnum( ::smoke::AnEnum config );
+    explicit StructWithAnEnum( ::smoke::AnEnum config );
 };
 }

--- a/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationMilliseconds.h
+++ b/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationMilliseconds.h
@@ -28,7 +28,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT DurationStruct {
         std::chrono::milliseconds duration_field;
         DurationStruct( );
-        DurationStruct( std::chrono::milliseconds duration_field );
+        explicit DurationStruct( std::chrono::milliseconds duration_field );
     };
 public:
     virtual std::chrono::milliseconds duration_function( const std::chrono::milliseconds input ) = 0;

--- a/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationSeconds.h
+++ b/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationSeconds.h
@@ -28,7 +28,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT DurationStruct {
         ::std::chrono::seconds duration_field;
         DurationStruct( );
-        DurationStruct( ::std::chrono::seconds duration_field );
+        explicit DurationStruct( ::std::chrono::seconds duration_field );
     };
 public:
     virtual ::std::chrono::seconds duration_function( const ::std::chrono::seconds input ) = 0;

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/Equatable.h
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/Equatable.h
@@ -21,7 +21,7 @@ using ErrorCodeToMessageMap = ::std::unordered_map< int32_t, ::std::string >;
 struct _GLUECODIUM_CPP_EXPORT NestedEquatableStruct {
     ::std::string foo_field;
     NestedEquatableStruct( );
-    NestedEquatableStruct( ::std::string foo_field );
+    explicit NestedEquatableStruct( ::std::string foo_field );
     bool operator==( const NestedEquatableStruct& rhs ) const;
     bool operator!=( const NestedEquatableStruct& rhs ) const;
 };

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Types.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Types.h
@@ -15,7 +15,7 @@ enum class Enum {
 struct _GLUECODIUM_CPP_EXPORT Struct {
     ::package::Enum null = ::package::Enum::NA_N;
     Struct( );
-    Struct( ::package::Enum null );
+    explicit Struct( ::package::Enum null );
 };
 using ULong = ::std::vector< ::package::Struct >;
 _GLUECODIUM_CPP_EXPORT extern const ::package::Enum CONST;

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithBothComments.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithBothComments.h
@@ -19,6 +19,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorWithBothComments {
      * This comment takes precedence
      * \param string_field
      */
-    FieldConstructorWithBothComments( ::std::string string_field );
+    explicit FieldConstructorWithBothComments( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithComment.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithComment.h
@@ -19,6 +19,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorWithComment {
      * Some field constructor
      * \param string_field Some field
      */
-    FieldConstructorWithComment( ::std::string string_field );
+    explicit FieldConstructorWithComment( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithDeprecationAndComment.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithDeprecationAndComment.h
@@ -14,6 +14,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorWithDeprecationAndComment {
      * \deprecated Shouldn't really use it
      * \param string_field
      */
-    FieldConstructorWithDeprecationAndComment( ::std::string string_field );
+    explicit FieldConstructorWithDeprecationAndComment( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithDeprecationOnly.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithDeprecationOnly.h
@@ -13,6 +13,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorWithDeprecationOnly {
      * \deprecated Shouldn't really use it
      * \param string_field
      */
-    FieldConstructorWithDeprecationOnly( ::std::string string_field );
+    explicit FieldConstructorWithDeprecationOnly( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithExcluded.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithExcluded.h
@@ -17,6 +17,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorWithExcluded {
      * \private
      * \param string_field Some field
      */
-    FieldConstructorWithExcluded( ::std::string string_field );
+    explicit FieldConstructorWithExcluded( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithExcludedOnly.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithExcludedOnly.h
@@ -13,6 +13,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorWithExcludedOnly {
      * \private
      * \param string_field
      */
-    FieldConstructorWithExcludedOnly( ::std::string string_field );
+    explicit FieldConstructorWithExcludedOnly( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithParentComment.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorWithParentComment.h
@@ -19,6 +19,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorWithParentComment {
      * There are constructors
      * \param string_field
      */
-    FieldConstructorWithParentComment( ::std::string string_field );
+    explicit FieldConstructorWithParentComment( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsAllDefaults.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsAllDefaults.h
@@ -12,7 +12,7 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorsAllDefaults {
     int32_t int_field = 42;
     bool bool_field = true;
     FieldConstructorsAllDefaults(  );
-    FieldConstructorsAllDefaults( int32_t int_field );
+    explicit FieldConstructorsAllDefaults( int32_t int_field );
     FieldConstructorsAllDefaults( int32_t int_field, ::std::string string_field );
     FieldConstructorsAllDefaults( bool bool_field, int32_t int_field, ::std::string string_field );
 };

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipDefault.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldConstructorsSkipDefault.h
@@ -11,6 +11,6 @@ struct _GLUECODIUM_CPP_EXPORT FieldConstructorsSkipDefault {
     ::std::string string_field = "";
     int32_t int_field = 42;
     FieldConstructorsSkipDefault( );
-    FieldConstructorsSkipDefault( ::std::string string_field );
+    explicit FieldConstructorsSkipDefault( ::std::string string_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldCustomConstructorsMix.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/FieldCustomConstructorsMix.h
@@ -12,7 +12,7 @@ struct _GLUECODIUM_CPP_EXPORT FieldCustomConstructorsMix {
     int32_t int_field = 42;
     bool bool_field = true;
     FieldCustomConstructorsMix( );
-    FieldCustomConstructorsMix( int32_t int_field );
+    explicit FieldCustomConstructorsMix( int32_t int_field );
     static ::smoke::FieldCustomConstructorsMix create_me( const int32_t int_value, const double dummy );
 };
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/MutableStructImmutableFields.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/MutableStructImmutableFields.h
@@ -8,7 +8,7 @@
 #include <cstdint>
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT MutableStructImmutableFields {
-    ::smoke::ImmutableStructNoClash struct_field = {};
+    ::smoke::ImmutableStructNoClash struct_field = ::smoke::ImmutableStructNoClash{};
     int32_t int_field = 42;
     bool bool_field = true;
     MutableStructImmutableFields(  );

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/OuterStructWithFieldConstructor.h
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/cpp/include/smoke/OuterStructWithFieldConstructor.h
@@ -9,10 +9,10 @@ struct _GLUECODIUM_CPP_EXPORT OuterStructWithFieldConstructor {
     struct _GLUECODIUM_CPP_EXPORT InnerStructWithDefaults {
         double inner_struct_field = 1.0;
         InnerStructWithDefaults( );
-        InnerStructWithDefaults( double inner_struct_field );
+        explicit InnerStructWithDefaults( double inner_struct_field );
     };
     ::smoke::OuterStructWithFieldConstructor::InnerStructWithDefaults outer_struct_field;
     OuterStructWithFieldConstructor( );
-    OuterStructWithFieldConstructor( ::smoke::OuterStructWithFieldConstructor::InnerStructWithDefaults outer_struct_field );
+    explicit OuterStructWithFieldConstructor( ::smoke::OuterStructWithFieldConstructor::InnerStructWithDefaults outer_struct_field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithCompoundTypes.h
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithCompoundTypes.h
@@ -33,7 +33,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT BasicStruct {
         double value;
         BasicStruct( );
-        BasicStruct( double value );
+        explicit BasicStruct( double value );
     };
 public:
     virtual ::std::vector< ::alien::FooStruct > method_with_struct_list( const ::std::vector< ::smoke::GenericTypesWithCompoundTypes::BasicStruct >& input ) = 0;

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/StructWithClass.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/StructWithClass.h
@@ -13,6 +13,6 @@ struct _GLUECODIUM_CPP_EXPORT StructWithClass {
     /// \warning @NotNull
     ::std::shared_ptr< ::smoke::SimpleClass > class_instance;
     StructWithClass( );
-    StructWithClass( ::std::shared_ptr< ::smoke::SimpleClass > class_instance );
+    explicit StructWithClass( ::std::shared_ptr< ::smoke::SimpleClass > class_instance );
 };
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/StructWithInterface.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/StructWithInterface.h
@@ -13,6 +13,6 @@ struct _GLUECODIUM_CPP_EXPORT StructWithInterface {
     /// \warning @NotNull
     ::std::shared_ptr< ::smoke::SimpleInterface > interface_instance;
     StructWithInterface( );
-    StructWithInterface( ::std::shared_ptr< ::smoke::SimpleInterface > interface_instance );
+    explicit StructWithInterface( ::std::shared_ptr< ::smoke::SimpleInterface > interface_instance );
 };
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/LambdasDeclarationOrder.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/LambdasDeclarationOrder.h
@@ -15,7 +15,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string some_field;
         SomeStruct( );
-        SomeStruct( ::std::string some_field );
+        explicit SomeStruct( ::std::string some_field );
     };
     using SomeCallback = ::std::function<void(const ::smoke::LambdasDeclarationOrder::SomeStruct&)>;
 };

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/CalculatorListener.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/CalculatorListener.h
@@ -24,7 +24,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT ResultStruct {
         double result;
         ResultStruct( );
-        ResultStruct( double result );
+        explicit ResultStruct( double result );
     };
 public:
     virtual void on_calculation_result( const double calculation_result ) = 0;

--- a/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
+++ b/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
@@ -26,7 +26,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT LocaleStruct {
         ::gluecodium::Locale locale_field;
         LocaleStruct( );
-        LocaleStruct( ::gluecodium::Locale locale_field );
+        explicit LocaleStruct( ::gluecodium::Locale locale_field );
     };
 public:
     virtual ::gluecodium::Locale locale_method( const ::gluecodium::Locale& input ) = 0;

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/cpp/include/root/space/smoke/BasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/cpp/include/root/space/smoke/BasicTypes.h
@@ -11,7 +11,7 @@ namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT SomeStruct {
     ::std::string some_field;
     SomeStruct( );
-    SomeStruct( ::std::string some_field );
+    explicit SomeStruct( ::std::string some_field );
 };
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
@@ -32,7 +32,7 @@ public:
                 _GLUECODIUM_CPP_EXPORT static const bool FOO;
                 ::std::string string_field;
                 LevelFour( );
-                LevelFour( ::std::string string_field );
+                explicit LevelFour( ::std::string string_field );
                 static ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour foo_factory(  );
             };
         public:

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/NestedReferences.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/NestedReferences.h
@@ -15,7 +15,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT NestedReferences {
         ::std::string string_field;
         NestedReferences( );
-        NestedReferences( ::std::string string_field );
+        explicit NestedReferences( ::std::string string_field );
     };
 public:
     /**

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
@@ -23,7 +23,7 @@ struct _GLUECODIUM_CPP_EXPORT OuterStruct {
     struct _GLUECODIUM_CPP_EXPORT InnerStruct {
         ::std::vector< ::std::chrono::system_clock::time_point > other_field;
         InnerStruct( );
-        InnerStruct( ::std::vector< ::std::chrono::system_clock::time_point > other_field );
+        explicit InnerStruct( ::std::vector< ::std::chrono::system_clock::time_point > other_field );
         void do_something(  ) const;
     };
     enum class InnerEnum {
@@ -64,7 +64,7 @@ struct _GLUECODIUM_CPP_EXPORT OuterStruct {
     };
     ::std::string field;
     OuterStruct( );
-    OuterStruct( ::std::string field );
+    explicit OuterStruct( ::std::string field );
     ::std::error_code do_nothing(  ) const;
 };
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::OuterStruct::InnerEnum value ) noexcept;

--- a/gluecodium/src/test/resources/smoke/nullable/output/cpp/include/smoke/Nullable.h
+++ b/gluecodium/src/test/resources/smoke/nullable/output/cpp/include/smoke/Nullable.h
@@ -30,7 +30,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string string_field;
         SomeStruct( );
-        SomeStruct( ::std::string string_field );
+        explicit SomeStruct( ::std::string string_field );
     };
     struct _GLUECODIUM_CPP_EXPORT NullableStruct {
         ::gluecodium::optional< ::std::string > string_field;

--- a/gluecodium/src/test/resources/smoke/packages/output/cpp/include/smoke/off/NestedPackages.h
+++ b/gluecodium/src/test/resources/smoke/packages/output/cpp/include/smoke/off/NestedPackages.h
@@ -15,7 +15,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string some_field;
         SomeStruct( );
-        SomeStruct( ::std::string some_field );
+        explicit SomeStruct( ::std::string some_field );
     };
 public:
     static ::smoke::off::NestedPackages::SomeStruct basic_method( const ::smoke::off::NestedPackages::SomeStruct& input );

--- a/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooTypes.h
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooTypes.h
@@ -14,7 +14,7 @@ using fooTypedef = double;
 struct _GLUECODIUM_CPP_EXPORT fooStruct {
     ::std::string FOO_FIELD;
     fooStruct( );
-    fooStruct( ::std::string FOO_FIELD );
+    explicit fooStruct( ::std::string FOO_FIELD );
     static ::smoke::fooStruct FooCreate( const ::std::string& FooParameter );
 };
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/cpp/include/smoke/Properties.h
+++ b/gluecodium/src/test/resources/smoke/properties/output/cpp/include/smoke/Properties.h
@@ -25,7 +25,7 @@ public:
     struct _GLUECODIUM_CPP_EXPORT ExampleStruct {
         double value;
         ExampleStruct( );
-        ExampleStruct( double value );
+        explicit ExampleStruct( double value );
     };
 public:
     virtual uint32_t get_built_in_type_property(  ) const = 0;

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfTypesEnabled.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfTypesEnabled.h
@@ -12,7 +12,7 @@ enum class EnableMe {
 struct _GLUECODIUM_CPP_EXPORT EnableMeToo {
     ::smoke::EnableMe field;
     EnableMeToo( );
-    EnableMeToo( ::smoke::EnableMe field );
+    explicit EnableMeToo( ::smoke::EnableMe field );
 };
 _GLUECODIUM_CPP_EXPORT extern const bool PLACE_HOLDER_ENABLED;
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipField.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipField.h
@@ -9,6 +9,6 @@ namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT SkipField {
     ::std::string field;
     SkipField( );
-    SkipField( ::std::string field );
+    explicit SkipField( ::std::string field );
 };
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructWithConstMethod.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructWithConstMethod.h
@@ -9,7 +9,7 @@ namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT StructWithConstMethod {
     ::std::string string_field;
     StructWithConstMethod( );
-    StructWithConstMethod( ::std::string string_field );
+    explicit StructWithConstMethod( ::std::string string_field );
     double double_const(  ) const;
 };
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
@@ -52,22 +52,22 @@ public:
     using ArrayOfImmutable = ::std::vector< ::smoke::Structs::AllTypesStruct >;
     struct _GLUECODIUM_CPP_EXPORT NestingImmutableStruct {
         ::smoke::Structs::AllTypesStruct struct_field;
-        NestingImmutableStruct( ::smoke::Structs::AllTypesStruct struct_field );
+        explicit NestingImmutableStruct( ::smoke::Structs::AllTypesStruct struct_field );
     };
     struct _GLUECODIUM_CPP_EXPORT DoubleNestingImmutableStruct {
         ::smoke::Structs::NestingImmutableStruct nesting_struct_field;
-        DoubleNestingImmutableStruct( ::smoke::Structs::NestingImmutableStruct nesting_struct_field );
+        explicit DoubleNestingImmutableStruct( ::smoke::Structs::NestingImmutableStruct nesting_struct_field );
     };
     struct _GLUECODIUM_CPP_EXPORT StructWithArrayOfImmutable {
         ::smoke::Structs::ArrayOfImmutable array_field;
         StructWithArrayOfImmutable( );
-        StructWithArrayOfImmutable( ::smoke::Structs::ArrayOfImmutable array_field );
+        explicit StructWithArrayOfImmutable( ::smoke::Structs::ArrayOfImmutable array_field );
     };
     struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithCppAccessors {
     private:
         ::std::string string_field;
     public:
-        ImmutableStructWithCppAccessors( ::std::string string_field );
+        explicit ImmutableStructWithCppAccessors( ::std::string string_field );
         ::std::string get_string_field( ) const { return string_field; }
     };
     struct _GLUECODIUM_CPP_EXPORT MutableStructWithCppAccessors {
@@ -75,7 +75,7 @@ public:
         ::std::string string_field;
     public:
         MutableStructWithCppAccessors( );
-        MutableStructWithCppAccessors( ::std::string string_field );
+        explicit MutableStructWithCppAccessors( ::std::string string_field );
         ::std::string get_string_field( ) const { return string_field; }
         void set_string_field( ::std::string value_ ) { string_field = value_; }
     };

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/TypeCollection.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/TypeCollection.h
@@ -17,7 +17,7 @@ using PointTypeDef = ::smoke::Point;
 struct _GLUECODIUM_CPP_EXPORT StructHavingAliasFieldDefinedBelow {
     ::smoke::StorageId field;
     StructHavingAliasFieldDefinedBelow( );
-    StructHavingAliasFieldDefinedBelow( ::smoke::StorageId field );
+    explicit StructHavingAliasFieldDefinedBelow( ::smoke::StorageId field );
 };
 _GLUECODIUM_CPP_EXPORT extern const ::smoke::StorageId INVALID_STORAGE_ID;
 }

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/TypeDefs.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/TypeDefs.h
@@ -19,12 +19,12 @@ public:
     struct _GLUECODIUM_CPP_EXPORT StructHavingAliasFieldDefinedBelow {
         ::smoke::TypeDefs::PrimitiveTypeDef field;
         StructHavingAliasFieldDefinedBelow( );
-        StructHavingAliasFieldDefinedBelow( ::smoke::TypeDefs::PrimitiveTypeDef field );
+        explicit StructHavingAliasFieldDefinedBelow( ::smoke::TypeDefs::PrimitiveTypeDef field );
     };
     struct _GLUECODIUM_CPP_EXPORT TestStruct {
         ::std::string something;
         TestStruct( );
-        TestStruct( ::std::string something );
+        explicit TestStruct( ::std::string something );
     };
     using StructArray = ::std::vector< ::smoke::TypeDefs::TestStruct >;
     using ComplexTypeDef = ::smoke::TypeDefs::StructArray;


### PR DESCRIPTION
Resolves: #1234
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>