### PR TITLE
Remove `LimeBasicType.isLiteralType`

### DIFF
--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
@@ -23,8 +23,7 @@ class LimeBasicType(val typeId: TypeId) : LimeType(path = LimePath.EMPTY_PATH) {
     enum class TypeId(
         private val tag: String,
         val isIntegerType: Boolean = false,
-        val isNumericType: Boolean = isIntegerType,
-        val isLiteralType: Boolean = isNumericType
+        val isNumericType: Boolean = isIntegerType
     ) {
         VOID("Void"),
         INT8("Byte", true),
@@ -37,10 +36,10 @@ class LimeBasicType(val typeId: TypeId) : LimeType(path = LimePath.EMPTY_PATH) {
         UINT64("ULong", true),
         FLOAT("Float", false, true),
         DOUBLE("Double", false, true),
-        BOOLEAN("Boolean", false, false, true),
-        STRING("String", false, false, true),
+        BOOLEAN("Boolean"),
+        STRING("String"),
         BLOB("Blob"),
-        DATE("Date", false, false, true),
+        DATE("Date"),
         DURATION("Duration"),
         LOCALE("Locale");
 


### PR DESCRIPTION
Moved the "is literal type" source-of-truth from `LimeBasicType` to
`LimeValuesValidator`, as it is not used in any templates or pre-template
analysis.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>