### PR TITLE
Make Java "automatic" constructors forward-compatible 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Breaking changes:
+  * All-fields constructors are no longer unconditionally generated for mutable structs in Java. They are now generated
+  only if there are no explicitly defined constructors and none of the fields have default values specified.
+
 ## 10.7.2
 Release date: 2022-02-14
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/ComplexListeners.lime
+++ b/functional-tests/functional/input/lime/ComplexListeners.lime
@@ -22,10 +22,15 @@ types ComplexListenerTypes {
         x: Double = 0.0
         y: Double = 0.0
         z: Double = 0.0
+        @Dart("withDefaults")
+        field constructor()
+        @Dart(Default)
+        field constructor(x, y, z)
     }
     struct NamedPoint3D {
         name: String
         pt: Point3D
+        field constructor(name, pt)
     }
     enum TrajectoryQuality {
         TRAJECTORY_POOR,

--- a/functional-tests/functional/input/lime/Defaults.lime
+++ b/functional-tests/functional/input/lime/Defaults.lime
@@ -29,6 +29,10 @@ class Defaults {
     }
     struct StructWithExternalDefaults {
         enumField: ExternalEnum = ExternalEnum.Another_Value
+        @Dart("withDefaults")
+        field constructor()
+        @Dart(Default)
+        field constructor(enumField)
     }
     @Immutable
     struct ImmutableStructWithDefaults {

--- a/functional-tests/functional/input/lime/Equatable.lime
+++ b/functional-tests/functional/input/lime/Equatable.lime
@@ -44,6 +44,11 @@ types Equatable {
         enumField: SomeSomeEnum? = null
         mapField: SomeMap? = null
         arrayField: List<String>? = null
+
+        @Dart("withDefaults")
+        field constructor()
+        @Dart(Default)
+        field constructor(boolField, intField, uintField, floatField, stringField, structField, enumField, mapField, arrayField)
     }
 
     @Equatable

--- a/functional-tests/functional/input/lime/TypeCollection.lime
+++ b/functional-tests/functional/input/lime/TypeCollection.lime
@@ -22,6 +22,7 @@ types TypeCollection {
     struct Point {
         x: Double = 0.0
         y: Double = 0.0
+        field constructor(x, y)
     }
     // Basic struct type
     struct Color {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -87,14 +87,6 @@ internal object CommonGeneratorPredicates {
             else -> false
         }
 
-    fun needsAllFieldsConstructor(limeStruct: Any) =
-        when {
-            limeStruct !is LimeStruct -> false
-            limeStruct.fieldConstructors.isEmpty() -> true
-            limeStruct.attributes.have(LimeAttributeType.IMMUTABLE) -> limeStruct.allFieldsConstructor == null
-            else -> false
-        }
-
     fun needsPublicFieldsConstructor(limeStruct: Any, platformAttribute: LimeAttributeType) =
         limeStruct is LimeStruct &&
             !limeStruct.attributes.have(platformAttribute, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
@@ -20,9 +20,11 @@
 package com.here.gluecodium.generator.java
 
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
+import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeExternalDescriptor
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeRef
@@ -56,9 +58,14 @@ internal object JavaGeneratorPredicates {
             }
         },
         "needsAllFieldsConstructor" to { limeStruct: Any ->
-            limeStruct is LimeStruct &&
-                !limeStruct.attributes.have(JAVA, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&
-                CommonGeneratorPredicates.needsAllFieldsConstructor(limeStruct)
+            when {
+                limeStruct !is LimeStruct -> false
+                limeStruct.external?.java?.get(LimeExternalDescriptor.CONVERTER_NAME) != null -> true
+                limeStruct.attributes.have(JAVA, LimeAttributeValueType.POSITIONAL_DEFAULTS) -> false
+                limeStruct.attributes.have(LimeAttributeType.IMMUTABLE) -> limeStruct.allFieldsConstructor == null
+                limeStruct.fieldConstructors.isEmpty() -> limeStruct.initializedFields.isEmpty()
+                else -> false
+            }
         },
         "needsDisposer" to { limeClass: Any ->
             limeClass is LimeClass && limeClass.parentClass == null
@@ -66,7 +73,6 @@ internal object JavaGeneratorPredicates {
         "needsNonNullAnnotation" to { limeTypeRef ->
             limeTypeRef is LimeTypeRef && !limeTypeRef.isNullable &&
                 JavaImportResolver.needsNonNullAnnotation(limeTypeRef.type.actualType)
-        },
-        "needsPublicFieldsConstructor" to { CommonGeneratorPredicates.needsPublicFieldsConstructor(it, JAVA) },
+        }
     )
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -88,7 +88,14 @@ internal class SwiftGeneratorPredicates(
         "isRefEquatable" to { limeField: Any ->
             limeField is LimeField && isRefEquatable(limeField)
         },
-        "needsAllFieldsConstructor" to { CommonGeneratorPredicates.needsAllFieldsConstructor(it) },
+        "needsAllFieldsConstructor" to { limeStruct: Any ->
+            when {
+                limeStruct !is LimeStruct -> false
+                limeStruct.fieldConstructors.isEmpty() -> true
+                limeStruct.attributes.have(LimeAttributeType.IMMUTABLE) -> limeStruct.allFieldsConstructor == null
+                else -> false
+            }
+        },
         "needsExplicitHashable" to { limeStruct: Any ->
             limeStruct is LimeStruct && limeStruct.attributes.have(LimeAttributeType.EQUATABLE) &&
                 limeStruct.fields.any { isRefEquatable(it) }

--- a/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
@@ -36,25 +36,7 @@
                    }}{{#unless defaultValue}}{{resolveName}}{{/unless}};
 {{/fields}}
     }
-{{/if}}{{!!
-
-}}{{#ifPredicate "needsPublicFieldsConstructor"}}
-
-{{#unless constructorComment.isEmpty}}
-    /**
-{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
-{{#publicFields}}
-     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
-{{/publicFields}}
-     */
-{{/unless}}
-    {{>structVisibility}}{{resolveName}}{{!!
-    }}({{#set noAttributes=true}}{{joinPartial publicFields "java/JavaParameter" ", "}}{{/set}}) {
-{{#fields}}        this.{{resolveName}} = {{#unless visibility.isInternal}}{{resolveName}}{{/unless}}{{!!
-                    }}{{#if visibility.isInternal}}{{resolveName defaultValue}}{{/if}};
-{{/fields}}
-    }
-{{/ifPredicate}}{{/unless}}{{!!
+{{/if}}{{/unless}}{{!!
 
 }}{{#ifPredicate "needsAllFieldsConstructor"}}
 

--- a/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/DateDefaults.java
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/DateDefaults.java
@@ -19,10 +19,4 @@ public final class DateDefaults {
         this.beforeEpoch = new Date(-1511793883000L);
         this.exactlyEpoch = new Date(0L);
     }
-    public DateDefaults(@NonNull final Date dateTime, @NonNull final Date dateTimeUtc, @NonNull final Date beforeEpoch, @NonNull final Date exactlyEpoch) {
-        this.dateTime = dateTime;
-        this.dateTimeUtc = dateTimeUtc;
-        this.beforeEpoch = beforeEpoch;
-        this.exactlyEpoch = exactlyEpoch;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/DefaultValues.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/DefaultValues.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
@@ -51,16 +50,6 @@ public final class DefaultValues extends NativeBase {
             this.enumField = DefaultValues.SomeEnum.BAR_VALUE;
             this.externalEnumField = DefaultValues.ExternalEnum.ANOTHER_VALUE;
         }
-        public StructWithDefaults(final int intField, final long uintField, final float floatField, final double doubleField, final boolean boolField, @NonNull final String stringField, @NonNull final DefaultValues.SomeEnum enumField, @NonNull final DefaultValues.ExternalEnum externalEnumField) {
-            this.intField = intField;
-            this.uintField = uintField;
-            this.floatField = floatField;
-            this.doubleField = doubleField;
-            this.boolField = boolField;
-            this.stringField = stringField;
-            this.enumField = enumField;
-            this.externalEnumField = externalEnumField;
-        }
     }
     public static final class NullableStructWithDefaults {
         @Nullable
@@ -83,14 +72,6 @@ public final class DefaultValues extends NativeBase {
             this.stringField = null;
             this.enumField = null;
         }
-        public NullableStructWithDefaults(@Nullable final Integer intField, @Nullable final Long uintField, @Nullable final Float floatField, @Nullable final Boolean boolField, @Nullable final String stringField, @Nullable final DefaultValues.SomeEnum enumField) {
-            this.intField = intField;
-            this.uintField = uintField;
-            this.floatField = floatField;
-            this.boolField = boolField;
-            this.stringField = stringField;
-            this.enumField = enumField;
-        }
     }
     public static final class StructWithSpecialDefaults {
         public float floatNanField;
@@ -106,14 +87,6 @@ public final class DefaultValues extends NativeBase {
             this.doubleNanField = Double.NaN;
             this.doubleInfinityField = Double.POSITIVE_INFINITY;
             this.doubleNegativeInfinityField = Double.NEGATIVE_INFINITY;
-        }
-        public StructWithSpecialDefaults(final float floatNanField, final float floatInfinityField, final float floatNegativeInfinityField, final double doubleNanField, final double doubleInfinityField, final double doubleNegativeInfinityField) {
-            this.floatNanField = floatNanField;
-            this.floatInfinityField = floatInfinityField;
-            this.floatNegativeInfinityField = floatNegativeInfinityField;
-            this.doubleNanField = doubleNanField;
-            this.doubleInfinityField = doubleInfinityField;
-            this.doubleNegativeInfinityField = doubleNegativeInfinityField;
         }
     }
     public static final class StructWithEmptyDefaults {
@@ -134,13 +107,6 @@ public final class DefaultValues extends NativeBase {
             this.structField = new DefaultValues.StructWithDefaults();
             this.setTypeField = new HashSet<>();
         }
-        public StructWithEmptyDefaults(@NonNull final List<Integer> intsField, @NonNull final List<Float> floatsField, @NonNull final Map<Long, String> mapField, @NonNull final DefaultValues.StructWithDefaults structField, @NonNull final Set<String> setTypeField) {
-            this.intsField = intsField;
-            this.floatsField = floatsField;
-            this.mapField = mapField;
-            this.structField = structField;
-            this.setTypeField = setTypeField;
-        }
     }
     public static final class StructWithTypedefDefaults {
         public long longField;
@@ -154,12 +120,6 @@ public final class DefaultValues extends NativeBase {
             this.boolField = true;
             this.stringField = "\\Jonny \"Magic\" Smith\n";
             this.enumField = DefaultValues.SomeEnum.BAR_VALUE;
-        }
-        public StructWithTypedefDefaults(final long longField, final boolean boolField, @NonNull final String stringField, @NonNull final DefaultValues.SomeEnum enumField) {
-            this.longField = longField;
-            this.boolField = boolField;
-            this.stringField = stringField;
-            this.enumField = enumField;
         }
     }
     /**

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/InternalEnumDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/InternalEnumDefaults.java
@@ -21,16 +21,4 @@ public final class InternalEnumDefaults {
         this.internalField = FooBarEnum.BAR;
         this.internalListField = new ArrayList<>(Arrays.asList(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ));
     }
-    public InternalEnumDefaults(@NonNull final FooBarEnum publicField, @NonNull final List<FooBarEnum> publicListField) {
-        this.publicField = publicField;
-        this.publicListField = publicListField;
-        this.internalField = FooBarEnum.BAR;
-        this.internalListField = new ArrayList<>(Arrays.asList(FooBarEnum.FOO, FooBarEnum.BAR, FooBarEnum.BAZ));
-    }
-    InternalEnumDefaults(@NonNull final FooBarEnum publicField, @NonNull final List<FooBarEnum> publicListField, @NonNull final FooBarEnum internalField, @NonNull final List<FooBarEnum> internalListField) {
-        this.publicField = publicField;
-        this.publicListField = publicListField;
-        this.internalField = internalField;
-        this.internalListField = internalListField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithAnEnum.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithAnEnum.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
@@ -9,8 +8,5 @@ public final class StructWithAnEnum {
     public AnEnum config;
     public StructWithAnEnum() {
         this.config = AnEnum.ENABLED;
-    }
-    public StructWithAnEnum(@NonNull final AnEnum config) {
-        this.config = config;
     }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithEnums.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithEnums.java
@@ -16,9 +16,4 @@ public final class StructWithEnums {
         this.explicitField = SomethingEnum.EXPLICIT;
         this.lastField = SomethingEnum.LAST;
     }
-    public StructWithEnums(@NonNull final SomethingEnum firstField, @NonNull final SomethingEnum explicitField, @NonNull final SomethingEnum lastField) {
-        this.firstField = firstField;
-        this.explicitField = explicitField;
-        this.lastField = lastField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithInitializerDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithInitializerDefaults.java
@@ -31,11 +31,4 @@ public final class StructWithInitializerDefaults {
         this.setTypeField = new HashSet<>(Arrays.asList("foo", "bar"));
         this.mapField = new HashMap<>(Stream.of(new AbstractMap.SimpleEntry<>(1L, "foo"), new AbstractMap.SimpleEntry<>(42L, "bar")).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
-    public StructWithInitializerDefaults(@NonNull final List<Integer> intsField, @NonNull final List<Float> floatsField, @NonNull final StructWithAnEnum structField, @NonNull final Set<String> setTypeField, @NonNull final Map<Long, String> mapField) {
-        this.intsField = intsField;
-        this.floatsField = floatsField;
-        this.structField = structField;
-        this.setTypeField = setTypeField;
-        this.mapField = mapField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/android/com/example/smoke/LearnToRead.java
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/android/com/example/smoke/LearnToRead.java
@@ -12,8 +12,4 @@ public final class LearnToRead {
         this.fieldA = com.example.smoke.Alphabet.A;
         this.fieldB = com.example.smoke.foo.Alphabet.BETA;
     }
-    public LearnToRead(@NonNull final com.example.smoke.Alphabet fieldA, @NonNull final com.example.smoke.foo.Alphabet fieldB) {
-        this.fieldA = fieldA;
-        this.fieldB = fieldB;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/android/com/example/smoke/LearnToReadAgain.java
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/android/com/example/smoke/LearnToReadAgain.java
@@ -12,8 +12,4 @@ public final class LearnToReadAgain {
         this.fieldB = com.example.smoke.foo.Alphabet.BETA;
         this.fieldC = com.example.smoke.bar.Alphabet.GIMEL;
     }
-    public LearnToReadAgain(@NonNull final com.example.smoke.foo.Alphabet fieldB, @NonNull final com.example.smoke.bar.Alphabet fieldC) {
-        this.fieldB = fieldB;
-        this.fieldC = fieldC;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/durations/output/android/com/example/smoke/DurationDefaults.java
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/com/example/smoke/DurationDefaults.java
@@ -28,13 +28,4 @@ public final class DurationDefaults {
         this.microz = Duration.ofNanos(665000L);
         this.nanoz = Duration.ofNanos(314635L);
     }
-    public DurationDefaults(@NonNull final Duration dayz, @NonNull final Duration hourz, @NonNull final Duration minutez, @NonNull final Duration secondz, @NonNull final Duration milliz, @NonNull final Duration microz, @NonNull final Duration nanoz) {
-        this.dayz = dayz;
-        this.hourz = hourz;
-        this.minutez = minutez;
-        this.secondz = secondz;
-        this.milliz = milliz;
-        this.microz = microz;
-        this.nanoz = nanoz;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Struct.java
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/com/example/package/Struct.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.package;
 import android.support.annotation.NonNull;
@@ -9,8 +8,5 @@ public final class Struct {
     public Enum null;
     public Struct() {
         this.null = Enum.NA_N;
-    }
-    public Struct(@NonNull final Enum null) {
-        this.null = null;
     }
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/OuterStructWithFieldConstructor.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/OuterStructWithFieldConstructor.java
@@ -11,9 +11,6 @@ public final class OuterStructWithFieldConstructor {
         public InnerStructWithDefaults() {
             this.innerStructField = 1.0;
         }
-        public InnerStructWithDefaults(final double innerStructField) {
-            this.innerStructField = innerStructField;
-        }
     }
     public OuterStructWithFieldConstructor(@NonNull final OuterStructWithFieldConstructor.InnerStructWithDefaults outerStructField) {
         this.outerStructField = outerStructField;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/EnumSets.java
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/EnumSets.java
@@ -13,7 +13,4 @@ public final class EnumSets {
     public EnumSets() {
         this.enumSetField = new EnumSet<>();
     }
-    public EnumSets(@NonNull final Set<GenericTypesWithCompoundTypes.SomeEnum> enumSetField) {
-        this.enumSetField = enumSetField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsAllInit.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsAllInit.java
@@ -12,12 +12,4 @@ public final class PublicFieldsAllInit {
         this.publicField = "bar";
         this.internalField = "foo";
     }
-    public PublicFieldsAllInit(@NonNull final String publicField) {
-        this.publicField = publicField;
-        this.internalField = "foo";
-    }
-    PublicFieldsAllInit(@NonNull final String publicField, @NonNull final String internalField) {
-        this.publicField = publicField;
-        this.internalField = internalField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsMixedInit.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsMixedInit.java
@@ -15,14 +15,4 @@ public final class PublicFieldsMixedInit {
         this.publicField2 = publicField2;
         this.internalField = "foo";
     }
-    public PublicFieldsMixedInit(@NonNull final String publicField1, @NonNull final String publicField2) {
-        this.publicField1 = publicField1;
-        this.publicField2 = publicField2;
-        this.internalField = "foo";
-    }
-    PublicFieldsMixedInit(@NonNull final String publicField1, @NonNull final String publicField2, @NonNull final String internalField) {
-        this.publicField1 = publicField1;
-        this.publicField2 = publicField2;
-        this.internalField = internalField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNoInit.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNoInit.java
@@ -12,8 +12,4 @@ public final class PublicFieldsNoInit {
         this.publicField = publicField;
         this.internalField = "foo";
     }
-    PublicFieldsNoInit(@NonNull final String publicField, @NonNull final String internalField) {
-        this.publicField = publicField;
-        this.internalField = internalField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNone.java
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/android/com/example/smoke/PublicFieldsNone.java
@@ -9,7 +9,4 @@ public final class PublicFieldsNone {
     public PublicFieldsNone() {
         this.internalField = "foo";
     }
-    PublicFieldsNone(@NonNull final String internalField) {
-        this.internalField = internalField;
-    }
 }

--- a/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicClass.java
+++ b/gluecodium/src/test/resources/smoke/visibility/output/android/com/example/smoke/PublicClass.java
@@ -1,6 +1,5 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
@@ -34,10 +33,6 @@ public final class PublicClass extends NativeBase {
         public float publicField;
         public PublicStructWithInternalDefaults(final float publicField) {
             this.internalField = "foo";
-            this.publicField = publicField;
-        }
-        PublicStructWithInternalDefaults(@NonNull final String internalField, final float publicField) {
-            this.internalField = internalField;
             this.publicField = publicField;
         }
     }


### PR DESCRIPTION
As a part of the effort to make automatically-generated struct constructors
forward-compatible, updated Java predicates and templates to omit the all-fields
constructor for mutable struct.

This way only a constructor for uninitialized fields is generated, making field
addition or removal a non-breaking change (as long as the added/removed field
has a default value).

This change does NOT affect:
* `@Immutable` structs
* structs with `@Java(PositionalDefaults)`
* structs with explicitly defined constructors

Updated functional test IDL files with explicit constructors to preserve APIs
that are used in tests.

See: https://github.com/heremaps/gluecodium/issues/1178
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>