### PR TITLE
Convert `Date` literals at generation instead of at parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   * All-fields constructors are no longer unconditionally generated for mutable structs in Java and Dart. They are now
   generated only if there are no explicitly defined constructors and none of the fields have default values specified.
   * A deprecated field with no default value is now a validation error when Swift code is generated.
+### Bug fixes:
+  * Fixed compilation issues in all languages when a `Date` literal is used in combination with a type alias.
 
 ## 10.7.2
 Release date: 2022-02-14

--- a/functional-tests/functional/input/lime/DateDefaults.lime
+++ b/functional-tests/functional/input/lime/DateDefaults.lime
@@ -27,3 +27,12 @@ struct DateDefaults {
 
     static fun getCppDefaults(): DateDefaults
 }
+
+typealias DateAlias = Date
+
+struct DateDefaultsAliased {
+    dateTime: DateAlias = "2022-02-04T11:15:17+02:00"
+    dateTimeUtc: DateAlias = "2022-02-04T09:15:17Z"
+    beforeEpoch: DateAlias = "1922-02-04T09:15:17Z"
+    exactlyEpoch: DateAlias = "1970-01-01T00:00:00Z"
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
@@ -30,6 +30,7 @@ import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypedElement
 import com.here.gluecodium.model.lime.LimeValue
 
@@ -94,6 +95,10 @@ internal class LimeValuesValidator(private val logger: LimeLogger) {
                 limeElement,
                 "string or numeric literal values cannot be assigned to `Blob`, `Duration`, or `Locale` types"
             )
+            return false
+        }
+        if (limeType.typeId == TypeId.DATE && LimeTypeHelper.dateLiteralEpochSeconds(limeValue.value) == null) {
+            logger.error(limeElement, "invalid `Date` literal:  '$limeValue'")
             return false
         }
         return true

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
@@ -76,7 +76,13 @@ class LimeValuesValidatorTest(
             arrayOf(LimeBasicTypeRef.FLOAT, LimeValue.Literal(fooTypeRef, ""), true),
             arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.BOOLEAN), LimeValue.Literal(fooTypeRef, ""), true),
             arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.STRING), LimeValue.Literal(fooTypeRef, ""), true),
-            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.DATE), LimeValue.Literal(fooTypeRef, ""), true),
+            arrayOf(
+                LimeBasicTypeRef(LimeBasicType.TypeId.DATE),
+                LimeValue.Literal(fooTypeRef, "2022-02-04T09:15:17Z"),
+                true
+            ),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.DATE), LimeValue.Literal(fooTypeRef, "bar"), false),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.BLOB), LimeValue.Literal(fooTypeRef, ""), false),
             arrayOf(fooTypeRef, LimeValue.Literal(fooTypeRef, ""), false),
             arrayOf(
                 LimeDirectTypeRef(LimeEnumeration(EMPTY_PATH)),

--- a/gluecodium/src/test/resources/smoke/dates/input/DateDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/dates/input/DateDefaults.lime
@@ -23,3 +23,12 @@ struct DateDefaults {
     beforeEpoch: Date = "1922-02-04T09:15:17Z"
     exactlyEpoch: Date = "1970-01-01T00:00:00Z"
 }
+
+typealias DateAlias = Date
+
+struct DateDefaultsAliased {
+    dateTime: DateAlias = "2022-02-04T11:15:17+02:00"
+    dateTimeUtc: DateAlias = "2022-02-04T09:15:17Z"
+    beforeEpoch: DateAlias = "1922-02-04T09:15:17Z"
+    exactlyEpoch: DateAlias = "1970-01-01T00:00:00Z"
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/DateDefaultsAliased.java
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/com/example/smoke/DateDefaultsAliased.java
@@ -1,0 +1,22 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import java.util.Date;
+public final class DateDefaultsAliased {
+    @NonNull
+    public Date dateTime;
+    @NonNull
+    public Date dateTimeUtc;
+    @NonNull
+    public Date beforeEpoch;
+    @NonNull
+    public Date exactlyEpoch;
+    public DateDefaultsAliased() {
+        this.dateTime = new Date(1643966117000L);
+        this.dateTimeUtc = new Date(1643966117000L);
+        this.beforeEpoch = new Date(-1511793883000L);
+        this.exactlyEpoch = new Date(0L);
+    }
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DateDefaultsAliased.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DateDefaultsAliased.h
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/DateAlias.h"
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT DateDefaultsAliased {
+    ::smoke::DateAlias date_time = ::std::chrono::system_clock::from_time_t(1643966117);
+    ::smoke::DateAlias date_time_utc = ::std::chrono::system_clock::from_time_t(1643966117);
+    ::smoke::DateAlias before_epoch = ::std::chrono::system_clock::from_time_t(-1511793883);
+    ::smoke::DateAlias exactly_epoch = ::std::chrono::system_clock::from_time_t(0);
+    DateDefaultsAliased( );
+    DateDefaultsAliased( ::smoke::DateAlias date_time, ::smoke::DateAlias date_time_utc, ::smoke::DateAlias before_epoch, ::smoke::DateAlias exactly_epoch );
+};
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults_aliased.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/date_defaults_aliased.dart
@@ -1,0 +1,99 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class DateDefaultsAliased {
+  DateTime dateTime;
+  DateTime dateTimeUtc;
+  DateTime beforeEpoch;
+  DateTime exactlyEpoch;
+  DateDefaultsAliased._(this.dateTime, this.dateTimeUtc, this.beforeEpoch, this.exactlyEpoch);
+  DateDefaultsAliased()
+    : dateTime = DateTime.fromMillisecondsSinceEpoch(1643966117000), dateTimeUtc = DateTime.fromMillisecondsSinceEpoch(1643966117000), beforeEpoch = DateTime.fromMillisecondsSinceEpoch(-1511793883000), exactlyEpoch = DateTime.fromMillisecondsSinceEpoch(0);
+}
+// DateDefaultsAliased "private" section, not exported.
+final _smokeDatedefaultsaliasedCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Uint64, Uint64, Uint64),
+    Pointer<Void> Function(int, int, int, int)
+  >('library_smoke_DateDefaultsAliased_create_handle'));
+final _smokeDatedefaultsaliasedReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_release_handle'));
+final _smokeDatedefaultsaliasedGetFielddateTime = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_get_field_dateTime'));
+final _smokeDatedefaultsaliasedGetFielddateTimeUtc = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_get_field_dateTimeUtc'));
+final _smokeDatedefaultsaliasedGetFieldbeforeEpoch = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_get_field_beforeEpoch'));
+final _smokeDatedefaultsaliasedGetFieldexactlyEpoch = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint64 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_get_field_exactlyEpoch'));
+Pointer<Void> smokeDatedefaultsaliasedToFfi(DateDefaultsAliased value) {
+  final _dateTimeHandle = dateToFfi(value.dateTime);
+  final _dateTimeUtcHandle = dateToFfi(value.dateTimeUtc);
+  final _beforeEpochHandle = dateToFfi(value.beforeEpoch);
+  final _exactlyEpochHandle = dateToFfi(value.exactlyEpoch);
+  final _result = _smokeDatedefaultsaliasedCreateHandle(_dateTimeHandle, _dateTimeUtcHandle, _beforeEpochHandle, _exactlyEpochHandle);
+  dateReleaseFfiHandle(_dateTimeHandle);
+  dateReleaseFfiHandle(_dateTimeUtcHandle);
+  dateReleaseFfiHandle(_beforeEpochHandle);
+  dateReleaseFfiHandle(_exactlyEpochHandle);
+  return _result;
+}
+DateDefaultsAliased smokeDatedefaultsaliasedFromFfi(Pointer<Void> handle) {
+  final _dateTimeHandle = _smokeDatedefaultsaliasedGetFielddateTime(handle);
+  final _dateTimeUtcHandle = _smokeDatedefaultsaliasedGetFielddateTimeUtc(handle);
+  final _beforeEpochHandle = _smokeDatedefaultsaliasedGetFieldbeforeEpoch(handle);
+  final _exactlyEpochHandle = _smokeDatedefaultsaliasedGetFieldexactlyEpoch(handle);
+  try {
+    return DateDefaultsAliased._(
+      dateFromFfi(_dateTimeHandle),
+      dateFromFfi(_dateTimeUtcHandle),
+      dateFromFfi(_beforeEpochHandle),
+      dateFromFfi(_exactlyEpochHandle)
+    );
+  } finally {
+    dateReleaseFfiHandle(_dateTimeHandle);
+    dateReleaseFfiHandle(_dateTimeUtcHandle);
+    dateReleaseFfiHandle(_beforeEpochHandle);
+    dateReleaseFfiHandle(_exactlyEpochHandle);
+  }
+}
+void smokeDatedefaultsaliasedReleaseFfiHandle(Pointer<Void> handle) => _smokeDatedefaultsaliasedReleaseHandle(handle);
+// Nullable DateDefaultsAliased
+final _smokeDatedefaultsaliasedCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_create_handle_nullable'));
+final _smokeDatedefaultsaliasedReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_release_handle_nullable'));
+final _smokeDatedefaultsaliasedGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DateDefaultsAliased_get_value_nullable'));
+Pointer<Void> smokeDatedefaultsaliasedToFfiNullable(DateDefaultsAliased? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeDatedefaultsaliasedToFfi(value);
+  final result = _smokeDatedefaultsaliasedCreateHandleNullable(_handle);
+  smokeDatedefaultsaliasedReleaseFfiHandle(_handle);
+  return result;
+}
+DateDefaultsAliased? smokeDatedefaultsaliasedFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeDatedefaultsaliasedGetValueNullable(handle);
+  final result = smokeDatedefaultsaliasedFromFfi(_handle);
+  smokeDatedefaultsaliasedReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeDatedefaultsaliasedReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDatedefaultsaliasedReleaseHandleNullable(handle);
+// End of DateDefaultsAliased "private" section.

--- a/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DateDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DateDefaults.lime
@@ -1,6 +1,6 @@
 package smoke
 struct DateDefaults {
-    dateTime: Date = "2022-02-04T09:15:17Z"
+    dateTime: Date = "2022-02-04T11:15:17+02:00"
     dateTimeUtc: Date = "2022-02-04T09:15:17Z"
     beforeEpoch: Date = "1922-02-04T09:15:17Z"
     exactlyEpoch: Date = "1970-01-01T00:00:00Z"

--- a/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DateDefaultsAliased.lime
+++ b/gluecodium/src/test/resources/smoke/dates/output/lime/smoke/DateDefaultsAliased.lime
@@ -1,0 +1,7 @@
+package smoke
+struct DateDefaultsAliased {
+    dateTime: DateAlias = "2022-02-04T11:15:17+02:00"
+    dateTimeUtc: DateAlias = "2022-02-04T09:15:17Z"
+    beforeEpoch: DateAlias = "1922-02-04T09:15:17Z"
+    exactlyEpoch: DateAlias = "1970-01-01T00:00:00Z"
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/DateDefaultsAliased.swift
+++ b/gluecodium/src/test/resources/smoke/dates/output/swift/smoke/DateDefaultsAliased.swift
@@ -1,0 +1,66 @@
+//
+//
+import Foundation
+public struct DateDefaultsAliased {
+    public var dateTime: DateAlias
+    public var dateTimeUtc: DateAlias
+    public var beforeEpoch: DateAlias
+    public var exactlyEpoch: DateAlias
+    public init(dateTime: DateAlias = Date(timeIntervalSince1970: 1643966117), dateTimeUtc: DateAlias = Date(timeIntervalSince1970: 1643966117), beforeEpoch: DateAlias = Date(timeIntervalSince1970: -1511793883), exactlyEpoch: DateAlias = Date(timeIntervalSince1970: 0)) {
+        self.dateTime = dateTime
+        self.dateTimeUtc = dateTimeUtc
+        self.beforeEpoch = beforeEpoch
+        self.exactlyEpoch = exactlyEpoch
+    }
+    internal init(cHandle: _baseRef) {
+        dateTime = moveFromCType(smoke_DateDefaultsAliased_dateTime_get(cHandle))
+        dateTimeUtc = moveFromCType(smoke_DateDefaultsAliased_dateTimeUtc_get(cHandle))
+        beforeEpoch = moveFromCType(smoke_DateDefaultsAliased_beforeEpoch_get(cHandle))
+        exactlyEpoch = moveFromCType(smoke_DateDefaultsAliased_exactlyEpoch_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> DateDefaultsAliased {
+    return DateDefaultsAliased(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> DateDefaultsAliased {
+    defer {
+        smoke_DateDefaultsAliased_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DateDefaultsAliased) -> RefHolder {
+    let c_dateTime = moveToCType(swiftType.dateTime)
+    let c_dateTimeUtc = moveToCType(swiftType.dateTimeUtc)
+    let c_beforeEpoch = moveToCType(swiftType.beforeEpoch)
+    let c_exactlyEpoch = moveToCType(swiftType.exactlyEpoch)
+    return RefHolder(smoke_DateDefaultsAliased_create_handle(c_dateTime.ref, c_dateTimeUtc.ref, c_beforeEpoch.ref, c_exactlyEpoch.ref))
+}
+internal func moveToCType(_ swiftType: DateDefaultsAliased) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateDefaultsAliased_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> DateDefaultsAliased? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_DateDefaultsAliased_unwrap_optional_handle(handle)
+    return DateDefaultsAliased(cHandle: unwrappedHandle) as DateDefaultsAliased
+}
+internal func moveFromCType(_ handle: _baseRef) -> DateDefaultsAliased? {
+    defer {
+        smoke_DateDefaultsAliased_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: DateDefaultsAliased?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_dateTime = moveToCType(swiftType.dateTime)
+    let c_dateTimeUtc = moveToCType(swiftType.dateTimeUtc)
+    let c_beforeEpoch = moveToCType(swiftType.beforeEpoch)
+    let c_exactlyEpoch = moveToCType(swiftType.exactlyEpoch)
+    return RefHolder(smoke_DateDefaultsAliased_create_optional_handle(c_dateTime.ref, c_dateTimeUtc.ref, c_beforeEpoch.ref, c_exactlyEpoch.ref))
+}
+internal func moveToCType(_ swiftType: DateDefaultsAliased?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_DateDefaultsAliased_release_optional_handle)
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -38,9 +38,6 @@ import com.here.gluecodium.model.lime.LimeValue
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream
 import org.antlr.v4.runtime.tree.ParseTreeWalker
-import java.time.DateTimeException
-import java.time.Instant
-import java.time.format.DateTimeFormatter
 
 internal object AntlrLimeConverter {
 
@@ -274,14 +271,5 @@ internal object AntlrLimeConverter {
             ?: throw LimeLoadingException("Unsupported time unit: '$timeUnitText'")
         val sign = if (isNegative) "-" else ""
         return LimeValue.Duration(limeTypeRef, sign + valueText, timeUnit)
-    }
-
-    fun convertDateLiteral(limeTypeRef: LimeTypeRef, literalText: String): LimeValue.Date {
-        val epochSeconds = try {
-            Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(literalText)).epochSecond
-        } catch (e: DateTimeException) {
-            throw LimeLoadingException("Invalid `Date` literal: '$literalText'")
-        }
-        return LimeValue.Date(limeTypeRef, epochSeconds)
     }
 }

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.antlr.LimeParser
 import com.here.gluecodium.common.ModelBuilderContextStack
 import com.here.gluecodium.model.lime.LimeAmbiguousEnumeratorRef
 import com.here.gluecodium.model.lime.LimeAmbiguousTypeRef
-import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeComment
@@ -677,11 +676,7 @@ internal class AntlrLimeModelBuilder(
             ctx.DoubleLiteral() != null -> ctx.DoubleLiteral().text
             else -> throw LimeLoadingException("Unsupported literal: '$ctx'")
         }
-        return if (limeTypeRef is LimeBasicTypeRef && limeTypeRef.type.typeId == LimeBasicType.TypeId.DATE) {
-            AntlrLimeConverter.convertDateLiteral(limeTypeRef, literalString)
-        } else {
-            LimeValue.Literal(limeTypeRef, if (ctx.Minus() != null) "-$literalString" else literalString)
-        }
+        return LimeValue.Literal(limeTypeRef, if (ctx.Minus() != null) "-$literalString" else literalString)
     }
 
     private fun convertSimpleId(simpleId: LimeParser.SimpleIdContext): String {

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
@@ -19,6 +19,10 @@
 
 package com.here.gluecodium.model.lime
 
+import java.time.DateTimeException
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
 object LimeTypeHelper {
 
     fun getAllTypes(limeElement: LimeNamedElement): List<LimeType> {
@@ -88,6 +92,15 @@ object LimeTypeHelper {
         val parentDistances = parentTypes.filterIsInstance<LimeContainerWithInheritance>()
             .mapNotNull { computeInheritanceDistance(it, parentFullName) }
         return parentDistances.minOrNull()?.let { it + 1 }
+    }
+
+    fun dateLiteralEpochSeconds(literalText: String): Long? {
+        val epochSeconds = try {
+            Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(literalText)).epochSecond
+        } catch (e: DateTimeException) {
+            return null
+        }
+        return epochSeconds
     }
 
     private val limeKeywords = setOf(

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
@@ -20,7 +20,7 @@
 package com.here.gluecodium.model.lime
 
 import com.here.gluecodium.common.StringHelper
-import java.time.Instant
+import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 
 /**
  * Represents a constant value on the right-hand side of an assignment (used in constants, field
@@ -34,9 +34,9 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
     class Literal(type: LimeTypeRef, val value: String) : LimeValue(type) {
         override fun toString(): String {
             val limeType = typeRef.type.actualType
-            return when {
-                limeType is LimeBasicType && limeType.typeId == LimeBasicType.TypeId.STRING ->
-                    StringHelper.escapeStringLiteral(value)
+            if (limeType !is LimeBasicType) return value
+            return when (limeType.typeId) {
+                TypeId.STRING, TypeId.DATE -> StringHelper.escapeStringLiteral(value)
                 else -> value
             }
         }
@@ -85,8 +85,7 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
         override fun toString() = values.joinToString(separator = ", ", prefix = "{", postfix = "}")
     }
 
-    class KeyValuePair(val key: LimeValue, val value: LimeValue) :
-        LimeValue(LimeBasicTypeRef(LimeBasicType.TypeId.VOID)) {
+    class KeyValuePair(val key: LimeValue, val value: LimeValue) : LimeValue(LimeBasicTypeRef(TypeId.VOID)) {
         override fun toString() = "$key: $value"
     }
 
@@ -108,10 +107,6 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
         }
 
         override fun toString() = value + timeUnit
-    }
-
-    class Date(typeRef: LimeTypeRef, val epochSeconds: Long) : LimeValue(typeRef) {
-        override fun toString() = "\"${Instant.ofEpochSecond(epochSeconds)}\""
     }
 
     open val escapedValue


### PR DESCRIPTION
LIME `Date` literals are indistiguishable from `String` literals at parsing
time. The initial implementation tried to use the type of the field of the
constant to make this distinction. However, this approach does not work for type
aliases, as they cannot be resolved until the whole model is parsed.

Due to this, the "old" approach generated uncompilable code with type aliases.
The "new" approach is to:
* treat all string literals the same at parsing time
* during validation, check string literals assigned to `Date` type field/const
to be ISO 8601 compliant
* do the actual `Date` literal conversion in the name/value resolvers

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
