### PR TITLE
Add support for `Locale` type literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for `Locale` type literal values.
+
 ## 11.0.1
 Release date: 2022-02-22
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -465,6 +465,9 @@ a limited set of escaped characters is currently supported: `\\`, `\"`, `\n`, `\
 A string literal can be used to initialize a `Date` value. In this case it has to conform to ISO 8601 standard: e.g.
 `"2022-02-04T11:15:17+02:00"`, or `"2022-02-04T09:15:17Z"` for a UTC value.
 
+A string literal can also be used to initialize a `Locale` value. In this case it has to conform to BCP 47 standard: 
+e.g. `"en-US"`, `"nan-Hant-TW"`, etc.
+
 #### Special literals
 
 * `null`: "null" value for nullable types.

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -468,6 +468,7 @@ feature(Locales cpp android swift dart SOURCES
     input/src/cpp/Locales.cpp
 
     input/lime/Locales.lime
+    input/lime/LocaleDefaults.lime
 )
 
 feature(CrossPackageNameClash cpp android swift dart SOURCES

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/LocalesTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/LocalesTest.java
@@ -120,4 +120,22 @@ public class LocalesTest {
     assertEquals(localesStruct, result);
     assertEquals(localesStruct.hashCode(), result.hashCode());
   }
+
+  @Test
+  public void localeDefaultsTct() {
+    Locale result = (new LocaleDefaults()).traditionalChineseTaiwan;
+
+    assertEquals("nan", result.getLanguage());
+    assertEquals("Hant", result.getScript());
+    assertEquals("TW", result.getCountry());
+  }
+
+  @Test
+  public void localeDefaultsTctFromCpp() {
+    Locale result = LocaleDefaults.getCppDefaults().traditionalChineseTaiwan;
+
+    assertEquals("nan", result.getLanguage());
+    assertEquals("Hant", result.getScript());
+    assertEquals("TW", result.getCountry());
+  }
 }

--- a/functional-tests/functional/dart/test/Locales_test.dart
+++ b/functional-tests/functional/dart/test/Locales_test.dart
@@ -82,4 +82,18 @@ void main() {
     expect(result, localesStruct);
     expect(result.hashCode == localesStruct.hashCode, isTrue);
   });
+  _testSuite.test("Locale defaults Traditional Chinese Taiwan", () {
+    final result = LocaleDefaults().traditionalChineseTaiwan;
+
+    expect(result.languageCode, "nan");
+    expect(result.scriptCode, "Hant");
+    expect(result.countryCode, "TW");
+  });
+  _testSuite.test("Locale defaults Traditional Chinese Taiwan from C++", () {
+    final result = LocaleDefaults.getCppDefaults().traditionalChineseTaiwan;
+
+    expect(result.languageCode, "nan");
+    expect(result.scriptCode, "Hant");
+    expect(result.countryCode, "TW");
+  });
 }

--- a/functional-tests/functional/input/lime/LocaleDefaults.lime
+++ b/functional-tests/functional/input/lime/LocaleDefaults.lime
@@ -1,0 +1,31 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+struct LocaleDefaults {
+    english: Locale = "en"
+    latAmSpanish: Locale = "es-419"
+    romanshSursilvan: Locale = "rm-sursilv"
+    serbianCyrillic: Locale = "sr-Cyrl"
+    traditionalChineseTaiwan: Locale = "nan-Hant-TW"
+    zuerichGerman: Locale = "gsw-u-sd-chzh"
+
+    field constructor()
+
+    static fun getCppDefaults(): LocaleDefaults
+}

--- a/functional-tests/functional/input/src/cpp/Locales.cpp
+++ b/functional-tests/functional/input/src/cpp/Locales.cpp
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/Locales.h"
+#include "test/LocaleDefaults.h"
 #include "test/LocaleGenerics.h"
 #include "test/LocalesStruct.h"
 
@@ -105,5 +106,10 @@ std::unordered_map<std::string, Locale>
 LocaleGenerics::locale_values_map_round_trip(const std::unordered_map<std::string, Locale>& input) {
     return input;
 }
+
+// LocaleDefaults
+
+LocaleDefaults
+LocaleDefaults::get_cpp_defaults() { return {}; }
 
 }

--- a/functional-tests/functional/swift/Tests/LocalesTests.swift
+++ b/functional-tests/functional/swift/Tests/LocalesTests.swift
@@ -98,6 +98,22 @@ class LocalesTests: XCTestCase {
         XCTAssertEqual(hash(result), hash(localesStruct))
     }
 
+    func testLocaleDefaultsTct() {
+        let result = LocaleDefaults().traditionalChineseTaiwan
+
+        XCTAssertEqual(result.languageCode, "nan")
+        XCTAssertEqual(result.scriptCode, "Hant")
+        XCTAssertEqual(result.regionCode, "TW")
+    }
+
+    func testLocaleDefaultsTctFromCpp() {
+        let result = LocaleDefaults.getCppDefaults().traditionalChineseTaiwan
+
+        XCTAssertEqual(result.languageCode, "nan")
+        XCTAssertEqual(result.scriptCode, "Hant")
+        XCTAssertEqual(result.regionCode, "TW")
+    }
+
     func hash<H>(_ value: H) -> Int where H: Hashable {
         var hasher = Hasher()
         value.hash(into: &hasher)
@@ -114,6 +130,8 @@ class LocalesTests: XCTestCase {
         ("testLocaleWithMalformedLanguage", testLocaleWithMalformedLanguage),
         ("testLocaleWithMalformedCountry", testLocaleWithMalformedCountry),
         ("testLocaleWithMalformedScript", testLocaleWithMalformedScript),
-        ("testLocalesStructRoundTrip", testLocalesStructRoundTrip)
+        ("testLocalesStructRoundTrip", testLocalesStructRoundTrip),
+        ("testLocaleDefaultsTct", testLocaleDefaultsTct),
+        ("testLocaleDefaultsTctFromCpp", testLocaleDefaultsTctFromCpp)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -166,8 +166,7 @@ internal class CppNameResolver(
     private fun resolveValue(limeValue: LimeValue): String =
         when (limeValue) {
             is LimeValue.Literal -> resolveLiteralValue(limeValue)
-            is LimeValue.Enumerator ->
-                nameCache.getFullyQualifiedName(limeValue.valueRef.enumerator)
+            is LimeValue.Enumerator -> nameCache.getFullyQualifiedName(limeValue.valueRef.enumerator)
             is LimeValue.Special -> {
                 val valueType = limeValue.typeRef.type
                 val isFloat = valueType is LimeBasicType && valueType.typeId == TypeId.FLOAT
@@ -192,6 +191,10 @@ internal class CppNameResolver(
             TypeId.DATE -> {
                 val epochSeconds = LimeTypeHelper.dateLiteralEpochSeconds(limeValue.value)
                 "::std::chrono::system_clock::from_time_t($epochSeconds)"
+            }
+            TypeId.LOCALE -> {
+                val localeTag = LimeTypeHelper.normalizeLocaleTag(limeValue.value)
+                "$localeTypeName(std::string{\"$localeTag\"})"
             }
             else -> limeValue.toString()
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -183,6 +183,10 @@ internal class DartNameResolver(
                 val epochSeconds = LimeTypeHelper.dateLiteralEpochSeconds(limeValue.value)?.let { it * 1000 }
                 "DateTime.fromMillisecondsSinceEpoch($epochSeconds)"
             }
+            TypeId.LOCALE -> {
+                val localeTag = LimeTypeHelper.normalizeLocaleTag(limeValue.value)
+                "Locale.parse(\"$localeTag\")"
+            }
             else -> limeValue.toString()
         }
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
@@ -66,6 +66,10 @@ internal class JavaValueResolver(private val nameResolver: JavaNameResolver) {
                 val epochSeconds = LimeTypeHelper.dateLiteralEpochSeconds(limeValue.value)?.let { it * 1000 }
                 "new Date(${epochSeconds}L)"
             }
+            TypeId.LOCALE -> {
+                val localeTag = LimeTypeHelper.normalizeLocaleTag(limeValue.value)
+                "Locale.forLanguageTag(\"$localeTag\")"
+            }
             else -> limeValue.toString()
         }
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -158,6 +158,10 @@ internal class SwiftNameResolver(
                 val epochSeconds = LimeTypeHelper.dateLiteralEpochSeconds(limeValue.value)
                 "Date(timeIntervalSince1970: $epochSeconds)"
             }
+            TypeId.LOCALE -> {
+                val localeTag = LimeTypeHelper.normalizeLocaleTag(limeValue.value)
+                "Locale(identifier: \"$localeTag\")"
+            }
             else -> limeValue.toString()
         }
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
@@ -93,7 +93,7 @@ internal class LimeValuesValidator(private val logger: LimeLogger) {
         if (nonLiteralTypes.contains(limeType.typeId)) {
             logger.error(
                 limeElement,
-                "string or numeric literal values cannot be assigned to `Blob`, `Duration`, or `Locale` types"
+                "string or numeric literal values cannot be assigned to `Blob` or `Duration` types"
             )
             return false
         }
@@ -101,10 +101,14 @@ internal class LimeValuesValidator(private val logger: LimeLogger) {
             logger.error(limeElement, "invalid `Date` literal:  '$limeValue'")
             return false
         }
+        if (limeType.typeId == TypeId.LOCALE && LimeTypeHelper.normalizeLocaleTag(limeValue.value) == null) {
+            logger.error(limeElement, "invalid `Locale` literal:  '$limeValue'")
+            return false
+        }
         return true
     }
 
     companion object {
-        private val nonLiteralTypes = setOf(TypeId.BLOB, TypeId.DURATION, TypeId.LOCALE)
+        private val nonLiteralTypes = setOf(TypeId.BLOB, TypeId.DURATION)
     }
 }

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
@@ -82,6 +82,9 @@ class LimeValuesValidatorTest(
                 true
             ),
             arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.DATE), LimeValue.Literal(fooTypeRef, "bar"), false),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.LOCALE), LimeValue.Literal(fooTypeRef, "en-US"), true),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.LOCALE), LimeValue.Literal(fooTypeRef, "und"), true),
+            arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.LOCALE), LimeValue.Literal(fooTypeRef, "42"), false),
             arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.BLOB), LimeValue.Literal(fooTypeRef, ""), false),
             arrayOf(fooTypeRef, LimeValue.Literal(fooTypeRef, ""), false),
             arrayOf(

--- a/gluecodium/src/test/resources/smoke/locales/input/LocaleDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/locales/input/LocaleDefaults.lime
@@ -1,0 +1,27 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+struct LocaleDefaults {
+    english: Locale = "en"
+    latAmSpanish: Locale = "es-419"
+    romanshSursilvan: Locale = "rm-sursilv"
+    serbianCyrillic: Locale = "sr-Cyrl"
+    traditionalChineseTaiwan: Locale = "nan-Hant-TW"
+    zuerichGerman: Locale = "gsw-u-sd-chzh"
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/LocaleDefaults.java
+++ b/gluecodium/src/test/resources/smoke/locales/output/android/com/example/smoke/LocaleDefaults.java
@@ -1,0 +1,28 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import java.util.Locale;
+public final class LocaleDefaults {
+    @NonNull
+    public Locale english;
+    @NonNull
+    public Locale latAmSpanish;
+    @NonNull
+    public Locale romanshSursilvan;
+    @NonNull
+    public Locale serbianCyrillic;
+    @NonNull
+    public Locale traditionalChineseTaiwan;
+    @NonNull
+    public Locale zuerichGerman;
+    public LocaleDefaults() {
+        this.english = Locale.forLanguageTag("en");
+        this.latAmSpanish = Locale.forLanguageTag("es-419");
+        this.romanshSursilvan = Locale.forLanguageTag("rm-sursilv");
+        this.serbianCyrillic = Locale.forLanguageTag("sr-Cyrl");
+        this.traditionalChineseTaiwan = Locale.forLanguageTag("nan-Hant-TW");
+        this.zuerichGerman = Locale.forLanguageTag("gsw-u-sd-chzh");
+    }
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/LocaleDefaults.h
+++ b/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/LocaleDefaults.h
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/Locale.h"
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT LocaleDefaults {
+    ::gluecodium::Locale english = ::gluecodium::Locale(std::string{"en"});
+    ::gluecodium::Locale lat_am_spanish = ::gluecodium::Locale(std::string{"es-419"});
+    ::gluecodium::Locale romansh_sursilvan = ::gluecodium::Locale(std::string{"rm-sursilv"});
+    ::gluecodium::Locale serbian_cyrillic = ::gluecodium::Locale(std::string{"sr-Cyrl"});
+    ::gluecodium::Locale traditional_chinese_taiwan = ::gluecodium::Locale(std::string{"nan-Hant-TW"});
+    ::gluecodium::Locale zuerich_german = ::gluecodium::Locale(std::string{"gsw-u-sd-chzh"});
+    LocaleDefaults( );
+    LocaleDefaults( ::gluecodium::Locale english, ::gluecodium::Locale lat_am_spanish, ::gluecodium::Locale romansh_sursilvan, ::gluecodium::Locale serbian_cyrillic, ::gluecodium::Locale traditional_chinese_taiwan, ::gluecodium::Locale zuerich_german );
+};
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locale_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locale_defaults.dart
@@ -1,0 +1,120 @@
+import 'dart:ffi';
+import 'package:intl/locale.dart';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class LocaleDefaults {
+  Locale english;
+  Locale latAmSpanish;
+  Locale romanshSursilvan;
+  Locale serbianCyrillic;
+  Locale traditionalChineseTaiwan;
+  Locale zuerichGerman;
+  LocaleDefaults._(this.english, this.latAmSpanish, this.romanshSursilvan, this.serbianCyrillic, this.traditionalChineseTaiwan, this.zuerichGerman);
+  LocaleDefaults()
+    : english = Locale.parse("en"), latAmSpanish = Locale.parse("es-419"), romanshSursilvan = Locale.parse("rm-sursilv"), serbianCyrillic = Locale.parse("sr-Cyrl"), traditionalChineseTaiwan = Locale.parse("nan-Hant-TW"), zuerichGerman = Locale.parse("gsw-u-sd-chzh");
+}
+// LocaleDefaults "private" section, not exported.
+final _smokeLocaledefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('library_smoke_LocaleDefaults_create_handle'));
+final _smokeLocaledefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_release_handle'));
+final _smokeLocaledefaultsGetFieldenglish = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_get_field_english'));
+final _smokeLocaledefaultsGetFieldlatAmSpanish = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_get_field_latAmSpanish'));
+final _smokeLocaledefaultsGetFieldromanshSursilvan = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_get_field_romanshSursilvan'));
+final _smokeLocaledefaultsGetFieldserbianCyrillic = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_get_field_serbianCyrillic'));
+final _smokeLocaledefaultsGetFieldtraditionalChineseTaiwan = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_get_field_traditionalChineseTaiwan'));
+final _smokeLocaledefaultsGetFieldzuerichGerman = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_get_field_zuerichGerman'));
+Pointer<Void> smokeLocaledefaultsToFfi(LocaleDefaults value) {
+  final _englishHandle = localeToFfi(value.english);
+  final _latAmSpanishHandle = localeToFfi(value.latAmSpanish);
+  final _romanshSursilvanHandle = localeToFfi(value.romanshSursilvan);
+  final _serbianCyrillicHandle = localeToFfi(value.serbianCyrillic);
+  final _traditionalChineseTaiwanHandle = localeToFfi(value.traditionalChineseTaiwan);
+  final _zuerichGermanHandle = localeToFfi(value.zuerichGerman);
+  final _result = _smokeLocaledefaultsCreateHandle(_englishHandle, _latAmSpanishHandle, _romanshSursilvanHandle, _serbianCyrillicHandle, _traditionalChineseTaiwanHandle, _zuerichGermanHandle);
+  localeReleaseFfiHandle(_englishHandle);
+  localeReleaseFfiHandle(_latAmSpanishHandle);
+  localeReleaseFfiHandle(_romanshSursilvanHandle);
+  localeReleaseFfiHandle(_serbianCyrillicHandle);
+  localeReleaseFfiHandle(_traditionalChineseTaiwanHandle);
+  localeReleaseFfiHandle(_zuerichGermanHandle);
+  return _result;
+}
+LocaleDefaults smokeLocaledefaultsFromFfi(Pointer<Void> handle) {
+  final _englishHandle = _smokeLocaledefaultsGetFieldenglish(handle);
+  final _latAmSpanishHandle = _smokeLocaledefaultsGetFieldlatAmSpanish(handle);
+  final _romanshSursilvanHandle = _smokeLocaledefaultsGetFieldromanshSursilvan(handle);
+  final _serbianCyrillicHandle = _smokeLocaledefaultsGetFieldserbianCyrillic(handle);
+  final _traditionalChineseTaiwanHandle = _smokeLocaledefaultsGetFieldtraditionalChineseTaiwan(handle);
+  final _zuerichGermanHandle = _smokeLocaledefaultsGetFieldzuerichGerman(handle);
+  try {
+    return LocaleDefaults._(
+      localeFromFfi(_englishHandle),
+      localeFromFfi(_latAmSpanishHandle),
+      localeFromFfi(_romanshSursilvanHandle),
+      localeFromFfi(_serbianCyrillicHandle),
+      localeFromFfi(_traditionalChineseTaiwanHandle),
+      localeFromFfi(_zuerichGermanHandle)
+    );
+  } finally {
+    localeReleaseFfiHandle(_englishHandle);
+    localeReleaseFfiHandle(_latAmSpanishHandle);
+    localeReleaseFfiHandle(_romanshSursilvanHandle);
+    localeReleaseFfiHandle(_serbianCyrillicHandle);
+    localeReleaseFfiHandle(_traditionalChineseTaiwanHandle);
+    localeReleaseFfiHandle(_zuerichGermanHandle);
+  }
+}
+void smokeLocaledefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeLocaledefaultsReleaseHandle(handle);
+// Nullable LocaleDefaults
+final _smokeLocaledefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_create_handle_nullable'));
+final _smokeLocaledefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_release_handle_nullable'));
+final _smokeLocaledefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_LocaleDefaults_get_value_nullable'));
+Pointer<Void> smokeLocaledefaultsToFfiNullable(LocaleDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeLocaledefaultsToFfi(value);
+  final result = _smokeLocaledefaultsCreateHandleNullable(_handle);
+  smokeLocaledefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+LocaleDefaults? smokeLocaledefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeLocaledefaultsGetValueNullable(handle);
+  final result = smokeLocaledefaultsFromFfi(_handle);
+  smokeLocaledefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeLocaledefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeLocaledefaultsReleaseHandleNullable(handle);
+// End of LocaleDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/locales/output/lime/smoke/LocaleDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/locales/output/lime/smoke/LocaleDefaults.lime
@@ -1,0 +1,9 @@
+package smoke
+struct LocaleDefaults {
+    english: Locale = "en"
+    latAmSpanish: Locale = "es-419"
+    romanshSursilvan: Locale = "rm-sursilv"
+    serbianCyrillic: Locale = "sr-Cyrl"
+    traditionalChineseTaiwan: Locale = "nan-Hant-TW"
+    zuerichGerman: Locale = "gsw-u-sd-chzh"
+}

--- a/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/LocaleDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/locales/output/swift/smoke/LocaleDefaults.swift
@@ -1,0 +1,76 @@
+//
+//
+import Foundation
+public struct LocaleDefaults {
+    public var english: Locale
+    public var latAmSpanish: Locale
+    public var romanshSursilvan: Locale
+    public var serbianCyrillic: Locale
+    public var traditionalChineseTaiwan: Locale
+    public var zuerichGerman: Locale
+    public init(english: Locale = Locale(identifier: "en"), latAmSpanish: Locale = Locale(identifier: "es-419"), romanshSursilvan: Locale = Locale(identifier: "rm-sursilv"), serbianCyrillic: Locale = Locale(identifier: "sr-Cyrl"), traditionalChineseTaiwan: Locale = Locale(identifier: "nan-Hant-TW"), zuerichGerman: Locale = Locale(identifier: "gsw-u-sd-chzh")) {
+        self.english = english
+        self.latAmSpanish = latAmSpanish
+        self.romanshSursilvan = romanshSursilvan
+        self.serbianCyrillic = serbianCyrillic
+        self.traditionalChineseTaiwan = traditionalChineseTaiwan
+        self.zuerichGerman = zuerichGerman
+    }
+    internal init(cHandle: _baseRef) {
+        english = moveFromCType(smoke_LocaleDefaults_english_get(cHandle))
+        latAmSpanish = moveFromCType(smoke_LocaleDefaults_latAmSpanish_get(cHandle))
+        romanshSursilvan = moveFromCType(smoke_LocaleDefaults_romanshSursilvan_get(cHandle))
+        serbianCyrillic = moveFromCType(smoke_LocaleDefaults_serbianCyrillic_get(cHandle))
+        traditionalChineseTaiwan = moveFromCType(smoke_LocaleDefaults_traditionalChineseTaiwan_get(cHandle))
+        zuerichGerman = moveFromCType(smoke_LocaleDefaults_zuerichGerman_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> LocaleDefaults {
+    return LocaleDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> LocaleDefaults {
+    defer {
+        smoke_LocaleDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: LocaleDefaults) -> RefHolder {
+    let c_english = moveToCType(swiftType.english)
+    let c_latAmSpanish = moveToCType(swiftType.latAmSpanish)
+    let c_romanshSursilvan = moveToCType(swiftType.romanshSursilvan)
+    let c_serbianCyrillic = moveToCType(swiftType.serbianCyrillic)
+    let c_traditionalChineseTaiwan = moveToCType(swiftType.traditionalChineseTaiwan)
+    let c_zuerichGerman = moveToCType(swiftType.zuerichGerman)
+    return RefHolder(smoke_LocaleDefaults_create_handle(c_english.ref, c_latAmSpanish.ref, c_romanshSursilvan.ref, c_serbianCyrillic.ref, c_traditionalChineseTaiwan.ref, c_zuerichGerman.ref))
+}
+internal func moveToCType(_ swiftType: LocaleDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_LocaleDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> LocaleDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_LocaleDefaults_unwrap_optional_handle(handle)
+    return LocaleDefaults(cHandle: unwrappedHandle) as LocaleDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> LocaleDefaults? {
+    defer {
+        smoke_LocaleDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: LocaleDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_english = moveToCType(swiftType.english)
+    let c_latAmSpanish = moveToCType(swiftType.latAmSpanish)
+    let c_romanshSursilvan = moveToCType(swiftType.romanshSursilvan)
+    let c_serbianCyrillic = moveToCType(swiftType.serbianCyrillic)
+    let c_traditionalChineseTaiwan = moveToCType(swiftType.traditionalChineseTaiwan)
+    let c_zuerichGerman = moveToCType(swiftType.zuerichGerman)
+    return RefHolder(smoke_LocaleDefaults_create_optional_handle(c_english.ref, c_latAmSpanish.ref, c_romanshSursilvan.ref, c_serbianCyrillic.ref, c_traditionalChineseTaiwan.ref, c_zuerichGerman.ref))
+}
+internal func moveToCType(_ swiftType: LocaleDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_LocaleDefaults_release_optional_handle)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.model.lime
 import java.time.DateTimeException
 import java.time.Instant
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 object LimeTypeHelper {
 
@@ -102,6 +103,16 @@ object LimeTypeHelper {
         }
         return epochSeconds
     }
+
+    fun normalizeLocaleTag(literalText: String): String? {
+        val originalTag = literalText.trim()
+        if (originalTag.toLowerCase() == LOCALE_UND) return LOCALE_UND
+
+        val normalizedTag = Locale.forLanguageTag(originalTag).toLanguageTag()
+        return if (normalizedTag.toLowerCase() != LOCALE_UND) normalizedTag else null
+    }
+
+    private val LOCALE_UND = Locale.forLanguageTag("").toLanguageTag().toLowerCase()
 
     private val limeKeywords = setOf(
         "class", "const", "constructor", "enum", "exception", "external", "field", "fun",

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeValue.kt
@@ -36,7 +36,7 @@ sealed class LimeValue(val typeRef: LimeTypeRef) : LimeElement() {
             val limeType = typeRef.type.actualType
             if (limeType !is LimeBasicType) return value
             return when (limeType.typeId) {
-                TypeId.STRING, TypeId.DATE -> StringHelper.escapeStringLiteral(value)
+                TypeId.STRING, TypeId.DATE, TypeId.LOCALE -> StringHelper.escapeStringLiteral(value)
                 else -> value
             }
         }


### PR DESCRIPTION
Added support for assigning string literals to `Locale` type fields and
constants. Such string should represent a valid BCP 47 locale identifier.

Updated LimeValuesValidator to validate such literals against the BCP 47
standard. Added new unit tests for the validator.

Added new smoke and functional tests, as appropriate.

Resolves: #1216
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>