### PR TITLE
Make Dart "automatic" constructors forward-compatible 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 ### Breaking changes:
-  * All-fields constructors are no longer unconditionally generated for mutable structs in Java. They are now generated
-  only if there are no explicitly defined constructors and none of the fields have default values specified.
+  * All-fields constructors are no longer unconditionally generated for mutable structs in Java and Dart. They are now
+  generated only if there are no explicitly defined constructors and none of the fields have default values specified.
 
 ## 10.7.2
 Release date: 2022-02-14

--- a/functional-tests/functional/dart/test/Defaults_test.dart
+++ b/functional-tests/functional/dart/test/Defaults_test.dart
@@ -26,7 +26,7 @@ final _testSuite = TestSuite("Defaults");
 
 void main() {
   _testSuite.test("Check defaults", () {
-    final result = new DefaultsStructWithDefaults.withDefaults();
+    final result = new DefaultsStructWithDefaults();
 
     expect(result.intField, 42);
     expect(result.uintField, 4294967295);
@@ -36,8 +36,7 @@ void main() {
     expect(result.enumField, DefaultsSomeEnum.barValue);
   });
   _testSuite.test("Check defaults immutable", () {
-    final result =
-        new DefaultsImmutableStructWithDefaults.withDefaults(77, true);
+    final result = new DefaultsImmutableStructWithDefaults.withDefaults(77, true);
 
     expect(result.intField, 42);
     expect(result.uintField, 77);
@@ -47,7 +46,7 @@ void main() {
     expect(result.enumField, DefaultsSomeEnum.barValue);
   });
   _testSuite.test("Check special defaults", () {
-    final result = new DefaultsStructWithSpecialDefaults.withDefaults();
+    final result = new DefaultsStructWithSpecialDefaults();
 
     expect(result.floatNanField, isNaN);
     expect(result.floatInfinityField, double.infinity);
@@ -57,7 +56,7 @@ void main() {
     expect(result.doubleNegativeInfinityField, double.negativeInfinity);
   });
   _testSuite.test("Check empty defaults", () {
-    final result = new DefaultsStructWithEmptyDefaults.withDefaults();
+    final result = new DefaultsStructWithEmptyDefaults();
 
     expect(result.intsField, isEmpty);
     expect(result.floatsField, isEmpty);
@@ -66,7 +65,7 @@ void main() {
     expect(result.setTypeField, isEmpty);
   });
   _testSuite.test("Check initializer defaults", () {
-    final result = new DefaultsStructWithInitializerDefaults.withDefaults();
+    final result = new DefaultsStructWithInitializerDefaults();
 
     expect(result.intsField, [4, -2, 42]);
     expect(result.floatsField, [3.14, double.negativeInfinity]);

--- a/functional-tests/functional/dart/test/Durations_test.dart
+++ b/functional-tests/functional/dart/test/Durations_test.dart
@@ -107,7 +107,7 @@ void main() {
     expect(result.durationField.inMicroseconds, 42042000);
   });
   _testSuite.test("Duration defaults", () {
-    final dartDefaults = DurationDefaults.withDefaults();
+    final dartDefaults = DurationDefaults();
     final cppDefaults = DurationDefaults.getCppDefaults();
 
     expect(dartDefaults.dayz, cppDefaults.dayz);

--- a/functional-tests/functional/dart/test/Enums_test.dart
+++ b/functional-tests/functional/dart/test/Enums_test.dart
@@ -40,18 +40,19 @@ void main() {
     expect(result, equals(EnumsInternalError.errorFatal));
   });
   _testSuite.test("Extract enum from struct to zero", () {
-    final input = EnumsErrorStruct(EnumsInternalError.errorFatal, "");
+    final input = EnumsErrorStruct();
+    input.type = EnumsInternalError.errorFatal;
 
     final result = Enums.extractEnumFromStruct(input);
 
-    expect(result, equals(EnumsInternalError.errorNone));
+    expect(result, EnumsInternalError.errorNone);
   });
   _testSuite.test("Extract enum from struct from zero", () {
-    final input = EnumsErrorStruct(EnumsInternalError.errorNone, "");
+    final input = EnumsErrorStruct();
 
     final result = Enums.extractEnumFromStruct(input);
 
-    expect(result, equals(EnumsInternalError.errorFatal));
+    expect(result, EnumsInternalError.errorFatal);
   });
   _testSuite.test("Create struct with enum inside to zero", () {
     final result = Enums.createStructWithEnumInside(EnumsInternalError.errorFatal, "");

--- a/functional-tests/functional/dart/test/EquatableStructs_test.dart
+++ b/functional-tests/functional/dart/test/EquatableStructs_test.dart
@@ -28,7 +28,6 @@ EquatableStruct createEquatableStruct() {
   return EquatableStruct(
       true, 65542, 2147484000, 1.0, 2.0, "nonsense",
       new NestedEquatableStruct("foo"),
-      new NestedImmutableStruct.withDefaults(),
       SomeSomeEnum.bar, {0: "one"}, ["two"]
   );
 }

--- a/functional-tests/functional/input/lime/Arrays.lime
+++ b/functional-tests/functional/input/lime/Arrays.lime
@@ -20,6 +20,9 @@ package test
 class Arrays {
     struct BasicStruct {
         value: Double = 0.0
+        @Dart(Skip)
+        field constructor()
+        field constructor(value)
     }
     struct FancyStruct {
         messages: StringArray

--- a/functional-tests/functional/input/lime/Maps.lime
+++ b/functional-tests/functional/input/lime/Maps.lime
@@ -22,9 +22,15 @@ import test.SomePointerEquatableClass
 class Maps {
     struct SomeStruct {
         value: String = ""
+        @Dart(Skip)
+        field constructor()
+        field constructor(value)
     }
     struct StructWithMap {
         errorMapping: ErrorCodeToMessageMap = []
+        @Dart(Skip)
+        field constructor()
+        field constructor(errorMapping)
     }
     enum SomeEnum {
         FooValue,

--- a/functional-tests/functional/input/lime/MethodOverloads.lime
+++ b/functional-tests/functional/input/lime/MethodOverloads.lime
@@ -21,6 +21,9 @@ class MethodOverloads {
     struct Point {
         x: Double = 0.0
         y: Double = 0.0
+        @Dart(Skip)
+        field constructor()
+        field constructor(x, y)
     }
     typealias StringArray = List<String>
     typealias IntArray = List<Byte>

--- a/functional-tests/functional/input/lime/Nullability.lime
+++ b/functional-tests/functional/input/lime/Nullability.lime
@@ -21,6 +21,9 @@ class NullableInterface {
     @Equatable
     struct SomeStruct {
         stringField: String = ""
+        @Dart(Skip)
+        field constructor()
+        field constructor(stringField)
     }
     struct NullableStruct {
         stringField: String? = null
@@ -32,6 +35,10 @@ class NullableInterface {
         inlineArrayField: List<String>? = null
         mapField: SomeMap? = null
         blobField: Blob? = null
+        @Dart("withDefaults")
+        field constructor()
+        @Dart(Default)
+        field constructor(stringField, boolField, doubleField, structField, enumField, arrayField, inlineArrayField, mapField, blobField)
     }
     struct NullableIntsStruct {
         int8Field: Byte? = null
@@ -42,6 +49,10 @@ class NullableInterface {
         uint16Field: UShort? = null
         uint32Field: UInt? = null
         uint64Field: ULong? = null
+        @Dart("withDefaults")
+        field constructor()
+        @Dart(Default)
+        field constructor(int8Field, int16Field, int32Field, int64Field, uint8Field, uint16Field, uint32Field, uint64Field)
     }
     struct StructWithSingleNullableField {
         nullableField: Int? = null

--- a/functional-tests/functional/input/lime/PlainDataStructures.lime
+++ b/functional-tests/functional/input/lime/PlainDataStructures.lime
@@ -22,6 +22,9 @@ class PlainDataStructures {
     struct Point {
         x: Double = 0.0
         y: Double = 0.0
+        @Dart(Skip)
+        field constructor()
+        field constructor(x, y)
     }
     // Basic struct type
     struct Color {
@@ -54,6 +57,12 @@ class PlainDataStructures {
         stringField: String = ""
         booleanField: Boolean = false
         pointField: Point
+        @Dart(Skip)
+        field constructor(pointField)
+        field constructor(
+            int8Field, uint8Field, int16Field, uint16Field, int32Field, uint32Field, int64Field, uint64Field,
+            floatField, doubleField, stringField, booleanField, pointField
+        )
     }
     @Cpp(Accessors)
     struct MutableStructWithCppAccessors {

--- a/functional-tests/functional/input/lime/PlainDataStructuresImmutable.lime
+++ b/functional-tests/functional/input/lime/PlainDataStructuresImmutable.lime
@@ -21,6 +21,9 @@ class PlainDataStructuresImmutable {
     struct Point {
         x: Double = 0.0
         y: Double = 0.0
+        @Dart(Skip)
+        field constructor()
+        field constructor(x, y)
     }
     // Immutable struct type containing all builtin and a custom data type
     @Immutable

--- a/functional-tests/functional/input/lime/TypeCollection.lime
+++ b/functional-tests/functional/input/lime/TypeCollection.lime
@@ -55,6 +55,12 @@ types TypeCollection {
         stringField: String = ""
         booleanField: Boolean = false
         pointField: Point
+        @Dart(Skip)
+        field constructor(pointField)
+        field constructor(
+            int8Field, uint8Field, int16Field, uint16Field, int32Field, uint32Field, int64Field, uint64Field,
+            floatField, doubleField, stringField, booleanField, pointField
+        )
     }
     // Typedef inside TypeCollection
     typealias PointTypedef = Point

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -87,12 +87,6 @@ internal object CommonGeneratorPredicates {
             else -> false
         }
 
-    fun needsPublicFieldsConstructor(limeStruct: Any, platformAttribute: LimeAttributeType) =
-        limeStruct is LimeStruct &&
-            !limeStruct.attributes.have(platformAttribute, LimeAttributeValueType.POSITIONAL_DEFAULTS) &&
-            limeStruct.internalFields.isNotEmpty() && limeStruct.internalFields.all { it.defaultValue != null } &&
-            limeStruct.publicFields.any { it.defaultValue != null }
-
     fun needsImportsForSkippedField(
         limeElement: LimeNamedElement,
         platformAttribute: LimeAttributeType,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -159,7 +159,8 @@ internal class DartNameResolver(
                 val noFieldsConstructor = actualType.noFieldsConstructor
                 val constructorName = when {
                     !useDefaultsConstructor -> ""
-                    noFieldsConstructor == null -> ".withDefaults"
+                    noFieldsConstructor == null ->
+                        if (DartGeneratorPredicates.allFieldsCtorIsPublic(actualType)) ".withDefaults" else ""
                     noFieldsConstructor.attributes.have(LimeAttributeType.DART, LimeAttributeValueType.DEFAULT) -> ""
                     else -> resolveName(noFieldsConstructor).let { if (it.isEmpty()) "" else ".$it" }
                 }

--- a/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStruct.mustache
@@ -140,7 +140,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/fields}}{{/set}}
   try {
 {{#if external.dart.converter}}
-    final resultInternal = {{resolveName}}Internal{{>allFieldsConstructorName}}(
+    final resultInternal = {{resolveName}}Internal(
 {{#set container=this}}{{#fields}}
 {{>fromFfiFieldInit}}
 {{/fields}}{{/set}}
@@ -149,7 +149,8 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#i
 {{/if}}{{#unless external.dart.converter}}
     return {{resolveName this "" "ref"}}{{#set container=this}}{{!!
     }}{{#if container.allFieldsConstructor}}{{#allFieldsConstructor}}{{>dart/DartConstructorName}}{{/allFieldsConstructor}}{{/if}}{{!!
-    }}{{#unless container.allfieldsConstructor}}{{#container}}{{>allFieldsConstructorName}}{{/container}}{{/unless}}(
+    }}{{#unless container.allFieldsConstructor}}{{#unless container.attributes.dart.positionalDefaults}}{{!!
+    }}{{#unlessPredicate container "allFieldsCtorIsPublic"}}._{{/unlessPredicate}}{{/unless}}{{/unless}}(
 {{#if attributes.dart.positionalDefaults initializedFields}}
 {{#each uninitializedFields initializedFields}}
 {{>fromFfiFieldInit}}
@@ -207,9 +208,4 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(Pointer<Void> handle) => _{{resolveNa
 }}{{prefixPartial "dart/InitLazyList" "      " skipFirstLine=true}}{{/set}}{{/setJoin}}{{/resolveName}}{{/if}}{{!!
 }}{{#unless typeRef.attributes.optimized}}{{!!
 }}{{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_{{resolveName}}Handle){{/unless}}{{#if iter.hasNext}}, {{/if}}
-{{/fromFfiFieldInit}}{{!!
-
-}}{{+allFieldsConstructorName}}{{#unless this.allFieldsConstructor}}{{!!
-}}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{!!
-}}{{#unlessPredicate "needsPrivateAllFieldsCtor"}}{{#ifPredicate "needsPublicFieldsConstructor"}}.allFields{{/ifPredicate}}{{/unlessPredicate}}{{!!
-}}{{/unless}}{{/allFieldsConstructorName}}
+{{/fromFfiFieldInit}}

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -19,6 +19,9 @@
   !
   !}}
 {{#if fields}}{{!!
+
+"Positional Defaults" constructor
+
 }}{{#if attributes.dart.positionalDefaults initializedFields}}{{>constructorComment}}{{!!
 }}{{#instanceOf attributes.dart.positionalDefaults "String"}}
   @Deprecated("{{attributes.dart.positionalDefaults}}")
@@ -29,34 +32,28 @@
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
 {{/if}}{{!!
 
-}}{{#unless attributes.dart.positionalDefaults initializedFields}}{{!!
+}}{{#unless attributes.dart.positionalDefaults}}{{!!
 
-}}{{#if constructors}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}._({{>thisDotFields}});
-{{/if}}{{!!
+All fields constructor
 
-}}{{#unless constructors}}{{#unless fieldConstructors}}{{#ifPredicate "needsPublicFieldsConstructor"}}{{!!
-}}{{>constructorComment}}{{!!
-}}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}({{!!
-}}{{#publicFields}}this.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/publicFields}}) : {{!!
-}}{{#internalFields}}{{resolveName visibility}}{{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/internalFields}};
-{{/ifPredicate}}{{/unless}}{{!!
-
-}}{{#unless this.allFieldsConstructor}}{{!!
-}}{{>constructorComment}}{{!!
+}}{{#unless this.allFieldsConstructor}}{{>constructorComment}}{{!!
 }}  {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
-}}{{#ifPredicate "needsPrivateAllFieldsCtor"}}._{{/ifPredicate}}{{!!
-}}{{#unlessPredicate "needsPrivateAllFieldsCtor"}}{{#ifPredicate "needsPublicFieldsConstructor"}}.allFields{{/ifPredicate}}{{/unlessPredicate}}{{!!
-}}({{>thisDotFields}});
-{{/unless}}{{/unless}}{{!!
+}}{{#unlessPredicate "allFieldsCtorIsPublic"}}._{{/unlessPredicate}}({{>thisDotFields}});
+{{/unless}}{{!!
 
-}}{{/unless}}
-{{#unless constructors}}{{#unless fieldConstructors}}{{#if initializedFields}}
+Initialized fields constructor
+
+}}{{#unless constructors}}{{#unless fieldConstructors}}{{#if initializedFields}}
   {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
-  }}.withDefaults({{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
+}}{{#ifPredicate "allFieldsCtorIsPublic"}}.withDefaults{{/ifPredicate}}({{!!
+}}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
     : {{#fields}}{{resolveName visibility}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
     }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
-{{/if}}{{/unless}}{{/unless}}{{/if}}{{!!
+{{/if}}{{/unless}}{{/unless}}{{!!
+
+}}{{/unless}}{{/if}}{{!!
+
+Explicit `field constructor` definitions
 
 }}{{#set struct=this container=this}}{{#fieldConstructors}}
 {{#unless comment.isEmpty}}{{#resolveName comment}}{{#unless this.isEmpty}}{{!!

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -24,8 +24,8 @@ class AttributesWithComments_SomeStruct {
   /// Field comment
   @OnField
   String field;
-  AttributesWithComments_SomeStruct(this.field);
-  AttributesWithComments_SomeStruct.withDefaults()
+  AttributesWithComments_SomeStruct._(this.field);
+  AttributesWithComments_SomeStruct()
     : field = "";
 }
 // AttributesWithComments_SomeStruct "private" section, not exported.
@@ -50,7 +50,7 @@ Pointer<Void> smokeAttributeswithcommentsSomestructToFfi(AttributesWithComments_
 AttributesWithComments_SomeStruct smokeAttributeswithcommentsSomestructFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeAttributeswithcommentsSomestructGetFieldfield(handle);
   try {
-    return AttributesWithComments_SomeStruct(
+    return AttributesWithComments_SomeStruct._(
       stringFromFfi(_fieldHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -23,8 +23,8 @@ class AttributesWithDeprecated_SomeStruct {
   @Deprecated("")
   @OnField
   String field;
-  AttributesWithDeprecated_SomeStruct(this.field);
-  AttributesWithDeprecated_SomeStruct.withDefaults()
+  AttributesWithDeprecated_SomeStruct._(this.field);
+  AttributesWithDeprecated_SomeStruct()
     : field = "";
 }
 // AttributesWithDeprecated_SomeStruct "private" section, not exported.
@@ -49,7 +49,7 @@ Pointer<Void> smokeAttributeswithdeprecatedSomestructToFfi(AttributesWithDepreca
 AttributesWithDeprecated_SomeStruct smokeAttributeswithdeprecatedSomestructFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeAttributeswithdeprecatedSomestructGetFieldfield(handle);
   try {
-    return AttributesWithDeprecated_SomeStruct(
+    return AttributesWithDeprecated_SomeStruct._(
       stringFromFfi(_fieldHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecated_with_no_message.dart
@@ -4,8 +4,8 @@ import 'package:library/src/builtin_types__conversion.dart';
 @Deprecated("")
 class DeprecatedWithNoMessage {
   String field;
-  DeprecatedWithNoMessage(this.field);
-  DeprecatedWithNoMessage.withDefaults()
+  DeprecatedWithNoMessage._(this.field);
+  DeprecatedWithNoMessage()
     : field = "";
 }
 // DeprecatedWithNoMessage "private" section, not exported.
@@ -30,7 +30,7 @@ Pointer<Void> smokeDeprecatedwithnomessageToFfi(DeprecatedWithNoMessage value) {
 DeprecatedWithNoMessage smokeDeprecatedwithnomessageFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeDeprecatedwithnomessageGetFieldfield(handle);
   try {
-    return DeprecatedWithNoMessage(
+    return DeprecatedWithNoMessage._(
       stringFromFfi(_fieldHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -110,8 +110,8 @@ class DeprecationComments_SomeStruct {
   /// How useful this struct is.
   @Deprecated("Unfortunately, this field is deprecated.\nUse [Comments_SomeStruct.someField] instead.")
   bool someField;
-  DeprecationComments_SomeStruct(this.someField);
-  DeprecationComments_SomeStruct.withDefaults()
+  DeprecationComments_SomeStruct._(this.someField);
+  DeprecationComments_SomeStruct()
     : someField = false;
 }
 // DeprecationComments_SomeStruct "private" section, not exported.
@@ -136,7 +136,7 @@ Pointer<Void> smokeDeprecationcommentsSomestructToFfi(DeprecationComments_SomeSt
 DeprecationComments_SomeStruct smokeDeprecationcommentsSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeDeprecationcommentsSomestructGetFieldsomeField(handle);
   try {
-    return DeprecationComments_SomeStruct(
+    return DeprecationComments_SomeStruct._(
       booleanFromFfi(_someFieldHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -85,8 +85,8 @@ void smokeDeprecationcommentsonlySomeenumReleaseFfiHandleNullable(Pointer<Void> 
 class DeprecationCommentsOnly_SomeStruct {
   @Deprecated("Unfortunately, this field is deprecated.")
   bool someField;
-  DeprecationCommentsOnly_SomeStruct(this.someField);
-  DeprecationCommentsOnly_SomeStruct.withDefaults()
+  DeprecationCommentsOnly_SomeStruct._(this.someField);
+  DeprecationCommentsOnly_SomeStruct()
     : someField = false;
 }
 // DeprecationCommentsOnly_SomeStruct "private" section, not exported.
@@ -111,7 +111,7 @@ Pointer<Void> smokeDeprecationcommentsonlySomestructToFfi(DeprecationCommentsOnl
 DeprecationCommentsOnly_SomeStruct smokeDeprecationcommentsonlySomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeDeprecationcommentsonlySomestructGetFieldsomeField(handle);
   try {
-    return DeprecationCommentsOnly_SomeStruct(
+    return DeprecationCommentsOnly_SomeStruct._(
       booleanFromFfi(_someFieldHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults.dart
@@ -6,8 +6,8 @@ class DateDefaults {
   DateTime dateTimeUtc;
   DateTime beforeEpoch;
   DateTime exactlyEpoch;
-  DateDefaults(this.dateTime, this.dateTimeUtc, this.beforeEpoch, this.exactlyEpoch);
-  DateDefaults.withDefaults()
+  DateDefaults._(this.dateTime, this.dateTimeUtc, this.beforeEpoch, this.exactlyEpoch);
+  DateDefaults()
     : dateTime = DateTime.fromMillisecondsSinceEpoch(1643966117000), dateTimeUtc = DateTime.fromMillisecondsSinceEpoch(1643966117000), beforeEpoch = DateTime.fromMillisecondsSinceEpoch(-1511793883000), exactlyEpoch = DateTime.fromMillisecondsSinceEpoch(0);
 }
 // DateDefaults "private" section, not exported.
@@ -53,7 +53,7 @@ DateDefaults smokeDatedefaultsFromFfi(Pointer<Void> handle) {
   final _beforeEpochHandle = _smokeDatedefaultsGetFieldbeforeEpoch(handle);
   final _exactlyEpochHandle = _smokeDatedefaultsGetFieldexactlyEpoch(handle);
   try {
-    return DateDefaults(
+    return DateDefaults._(
       dateFromFfi(_dateTimeHandle),
       dateFromFfi(_dateTimeUtcHandle),
       dateFromFfi(_beforeEpochHandle),

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults.dart
@@ -11,8 +11,6 @@ class DartDeprecatedPosDefaults {
   @Deprecated("Sorry, this is deprecated.")
   DartDeprecatedPosDefaults(String stringField, [int intField = 42])
     : intField = intField, stringField = stringField;
-  DartDeprecatedPosDefaults.withDefaults(String stringField)
-    : intField = 42, stringField = stringField;
 }
 // DartDeprecatedPosDefaults "private" section, not exported.
 final _smokeDartdeprecatedposdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/dart_deprecated_pos_defaults_custom.dart
@@ -58,7 +58,7 @@ DartDeprecatedPosDefaultsCustom smokeDartdeprecatedposdefaultscustomFromFfi(Poin
   final _intFieldHandle = _smokeDartdeprecatedposdefaultscustomGetFieldintField(handle);
   final _stringFieldHandle = _smokeDartdeprecatedposdefaultscustomGetFieldstringField(handle);
   try {
-    return DartDeprecatedPosDefaultsCustom._(
+    return DartDeprecatedPosDefaultsCustom(
       stringFromFfi(_stringFieldHandle),
       (_intFieldHandle)
     );

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -6,7 +6,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class DefaultValues {
-
   static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) => $prototype.processStructWithDefaults(input);
   /// @nodoc
   @visibleForTesting
@@ -131,8 +130,8 @@ class DefaultValues_StructWithDefaults {
   String stringField;
   DefaultValues_SomeEnum enumField;
   DefaultValues_ExternalEnum externalEnumField;
-  DefaultValues_StructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField, this.externalEnumField);
-  DefaultValues_StructWithDefaults.withDefaults()
+  DefaultValues_StructWithDefaults._(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField, this.externalEnumField);
+  DefaultValues_StructWithDefaults()
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue, externalEnumField = DefaultValues_ExternalEnum.anotherValue;
 }
 // DefaultValues_StructWithDefaults "private" section, not exported.
@@ -202,7 +201,7 @@ DefaultValues_StructWithDefaults smokeDefaultvaluesStructwithdefaultsFromFfi(Poi
   final _enumFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldenumField(handle);
   final _externalEnumFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldexternalEnumField(handle);
   try {
-    return DefaultValues_StructWithDefaults(
+    return DefaultValues_StructWithDefaults._(
       (_intFieldHandle),
       (_uintFieldHandle),
       (_floatFieldHandle),
@@ -257,8 +256,8 @@ class DefaultValues_NullableStructWithDefaults {
   bool? boolField;
   String? stringField;
   DefaultValues_SomeEnum? enumField;
-  DefaultValues_NullableStructWithDefaults(this.intField, this.uintField, this.floatField, this.boolField, this.stringField, this.enumField);
-  DefaultValues_NullableStructWithDefaults.withDefaults()
+  DefaultValues_NullableStructWithDefaults._(this.intField, this.uintField, this.floatField, this.boolField, this.stringField, this.enumField);
+  DefaultValues_NullableStructWithDefaults()
     : intField = null, uintField = null, floatField = null, boolField = null, stringField = null, enumField = null;
 }
 // DefaultValues_NullableStructWithDefaults "private" section, not exported.
@@ -318,7 +317,7 @@ DefaultValues_NullableStructWithDefaults smokeDefaultvaluesNullablestructwithdef
   final _stringFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldstringField(handle);
   final _enumFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldenumField(handle);
   try {
-    return DefaultValues_NullableStructWithDefaults(
+    return DefaultValues_NullableStructWithDefaults._(
       intFromFfiNullable(_intFieldHandle),
       uIntFromFfiNullable(_uintFieldHandle),
       floatFromFfiNullable(_floatFieldHandle),
@@ -373,8 +372,8 @@ class DefaultValues_StructWithSpecialDefaults {
   double doubleNanField;
   double doubleInfinityField;
   double doubleNegativeInfinityField;
-  DefaultValues_StructWithSpecialDefaults(this.floatNanField, this.floatInfinityField, this.floatNegativeInfinityField, this.doubleNanField, this.doubleInfinityField, this.doubleNegativeInfinityField);
-  DefaultValues_StructWithSpecialDefaults.withDefaults()
+  DefaultValues_StructWithSpecialDefaults._(this.floatNanField, this.floatInfinityField, this.floatNegativeInfinityField, this.doubleNanField, this.doubleInfinityField, this.doubleNegativeInfinityField);
+  DefaultValues_StructWithSpecialDefaults()
     : floatNanField = double.nan, floatInfinityField = double.infinity, floatNegativeInfinityField = double.negativeInfinity, doubleNanField = double.nan, doubleInfinityField = double.infinity, doubleNegativeInfinityField = double.negativeInfinity;
 }
 // DefaultValues_StructWithSpecialDefaults "private" section, not exported.
@@ -428,7 +427,7 @@ DefaultValues_StructWithSpecialDefaults smokeDefaultvaluesStructwithspecialdefau
   final _doubleInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleInfinityField(handle);
   final _doubleNegativeInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleNegativeInfinityField(handle);
   try {
-    return DefaultValues_StructWithSpecialDefaults(
+    return DefaultValues_StructWithSpecialDefaults._(
       (_floatNanFieldHandle),
       (_floatInfinityFieldHandle),
       (_floatNegativeInfinityFieldHandle),
@@ -476,9 +475,9 @@ class DefaultValues_StructWithEmptyDefaults {
   Map<int, String> mapField;
   DefaultValues_StructWithDefaults structField;
   Set<String> setTypeField;
-  DefaultValues_StructWithEmptyDefaults(this.intsField, this.floatsField, this.mapField, this.structField, this.setTypeField);
-  DefaultValues_StructWithEmptyDefaults.withDefaults()
-    : intsField = [], floatsField = [], mapField = {}, structField = DefaultValues_StructWithDefaults.withDefaults(), setTypeField = {};
+  DefaultValues_StructWithEmptyDefaults._(this.intsField, this.floatsField, this.mapField, this.structField, this.setTypeField);
+  DefaultValues_StructWithEmptyDefaults()
+    : intsField = [], floatsField = [], mapField = {}, structField = DefaultValues_StructWithDefaults(), setTypeField = {};
 }
 // DefaultValues_StructWithEmptyDefaults "private" section, not exported.
 final _smokeDefaultvaluesStructwithemptydefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -530,7 +529,7 @@ DefaultValues_StructWithEmptyDefaults smokeDefaultvaluesStructwithemptydefaultsF
   final _structFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldstructField(handle);
   final _setTypeFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldsetTypeField(handle);
   try {
-    return DefaultValues_StructWithEmptyDefaults(
+    return DefaultValues_StructWithEmptyDefaults._(
       listofIntFromFfi(_intsFieldHandle),
       listofFloatFromFfi(_floatsFieldHandle),
       mapofUintToStringFromFfi(_mapFieldHandle),
@@ -581,8 +580,8 @@ class DefaultValues_StructWithTypedefDefaults {
   bool boolField;
   String stringField;
   DefaultValues_SomeEnum enumField;
-  DefaultValues_StructWithTypedefDefaults(this.longField, this.boolField, this.stringField, this.enumField);
-  DefaultValues_StructWithTypedefDefaults.withDefaults()
+  DefaultValues_StructWithTypedefDefaults._(this.longField, this.boolField, this.stringField, this.enumField);
+  DefaultValues_StructWithTypedefDefaults()
     : longField = 42, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = DefaultValues_SomeEnum.barValue;
 }
 // DefaultValues_StructWithTypedefDefaults "private" section, not exported.
@@ -627,7 +626,7 @@ DefaultValues_StructWithTypedefDefaults smokeDefaultvaluesStructwithtypedefdefau
   final _stringFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldstringField(handle);
   final _enumFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldenumField(handle);
   try {
-    return DefaultValues_StructWithTypedefDefaults(
+    return DefaultValues_StructWithTypedefDefaults._(
       (_longFieldHandle),
       booleanFromFfi(_boolFieldHandle),
       stringFromFfi(_stringFieldHandle),
@@ -687,7 +686,6 @@ final _smokeDefaultvaluesReleaseHandle = __lib.catchArgumentError(() => __lib.na
 @visibleForTesting
 class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
   DefaultValues$Impl(Pointer<Void> handle) : super(handle);
-
   DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
     final _processStructWithDefaultsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults'));
     final _inputHandle = smokeDefaultvaluesStructwithdefaultsToFfi(input);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/internal_enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/internal_enum_defaults.dart
@@ -12,9 +12,8 @@ class InternalEnumDefaults {
   /// @nodoc
   @internal
   List<FooBarEnum> internal_internalListField;
-  InternalEnumDefaults(this.publicField, this.publicListField) : internal_internalField = FooBarEnum.bar, internal_internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz];
-  InternalEnumDefaults.allFields(this.publicField, this.publicListField, this.internal_internalField, this.internal_internalListField);
-  InternalEnumDefaults.withDefaults()
+  InternalEnumDefaults._(this.publicField, this.publicListField, this.internal_internalField, this.internal_internalListField);
+  InternalEnumDefaults()
     : publicField = FooBarEnum.foo, publicListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz], internal_internalField = FooBarEnum.bar, internal_internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz];
 }
 // InternalEnumDefaults "private" section, not exported.
@@ -60,7 +59,7 @@ InternalEnumDefaults smokeInternalenumdefaultsFromFfi(Pointer<Void> handle) {
   final _internalFieldHandle = _smokeInternalenumdefaultsGetFieldinternalField(handle);
   final _internalListFieldHandle = _smokeInternalenumdefaultsGetFieldinternalListField(handle);
   try {
-    return InternalEnumDefaults.allFields(
+    return InternalEnumDefaults._(
       smokeFoobarenumFromFfi(_publicFieldHandle),
       listofSmokeFoobarenumFromFfi(_publicListFieldHandle),
       smokeFoobarenumFromFfi(_internalFieldHandle),

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_defaults_with_duration.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_defaults_with_duration.dart
@@ -6,8 +6,6 @@ class PosDefaultsWithDuration {
   Duration nanosField;
   PosDefaultsWithDuration([Duration durationField = const Duration(seconds: 42), Duration nanosField = const Duration(microseconds: 28)])
     : durationField = durationField, nanosField = nanosField;
-  PosDefaultsWithDuration.withDefaults()
-    : durationField = const Duration(seconds: 42), nanosField = const Duration(microseconds: 28);
 }
 // PosDefaultsWithDuration "private" section, not exported.
 final _smokePosdefaultswithdurationCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_all_defaults.dart
@@ -6,8 +6,6 @@ class StructWithAllDefaults {
   String stringField;
   StructWithAllDefaults([int intField = 42, String stringField = "\\Jonny \"Magic\" Smith\n"])
     : intField = intField, stringField = stringField;
-  StructWithAllDefaults.withDefaults()
-    : intField = 42, stringField = "\\Jonny \"Magic\" Smith\n";
 }
 // StructWithAllDefaults "private" section, not exported.
 final _smokeStructwithalldefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_collection_defaults.dart
@@ -10,8 +10,6 @@ class StructWithCollectionDefaults {
   Set<String> setField;
   StructWithCollectionDefaults([List<String> emptyListField = const [], Map<String, String> emptyMapField = const {}, Set<String> emptySetField = const {}, List<String> listField = const ["foo", "bar"], Map<String, String> mapField = const {"foo": "bar"}, Set<String> setField = const {"foo", "bar"}])
     : emptyListField = emptyListField, emptyMapField = emptyMapField, emptySetField = emptySetField, listField = listField, mapField = mapField, setField = setField;
-  StructWithCollectionDefaults.withDefaults()
-    : emptyListField = [], emptyMapField = {}, emptySetField = {}, listField = ["foo", "bar"], mapField = {"foo": "bar"}, setField = {"foo", "bar"};
 }
 // StructWithCollectionDefaults "private" section, not exported.
 final _smokeStructwithcollectiondefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_enums.dart
@@ -5,8 +5,8 @@ class StructWithEnums {
   SomethingEnum firstField;
   SomethingEnum explicitField;
   SomethingEnum lastField;
-  StructWithEnums(this.firstField, this.explicitField, this.lastField);
-  StructWithEnums.withDefaults()
+  StructWithEnums._(this.firstField, this.explicitField, this.lastField);
+  StructWithEnums()
     : firstField = SomethingEnum.reallyFirst, explicitField = SomethingEnum.explicit, lastField = SomethingEnum.last;
   static final SomethingEnum firstConstant = SomethingEnum.reallyFirst;
 }
@@ -46,7 +46,7 @@ StructWithEnums smokeStructwithenumsFromFfi(Pointer<Void> handle) {
   final _explicitFieldHandle = _smokeStructwithenumsGetFieldexplicitField(handle);
   final _lastFieldHandle = _smokeStructwithenumsGetFieldlastField(handle);
   try {
-    return StructWithEnums(
+    return StructWithEnums._(
       smokeSomethingenumFromFfi(_firstFieldHandle),
       smokeSomethingenumFromFfi(_explicitFieldHandle),
       smokeSomethingenumFromFfi(_lastFieldHandle)

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_initializer_defaults.dart
@@ -8,8 +8,8 @@ class StructWithInitializerDefaults {
   StructWithAnEnum structField;
   Set<String> setTypeField;
   Map<int, String> mapField;
-  StructWithInitializerDefaults(this.intsField, this.floatsField, this.structField, this.setTypeField, this.mapField);
-  StructWithInitializerDefaults.withDefaults()
+  StructWithInitializerDefaults._(this.intsField, this.floatsField, this.structField, this.setTypeField, this.mapField);
+  StructWithInitializerDefaults()
     : intsField = [4, -2, 42], floatsField = [3.14, double.negativeInfinity], structField = StructWithAnEnum(AnEnum.disabled), setTypeField = {"foo", "bar"}, mapField = {1: "foo", 42: "bar"};
 }
 // StructWithInitializerDefaults "private" section, not exported.
@@ -62,7 +62,7 @@ StructWithInitializerDefaults smokeStructwithinitializerdefaultsFromFfi(Pointer<
   final _setTypeFieldHandle = _smokeStructwithinitializerdefaultsGetFieldsetTypeField(handle);
   final _mapFieldHandle = _smokeStructwithinitializerdefaultsGetFieldmapField(handle);
   try {
-    return StructWithInitializerDefaults(
+    return StructWithInitializerDefaults._(
       listofIntFromFfi(_intsFieldHandle),
       listofFloatFromFfi(_floatsFieldHandle),
       smokeTypeswithdefaultsStructwithanenumFromFfi(_structFieldHandle),

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_some_defaults.dart
@@ -6,8 +6,6 @@ class StructWithSomeDefaults {
   String stringField;
   StructWithSomeDefaults(String stringField, [int intField = 42])
     : intField = intField, stringField = stringField;
-  StructWithSomeDefaults.withDefaults(String stringField)
-    : intField = 42, stringField = stringField;
 }
 // StructWithSomeDefaults "private" section, not exported.
 final _smokeStructwithsomedefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -67,8 +67,8 @@ class StructWithDefaults {
   bool boolField;
   String stringField;
   SomeEnum enumField;
-  StructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField);
-  StructWithDefaults.withDefaults()
+  StructWithDefaults._(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField, this.enumField);
+  StructWithDefaults()
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n", enumField = SomeEnum.barValue;
 }
 // StructWithDefaults "private" section, not exported.
@@ -131,7 +131,7 @@ StructWithDefaults smokeTypeswithdefaultsStructwithdefaultsFromFfi(Pointer<Void>
   final _stringFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldstringField(handle);
   final _enumFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldenumField(handle);
   try {
-    return StructWithDefaults(
+    return StructWithDefaults._(
       (_intFieldHandle),
       (_uintFieldHandle),
       (_floatFieldHandle),
@@ -308,8 +308,8 @@ void smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseFfiHandleNullable(P
 // End of ImmutableStructWithDefaults "private" section.
 class StructWithAnEnum {
   AnEnum config;
-  StructWithAnEnum(this.config);
-  StructWithAnEnum.withDefaults()
+  StructWithAnEnum._(this.config);
+  StructWithAnEnum()
     : config = AnEnum.enabled;
 }
 // StructWithAnEnum "private" section, not exported.
@@ -334,7 +334,7 @@ Pointer<Void> smokeTypeswithdefaultsStructwithanenumToFfi(StructWithAnEnum value
 StructWithAnEnum smokeTypeswithdefaultsStructwithanenumFromFfi(Pointer<Void> handle) {
   final _configHandle = _smokeTypeswithdefaultsStructwithanenumGetFieldconfig(handle);
   try {
-    return StructWithAnEnum(
+    return StructWithAnEnum._(
       smokeAnenumAnenumFromFfi(_configHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/dart/lib/src/smoke/learn_to_read.dart
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/dart/lib/src/smoke/learn_to_read.dart
@@ -5,8 +5,8 @@ import 'package:library/src/smoke/foo/alphabet.dart' as smoke_foo;
 class LearnToRead {
   smoke.Alphabet fieldA;
   smoke_foo.Alphabet fieldB;
-  LearnToRead(this.fieldA, this.fieldB);
-  LearnToRead.withDefaults()
+  LearnToRead._(this.fieldA, this.fieldB);
+  LearnToRead()
     : fieldA = smoke.Alphabet.a, fieldB = smoke_foo.Alphabet.beta;
 }
 // LearnToRead "private" section, not exported.
@@ -38,7 +38,7 @@ LearnToRead smokeLearntoreadFromFfi(Pointer<Void> handle) {
   final _fieldAHandle = _smokeLearntoreadGetFieldfieldA(handle);
   final _fieldBHandle = _smokeLearntoreadGetFieldfieldB(handle);
   try {
-    return LearnToRead(
+    return LearnToRead._(
       smoke.smokeAlphabetFromFfi(_fieldAHandle),
       smoke_foo.smokeFooAlphabetFromFfi(_fieldBHandle)
     );

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/dart/lib/src/smoke/learn_to_read_again.dart
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/dart/lib/src/smoke/learn_to_read_again.dart
@@ -5,8 +5,8 @@ import 'package:library/src/smoke/foo/alphabet.dart' as smoke_foo;
 class LearnToReadAgain {
   smoke_foo.Alphabet fieldB;
   smoke_bar.Alphabet fieldC;
-  LearnToReadAgain(this.fieldB, this.fieldC);
-  LearnToReadAgain.withDefaults()
+  LearnToReadAgain._(this.fieldB, this.fieldC);
+  LearnToReadAgain()
     : fieldB = smoke_foo.Alphabet.beta, fieldC = smoke_bar.Alphabet.gimel;
 }
 // LearnToReadAgain "private" section, not exported.
@@ -38,7 +38,7 @@ LearnToReadAgain smokeLearntoreadagainFromFfi(Pointer<Void> handle) {
   final _fieldBHandle = _smokeLearntoreadagainGetFieldfieldB(handle);
   final _fieldCHandle = _smokeLearntoreadagainGetFieldfieldC(handle);
   try {
-    return LearnToReadAgain(
+    return LearnToReadAgain._(
       smoke_foo.smokeFooAlphabetFromFfi(_fieldBHandle),
       smoke_bar.smokeBarAlphabetFromFfi(_fieldCHandle)
     );

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_defaults.dart
@@ -9,8 +9,8 @@ class DurationDefaults {
   Duration milliz;
   Duration microz;
   Duration nanoz;
-  DurationDefaults(this.dayz, this.hourz, this.minutez, this.secondz, this.milliz, this.microz, this.nanoz);
-  DurationDefaults.withDefaults()
+  DurationDefaults._(this.dayz, this.hourz, this.minutez, this.secondz, this.milliz, this.microz, this.nanoz);
+  DurationDefaults()
     : dayz = const Duration(days: 28), hourz = const Duration(hours: 22), minutez = const Duration(minutes: 45), secondz = const Duration(seconds: 42), milliz = const Duration(milliseconds: 500), microz = const Duration(microseconds: 665), nanoz = const Duration(microseconds: 314);
 }
 // DurationDefaults "private" section, not exported.
@@ -77,7 +77,7 @@ DurationDefaults smokeDurationdefaultsFromFfi(Pointer<Void> handle) {
   final _microzHandle = _smokeDurationdefaultsGetFieldmicroz(handle);
   final _nanozHandle = _smokeDurationdefaultsGetFieldnanoz(handle);
   try {
-    return DurationDefaults(
+    return DurationDefaults._(
       durationFromFfi(_dayzHandle),
       durationFromFfi(_hourzHandle),
       durationFromFfi(_minutezHandle),

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -56,8 +56,8 @@ class ExceptionException implements Exception {
 }
 class Struct {
   Enum null;
-  Struct(this.null);
-  Struct.withDefaults()
+  Struct._(this.null);
+  Struct()
     : null = Enum.naN;
 }
 // Struct "private" section, not exported.
@@ -82,7 +82,7 @@ Pointer<Void> packageTypesStructToFfi(Struct value) {
 Struct packageTypesStructFromFfi(Pointer<Void> handle) {
   final _nullHandle = _packageTypesStructGetFieldnull(handle);
   try {
-    return Struct(
+    return Struct._(
       packageTypesEnumFromFfi(_nullHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/outer_struct_with_field_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/outer_struct_with_field_constructor.dart
@@ -6,8 +6,8 @@ class OuterStructWithFieldConstructor {
 }
 class OuterStructWithFieldConstructor_InnerStructWithDefaults {
   double innerStructField;
-  OuterStructWithFieldConstructor_InnerStructWithDefaults(this.innerStructField);
-  OuterStructWithFieldConstructor_InnerStructWithDefaults.withDefaults()
+  OuterStructWithFieldConstructor_InnerStructWithDefaults._(this.innerStructField);
+  OuterStructWithFieldConstructor_InnerStructWithDefaults()
     : innerStructField = 1.0;
 }
 // OuterStructWithFieldConstructor_InnerStructWithDefaults "private" section, not exported.
@@ -31,7 +31,7 @@ Pointer<Void> smokeOuterstructwithfieldconstructorInnerstructwithdefaultsToFfi(O
 OuterStructWithFieldConstructor_InnerStructWithDefaults smokeOuterstructwithfieldconstructorInnerstructwithdefaultsFromFfi(Pointer<Void> handle) {
   final _innerStructFieldHandle = _smokeOuterstructwithfieldconstructorInnerstructwithdefaultsGetFieldinnerStructField(handle);
   try {
-    return OuterStructWithFieldConstructor_InnerStructWithDefaults(
+    return OuterStructWithFieldConstructor_InnerStructWithDefaults._(
       (_innerStructFieldHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init.dart
@@ -7,9 +7,8 @@ class PublicFieldsAllInit {
   /// @nodoc
   @internal
   String internal_internalField;
-  PublicFieldsAllInit(this.publicField) : internal_internalField = "foo";
-  PublicFieldsAllInit.allFields(this.publicField, this.internal_internalField);
-  PublicFieldsAllInit.withDefaults()
+  PublicFieldsAllInit._(this.publicField, this.internal_internalField);
+  PublicFieldsAllInit()
     : publicField = "bar", internal_internalField = "foo";
 }
 // PublicFieldsAllInit "private" section, not exported.
@@ -41,7 +40,7 @@ PublicFieldsAllInit smokePublicfieldsallinitFromFfi(Pointer<Void> handle) {
   final _publicFieldHandle = _smokePublicfieldsallinitGetFieldpublicField(handle);
   final _internalFieldHandle = _smokePublicfieldsallinitGetFieldinternalField(handle);
   try {
-    return PublicFieldsAllInit.allFields(
+    return PublicFieldsAllInit._(
       stringFromFfi(_publicFieldHandle),
       stringFromFfi(_internalFieldHandle)
     );

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init_pos_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init_pos_defaults.dart
@@ -9,8 +9,6 @@ class PublicFieldsAllInitPosDefaults {
   String internal_internalField;
   PublicFieldsAllInitPosDefaults([String publicField = "bar", String internalField = "foo"])
     : publicField = publicField, internal_internalField = internalField;
-  PublicFieldsAllInitPosDefaults.withDefaults()
-    : publicField = "bar", internal_internalField = "foo";
 }
 // PublicFieldsAllInitPosDefaults "private" section, not exported.
 final _smokePublicfieldsallinitposdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_mixed_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_mixed_init.dart
@@ -8,9 +8,8 @@ class PublicFieldsMixedInit {
   /// @nodoc
   @internal
   String internal_internalField;
-  PublicFieldsMixedInit(this.publicField1, this.publicField2) : internal_internalField = "foo";
-  PublicFieldsMixedInit.allFields(this.publicField1, this.publicField2, this.internal_internalField);
-  PublicFieldsMixedInit.withDefaults(String publicField2)
+  PublicFieldsMixedInit._(this.publicField1, this.publicField2, this.internal_internalField);
+  PublicFieldsMixedInit(String publicField2)
     : publicField1 = "bar", publicField2 = publicField2, internal_internalField = "foo";
 }
 // PublicFieldsMixedInit "private" section, not exported.
@@ -49,7 +48,7 @@ PublicFieldsMixedInit smokePublicfieldsmixedinitFromFfi(Pointer<Void> handle) {
   final _publicField2Handle = _smokePublicfieldsmixedinitGetFieldpublicField2(handle);
   final _internalFieldHandle = _smokePublicfieldsmixedinitGetFieldinternalField(handle);
   try {
-    return PublicFieldsMixedInit.allFields(
+    return PublicFieldsMixedInit._(
       stringFromFfi(_publicField1Handle),
       stringFromFfi(_publicField2Handle),
       stringFromFfi(_internalFieldHandle)

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_no_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_no_init.dart
@@ -7,8 +7,8 @@ class PublicFieldsNoInit {
   /// @nodoc
   @internal
   String internal_internalField;
-  PublicFieldsNoInit(this.publicField, this.internal_internalField);
-  PublicFieldsNoInit.withDefaults(String publicField)
+  PublicFieldsNoInit._(this.publicField, this.internal_internalField);
+  PublicFieldsNoInit(String publicField)
     : publicField = publicField, internal_internalField = "foo";
 }
 // PublicFieldsNoInit "private" section, not exported.
@@ -40,7 +40,7 @@ PublicFieldsNoInit smokePublicfieldsnoinitFromFfi(Pointer<Void> handle) {
   final _publicFieldHandle = _smokePublicfieldsnoinitGetFieldpublicField(handle);
   final _internalFieldHandle = _smokePublicfieldsnoinitGetFieldinternalField(handle);
   try {
-    return PublicFieldsNoInit(
+    return PublicFieldsNoInit._(
       stringFromFfi(_publicFieldHandle),
       stringFromFfi(_internalFieldHandle)
     );

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_none.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_none.dart
@@ -6,8 +6,8 @@ class PublicFieldsNone {
   /// @nodoc
   @internal
   String internal_internalField;
-  PublicFieldsNone(this.internal_internalField);
-  PublicFieldsNone.withDefaults()
+  PublicFieldsNone._(this.internal_internalField);
+  PublicFieldsNone()
     : internal_internalField = "foo";
 }
 // PublicFieldsNone "private" section, not exported.
@@ -32,7 +32,7 @@ Pointer<Void> smokePublicfieldsnoneToFfi(PublicFieldsNone value) {
 PublicFieldsNone smokePublicfieldsnoneFromFfi(Pointer<Void> handle) {
   final _internalFieldHandle = _smokePublicfieldsnoneGetFieldinternalField(handle);
   try {
-    return PublicFieldsNone(
+    return PublicFieldsNone._(
       stringFromFfi(_internalFieldHandle)
     );
   } finally {

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_class.dart
@@ -5,7 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class PublicClass {
-
   /// @nodoc
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input);
   /// @nodoc
@@ -215,8 +214,8 @@ class PublicClass_PublicStructWithInternalDefaults {
   @internal
   String internal_internalField;
   double publicField;
-  PublicClass_PublicStructWithInternalDefaults(this.internal_internalField, this.publicField);
-  PublicClass_PublicStructWithInternalDefaults.withDefaults(double publicField)
+  PublicClass_PublicStructWithInternalDefaults._(this.internal_internalField, this.publicField);
+  PublicClass_PublicStructWithInternalDefaults(double publicField)
     : internal_internalField = "foo", publicField = publicField;
 }
 // PublicClass_PublicStructWithInternalDefaults "private" section, not exported.
@@ -247,7 +246,7 @@ PublicClass_PublicStructWithInternalDefaults smokePublicclassPublicstructwithint
   final _internalFieldHandle = _smokePublicclassPublicstructwithinternaldefaultsGetFieldinternalField(handle);
   final _publicFieldHandle = _smokePublicclassPublicstructwithinternaldefaultsGetFieldpublicField(handle);
   try {
-    return PublicClass_PublicStructWithInternalDefaults(
+    return PublicClass_PublicStructWithInternalDefaults._(
       stringFromFfi(_internalFieldHandle),
       (_publicFieldHandle)
     );
@@ -301,7 +300,6 @@ final _smokePublicclassReleaseHandle = __lib.catchArgumentError(() => __lib.nati
   >('library_smoke_PublicClass_release_handle'));
 class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
   PublicClass$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input) {
     final _internalMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct'));

--- a/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -8,8 +8,8 @@ class PublicStructWithNonDefaultInternalField {
   @internal
   String internal_internalField;
   bool publicField;
-  PublicStructWithNonDefaultInternalField(this.defaultedField, this.internal_internalField, this.publicField);
-  PublicStructWithNonDefaultInternalField.withDefaults(String internalField, bool publicField)
+  PublicStructWithNonDefaultInternalField._(this.defaultedField, this.internal_internalField, this.publicField);
+  PublicStructWithNonDefaultInternalField(String internalField, bool publicField)
     : defaultedField = 42, internal_internalField = internalField, publicField = publicField;
 }
 // PublicStructWithNonDefaultInternalField "private" section, not exported.
@@ -47,7 +47,7 @@ PublicStructWithNonDefaultInternalField smokePublicstructwithnondefaultinternalf
   final _internalFieldHandle = _smokePublicstructwithnondefaultinternalfieldGetFieldinternalField(handle);
   final _publicFieldHandle = _smokePublicstructwithnondefaultinternalfieldGetFieldpublicField(handle);
   try {
-    return PublicStructWithNonDefaultInternalField(
+    return PublicStructWithNonDefaultInternalField._(
       (_defaultedFieldHandle),
       stringFromFfi(_internalFieldHandle),
       booleanFromFfi(_publicFieldHandle)


### PR DESCRIPTION
As a part of the effort to make automatically-generated struct constructors
forward-compatible, updated Dart predicates and templates to make the all-fields
constructor private for mutable structs.

This way only a constructor for uninitialized fields is generated, making field
addition or removal a non-breaking change (as long as the added/removed field
has a default value).

As a consequence, the "initialized-fields" constructor for mutable structs is
now nameless, instead of `withDefaults()` as before.

This change does NOT affect:
* `@Immutable` structs
* structs with `@Dart(PositionalDefaults)`
* structs with explicitly defined constructors

Updated Dart functional tests to use a nameless constructor instead of old
`withDefaults()` where appropriate. Updated functional test IDL files with
explicit constructors to preserve APIs that are used in Dart tests.

See: https://github.com/heremaps/gluecodium/issues/1178
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>