### PR TITLE
Upgrade MockK dependency to 1.12.2

### DIFF
--- a/gluecodium-gradle/build.gradle
+++ b/gluecodium-gradle/build.gradle
@@ -15,8 +15,8 @@ dependencies {
     }
     implementation 'com.natpryce:konfig:1.6.10.0'
 
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
-    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.2'
+    testImplementation 'io.mockk:mockk:1.12.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/gluecodium/build.gradle
+++ b/gluecodium/build.gradle
@@ -39,8 +39,8 @@ dependencies {
     implementation 'org.trimou:trimou-core:2.5.0.Final'
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
-    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.2'
+    testImplementation 'io.mockk:mockk:1.12.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/lime-loader/build.gradle
+++ b/lime-loader/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     implementation "org.antlr:antlr4-runtime:4.9.1"
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
-    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.2'
+    testImplementation 'io.mockk:mockk:1.12.2'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/lime-runtime/build.gradle
+++ b/lime-runtime/build.gradle
@@ -21,8 +21,8 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.31'
     compileOnly 'org.jetbrains:annotations:13.0'
 
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.0'
-    testImplementation 'io.mockk:mockk:1.12.0'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.2'
+    testImplementation 'io.mockk:mockk:1.12.2'
     testImplementation 'junit:junit:4.13.2'
 }
 


### PR DESCRIPTION
Upgrade MockK library dependency to 1.12.2 to resolve build issues.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
