### PR TITLE
Don't generate export macro for nested constants in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added support for `@NoCache` attribute in Swift and Dart. This is an experimental feature.
+### Bug fixes:
+  * Fixed a Windows compilation issue in C++ for constants nested in classes/interfaces/structs.
 
 ## 10.6.2
 Release date: 2022-01-26

--- a/gluecodium/src/main/resources/templates/cpp/CppConstant.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppConstant.mustache
@@ -19,4 +19,4 @@
   !
   !}}
 {{>cpp/CppDocComment}}{{>cpp/CppAttributes}}
-{{>cpp/CppExportMacro}}{{storageQualifier}} const {{resolveName typeRef}} {{resolveName}};
+{{#if needsExport}}{{>cpp/CppExportMacro}}{{/if}}{{storageQualifier}} const {{resolveName typeRef}} {{resolveName}};

--- a/gluecodium/src/main/resources/templates/cpp/CppTypes.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppTypes.mustache
@@ -23,6 +23,6 @@
 }}{{#instanceOf this "LimeLambda"}}{{>cpp/CppLambda}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeTypeAlias"}}{{>cpp/CppTypeAlias}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeStruct"}}{{>cpp/CppStruct}}{{/instanceOf}}{{!!
-}}{{#instanceOf this "LimeConstant"}}{{#set constant=this storageQualifier="extern"}}{{#constant}}{{!!
+}}{{#instanceOf this "LimeConstant"}}{{#set constant=this storageQualifier="extern" needsExport=true}}{{#constant}}{{!!
 }}{{>cpp/CppConstant}}{{/constant}}{{/set}}{{/instanceOf}}
 {{/sort}}

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesClass.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesClass.h
@@ -12,7 +12,7 @@ public:
     virtual ~AttributesClass() = 0;
 public:
     [[OnConstInClass]]
-    _GLUECODIUM_CPP_EXPORT static const bool PI;
+    static const bool PI;
 public:
     [[OnFunctionInClass]]
     virtual void very_fun( [[OnParameterInClass]] const ::std::string& param ) = 0;

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesInterface.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesInterface.h
@@ -13,7 +13,7 @@ public:
     virtual ~AttributesInterface() = 0;
 public:
     [[OnConstInInterface]]
-    _GLUECODIUM_CPP_EXPORT static const bool PI;
+    static const bool PI;
 public:
     [[OnFunctionInInterface]]
     virtual void very_fun( [[OnParameterInInterface]] const ::std::string& param ) = 0;

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesStruct.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesStruct.h
@@ -8,7 +8,7 @@
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT [[OnStruct]] AttributesStruct {
     [[OnConstInStruct]]
-    _GLUECODIUM_CPP_EXPORT static const bool PI;
+    static const bool PI;
     [[OnField]]
     ::std::string field;
     AttributesStruct( );

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithComments.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithComments.h
@@ -27,7 +27,7 @@ public:
      * Const comment
      */
     [[OnConstInClass]]
-    _GLUECODIUM_CPP_EXPORT static const bool PI;
+    static const bool PI;
 public:
     /**
      * Function comment

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
@@ -27,7 +27,7 @@ public:
      * \deprecated
      */
     [[OnConstInClass]]
-    _GLUECODIUM_CPP_EXPORT static const bool PI;
+    static const bool PI;
 public:
     /**
      *

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -76,7 +76,7 @@ public:
     /**
      * This is some very useful constant.
      */
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::Comments::Usefulness VERY_USEFUL;
+    static const ::smoke::Comments::Usefulness VERY_USEFUL;
 public:
     /**
      * This is some very useful method that measures the usefulness of its input.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
@@ -53,7 +53,7 @@ public:
      * This is some very useful constant.
      * \deprecated Unfortunately, this constant is deprecated. Use ::smoke::Comments::VERY_USEFUL instead.
      */
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::DeprecationComments::Usefulness VERY_USEFUL;
+    static const ::smoke::DeprecationComments::Usefulness VERY_USEFUL;
 public:
     /**
      * This is some very useful method that measures the usefulness of its input.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
@@ -43,7 +43,7 @@ public:
     /**
      * \deprecated Unfortunately, this constant is deprecated.
      */
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::DeprecationCommentsOnly::Usefulness VERY_USEFUL;
+    static const ::smoke::DeprecationCommentsOnly::Usefulness VERY_USEFUL;
 public:
     /**
      *

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
@@ -66,7 +66,7 @@ public:
      * This is some very useful constant.
      * \private
      */
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::ExcludedComments::Usefulness VERY_USEFUL;
+    static const ::smoke::ExcludedComments::Usefulness VERY_USEFUL;
 public:
     /**
      * This is some very useful method that measures the usefulness of its input.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
@@ -49,7 +49,7 @@ public:
     /**
      * \private
      */
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::ExcludedCommentsOnly::Usefulness VERY_USEFUL;
+    static const ::smoke::ExcludedCommentsOnly::Usefulness VERY_USEFUL;
 public:
     /**
      *

--- a/gluecodium/src/test/resources/smoke/constants/output/cpp/include/smoke/CollectionConstants.h
+++ b/gluecodium/src/test/resources/smoke/constants/output/cpp/include/smoke/CollectionConstants.h
@@ -17,9 +17,9 @@ public:
     CollectionConstants();
     virtual ~CollectionConstants() = 0;
 public:
-    _GLUECODIUM_CPP_EXPORT static const ::std::vector< ::std::string > LIST_CONSTANT;
-    _GLUECODIUM_CPP_EXPORT static const ::std::unordered_set< ::std::string > SET_CONSTANT;
-    _GLUECODIUM_CPP_EXPORT static const ::std::unordered_map< ::std::string, ::std::string > MAP_CONSTANT;
-    _GLUECODIUM_CPP_EXPORT static const ::std::unordered_map< ::std::vector< ::std::string >, ::std::unordered_set< ::std::string >, ::gluecodium::hash< ::std::vector< ::std::string > > > MIXED_CONSTANT;
+    static const ::std::vector< ::std::string > LIST_CONSTANT;
+    static const ::std::unordered_set< ::std::string > SET_CONSTANT;
+    static const ::std::unordered_map< ::std::string, ::std::string > MAP_CONSTANT;
+    static const ::std::unordered_map< ::std::vector< ::std::string >, ::std::unordered_set< ::std::string >, ::gluecodium::hash< ::std::vector< ::std::string > > > MIXED_CONSTANT;
 };
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/StructWithEnums.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/StructWithEnums.h
@@ -7,7 +7,7 @@
 #include "smoke/SomethingEnum.h"
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT StructWithEnums {
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::SomethingEnum FIRST_CONSTANT;
+    static const ::smoke::SomethingEnum FIRST_CONSTANT;
     ::smoke::SomethingEnum first_field = ::smoke::SomethingEnum::REALLY_FIRST;
     ::smoke::SomethingEnum explicit_field = ::smoke::SomethingEnum::EXPLICIT;
     ::smoke::SomethingEnum last_field = ::smoke::SomethingEnum::LAST;

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/FreePoint.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/FreePoint.h
@@ -7,7 +7,7 @@
 #include "smoke/FreeEnum.h"
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT FreePoint {
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::FreeEnum A_BAR;
+    static const ::smoke::FreeEnum A_BAR;
     double x;
     double y;
     FreePoint( );

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
@@ -29,7 +29,7 @@ public:
                 NONE
             };
             struct _GLUECODIUM_CPP_EXPORT LevelFour {
-                _GLUECODIUM_CPP_EXPORT static const bool FOO;
+                static const bool FOO;
                 ::std::string string_field;
                 LevelFour( );
                 explicit LevelFour( ::std::string string_field );

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithConstants.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithConstants.h
@@ -8,8 +8,8 @@
 #include <string>
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT Route {
-    _GLUECODIUM_CPP_EXPORT static const ::std::string DEFAULT_DESCRIPTION;
-    _GLUECODIUM_CPP_EXPORT static const ::smoke::RouteType DEFAULT_TYPE;
+    static const ::std::string DEFAULT_DESCRIPTION;
+    static const ::smoke::RouteType DEFAULT_TYPE;
     ::std::string description;
     ::smoke::RouteType type;
     Route( );

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithConstantsInterface.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithConstantsInterface.h
@@ -15,15 +15,15 @@ public:
     virtual ~StructsWithConstantsInterface() = 0;
 public:
     struct _GLUECODIUM_CPP_EXPORT MultiRoute {
-        _GLUECODIUM_CPP_EXPORT static const ::std::string DEFAULT_DESCRIPTION;
-        _GLUECODIUM_CPP_EXPORT static const ::smoke::RouteType DEFAULT_TYPE;
+        static const ::std::string DEFAULT_DESCRIPTION;
+        static const ::smoke::RouteType DEFAULT_TYPE;
         ::std::vector< ::std::string > descriptions;
         ::smoke::RouteType type;
         MultiRoute( );
         MultiRoute( ::std::vector< ::std::string > descriptions, ::smoke::RouteType type );
     };
     struct _GLUECODIUM_CPP_EXPORT StructWithConstantsOnly {
-        _GLUECODIUM_CPP_EXPORT static const ::std::string DEFAULT_DESCRIPTION;
+        static const ::std::string DEFAULT_DESCRIPTION;
     };
 };
 }


### PR DESCRIPTION
Updated C++ Mustache templates to skip `EXPORT` macro for constants that are
nested inside a class/interface/struct. The outer type has the same macro anyway
and this is enough to ensure symbol visibility for the constant.

Only stand-alone constants (declared inside `types` in IDL) are getting the
`EXPORT` macro now. This fixes a compilation issue for nested constants on
Windows platform.

Updated affected smoke tests.

Resolves: #1244
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>