### PR TITLE
Add support for `Date` literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for `Date` type literal values.
+
 ## 10.6.5
 Release date: 2022-02-03
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -462,6 +462,9 @@ Binary, octal or hexadecimal integer literals are currently not supported.
 String literals are enclosed in quotes `"`, e.g. `"hello"`. Unicode characters are supported. Also,
 a limited set of escaped characters is currently supported: `\\`, `\"`, `\n`, `\r`, `\t`.
 
+A string literal can be used to initialize a `Date` value. In this case it has to conform to ISO 8601 standard: e.g.
+`"2022-02-04T11:15:17+02:00"`, or `"2022-02-04T09:15:17Z"` for a UTC value.
+
 #### Special literals
 
 * `null`: "null" value for nullable types.

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -372,6 +372,7 @@ feature(Dates cpp android swift dart SOURCES
     input/src/cpp/Dates.cpp
 
     input/lime/Dates.lime
+    input/lime/DateDefaults.lime
 )
 
 feature(Durations cpp android swift dart SOURCES

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/DatesTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/DatesTest.java
@@ -26,6 +26,7 @@ import com.here.android.RobolectricApplication;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.TimeZone;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -129,5 +130,65 @@ public class DatesTest {
     assertEquals(dateCalendar.get(Calendar.HOUR) + 1, resultCalendar.get(Calendar.HOUR));
     assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE));
     assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND));
+  }
+
+  @Test
+  public void dateDefaultsCet() {
+    DateDefaults defaults = new DateDefaults();
+    Date date = defaults.dateTime;
+
+    Calendar resultCalendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+    resultCalendar.setTime(date);
+    assertEquals(2022, resultCalendar.get(Calendar.YEAR));
+    assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH));
+    assertEquals(4, resultCalendar.get(Calendar.DATE));
+    assertEquals(9, resultCalendar.get(Calendar.HOUR));
+    assertEquals(15, resultCalendar.get(Calendar.MINUTE));
+    assertEquals(17, resultCalendar.get(Calendar.SECOND));
+  }
+
+  @Test
+  public void dateDefaultsUtc() {
+    DateDefaults defaults = new DateDefaults();
+    Date date = defaults.dateTimeUtc;
+
+    Calendar resultCalendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+    resultCalendar.setTime(date);
+    assertEquals(2022, resultCalendar.get(Calendar.YEAR));
+    assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH));
+    assertEquals(4, resultCalendar.get(Calendar.DATE));
+    assertEquals(9, resultCalendar.get(Calendar.HOUR));
+    assertEquals(15, resultCalendar.get(Calendar.MINUTE));
+    assertEquals(17, resultCalendar.get(Calendar.SECOND));
+  }
+
+  @Test
+  public void dateDefaultsBefore() {
+    DateDefaults defaults = new DateDefaults();
+    Date date = defaults.beforeEpoch;
+
+    Calendar resultCalendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+    resultCalendar.setTime(date);
+    assertEquals(1922, resultCalendar.get(Calendar.YEAR));
+    assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH));
+    assertEquals(4, resultCalendar.get(Calendar.DATE));
+    assertEquals(9, resultCalendar.get(Calendar.HOUR));
+    assertEquals(15, resultCalendar.get(Calendar.MINUTE));
+    assertEquals(17, resultCalendar.get(Calendar.SECOND));
+  }
+
+  @Test
+  public void dateDefaultsCpp() {
+    DateDefaults defaults = DateDefaults.getCppDefaults();
+    Date date = defaults.dateTimeUtc;
+
+    Calendar resultCalendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+    resultCalendar.setTime(date);
+    assertEquals(2022, resultCalendar.get(Calendar.YEAR));
+    assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH));
+    assertEquals(4, resultCalendar.get(Calendar.DATE));
+    assertEquals(9, resultCalendar.get(Calendar.HOUR));
+    assertEquals(15, resultCalendar.get(Calendar.MINUTE));
+    assertEquals(17, resultCalendar.get(Calendar.SECOND));
   }
 }

--- a/functional-tests/functional/dart/test/Dates_test.dart
+++ b/functional-tests/functional/dart/test/Dates_test.dart
@@ -91,4 +91,52 @@ void main() {
     expect(result?.minute, 10);
     expect(result?.second, 12);
   });
+  _testSuite.test("Date literal CET", () {
+    final defaults = DateDefaults();
+
+    final result = defaults.dateTime;
+
+    expect(result.year, 2022);
+    expect(result.month, 2);
+    expect(result.day, 4);
+    expect(result.hour, 9);
+    expect(result.minute, 15);
+    expect(result.second, 17);
+  });
+  _testSuite.test("Date literal UTC", () {
+    final defaults = DateDefaults();
+
+    final result = defaults.dateTimeUtc;
+
+    expect(result.year, 2022);
+    expect(result.month, 2);
+    expect(result.day, 4);
+    expect(result.hour, 9);
+    expect(result.minute, 15);
+    expect(result.second, 17);
+  });
+  _testSuite.test("Date literal before epoch", () {
+    final defaults = DateDefaults();
+
+    final result = defaults.beforeEpoch;
+
+    expect(result.year, 1922);
+    expect(result.month, 2);
+    expect(result.day, 4);
+    expect(result.hour, 9);
+    expect(result.minute, 15);
+    expect(result.second, 17);
+  });
+  _testSuite.test("Date literal from C++", () {
+    final defaults = DateDefaults.getCppDefaults();
+
+    final result = defaults.dateTimeUtc;
+
+    expect(result.year, 2022);
+    expect(result.month, 2);
+    expect(result.day, 4);
+    expect(result.hour, 9);
+    expect(result.minute, 15);
+    expect(result.second, 17);
+  });
 }

--- a/functional-tests/functional/input/lime/DateDefaults.lime
+++ b/functional-tests/functional/input/lime/DateDefaults.lime
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct DateDefaults {
+    dateTime: Date = "2022-02-04T11:15:17+02:00"
+    dateTimeUtc: Date = "2022-02-04T09:15:17Z"
+    beforeEpoch: Date = "1922-02-04T09:15:17Z"
+
+    field constructor()
+
+    static fun getCppDefaults(): DateDefaults
+}

--- a/functional-tests/functional/input/src/cpp/Dates.cpp
+++ b/functional-tests/functional/input/src/cpp/Dates.cpp
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+#include "test/DateDefaults.h"
 #include "test/Dates.h"
 #include "test/DatesSteady.h"
 
@@ -77,5 +78,8 @@ std::vector<steady_clock::time_point>
 DatesSteady::date_list_method(const std::vector<steady_clock::time_point>& input) {
     return input;
 }
+
+DateDefaults
+DateDefaults::get_cpp_defaults() { return {}; }
 
 }

--- a/functional-tests/functional/swift/Tests/DatesTests.swift
+++ b/functional-tests/functional/swift/Tests/DatesTests.swift
@@ -119,6 +119,57 @@ class DatesTests: XCTestCase {
         XCTAssertEqual(calendar.component(.second, from: result!), dateComponents.second! + 1)
     }
 
+    func testDateDefaultsCet() {
+        let date = DateDefaults().dateTime
+        let dateComponents =
+            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+
+        XCTAssertEqual(2022, dateComponents.year!)
+        XCTAssertEqual(2, dateComponents.month!)
+        XCTAssertEqual(4, dateComponents.day!)
+        XCTAssertEqual(9, dateComponents.hour!)
+        XCTAssertEqual(15, dateComponents.minute!)
+        XCTAssertEqual(17, dateComponents.second!)
+    }
+
+    func testDateDefaultsUtc() {
+        let date = DateDefaults().dateTimeUtc
+        let dateComponents =
+            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+
+        XCTAssertEqual(2022, dateComponents.year!)
+        XCTAssertEqual(2, dateComponents.month!)
+        XCTAssertEqual(4, dateComponents.day!)
+        XCTAssertEqual(9, dateComponents.hour!)
+        XCTAssertEqual(15, dateComponents.minute!)
+        XCTAssertEqual(17, dateComponents.second!)
+    }
+
+    func testDateDefaultsBeforeEpoch() {
+        let date = DateDefaults().beforeEpoch
+        let dateComponents =
+            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+
+        XCTAssertEqual(1922, dateComponents.year!)
+        XCTAssertEqual(2, dateComponents.month!)
+        XCTAssertEqual(4, dateComponents.day!)
+        XCTAssertEqual(9, dateComponents.hour!)
+        XCTAssertEqual(15, dateComponents.minute!)
+        XCTAssertEqual(17, dateComponents.second!)
+    }
+
+    func testDateDefaultsCpp() {
+        let date = DateDefaults.getCppDefaults().dateTimeUtc
+        let dateComponents =
+            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+
+        XCTAssertEqual(2022, dateComponents.year!)
+        XCTAssertEqual(2, dateComponents.month!)
+        XCTAssertEqual(4, dateComponents.day!)
+        XCTAssertEqual(9, dateComponents.hour!)
+        XCTAssertEqual(15, dateComponents.minute!)
+        XCTAssertEqual(17, dateComponents.second!)
+    }
 
     static var allTests = [
         ("testDateAttributeRoundTrip", testDateAttributeRoundTrip),
@@ -128,6 +179,10 @@ class DatesTests: XCTestCase {
         ("testMethodNullableRoundTrip", testMethodNullableRoundTrip),
         ("testDatesSteadyMethodRoundTrip", testDatesSteadyMethodRoundTrip),
         ("testDatesSteadyMethodNullableNullRoundTrip", testDatesSteadyMethodNullableNullRoundTrip),
-        ("testDatesSteadyMethodNullableRoundTrip", testDatesSteadyMethodNullableRoundTrip)
+        ("testDatesSteadyMethodNullableRoundTrip", testDatesSteadyMethodNullableRoundTrip),
+        ("testDateDefaultsCet", testDateDefaultsCet),
+        ("testDateDefaultsUtc", testDateDefaultsUtc),
+        ("testDateDefaultsBeforeEpoch", testDateDefaultsBeforeEpoch),
+        ("testDateDefaultsCpp", testDateDefaultsCpp)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -185,6 +185,7 @@ internal class CppNameResolver(
                 limeValue.values.joinToString(", ", "${resolveName(limeValue.typeRef)}{", "}") { resolveValue(it) }
             is LimeValue.KeyValuePair -> "{${resolveValue(limeValue.key)}, ${resolveValue(limeValue.value)}}"
             is LimeValue.Duration -> resolveDurationValue(limeValue)
+            is LimeValue.Date -> "::std::chrono::system_clock::from_time_t(${limeValue.epochSeconds})"
         }
 
     private fun resolveDurationValue(limeValue: LimeValue.Duration): String {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -171,6 +171,7 @@ internal class DartNameResolver(
             }
             is LimeValue.KeyValuePair -> "${resolveValue(limeValue.key)}: ${resolveValue(limeValue.value)}"
             is LimeValue.Duration -> resolveDurationValue(limeValue)
+            is LimeValue.Date -> "DateTime.fromMillisecondsSinceEpoch(${limeValue.epochSeconds}000)"
         }
 
     private fun resolveDurationValue(limeValue: LimeValue.Duration): String {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
@@ -63,6 +63,7 @@ internal class JavaValueResolver(private val nameResolver: JavaNameResolver) {
                 "new AbstractMap.SimpleEntry<>($keyValue, $valueValue)"
             }
             is LimeValue.Duration -> mapDurationValue(limeValue)
+            is LimeValue.Date -> "new Date(${limeValue.epochSeconds}000L)"
         }
 
     private fun mapInitializerList(limeValue: LimeValue.InitializerList): String {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -147,6 +147,7 @@ internal class SwiftNameResolver(
             }
             is LimeValue.KeyValuePair -> "${resolveValue(limeValue.key)}: ${resolveValue(limeValue.value)}"
             is LimeValue.Duration -> resolveDurationValue(limeValue)
+            is LimeValue.Date -> "Date(timeIntervalSince1970: ${limeValue.epochSeconds})"
         }
 
     private fun resolveDurationValue(limeValue: LimeValue.Duration): String {

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
@@ -76,7 +76,7 @@ class LimeValuesValidatorTest(
             arrayOf(LimeBasicTypeRef.FLOAT, LimeValue.Literal(fooTypeRef, ""), true),
             arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.BOOLEAN), LimeValue.Literal(fooTypeRef, ""), true),
             arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.STRING), LimeValue.Literal(fooTypeRef, ""), true),
-            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.DATE), LimeValue.Literal(fooTypeRef, ""), false),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.DATE), LimeValue.Literal(fooTypeRef, ""), true),
             arrayOf(fooTypeRef, LimeValue.Literal(fooTypeRef, ""), false),
             arrayOf(
                 LimeDirectTypeRef(LimeEnumeration(EMPTY_PATH)),

--- a/gluecodium/src/test/resources/smoke/dates/input/DateDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/dates/input/DateDefaults.lime
@@ -1,0 +1,24 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct DateDefaults {
+    dateTime: Date = "2022-02-04T11:15:17+02:00"
+    dateTimeUtc: Date = "2022-02-04T09:15:17Z"
+    beforeEpoch: Date = "1922-02-04T09:15:17Z"
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/DateDefaults.java
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/DateDefaults.java
@@ -1,0 +1,24 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import java.util.Date;
+public final class DateDefaults {
+    @NonNull
+    public Date dateTime;
+    @NonNull
+    public Date dateTimeUtc;
+    @NonNull
+    public Date beforeEpoch;
+    public DateDefaults() {
+        this.dateTime = new Date(1643966117000L);
+        this.dateTimeUtc = new Date(1643966117000L);
+        this.beforeEpoch = new Date(-1511793883000L);
+    }
+    public DateDefaults(@NonNull final Date dateTime, @NonNull final Date dateTimeUtc, @NonNull final Date beforeEpoch) {
+        this.dateTime = dateTime;
+        this.dateTimeUtc = dateTimeUtc;
+        this.beforeEpoch = beforeEpoch;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DateDefaults.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DateDefaults.h
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/TimePointHash.h"
+#include <chrono>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT DateDefaults {
+    ::std::chrono::system_clock::time_point date_time = ::std::chrono::system_clock::from_time_t(1643966117);
+    ::std::chrono::system_clock::time_point date_time_utc = ::std::chrono::system_clock::from_time_t(1643966117);
+    ::std::chrono::system_clock::time_point before_epoch = ::std::chrono::system_clock::from_time_t(-1511793883);
+    DateDefaults( );
+    DateDefaults( ::std::chrono::system_clock::time_point date_time, ::std::chrono::system_clock::time_point date_time_utc, ::std::chrono::system_clock::time_point before_epoch );
+};
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults.dart
@@ -1,0 +1,89 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class DateDefaults {
+  DateTime dateTime;
+  DateTime dateTimeUtc;
+  DateTime beforeEpoch;
+  DateDefaults(this.dateTime, this.dateTimeUtc, this.beforeEpoch);
+  DateDefaults.withDefaults()
+    : dateTime = DateTime.fromMillisecondsSinceEpoch(1643966117000), dateTimeUtc = DateTime.fromMillisecondsSinceEpoch(1643966117000), beforeEpoch = DateTime.fromMillisecondsSinceEpoch(-1511793883000);
+}
+// DateDefaults "private" section, not exported.
+final _smokeDatedefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Uint64, Uint64),
+    Pointer<Void> Function(int, int, int)
+  >('library_smoke_DateDefaults_create_handle'));
+final _smokeDatedefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DateDefaults_release_handle'));
+final _smokeDatedefaultsGetFielddateTime = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DateDefaults_get_field_dateTime'));
+final _smokeDatedefaultsGetFielddateTimeUtc = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DateDefaults_get_field_dateTimeUtc'));
+final _smokeDatedefaultsGetFieldbeforeEpoch = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DateDefaults_get_field_beforeEpoch'));
+Pointer<Void> smokeDatedefaultsToFfi(DateDefaults value) {
+  final _dateTimeHandle = dateToFfi(value.dateTime);
+  final _dateTimeUtcHandle = dateToFfi(value.dateTimeUtc);
+  final _beforeEpochHandle = dateToFfi(value.beforeEpoch);
+  final _result = _smokeDatedefaultsCreateHandle(_dateTimeHandle, _dateTimeUtcHandle, _beforeEpochHandle);
+  dateReleaseFfiHandle(_dateTimeHandle);
+  dateReleaseFfiHandle(_dateTimeUtcHandle);
+  dateReleaseFfiHandle(_beforeEpochHandle);
+  return _result;
+}
+DateDefaults smokeDatedefaultsFromFfi(Pointer<Void> handle) {
+  final _dateTimeHandle = _smokeDatedefaultsGetFielddateTime(handle);
+  final _dateTimeUtcHandle = _smokeDatedefaultsGetFielddateTimeUtc(handle);
+  final _beforeEpochHandle = _smokeDatedefaultsGetFieldbeforeEpoch(handle);
+  try {
+    return DateDefaults(
+      dateFromFfi(_dateTimeHandle),
+      dateFromFfi(_dateTimeUtcHandle),
+      dateFromFfi(_beforeEpochHandle)
+    );
+  } finally {
+    dateReleaseFfiHandle(_dateTimeHandle);
+    dateReleaseFfiHandle(_dateTimeUtcHandle);
+    dateReleaseFfiHandle(_beforeEpochHandle);
+  }
+}
+void smokeDatedefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDatedefaultsReleaseHandle(handle);
+// Nullable DateDefaults
+final _smokeDatedefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DateDefaults_create_handle_nullable'));
+final _smokeDatedefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DateDefaults_release_handle_nullable'));
+final _smokeDatedefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DateDefaults_get_value_nullable'));
+Pointer<Void> smokeDatedefaultsToFfiNullable(DateDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDatedefaultsToFfi(value);
+  final result = _smokeDatedefaultsCreateHandleNullable(_handle);
+  smokeDatedefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+DateDefaults? smokeDatedefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDatedefaultsGetValueNullable(handle);
+  final result = smokeDatedefaultsFromFfi(_handle);
+  smokeDatedefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDatedefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDatedefaultsReleaseHandleNullable(handle);
+// End of DateDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DateDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DateDefaults.lime
@@ -1,0 +1,6 @@
+package smoke
+struct DateDefaults {
+    dateTime: Date = "2022-02-04T09:15:17Z"
+    dateTimeUtc: Date = "2022-02-04T09:15:17Z"
+    beforeEpoch: Date = "1922-02-04T09:15:17Z"
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/DateDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/DateDefaults.swift
@@ -1,0 +1,61 @@
+//
+//
+import Foundation
+public struct DateDefaults {
+    public var dateTime: Date
+    public var dateTimeUtc: Date
+    public var beforeEpoch: Date
+    public init(dateTime: Date = Date(timeIntervalSince1970: 1643966117), dateTimeUtc: Date = Date(timeIntervalSince1970: 1643966117), beforeEpoch: Date = Date(timeIntervalSince1970: -1511793883)) {
+        self.dateTime = dateTime
+        self.dateTimeUtc = dateTimeUtc
+        self.beforeEpoch = beforeEpoch
+    }
+    internal init(cHandle: _baseRef) {
+        dateTime = moveFromCType(smoke_DateDefaults_dateTime_get(cHandle))
+        dateTimeUtc = moveFromCType(smoke_DateDefaults_dateTimeUtc_get(cHandle))
+        beforeEpoch = moveFromCType(smoke_DateDefaults_beforeEpoch_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> DateDefaults {
+    return DateDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> DateDefaults {
+    defer {
+        smoke_DateDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DateDefaults) -> RefHolder {
+    let c_dateTime = moveToCType(swiftType.dateTime)
+    let c_dateTimeUtc = moveToCType(swiftType.dateTimeUtc)
+    let c_beforeEpoch = moveToCType(swiftType.beforeEpoch)
+    return RefHolder(smoke_DateDefaults_create_handle(c_dateTime.ref, c_dateTimeUtc.ref, c_beforeEpoch.ref))
+}
+internal func moveToCType(_ swiftType: DateDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> DateDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_DateDefaults_unwrap_optional_handle(handle)
+    return DateDefaults(cHandle: unwrappedHandle) as DateDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> DateDefaults? {
+    defer {
+        smoke_DateDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DateDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_dateTime = moveToCType(swiftType.dateTime)
+    let c_dateTimeUtc = moveToCType(swiftType.dateTimeUtc)
+    let c_beforeEpoch = moveToCType(swiftType.beforeEpoch)
+    return RefHolder(smoke_DateDefaults_create_optional_handle(c_dateTime.ref, c_dateTimeUtc.ref, c_beforeEpoch.ref))
+}
+internal func moveToCType(_ swiftType: DateDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateDefaults_release_optional_handle)
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -38,6 +38,9 @@ import com.here.gluecodium.model.lime.LimeValue
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.tree.ParseTreeWalker
+import java.time.DateTimeException
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 
 internal object AntlrLimeConverter {
 
@@ -271,5 +274,14 @@ internal object AntlrLimeConverter {
             ?: throw LimeLoadingException("Unsupported time unit: '$timeUnitText'")
         val sign = if (isNegative) "-" else ""
         return LimeValue.Duration(limeTypeRef, sign + valueText, timeUnit)
+    }
+
+    fun convertDateLiteral(limeTypeRef: LimeTypeRef, literalText: String): LimeValue.Date {
+        val epochSeconds = try {
+            Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(literalText)).epochSecond
+        } catch (e: DateTimeException) {
+            throw LimeLoadingException("Invalid `Date` literal: '$literalText'")
+        }
+        return LimeValue.Date(limeTypeRef, epochSeconds)
     }
 }

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.antlr.LimeParser
 import com.here.gluecodium.common.ModelBuilderContextStack
 import com.here.gluecodium.model.lime.LimeAmbiguousEnumeratorRef
 import com.here.gluecodium.model.lime.LimeAmbiguousTypeRef
+import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeComment
@@ -676,10 +677,11 @@ internal class AntlrLimeModelBuilder(
             ctx.DoubleLiteral() != null -> ctx.DoubleLiteral().text
             else -> throw LimeLoadingException("Unsupported literal: '$ctx'")
         }
-        return LimeValue.Literal(
-            limeTypeRef,
-            if (ctx.Minus() != null) "-$literalString" else literalString
-        )
+        return if (limeTypeRef is LimeBasicTypeRef && limeTypeRef.type.typeId == LimeBasicType.TypeId.DATE) {
+            AntlrLimeConverter.convertDateLiteral(limeTypeRef, literalString)
+        } else {
+            LimeValue.Literal(limeTypeRef, if (ctx.Minus() != null) "-$literalString" else literalString)
+        }
     }
 
     private fun convertSimpleId(simpleId: LimeParser.SimpleIdContext): String {

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
@@ -40,7 +40,7 @@ class LimeBasicType(val typeId: TypeId) : LimeType(path = LimePath.EMPTY_PATH) {
         BOOLEAN("Boolean", false, false, true),
         STRING("String", false, false, true),
         BLOB("Blob"),
-        DATE("Date"),
+        DATE("Date", false, false, true),
         DURATION("Duration"),
         LOCALE("Locale");
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
@@ -20,6 +20,7 @@
 package com.here.gluecodium.model.lime
 
 import com.here.gluecodium.common.StringHelper
+import java.time.Instant
 
 /**
  * Represents a constant value on the right-hand side of an assignment (used in constants, field
@@ -107,6 +108,10 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
         }
 
         override fun toString() = value + timeUnit
+    }
+
+    class Date(typeRef: LimeTypeRef, val epochSeconds: Long) : LimeValue(typeRef) {
+        override fun toString() = "\"${Instant.ofEpochSecond(epochSeconds)}\""
     }
 
     open val escapedValue


### PR DESCRIPTION
Updated name resolvers for all output languages and LIME model builder to
support ISO 8601 date-time strings as `Date` type literals. Added smoke and
functional tests.

Resolves: #1215
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>