### PR TITLE
Fix strict validation for internal structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added support for `Locale` type literal values.
+### Bug fixes:
+  * "Strict mode" validation no longer erroneously fails for structs that have `internal` visibility.
 
 ## 11.0.1
 Release date: 2022-02-22

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeStructsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeStructsValidator.kt
@@ -95,7 +95,7 @@ internal class LimeStructsValidator(private val logger: LimeLogger, private val 
             logger.error(limeStruct, "an immutable struct should have at least one explicit constructor")
             result = false
         }
-        if (limeStruct.internalFields.any { it.defaultValue == null }) {
+        if (!limeStruct.visibility.isInternal && limeStruct.internalFields.any { it.defaultValue == null }) {
             logger.error(
                 limeStruct,
                 "if any internal field does not have a default value, " +

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorStrictTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorStrictTest.kt
@@ -149,4 +149,11 @@ class LimeStructsValidatorStrictTest {
 
         assertTrue(validator.validate(limeModel))
     }
+
+    @Test
+    fun validateInternalStructWithNoConstructors() {
+        allElements[""] = LimeStruct(EMPTY_PATH, fields = listOf(limeField), visibility = LimeVisibility.INTERNAL)
+
+        assertTrue(validator.validate(limeModel))
+    }
 }

--- a/gluecodium/src/test/resources/smoke/strict/input/StrictStructs.lime
+++ b/gluecodium/src/test/resources/smoke/strict/input/StrictStructs.lime
@@ -42,3 +42,7 @@ struct InternalFieldWithCustomConstructor {
 struct InternalFieldWithDefaultValue {
     internal stringField: String = ""
 }
+
+internal struct WholeStructInternal {
+    stringField: String
+}

--- a/gluecodium/src/test/resources/smoke/strict/output/lime/smoke/WholeStructInternal.lime
+++ b/gluecodium/src/test/resources/smoke/strict/output/lime/smoke/WholeStructInternal.lime
@@ -1,0 +1,4 @@
+package smoke
+internal struct WholeStructInternal {
+    stringField: String
+}


### PR DESCRIPTION
Updated LimeStructsValidator to ignore structs with `internal` visibility when
doing "strict" validation. The strict validation error about unintialized
internal fields is intended to prevent exposing said fields through public
constructors. None of this is a concern for structs that are themselves
`internal`.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
