### PR TITLE
Validate tag-filtered model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Validation now takes `@Skip(Tag="TagName")` and `@EnableIf(Tag="TagName")` attributes into account. This fixes some
+  validation issues when field constructors and/or fields are skipped/enabled by tags.
+
 ## 10.7.1
 Release date: 2022-02-08
 ### Bug fixes:

--- a/gluecodium/src/test/resources/smoke/skip/input/FieldConstructorsSkipTag.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/FieldConstructorsSkipTag.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct FieldConstructorsSkipTag {
+     field1: String
+
+     @Skip("Lite")
+     field2: String
+
+     @EnableIf("Lite")
+     field constructor(field1)
+
+     @Skip("Lite")
+     field constructor(field1, field2)
+}


### PR DESCRIPTION
Updated LIME model validation logic so that the "main" (i.e.
generator-unspecific) validation is now done on a model that is pre-filtered with
`@Skip(Tag="TagName")` and `@EnableIf(Tag="TagName")` attributes.

This fixes the issue where validation failed when fields and related field
constructors were skipped/enabled by tags.

Resolves: #1263
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>