### PR TITLE
Clean up code

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/ReferenceMapBasedResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/ReferenceMapBasedResolver.kt
@@ -42,7 +42,4 @@ internal abstract class ReferenceMapBasedResolver(protected val limeReferenceMap
                 )
             )
     }
-
-    protected fun getTopElement(limeElement: LimeNamedElement) =
-        generateSequence(limeElement) { limeReferenceMap[it.path.parent.toString()] as? LimeNamedElement }.last()
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppHeaderIncludesCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppHeaderIncludesCollector.kt
@@ -55,7 +55,7 @@ internal class CppHeaderIncludesCollector(
             allTypeRefs.flatMap { includesResolver.resolveElementImports(it) } +
             allValues.flatMap { includesResolver.resolveElementImports(it) } +
             allTypes.flatMap { includesResolver.resolveElementImports(it) } +
-            additionalIncludes - forwardDeclaredTypes.flatMap { includesResolver.resolveElementImports(it) }
+            additionalIncludes - forwardDeclaredTypes.flatMap { includesResolver.resolveElementImports(it) }.toSet()
     }
 
     private fun collectAdditionalIncludes(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartOverloadsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartOverloadsValidator.kt
@@ -50,7 +50,7 @@ internal class DartOverloadsValidator(
             ((limeContainer as? LimeContainerWithInheritance)?.inheritedFunctions ?: emptyList())
         val constructors = allFunctions.filter { it.isConstructor }
 
-        val overloadedFunctions = (allFunctions - constructors)
+        val overloadedFunctions = (allFunctions - constructors.toSet())
             .groupBy { nameResolver.resolveName(it) }
             .filter { it.value.size > 1 }
         overloadedFunctions.forEach { entry ->

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportCollector.kt
@@ -55,9 +55,9 @@ internal class JavaImportCollector(
 
     fun collectImplImports(limeInterface: LimeInterface, defImports: List<JavaImport>): List<JavaImport> {
         if (limeInterface.parents.isEmpty()) return defImports
-        val parentImport =
+        val parentImports =
             limeInterface.parents.mapNotNull { importsResolver.createTopElementImport(it.type.actualType) }
-        return defImports - parentImport +
+        return defImports - parentImports.toSet() +
             (limeInterface.inheritedFunctions + limeInterface.inheritedProperties).flatMap { collectImports(it) }
     }
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/CaseInsensitiveSet.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/CaseInsensitiveSet.kt
@@ -28,9 +28,9 @@ class CaseInsensitiveSet(elements: Collection<String> = emptySet()) :
 
     override fun remove(element: String) = super.remove(element.toLowerCase())
 
-    override fun removeAll(elements: Collection<String>) = super.removeAll(elements.map { it.toLowerCase() })
+    override fun removeAll(elements: Collection<String>) = super.removeAll(elements.map { it.toLowerCase() }.toSet())
 
-    override fun retainAll(elements: Collection<String>) = super.retainAll(elements.map { it.toLowerCase() })
+    override fun retainAll(elements: Collection<String>) = super.retainAll(elements.map { it.toLowerCase() }.toSet())
 
     override fun contains(element: String) = super.contains(element.toLowerCase())
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeFieldConstructor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeFieldConstructor.kt
@@ -32,7 +32,7 @@ class LimeFieldConstructor(
     val fields
         get() = fieldRefs.map { it.field }
     val omittedFields
-        get() = struct.fields - fields
+        get() = struct.fields - fields.toSet()
 
     fun asFunction() = LimeFunction(
         path = path,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
@@ -41,7 +41,7 @@ open class LimeSignatureResolver(private val referenceMap: Map<String, LimeEleme
         functions: List<LimeFunction> = getAllOverloads(limeFunction)
     ): Boolean {
         val signature = getSignature(limeFunction)
-        return functions.map { getSignature(it) }.filter { it == signature }.count() > 1
+        return functions.map { getSignature(it) }.count { it == signature } > 1
     }
 
     fun hasConstructorSignatureClash(limeFunction: LimeFunction): Boolean {


### PR DESCRIPTION
Removed unused `ReferenceMapBasedResolver.getTopElemen()` function.

Updated usages of "set subtraction" operator to have the right operand of
`Set<>` type. This improves the performance of the operation slightly.