### PR TITLE
Improve field deprecation logic in Swift 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Features:
+  * Structs with deprecated fields now have an additional "non-deprecated-fields" constructor generated in Swift. The
+  existing "all-fields" constructor is now marked as `@available(*, deprecated)` in Swift for such structs.
 ### Breaking changes:
   * All-fields constructors are no longer unconditionally generated for mutable structs in Java and Dart. They are now
   generated only if there are no explicitly defined constructors and none of the fields have default values specified.
+  * A deprecated field with no default value is now a validation error when Swift code is generated.
 
 ## 10.7.2
 Release date: 2022-02-14

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -133,7 +133,7 @@ feature(InstanceInStruct cpp android swift dart SOURCES
 feature(Structs cpp android swift dart SOURCES
     input/src/cpp/PlainDataStructures.cpp
 
-    input/lime/PlainDataStructures.lime
+    input/lime/Structs.lime
 )
 
 feature(StructsInTypes cpp android swift dart SOURCES

--- a/functional-tests/functional/input/lime/Structs.lime
+++ b/functional-tests/functional/input/lime/Structs.lime
@@ -105,3 +105,11 @@ class PlainDataStructures {
     // Static test method which checks that all fields in the Point struct are initialized in C++
     static fun checkAllFieldsAreInitialized(): Boolean
 }
+
+@Skip(Java, Dart)
+struct DeprecatedFields {
+    normalField1: String
+    @Deprecated
+    deprecatedField: String = ""
+    normalField2: String
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftFieldsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftFieldsValidator.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.swift
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeAttributeType.DEPRECATED
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeField
+
+/**
+ * Validate that all deprecated fields have default values.
+ */
+internal class SwiftFieldsValidator(private val logger: LimeLogger) {
+
+    fun validate(limeElements: Collection<LimeElement>): Boolean {
+        val validationResults = limeElements.filterIsInstance<LimeField>().map { validateField(it) }
+        return !validationResults.contains(false)
+    }
+
+    private fun validateField(limeField: LimeField) =
+        when {
+            !limeField.attributes.have(DEPRECATED) -> true
+            limeField.defaultValue == null -> {
+                logger.error(limeField, "A `@Deprecated` field should have a default value.")
+                false
+            }
+            else -> true
+        }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -104,9 +104,11 @@ internal class SwiftGenerator : Generator {
         val overloadsValidator =
             LimeOverloadsValidator(swiftSignatureResolver, limeLogger, validateCustomConstructors = true)
         val weakPropertiesValidator = SwiftWeakPropertiesValidator(limeLogger)
+        val fieldsValidator = SwiftFieldsValidator(limeLogger)
         val validationResults = listOf(
             overloadsValidator.validate(cbridgeFilteredModel.referenceMap.values),
-            weakPropertiesValidator.validate(cbridgeFilteredModel.referenceMap.values)
+            weakPropertiesValidator.validate(cbridgeFilteredModel.referenceMap.values),
+            fieldsValidator.validate(cbridgeFilteredModel.referenceMap.values)
         )
         if (validationResults.contains(false)) {
             throw GluecodiumExecutionException("Validation errors found, see log for details.")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -73,6 +73,10 @@ internal class SwiftGeneratorPredicates(
                 else -> false
             }
         },
+        "hasInternalAvailableFields" to { limeStruct: Any ->
+            limeStruct is LimeStruct && limeStruct.availableFields.isNotEmpty() &&
+                limeStruct.availableFields.any { it.visibility.isInternal }
+        },
         "hasTypeRepository" to { CommonGeneratorPredicates.hasTypeRepository(it) },
         "hasWeakSupport" to fun(limeInterface: Any): Boolean {
             if (limeInterface !is LimeInterface) return false

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
@@ -70,13 +70,34 @@
 
 {{#resolveName constructorComment}}{{#unless this.isEmpty}}
 {{prefix this "    /// "}}
-{{#if publicFields}}
+{{#if availableFields}}
+    /// - Parameters
+{{#availableFields}}
+    ///   - {{resolveName}}: {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "    ///       " skipFirstLine=true}}{{/unless}}{{/resolveName}}
+{{/availableFields}}
+{{/if}}
+{{/unless}}{{/resolveName}}
+    {{#ifPredicate "hasInternalAvailableFields"}}internal{{/ifPredicate}}{{!!
+    }}{{#unless internalFields}}{{>swift/TypeVisibility}}{{/unless}}{{!!
+    }} init({{joinPartial availableFields "initParameter" ", "}}) {
+{{#availableFields}}
+        self.{{resolveName}} = {{resolveName}}
+{{/availableFields}}
+{{#deprecatedFields}}
+        self.{{resolveName}} = {{resolveName defaultValue}}
+{{/deprecatedFields}}
+    }{{!!
+
+}}{{#if deprecatedFields}}
+
+{{#resolveName constructorComment}}{{#unless this.isEmpty}}
+{{prefix this "    /// "}}
     /// - Parameters
 {{#fields}}
     ///   - {{resolveName}}: {{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "    ///       " skipFirstLine=true}}{{/unless}}{{/resolveName}}
 {{/fields}}
-{{/if}}
 {{/unless}}{{/resolveName}}
+    @available(*, deprecated)
     {{#if internalFields}}internal{{/if}}{{!!
     }}{{#unless internalFields}}{{>swift/TypeVisibility}}{{/unless}}{{!!
     }} init({{joinPartial fields "initParameter" ", "}}) {
@@ -84,7 +105,7 @@
         self.{{resolveName}} = {{resolveName}}
 {{/fields}}
     }
-{{/ifPredicate}}{{!!
+{{/if}}{{/ifPredicate}}{{!!
 
 }}{{/unless}}{{!!
 

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftFieldsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/swift/SwiftFieldsValidatorTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016-2021 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.swift
+
+import com.here.gluecodium.model.lime.LimeAttributeType.DEPRECATED
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
+import com.here.gluecodium.model.lime.LimeValue
+import io.mockk.MockKAnnotations
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SwiftFieldsValidatorTest {
+
+    private lateinit var validator: SwiftFieldsValidator
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxed = true)
+        validator = SwiftFieldsValidator(mockk(relaxed = true))
+    }
+
+    @Test
+    fun validateFieldWithNothing() {
+        val limeField = LimeField(EMPTY_PATH, typeRef = LimeBasicTypeRef.INT)
+
+        assertTrue(validator.validate(listOf(limeField)))
+    }
+
+    @Test
+    fun validateFieldWithDeprecatedOnly() {
+        val limeField = LimeField(
+            EMPTY_PATH,
+            typeRef = LimeBasicTypeRef.INT,
+            attributes = LimeAttributes.Builder().addAttribute(DEPRECATED).build()
+        )
+
+        assertFalse(validator.validate(listOf(limeField)))
+    }
+
+    @Test
+    fun validateFieldWithDefaultValueOnly() {
+        val limeField = LimeField(
+            EMPTY_PATH,
+            typeRef = LimeBasicTypeRef.INT,
+            defaultValue = LimeValue.ZERO
+        )
+
+        assertTrue(validator.validate(listOf(limeField)))
+    }
+
+    @Test
+    fun validateFieldWithDeprecatedAndDefaultValue() {
+        val limeField = LimeField(
+            EMPTY_PATH,
+            typeRef = LimeBasicTypeRef.INT,
+            attributes = LimeAttributes.Builder().addAttribute(DEPRECATED).build(),
+            defaultValue = LimeValue.ZERO
+        )
+
+        assertTrue(validator.validate(listOf(limeField)))
+    }
+}

--- a/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
+++ b/gluecodium/src/test/resources/smoke/attributes/output/swift/smoke/AttributesWithDeprecated.swift
@@ -34,6 +34,10 @@ public class AttributesWithDeprecated {
         @available(*, deprecated)
         @OnField
         public var field: String
+        public init() {
+            self.field = ""
+        }
+        @available(*, deprecated)
         public init(field: String = "") {
             self.field = field
         }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationComments.swift
@@ -109,6 +109,10 @@ public struct SomeStruct {
     /// How useful this struct is.
     @available(*, deprecated, message: "Unfortunately, this field is deprecated.\nUse `Comments.SomeStruct.someField` instead.")
     public var someField: DeprecationComments.Usefulness
+    public init() {
+        self.someField = false
+    }
+    @available(*, deprecated)
     public init(someField: DeprecationComments.Usefulness = false) {
         self.someField = someField
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/DeprecationCommentsOnly.swift
@@ -83,6 +83,10 @@ public enum SomeEnum : UInt32, CaseIterable, Codable {
 public struct SomeStruct {
     @available(*, deprecated, message: "Unfortunately, this field is deprecated.")
     public var someField: DeprecationCommentsOnly.Usefulness
+    public init() {
+        self.someField = false
+    }
+    @available(*, deprecated)
     public init(someField: DeprecationCommentsOnly.Usefulness = false) {
         self.someField = someField
     }

--- a/gluecodium/src/test/resources/smoke/structs/input/Structs.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/Structs.lime
@@ -112,3 +112,11 @@ types TypeCollection {
     }
     typealias PointTypedef = Point
 }
+
+@Skip(Java, Dart)
+struct DeprecatedFields {
+    normalField1: String
+    @Deprecated
+    deprecatedField: String = ""
+    normalField2: String
+}

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/DeprecatedFields.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/DeprecatedFields.swift
@@ -1,0 +1,68 @@
+//
+//
+import Foundation
+public struct DeprecatedFields {
+    public var normalField1: String
+    @available(*, deprecated)
+    public var deprecatedField: String
+    public var normalField2: String
+    public init(normalField1: String, normalField2: String) {
+        self.normalField1 = normalField1
+        self.normalField2 = normalField2
+        self.deprecatedField = ""
+    }
+    @available(*, deprecated)
+    public init(normalField1: String, deprecatedField: String = "", normalField2: String) {
+        self.normalField1 = normalField1
+        self.deprecatedField = deprecatedField
+        self.normalField2 = normalField2
+    }
+    internal init(cHandle: _baseRef) {
+        normalField1 = moveFromCType(smoke_DeprecatedFields_normalField1_get(cHandle))
+        deprecatedField = moveFromCType(smoke_DeprecatedFields_deprecatedField_get(cHandle))
+        normalField2 = moveFromCType(smoke_DeprecatedFields_normalField2_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> DeprecatedFields {
+    return DeprecatedFields(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> DeprecatedFields {
+    defer {
+        smoke_DeprecatedFields_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DeprecatedFields) -> RefHolder {
+    let c_normalField1 = moveToCType(swiftType.normalField1)
+    let c_deprecatedField = moveToCType(swiftType.deprecatedField)
+    let c_normalField2 = moveToCType(swiftType.normalField2)
+    return RefHolder(smoke_DeprecatedFields_create_handle(c_normalField1.ref, c_deprecatedField.ref, c_normalField2.ref))
+}
+internal func moveToCType(_ swiftType: DeprecatedFields) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecatedFields_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> DeprecatedFields? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_DeprecatedFields_unwrap_optional_handle(handle)
+    return DeprecatedFields(cHandle: unwrappedHandle) as DeprecatedFields
+}
+internal func moveFromCType(_ handle: _baseRef) -> DeprecatedFields? {
+    defer {
+        smoke_DeprecatedFields_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DeprecatedFields?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_normalField1 = moveToCType(swiftType.normalField1)
+    let c_deprecatedField = moveToCType(swiftType.deprecatedField)
+    let c_normalField2 = moveToCType(swiftType.normalField2)
+    return RefHolder(smoke_DeprecatedFields_create_optional_handle(c_normalField1.ref, c_deprecatedField.ref, c_normalField2.ref))
+}
+internal func moveToCType(_ swiftType: DeprecatedFields?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DeprecatedFields_release_optional_handle)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
@@ -52,18 +52,26 @@ class LimeStruct(
     override val childTypes
         get() = fields.map { it.typeRef }
 
-    @Suppress("unused")
     val initializedFields
         get() = fields.filter { it.defaultValue != null }
 
     val uninitializedFields
         get() = fields.filter { it.defaultValue == null }
 
+    @Suppress("unused")
     val publicFields
         get() = fields.filter { !it.visibility.isInternal }
 
     val internalFields
         get() = fields.filter { it.visibility.isInternal }
+
+    @Suppress("unused")
+    val deprecatedFields
+        get() = fields.filter { it.attributes.have(LimeAttributeType.DEPRECATED) }
+
+    @Suppress("unused")
+    val availableFields
+        get() = fields.filter { !it.attributes.have(LimeAttributeType.DEPRECATED) }
 
     val allFieldsConstructor
         get() = fieldConstructors.firstOrNull { it.fieldRefs.size == fields.size }


### PR DESCRIPTION
As a part of the effort to make automatically-generated struct constructors
forward-compatible, updated Swift predicates and templates to generate an
addition "non-deprecated-fields" constructor for structs with deprecated fieds.

Together with a Swift deprecation attribute on the all-fields constructor for
such structs, this helps to support a better deprecation path for struct fields.
This change does not affect structs with explicitly defined constructors

Added SwiftFieldsValidator to check that all deprecated fields have default
values defined. Added unit tests for the new validator.

Added/updated smoke tests accordingly.

Resolves: https://github.com/heremaps/gluecodium/issues/1178
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>