### PR TITLE
Improve support for `@Platform(Skip)` attributes on struct fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Improved support for `@Platform(Skip)` attributes on struct fields. They are now almost always allowed, except for
+  some narrow corner cases.
+
 ## 10.5.4
 Release date: 2022-01-11
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -541,8 +541,8 @@ element is skipped (not generated). Custom tags are case-insensitive.
   * **FunctionName** **=** **"**_FunctionName_**"**: marks a lambda type to have a specific function
   name in the generated functional interface in Java (instead of a default name).
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Java. Can be applied to
-  any element except for enumerators and fields of `@Immutable` structs. Optionally, if custom tag is specified, the
-  element is only skipped if that tag was defined (see `@Skip` above).
+  any element except for enumerators. Optionally, if custom tag is specified, the element is only skipped if that tag
+  was defined (see `@Skip` above).
   * **EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Java only if a custom tag with that
   name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).   
   * **Attribute** **=** **"**_Annotation_**"**: marks an element to be marked with the given annotation in Java
@@ -564,8 +564,8 @@ element is skipped (not generated). Custom tags are case-insensitive.
   Extending a generated type is also possible, but requires usage of `Name` attribute to avoid name
   clashes on other platforms.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Swift. Can be applied to
-  any element except for enumerators and fields of `@Immutable` structs. Optionally, if custom tag is specified, the
-  element is only skipped if that tag was defined (see `@Skip` above).
+  any element except for enumerators. Optionally, if custom tag is specified, the element is only skipped if that tag
+  was defined (see `@Skip` above).
   * **EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Swift only if a custom tag with that
   name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).
   * **Weak**: marks a property in an interface as `weak` in Swift. Property should have a nullable type. Please note
@@ -583,8 +583,8 @@ element is skipped (not generated). Custom tags are case-insensitive.
   name concatenation. This attribute is only meaningful for nested type declarations.
   * **Default**: marks a constructor as a "default" (nameless) in Dart.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Dart. Can be applied to
-  any element except for enumerators and fields of `@Immutable` structs. Optionally, if custom tag is specified, the
-  element is only skipped if that tag was defined (see `@Skip` above).
+  any element except for enumerators. Optionally, if custom tag is specified, the element is only skipped if that tag
+  was defined (see `@Skip` above).
   * **EnableIf** **=** **"**_CustomTag_**"**: marks an element to be enabled in Dart only if a custom tag with that
   name was defined through command-line parameters. If the tag is not present, the element is skipped (not generated).
   * **PositionalDefaults** \[**=** **"**_DeprecationMessage_**"** \]: marks a struct to have a constructor with optional

--- a/functional-tests/functional/input/lime/Skip.lime
+++ b/functional-tests/functional/input/lime/Skip.lime
@@ -85,3 +85,15 @@ struct SkipFieldInPlatform {
     stringField: String
     boolField: Boolean
 }
+
+@Immutable
+struct SkipFieldInPlatformImmutable {
+    intField: Int
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    stringField: DummyStruct = {}
+    boolField: Boolean
+}
+
+struct DummyStruct {
+    stringField: String = ""
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeHeaderIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeHeaderIncludeResolver.kt
@@ -39,8 +39,7 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypedElement
 
 internal class CBridgeHeaderIncludeResolver(
-    limeReferenceMap: Map<String, LimeElement>,
-    private val fileNames: CBridgeFileNames
+    limeReferenceMap: Map<String, LimeElement>
 ) : ReferenceMapBasedResolver(limeReferenceMap), ImportsResolver<Include> {
 
     override fun resolveElementImports(limeElement: LimeElement) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -23,6 +23,8 @@ import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFieldConstructor
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
@@ -98,6 +100,18 @@ internal object CommonGeneratorPredicates {
             !limeStruct.attributes.have(platformAttribute, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&
             limeStruct.internalFields.isNotEmpty() && limeStruct.internalFields.all { it.defaultValue != null } &&
             limeStruct.publicFields.any { it.defaultValue != null }
+
+    fun needsImportsForSkippedField(
+        limeElement: LimeNamedElement,
+        platformAttribute: LimeAttributeType,
+        referenceMap: Map<String, LimeElement>
+    ): Boolean {
+        if (limeElement !is LimeField) return false
+        if (!limeElement.attributes.have(platformAttribute, LimeAttributeValueType.SKIP)) return false
+        val parentKey = limeElement.path.parent.toString()
+        val limeStruct = referenceMap[parentKey] as? LimeStruct ?: return false
+        return hasImmutableFields(limeStruct)
+    }
 
     private fun getAllFieldTypes(limeType: LimeType) = getAllFieldTypesRec(getLeafType(limeType), mutableSetOf())
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GenericImportsCollector.kt
@@ -73,10 +73,9 @@ internal open class GenericImportsCollector<T>(
         val lambdas = allTypes.filterIsInstance<LimeLambda>()
         val exceptions = allTypes.filterIsInstance<LimeException>()
         val structs = allTypes.filterIsInstance<LimeStruct>()
-        return structs.flatMap { it.fields }.map { it.typeRef } +
-            functions.flatMap { collectTypeRefs(it) } + properties.map { it.typeRef } +
-            lambdas.flatMap { collectTypeRefs(it.asFunction()) } +
-            exceptions.map { it.errorType }
+        val fields = structs.flatMap { it.fields }.filter { shouldRetain(it) }
+        return fields.map { it.typeRef } + functions.flatMap { collectTypeRefs(it) } + properties.map { it.typeRef } +
+            lambdas.flatMap { collectTypeRefs(it.asFunction()) } + exceptions.map { it.errorType }
     }
 
     protected fun collectTypeRefs(limeFunction: LimeFunction) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -104,9 +104,9 @@ internal class DartGenerator : Generator {
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
         val ffiFilteredModel = LimeModelFilter
-            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, DART, retainFunctions = true) }
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, DART, retainFunctionsAndFields = true) }
         val dartFilteredModel = LimeModelFilter
-            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, DART, retainFunctions = false) }
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, DART, retainFunctionsAndFields = false) }
 
         val dartNameResolver = DartNameResolver(ffiFilteredModel.referenceMap, nameRules, limeLogger, commentsProcessor)
         val ffiNameResolver = FfiNameResolver(dartFilteredModel.referenceMap, nameRules, internalPrefix)
@@ -149,7 +149,10 @@ internal class DartGenerator : Generator {
         val includeResolver = FfiCppIncludeResolver(ffiFilteredModel.referenceMap, cppNameRules, internalNamespace)
         val includeCollector = GenericImportsCollector(
             includeResolver,
-            retainPredicate = { generatorPredicates.shouldRetain(it) },
+            retainPredicate = {
+                generatorPredicates.shouldRetain(it) ||
+                    CommonGeneratorPredicates.needsImportsForSkippedField(it, DART, ffiFilteredModel.referenceMap)
+            },
             collectTypeRefImports = true,
             collectOwnImports = true
         )

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -86,9 +86,9 @@ internal class JavaGenerator : Generator {
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val cachingNameResolver = CppNameCache(rootNamespace, limeModel.referenceMap, cppNameRules)
         val jniFilteredModel = LimeModelFilter
-            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, JAVA, retainFunctions = true) }
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, JAVA, retainFunctionsAndFields = true) }
         val javaFilteredModel = LimeModelFilter
-            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, JAVA, retainFunctions = false) }
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, JAVA, retainFunctionsAndFields = false) }
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
         val signatureResolver = JavaSignatureResolver(limeModel.referenceMap, javaNameRules, activeTags)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -95,9 +95,9 @@ internal class SwiftGenerator : Generator {
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
         val cbridgeFilteredModel = LimeModelFilter
-            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, SWIFT, retainFunctions = true) }
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, SWIFT, retainFunctionsAndFields = true) }
         val swiftFilteredModel = LimeModelFilter
-            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, SWIFT, retainFunctions = false) }
+            .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, SWIFT, retainFunctionsAndFields = false) }
         val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
 
         val swiftSignatureResolver = SwiftSignatureResolver(cbridgeFilteredModel.referenceMap, nameRules, activeTags)

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeSkipValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeSkipValidator.kt
@@ -21,9 +21,9 @@ package com.here.gluecodium.validator
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeType.DART
-import com.here.gluecodium.model.lime.LimeAttributeType.IMMUTABLE
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
@@ -55,13 +55,13 @@ internal class LimeSkipValidator(private val logger: LimeLogger) {
         }
 
     private fun validateFields(limeStruct: LimeStruct) =
-        !limeStruct.attributes.have(IMMUTABLE) ||
-            !limeStruct.fields.flatMap { validateSkipAttributes(it) }.contains(false)
+        !CommonGeneratorPredicates.hasImmutableFields(limeStruct) ||
+            !limeStruct.fields.filter { it.defaultValue == null }.flatMap { validateSkipAttributes(it) }.contains(false)
 
     companion object {
         private fun getErrorMessage(limeElement: LimeNamedElement, limeAttributeType: LimeAttributeType): String {
             val typePrefix = when (limeElement) {
-                is LimeField -> "field of `@Immutable` struct"
+                is LimeField -> "field of an immutable struct without a default value"
                 is LimeEnumerator -> "enumerator"
                 else -> throw GluecodiumExecutionException("Unsupported element type ${limeElement.javaClass.name}")
             }

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeStructHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeStructHeader.mustache
@@ -19,18 +19,18 @@
   !
   !}}
 _GLUECODIUM_C_EXPORT _baseRef {{resolveName}}_create_handle({{!!
-}}{{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+}}{{#filter fields predicate="shouldRetain"}}{{#this}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this}}{{/filter}});
 _GLUECODIUM_C_EXPORT void {{resolveName}}_release_handle(_baseRef handle);
 
 _GLUECODIUM_C_EXPORT _baseRef {{resolveName}}_create_optional_handle({{!!
-}}{{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+}}{{#filter fields predicate="shouldRetain"}}{{#this}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this}}{{/filter}});
 _GLUECODIUM_C_EXPORT _baseRef {{resolveName}}_unwrap_optional_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT void {{resolveName}}_release_optional_handle(_baseRef handle);
 
 {{#resolveName}}{{#set structName=this}}
-{{#fields}}
+{{#fields}}{{#ifPredicate "shouldRetain"}}
 _GLUECODIUM_C_EXPORT {{resolveName typeRef}} {{structName}}_{{resolveName}}_get(_baseRef handle);
-{{/fields}}
+{{/ifPredicate}}{{/fields}}
 {{/set}}{{/resolveName}}
 
 {{#structs}}

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeStructImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeStructImpl.mustache
@@ -20,13 +20,14 @@
   !}}
 {{#if fields}}
 _baseRef
-{{resolveName}}_create_handle( {{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}} )
+{{resolveName}}_create_handle( {{!!
+}}{{#filter fields predicate="shouldRetain"}}{{#this}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this}}{{/filter}} )
 {
 {{#unlessPredicate "hasImmutableFields"}}{{!!
 }}    {{resolveName "C++"}}* _struct = new ( ::std::nothrow ) {{resolveName "C++"}}();{{/unlessPredicate}}
-{{#set cppStruct="_struct" structElement=this}}{{#fields}}
+{{#set cppStruct="_struct" structElement=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}
 {{>setCppFieldValue}}
-{{/fields}}{{/set}}
+{{/ifPredicate}}{{/fields}}{{/set}}
 {{#ifPredicate "hasImmutableFields"}}{{!!
 }}    {{resolveName "C++"}}* _struct = new ( ::std::nothrow ) {{resolveName "C++"}}( {{>immutableFieldsInit}} );{{/ifPredicate}}
     return reinterpret_cast<_baseRef>( _struct );
@@ -39,13 +40,14 @@ void
 }
 
 _baseRef
-{{resolveName}}_create_optional_handle({{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}})
+{{resolveName}}_create_optional_handle({{!!
+}}{{#filter fields predicate="shouldRetain"}}{{#this}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this}}{{/filter}})
 {
 {{#unlessPredicate "hasImmutableFields"}}{{!!
 }}    auto _struct = new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{resolveName "C++"}}>( {{resolveName "C++"}}( ) );{{/unlessPredicate}}
-{{#set cppStruct="(*_struct)" structElement=this}}{{#fields}}
+{{#set cppStruct="(*_struct)" structElement=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}
 {{>setCppFieldValue}}
-{{/fields}}{{/set}}
+{{/ifPredicate}}{{/fields}}{{/set}}
 {{#ifPredicate "hasImmutableFields"}}{{!!
 }}    auto _struct = new ( ::std::nothrow ) {{>common/InternalNamespace}}optional<{{resolveName "C++"}}>( {{!!
 }}{{resolveName "C++"}}( {{>immutableFieldsInit}} ) );{{/ifPredicate}}
@@ -63,7 +65,7 @@ void {{resolveName}}_release_optional_handle(_baseRef handle) {
 }
 
 {{#set structElement=this}}
-{{#fields}}
+{{#fields}}{{#ifPredicate "shouldRetain"}}
 {{resolveName typeRef}} {{resolveName structElement}}_{{resolveName}}_get(_baseRef handle) {
     auto struct_pointer = get_pointer<const {{resolveName structElement "C++"}}>(handle);
     return {{#set field=this}}{{#if typeRef.attributes.optimized}}{{!!
@@ -79,7 +81,7 @@ void {{resolveName}}_release_optional_handle(_baseRef handle) {
 }}{{#notInstanceOf typeRef.type.actualType "LimeEnumeration"}}{{>getCppFieldValue}};{{/notInstanceOf}}{{!!
 }}{{/unlessPredicate}}{{/unless}}{{/set}}
 }
-{{/fields}}
+{{/ifPredicate}}{{/fields}}
 {{/set}}
 
 {{/if}}
@@ -113,9 +115,10 @@ void {{resolveName}}_release_optional_handle(_baseRef handle) {
 }}{{#unlessPredicate structElement "hasImmutableFields"}}{{#ifPredicate "hasCppSetter"}} ){{/ifPredicate}}{{/unlessPredicate}};
 {{/setCppFieldValue}}{{!!
 
-}}{{+immutableFieldsInit}}{{#if allFieldsConstructor}}{{!!
-}}{{#allFieldsConstructor}}{{#fields}}_{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/allFieldsConstructor}}{{!!
-}}{{/if}}{{!!
-}}{{#unless allFieldsConstructor}}{{!!
-}}{{#fields}}_{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{!!
-}}{{/unless}}{{/immutableFieldsInit}}
+}}{{+immutableFieldsInit}}{{!!
+}}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{>immutableFieldsParameters}}{{/allFieldsConstructor}}{{/if}}{{!!
+}}{{#unless allFieldsConstructor}}{{>immutableFieldsParameters}}{{/unless}}{{/immutableFieldsInit}}{{!!
+
+}}{{+immutableFieldsParameters}}{{#fields}}{{#ifPredicate "shouldRetain"}}_{{resolveName}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "shouldRetain"}}{{resolveName defaultValue "C++"}}{{/unlessPredicate}}{{!!
+}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/immutableFieldsParameters}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
@@ -57,11 +57,12 @@ _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_create_pr
 {{/each}}
 
 {{#structs}}
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_create_handle({{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}});
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_create_handle({{!!
+}}{{#filter fields predicate="shouldRetain"}}{{#this}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this}}{{/filter}});
 _GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_release_handle(FfiOpaqueHandle handle);
-{{#set parent=this}}{{#fields}}
+{{#set parent=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}
 _GLUECODIUM_FFI_EXPORT {{resolveName typeRef}} {{libraryName}}_{{resolveName parent}}_get_field_{{resolveName}}(FfiOpaqueHandle handle);
-{{/fields}}{{/set}}
+{{/ifPredicate}}{{/fields}}{{/set}}
 {{#set type=this handleType="FfiOpaqueHandle"}}{{>ffi/FfiNullableDeclaration}}{{/set}}
 
 {{/structs}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -136,15 +136,17 @@ FfiOpaqueHandle
 
 {{#structs}}
 FfiOpaqueHandle
-{{libraryName}}_{{resolveName}}_create_handle({{#fields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}}) {
+{{libraryName}}_{{resolveName}}_create_handle({{!!
+}}{{#filter fields predicate="shouldRetain"}}{{#this}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this}}{{/filter}}{{!!
+}}) {
 {{#ifPredicate "hasImmutableFields"}}
     auto _result = new (std::nothrow) {{resolveName "C++"}}({{!!
-    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{joinPartial fields "ffiFieldToCpp" ", "}}{{/allFieldsConstructor}}{{/if}}{{!!
-    }}{{#unless allFieldsConstructor}}{{joinPartial fields "ffiFieldToCpp" ", "}}{{/unless}});
+    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{>immutableFieldsParameters}}{{/allFieldsConstructor}}{{/if}}{{!!
+    }}{{#unless allFieldsConstructor}}{{>immutableFieldsParameters}}{{/unless}});
 {{/ifPredicate}}
 {{#unlessPredicate "hasImmutableFields"}}
     auto _result = new (std::nothrow) {{resolveName "C++"}}();
-{{#set struct=this}}{{#fields}}{{>ffiSetCppField}}{{/fields}}{{/set}}
+{{#set struct=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}{{>ffiSetCppField}}{{/ifPredicate}}{{/fields}}{{/set}}
 {{/unlessPredicate}}
     return reinterpret_cast<FfiOpaqueHandle>(_result);
 }
@@ -175,7 +177,7 @@ void
     delete reinterpret_cast<{{resolveName "C++"}}*>(handle);
 }
 
-{{#set parent=this}}{{#fields}}
+{{#set parent=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}
 {{resolveName typeRef}}
 {{libraryName}}_{{resolveName parent}}_get_field_{{resolveName}}(FfiOpaqueHandle handle) {
     return {{#if typeRef.attributes.optimized}}{{!!
@@ -190,7 +192,7 @@ void
     );{{/unless}}
 }
 
-{{/fields}}{{/set}}
+{{/ifPredicate}}{{/fields}}{{/set}}
 
 {{#set type=this handleType="FfiOpaqueHandle"}}{{>ffi/FfiNullableImpl}}{{/set}}
 
@@ -281,6 +283,10 @@ FfiOpaqueHandle
 }}{{+ffiParameter}}            {{>ffi/FfiInternal}}::Conversion<{{resolveName typeRef "C++"}}>::toCpp({{resolveName}}){{/ffiParameter}}{{!!
 
 }}{{+ffiFieldToCpp}}{{>ffi/FfiInternal}}::Conversion<{{resolveName typeRef "C++"}}>::toCpp({{resolveName}}){{/ffiFieldToCpp}}{{!!
+
+}}{{+immutableFieldsParameters}}{{#fields}}{{#ifPredicate "shouldRetain"}}{{>ffiFieldToCpp}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "shouldRetain"}}{{resolveName defaultValue "C++"}}{{/unlessPredicate}}{{!!
+}}{{#if iter.hasNext}}, {{/if}}{{/fields}}{{/immutableFieldsParameters}}{{!!
 
 }}{{+ffiCallCppFunction}}{{!!
 }}        {{#if isStatic}}{{resolveName parent "C++"}}::{{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
@@ -47,7 +47,7 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
 {{prefixPartial "jni/ExternalConversionFromJni" "    "}}
 {{/if}}
     {{#unlessPredicate "hasImmutableFields"}}{{resolveName "C++ FQN"}} _nout{};{{/unlessPredicate}}
-{{#fields}}{{#if external.java.getterName}}{{#unlessPredicate typeRef "isJniPrimitive"}}
+{{#fields}}{{#ifPredicate "shouldRetain"}}{{#if external.java.getterName}}{{#unlessPredicate typeRef "isJniPrimitive"}}
     auto j_{{resolveName "C++"}} = call_java_method<{{resolveName typeRef}}>(_jenv, _jinput, {{!!
     }}"{{external.java.getterName}}", "(){{resolveName typeRef "signature"}}");
     auto n_{{resolveName "C++"}} = {{>jni/JniConversionPrefix}}convert_from_jni(_jenv, j_{{resolveName "C++"}}, ({{resolveName typeRef "C++"}}*)nullptr);
@@ -78,11 +78,10 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
     }}{{#ifPredicate "hasCppSetter"}}{{resolveName this "C++" "setter"}}(n_{{resolveName this "C++"}}){{/ifPredicate}}{{!!
     }}{{#unlessPredicate "hasCppSetter"}}{{resolveName this "C++"}} = n_{{resolveName this "C++"}}{{/unlessPredicate}}{{!!
     }};{{/unlessPredicate}}
-{{/fields}}
+{{/ifPredicate}}{{/fields}}
     {{#ifPredicate struct "hasImmutableFields"}}return {{resolveName "C++ FQN"}}({{!!
-    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{!!
-    }}{{#fields}}std::move(n_{{resolveName "C++"}}){{#if iter.hasNext}}, {{/if}}{{/fields}}{{/allFieldsConstructor}}{{/if}}{{!!
-    }}{{#unless allFieldsConstructor}}{{#fields}}std::move(n_{{resolveName "C++"}}){{#if iter.hasNext}}, {{/if}}{{/fields}}{{/unless}}{{!!
+    }}{{#if allFieldsConstructor}}{{#allFieldsConstructor}}{{>immutableFieldsInit}}{{/allFieldsConstructor}}{{/if}}{{!!
+    }}{{#unless allFieldsConstructor}}{{>immutableFieldsInit}}{{/unless}}{{!!
     }});{{/ifPredicate}}{{!!
     }}{{#unlessPredicate struct "hasImmutableFields"}}return _nout;{{/unlessPredicate}}
 }
@@ -102,7 +101,7 @@ convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput)
 {
     auto& javaClass = CachedJavaClass<{{resolveName "C++ FQN"}}>::java_class;
     auto _jresult = {{>common/InternalNamespace}}jni::alloc_object(_jenv, javaClass);
-{{#set struct=this}}{{#fields}}{{#if external.java.setterName}}{{#unlessPredicate typeRef "isJniPrimitive"}}
+{{#set struct=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}{{#if external.java.setterName}}{{#unlessPredicate typeRef "isJniPrimitive"}}
     auto j{{resolveName "C++"}} = {{>jni/JniConversionPrefix}}convert_to_jni(_jenv, {{>getCppFieldValue}});
     call_java_method<void>(_jenv, _jresult, "{{external.java.setterName}}", {{!!
     }}"({{resolveName typeRef "signature"}})V", j{{cppField.name}});
@@ -118,7 +117,7 @@ convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput)
     }}_jenv, _jresult, "{{resolveName}}", "L{{resolveName typeRef.type.actualType}};", j{{resolveName "C++"}});
 {{/notInstanceOf}}{{#instanceOf typeRef.type.actualType "LimeBasicType"}}
     {{>common/InternalNamespace}}jni::set_field_value(_jenv, _jresult, "{{resolveName}}", {{>getCppFieldValue}});
-{{/instanceOf}}{{/unless}}{{/fields}}{{/set}}
+{{/instanceOf}}{{/unless}}{{/ifPredicate}}{{/fields}}{{/set}}
 {{#if external.java.converter}}
 {{prefixPartial "jni/ExternalConversionToJni" "    "}}
 {{/if}}
@@ -141,4 +140,9 @@ convert_to_jni(JNIEnv* _jenv, const {{>common/InternalNamespace}}optional<{{reso
 }}{{+getCppFieldValue}}_ninput.{{!!
 }}{{#ifPredicate "hasCppGetter"}}{{resolveName this "C++" "getter"}}(){{/ifPredicate}}{{!!
 }}{{#unlessPredicate "hasCppGetter"}}{{resolveName this "C++"}}{{/unlessPredicate}}{{!!
-}}{{/getCppFieldValue}}
+}}{{/getCppFieldValue}}{{!!
+
+}}{{+immutableFieldsInit}}{{#fields}}{{!!
+}}{{#ifPredicate "shouldRetain"}}std::move(n_{{resolveName "C++"}}){{/ifPredicate}}{{!!
+}}{{#unlessPredicate "shouldRetain"}}{{resolveName defaultValue "C++"}}{{/unlessPredicate}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/fields}}{{/immutableFieldsInit}}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeSkipValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeSkipValidatorTest.kt
@@ -27,12 +27,14 @@ import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
 import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeValue
 import io.mockk.mockk
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -71,6 +73,60 @@ class LimeSkipValidatorTest(private val platformAttribute: LimeAttributeType?) {
 
         val expectedResult = platformAttribute == null
         assertEquals(expectedResult, validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateStructWithImmutableFields() {
+        val immutableStruct = LimeStruct(
+            EMPTY_PATH,
+            attributes = LimeAttributes.Builder().addAttribute(IMMUTABLE).build()
+        )
+        val attributesBuilder = LimeAttributes.Builder()
+        if (platformAttribute != null) attributesBuilder.addAttribute(platformAttribute, SKIP)
+        val limeField =
+            LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(immutableStruct), attributes = attributesBuilder.build())
+        allElements[""] = LimeStruct(EMPTY_PATH, fields = listOf(limeField))
+
+        val expectedResult = platformAttribute == null
+        assertEquals(expectedResult, validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateImmutableStructWithDefaultValue() {
+        val attributesBuilder = LimeAttributes.Builder()
+        if (platformAttribute != null) attributesBuilder.addAttribute(platformAttribute, SKIP)
+        val limeField = LimeField(
+            EMPTY_PATH,
+            typeRef = LimeBasicTypeRef.INT,
+            attributes = attributesBuilder.build(),
+            defaultValue = LimeValue.ZERO
+        )
+        allElements[""] = LimeStruct(
+            EMPTY_PATH,
+            fields = listOf(limeField),
+            attributes = LimeAttributes.Builder().addAttribute(IMMUTABLE).build()
+        )
+
+        assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateStructWithImmutableFieldsWithDefaultValue() {
+        val immutableStruct = LimeStruct(
+            EMPTY_PATH,
+            attributes = LimeAttributes.Builder().addAttribute(IMMUTABLE).build()
+        )
+        val attributesBuilder = LimeAttributes.Builder()
+        if (platformAttribute != null) attributesBuilder.addAttribute(platformAttribute, SKIP)
+        val limeField = LimeField(
+            EMPTY_PATH,
+            typeRef = LimeDirectTypeRef(immutableStruct),
+            attributes = attributesBuilder.build(),
+            defaultValue = LimeValue.ZERO
+        )
+        allElements[""] = LimeStruct(EMPTY_PATH, fields = listOf(limeField))
+
+        assertTrue(validator.validate(limeModel))
     }
 
     @Test

--- a/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
@@ -85,3 +85,15 @@ struct SkipFieldInPlatform {
     stringField: String
     boolField: Boolean
 }
+
+@Immutable
+struct SkipFieldInPlatformImmutable {
+    intField: Int
+    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    stringField: DummyStruct = {}
+    boolField: Boolean
+}
+
+struct DummyStruct {
+    stringField: String = ""
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.cpp
@@ -1,0 +1,52 @@
+/*
+ *
+ */
+#include "com_example_smoke_SkipFieldInPlatformImmutable__Conversion.h"
+#include "smoke/DummyStruct.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::SkipFieldInPlatformImmutable
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::SkipFieldInPlatformImmutable*)
+{
+    int32_t n_int_field = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "intField",
+        (int32_t*)nullptr );
+    bool n_bool_field = ::gluecodium::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "boolField",
+        (bool*)nullptr );
+    return ::smoke::SkipFieldInPlatformImmutable(std::move(n_int_field), ::smoke::DummyStruct{}, std::move(n_bool_field));
+}
+::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>(convert_from_jni(_jenv, _jinput, (::smoke::SkipFieldInPlatformImmutable*)nullptr))
+        : ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/SkipFieldInPlatformImmutable", com_example_smoke_SkipFieldInPlatformImmutable, ::smoke::SkipFieldInPlatformImmutable)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::SkipFieldInPlatformImmutable& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::SkipFieldInPlatformImmutable>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
+    ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
+    return _jresult;
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.h
@@ -1,0 +1,17 @@
+/*
+ *
+ */
+#pragma once
+#include "smoke/SkipFieldInPlatformImmutable.h"
+#include "JniReference.h"
+#include "gluecodium/Optional.h"
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::SkipFieldInPlatformImmutable convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::SkipFieldInPlatformImmutable*);
+JNIEXPORT ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>*);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::SkipFieldInPlatformImmutable& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipFieldInPlatformImmutable.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipFieldInPlatformImmutable.h
@@ -1,0 +1,20 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+#include <stdbool.h>
+#include <stdint.h>
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipFieldInPlatformImmutable_create_handle(int32_t intField, bool boolField);
+_GLUECODIUM_C_EXPORT void smoke_SkipFieldInPlatformImmutable_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipFieldInPlatformImmutable_create_optional_handle(int32_t intField, bool boolField);
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipFieldInPlatformImmutable_unwrap_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_SkipFieldInPlatformImmutable_release_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT int32_t smoke_SkipFieldInPlatformImmutable_intField_get(_baseRef handle);
+_GLUECODIUM_C_EXPORT bool smoke_SkipFieldInPlatformImmutable_boolField_get(_baseRef handle);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipFieldInPlatformImmutable.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipFieldInPlatformImmutable.cpp
@@ -1,0 +1,47 @@
+//
+//
+#include "cbridge/include/smoke/cbridge_SkipFieldInPlatformImmutable.h"
+#include "cbridge_internal/include/BaseHandleImpl.h"
+#include "gluecodium/Optional.h"
+#include "smoke/DummyStruct.h"
+#include "smoke/SkipFieldInPlatformImmutable.h"
+#include <cstdint>
+#include <memory>
+#include <new>
+_baseRef
+smoke_SkipFieldInPlatformImmutable_create_handle( int32_t intField, bool boolField )
+{
+    auto _intField = intField;
+    auto _boolField = boolField;
+    ::smoke::SkipFieldInPlatformImmutable* _struct = new ( ::std::nothrow ) ::smoke::SkipFieldInPlatformImmutable( _intField, ::smoke::DummyStruct{}, _boolField );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+void
+smoke_SkipFieldInPlatformImmutable_release_handle( _baseRef handle )
+{
+    delete get_pointer<::smoke::SkipFieldInPlatformImmutable>( handle );
+}
+_baseRef
+smoke_SkipFieldInPlatformImmutable_create_optional_handle(int32_t intField, bool boolField)
+{
+    auto _intField = intField;
+    auto _boolField = boolField;
+    auto _struct = new ( ::std::nothrow ) ::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>( ::smoke::SkipFieldInPlatformImmutable( _intField, ::smoke::DummyStruct{}, _boolField ) );
+    return reinterpret_cast<_baseRef>( _struct );
+}
+_baseRef
+smoke_SkipFieldInPlatformImmutable_unwrap_optional_handle( _baseRef handle )
+{
+    return reinterpret_cast<_baseRef>( &**reinterpret_cast<::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>*>( handle ) );
+}
+void smoke_SkipFieldInPlatformImmutable_release_optional_handle(_baseRef handle) {
+    delete reinterpret_cast<::gluecodium::optional<::smoke::SkipFieldInPlatformImmutable>*>( handle );
+}
+int32_t smoke_SkipFieldInPlatformImmutable_intField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::SkipFieldInPlatformImmutable>(handle);
+    return struct_pointer->int_field;
+}
+bool smoke_SkipFieldInPlatformImmutable_boolField_get(_baseRef handle) {
+    auto struct_pointer = get_pointer<const ::smoke::SkipFieldInPlatformImmutable>(handle);
+    return struct_pointer->bool_field;
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFieldInPlatformImmutable.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFieldInPlatformImmutable.cpp
@@ -1,0 +1,55 @@
+#include "ffi_smoke_SkipFieldInPlatformImmutable.h"
+#include "ConversionBase.h"
+#include "smoke/DummyStruct.h"
+#include "smoke/SkipFieldInPlatformImmutable.h"
+#include <cstdint>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+FfiOpaqueHandle
+library_smoke_SkipFieldInPlatformImmutable_create_handle(int32_t intField, bool boolField) {
+    auto _result = new (std::nothrow) smoke::SkipFieldInPlatformImmutable(gluecodium::ffi::Conversion<int32_t>::toCpp(intField), smoke::DummyStruct{}, gluecodium::ffi::Conversion<bool>::toCpp(boolField));
+    return reinterpret_cast<FfiOpaqueHandle>(_result);
+}
+void
+library_smoke_SkipFieldInPlatformImmutable_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<smoke::SkipFieldInPlatformImmutable*>(handle);
+}
+int32_t
+library_smoke_SkipFieldInPlatformImmutable_get_field_intField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<int32_t>::toFfi(
+        reinterpret_cast<smoke::SkipFieldInPlatformImmutable*>(handle)->int_field
+    );
+}
+bool
+library_smoke_SkipFieldInPlatformImmutable_get_field_boolField(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<bool>::toFfi(
+        reinterpret_cast<smoke::SkipFieldInPlatformImmutable*>(handle)->bool_field
+    );
+}
+FfiOpaqueHandle
+library_smoke_SkipFieldInPlatformImmutable_create_handle_nullable(FfiOpaqueHandle value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) gluecodium::optional<smoke::SkipFieldInPlatformImmutable>(
+            gluecodium::ffi::Conversion<smoke::SkipFieldInPlatformImmutable>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_SkipFieldInPlatformImmutable_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<gluecodium::optional<smoke::SkipFieldInPlatformImmutable>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_SkipFieldInPlatformImmutable_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<smoke::SkipFieldInPlatformImmutable>::toFfi(
+        **reinterpret_cast<gluecodium::optional<smoke::SkipFieldInPlatformImmutable>*>(handle)
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFieldInPlatformImmutable.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFieldInPlatformImmutable.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include <stdint.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipFieldInPlatformImmutable_create_handle(int32_t intField, bool boolField);
+_GLUECODIUM_FFI_EXPORT void library_smoke_SkipFieldInPlatformImmutable_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT int32_t library_smoke_SkipFieldInPlatformImmutable_get_field_intField(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT bool library_smoke_SkipFieldInPlatformImmutable_get_field_boolField(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipFieldInPlatformImmutable_create_handle_nullable(FfiOpaqueHandle value);
+_GLUECODIUM_FFI_EXPORT void library_smoke_SkipFieldInPlatformImmutable_release_handle_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipFieldInPlatformImmutable_get_value_nullable(FfiOpaqueHandle handle);
+#ifdef __cplusplus
+}
+#endif

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelSkipPredicates.kt
@@ -25,6 +25,7 @@ import com.here.gluecodium.model.lime.LimeAttributeValueType.ENABLE_IF
 import com.here.gluecodium.model.lime.LimeAttributeValueType.SKIP
 import com.here.gluecodium.model.lime.LimeAttributeValueType.TAG
 import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
@@ -34,10 +35,11 @@ object LimeModelSkipPredicates {
         limeElement: LimeNamedElement,
         activeTags: Set<String>,
         platformAttribute: LimeAttributeType? = null,
-        retainFunctions: Boolean = false
+        retainFunctionsAndFields: Boolean = false
     ) = when {
         isSkippedByTags(limeElement, activeTags) -> false
-        retainFunctions && (limeElement is LimeFunction || limeElement is LimeProperty) -> true
+        retainFunctionsAndFields &&
+            (limeElement is LimeFunction || limeElement is LimeProperty || limeElement is LimeField) -> true
         platformAttribute == null -> true
         isSkippedByTagsOnPlatform(limeElement, activeTags, platformAttribute) -> false
         else -> true


### PR DESCRIPTION
Updated JNI/CBridge/FFI templates for struct conversion in "platform->C++"
direction to use the field's default value if the field itself is skipped in the
platform code. This makes "platform skip" attributes available on fields for
most cases.

The only unsupported corner case is when the field does not have a default value
defined, and the struct has some immutable fields (including when the struct is
itself `@Immutable`). Updated LimeSkipValidator to produce a validation error
for this corner case. Added new unit tests for the validator accordingly.

Added new smoke and functional tests for the newly supported "platform skip" use
cases.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>