### PR TITLE
Fix doc-less field constructors in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * For the field constructors which have to documentation comment specified, parameters documentation is no longer
+  erroneously generated in Dart.
+
 ## 10.6.3
 Release date: 2022-01-31
 ### Features:

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -59,16 +59,18 @@
 {{/if}}{{/unless}}{{/unless}}{{/if}}{{!!
 
 }}{{#set struct=this container=this}}{{#fieldConstructors}}
-{{#unless comment.isEmpty}}{{#resolveName comment}}{{!!
-}}{{prefix this "  /// "}}{{/resolveName}}
-{{/unless}}{{!!
-}}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
+{{#unless comment.isEmpty}}{{#resolveName comment}}{{#unless this.isEmpty}}{{!!
 }}{{prefix this "  /// "}}
-{{/unless}}{{/resolveName}}{{/if}}
-{{#ifPredicate "hasAnyComment"}}{{#fields}}
+{{#fields}}
   /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
   }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
-{{/fields}}{{/ifPredicate}}{{!!
+{{/fields}}{{/unless}}{{/resolveName}}{{/unless}}{{!!
+}}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
+}}{{prefix this "  /// "}}
+{{#fields}}
+  /// [{{resolveName}}] {{#resolveName comment}}{{#unless this.isEmpty}}{{!!
+  }}{{prefix this "  /// " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/fields}}{{/unless}}{{/resolveName}}{{/if}}{{!!
 }}{{#if this.comment.isExcluded}}
   /// @nodoc
 {{/if}}{{!!

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_only.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_deprecation_only.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 class FieldConstructorWithDeprecationOnly {
   String stringField;
-  /// [stringField]
   @Deprecated("Shouldn't really use it")
   FieldConstructorWithDeprecationOnly(this.stringField);
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded_only.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructor_with_excluded_only.dart
@@ -3,7 +3,6 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 class FieldConstructorWithExcludedOnly {
   String stringField;
-  /// [stringField]
   /// @nodoc
   FieldConstructorWithExcludedOnly(this.stringField);
 }


### PR DESCRIPTION
Updated DartStructConstructors template to avoid generating field constructor
parameters documentation when the field constructor itself has no documentation.

Updated smoke tests accordingly.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>