### PR TITLE
Add `Blob` type collection initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features:
   * Added support for `Locale` type literal values.
+  * Added support for `Blob` type collection initializers.
 ### Bug fixes:
   * "Strict mode" validation no longer erroneously fails for structs that have `internal` visibility.
 

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -489,7 +489,7 @@ order of declaration of struct's fields.
 * Syntax: **[** \[*list-of-values*\] **]**
 * where *list-of-values* is a comma-separated list of values
 * Example: `const ValidKeys: Set<String> = ["name", "address"]`
-* Description: initializes a list or a set with the given values. `[]` initializes an empty list or
+* Description: initializes a `List<>`, a `Set<>`, or a `Blob` with the given values. `[]` initializes an empty list or
 set.
 
 #### Map initializer
@@ -497,7 +497,7 @@ set.
 * Syntax: **[** \[*list-of-pairs*\] **]**
 * where *list-of-pairs* is a comma-separated list of *key*__:__ *value* pairs
 * Example: `const FieldNames: Map<Int, String> = [1: "name", 42: "address"]`
-* Description: initializes a map with the given key-value pairs. `[]` initializes an empty map.
+* Description: initializes a `Map<>` with the given key-value pairs. `[]` initializes an empty map.
 
 #### Enumerator reference
 

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/BlobsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/BlobsTest.java
@@ -183,4 +183,31 @@ public class BlobsTest {
 
     assertNull(resultBuffer);
   }
+
+  @Test
+  public void blobDefaultsEmpty() {
+    byte[] result = (new BlobDefaults()).emptyList;
+
+    assertEquals(0, result.length);
+  }
+
+  @Test
+  public void blobDefaultsDeadBeef() {
+    byte[] result = (new BlobDefaults()).deadBeef;
+
+    assertEquals((byte) 0xDE, result[0]);
+    assertEquals((byte) 0xAD, result[1]);
+    assertEquals((byte) 0xBE, result[2]);
+    assertEquals((byte) 0xEF, result[3]);
+  }
+
+  @Test
+  public void blobDefaultsDeadBeefFromCpp() {
+    byte[] result = BlobDefaults.getCppDefaults().deadBeef;
+
+    assertEquals((byte) 0xDE, result[0]);
+    assertEquals((byte) 0xAD, result[1]);
+    assertEquals((byte) 0xBE, result[2]);
+    assertEquals((byte) 0xEF, result[3]);
+  }
 }

--- a/functional-tests/functional/dart/test/Blobs_test.dart
+++ b/functional-tests/functional/dart/test/Blobs_test.dart
@@ -77,4 +77,19 @@ void main() {
     expect(exception, isNull);
     expect(result, Uint8List.fromList([0, 1, 2]));
   });
+  _testSuite.test("Blob defaults empty", () {
+    final result = BlobDefaults().emptyList;
+
+    expect(result, isEmpty);
+  });
+  _testSuite.test("Blob defaults DEAF BEEF", () {
+    final result = BlobDefaults().deadBeef;
+
+    expect(result, [0xDE, 0xAD, 0xBE, 0xEF]);
+  });
+  _testSuite.test("Blob defaults DEAF BEEF from C++", () {
+    final result = BlobDefaults.getCppDefaults().deadBeef;
+
+    expect(result, [0xDE, 0xAD, 0xBE, 0xEF]);
+  });
 }

--- a/functional-tests/functional/input/lime/Defaults.lime
+++ b/functional-tests/functional/input/lime/Defaults.lime
@@ -118,3 +118,12 @@ class Defaults {
     static fun getEmptyDefaults(): StructWithEmptyDefaults
     static fun getInitializerDefaults(): StructWithInitializerDefaults
 }
+
+struct BlobDefaults {
+    emptyList: Blob = []
+    deadBeef: Blob = [222, 173, 190, 239]
+
+    field constructor()
+
+    static fun getCppDefaults(): BlobDefaults
+}

--- a/functional-tests/functional/input/src/cpp/Defaults.cpp
+++ b/functional-tests/functional/input/src/cpp/Defaults.cpp
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+#include "test/BlobDefaults.h"
 #include "test/Defaults.h"
 #include <cmath>
 
@@ -89,4 +90,7 @@ Defaults::get_initializer_defaults( )
     return {};
 }
 
-}  // namespace test
+BlobDefaults
+BlobDefaults::get_cpp_defaults() { return {}; }
+
+}

--- a/functional-tests/functional/swift/Tests/BlobsTests.swift
+++ b/functional-tests/functional/swift/Tests/BlobsTests.swift
@@ -1,0 +1,49 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2022 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import functional
+
+class BlobsTests: XCTestCase {
+
+    func testBlobDefaultsEmpty() {
+        let result = BlobDefaults().emptyList
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBlobDefaultsDeadBeef() {
+        let result = BlobDefaults().deadBeef
+
+        XCTAssertEqual(result, Data([0xDE, 0xAD, 0xBE, 0xEF]))
+    }
+
+    func testBlobDefaultsDeadBeefFromCpp() {
+        let result = BlobDefaults.getCppDefaults().deadBeef
+
+        XCTAssertEqual(result, Data([0xDE, 0xAD, 0xBE, 0xEF]))
+    }
+
+    static var allTests = [
+        ("testBlobDefaultsEmpty", testBlobDefaultsEmpty),
+        ("testBlobDefaultsDeadBeef", testBlobDefaultsDeadBeef),
+        ("testBlobDefaultsDeadBeefFromCpp", testBlobDefaultsDeadBeefFromCpp)
+    ]
+}

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -33,6 +33,7 @@ func getAllTests() -> [XCTestCaseEntry] {
         testCase(ArraysTests.allTests),
         testCase(AttributesInterfaceTests.allTests),
         testCase(AttributesTests.allTests),
+        testCase(BlobsTests.allTests),
         testCase(ConstantsTests.allTests),
         testCase(CppConstMethodsTests.allTests),
         testCase(DatesTests.allTests),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -176,7 +176,7 @@ internal class CppNameResolver(
                 "${signPrefix}std::numeric_limits<$typeString>::$valueString()"
             }
             is LimeValue.Null -> "${resolveName(limeValue.typeRef)}()"
-            is LimeValue.InitializerList -> limeValue.values.joinToString(", ", "{", "}") { resolveValue(it) }
+            is LimeValue.InitializerList -> resolveListValue(limeValue)
             is LimeValue.StructInitializer ->
                 limeValue.values.joinToString(", ", "${resolveName(limeValue.typeRef)}{", "}") { resolveValue(it) }
             is LimeValue.KeyValuePair -> "{${resolveValue(limeValue.key)}, ${resolveValue(limeValue.value)}}"
@@ -197,6 +197,16 @@ internal class CppNameResolver(
                 "$localeTypeName(std::string{\"$localeTag\"})"
             }
             else -> limeValue.toString()
+        }
+    }
+
+    private fun resolveListValue(limeValue: LimeValue.InitializerList): String {
+        val limeType = limeValue.typeRef.type.actualType
+        val values = limeValue.values.joinToString(", ", "{", "}") { resolveValue(it) }
+        return when {
+            limeType is LimeBasicType && limeType.typeId == TypeId.BLOB ->
+                "::std::make_shared<::std::vector<uint8_t>>(::std::vector<uint8_t>($values))"
+            else -> values
         }
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -131,26 +131,7 @@ internal class DartNameResolver(
                 "double.$specialName"
             }
             is LimeValue.Null -> "null"
-            is LimeValue.InitializerList -> {
-                val actualType = limeValue.typeRef.type.actualType
-                val prefix: String
-                val postfix: String
-                when (actualType) {
-                    is LimeList -> {
-                        prefix = "["
-                        postfix = "]"
-                    }
-                    else -> {
-                        prefix = "{"
-                        postfix = "}"
-                    }
-                }
-                limeValue.values.joinToString(
-                    prefix = prefix,
-                    postfix = postfix,
-                    separator = ", "
-                ) { resolveValue(it) }
-            }
+            is LimeValue.InitializerList -> resolveListValue(limeValue)
             is LimeValue.StructInitializer -> {
                 val actualType = limeValue.typeRef.type.actualType
                 if (actualType !is LimeStruct) {
@@ -188,6 +169,16 @@ internal class DartNameResolver(
                 "Locale.parse(\"$localeTag\")"
             }
             else -> limeValue.toString()
+        }
+    }
+
+    private fun resolveListValue(limeValue: LimeValue.InitializerList): String {
+        val limeType = limeValue.typeRef.type.actualType
+        val values = limeValue.values.joinToString(separator = ", ") { resolveValue(it) }
+        return when {
+            limeType is LimeList -> "[$values]"
+            limeType is LimeBasicType && limeType.typeId == TypeId.BLOB -> "Uint8List.fromList([$values])"
+            else -> "{$values}"
         }
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
@@ -75,8 +75,14 @@ internal class JavaValueResolver(private val nameResolver: JavaNameResolver) {
     }
 
     private fun mapInitializerList(limeValue: LimeValue.InitializerList): String {
+        val limeType = limeValue.typeRef.type.actualType
+        if (limeType is LimeBasicType && limeType.typeId == TypeId.BLOB) {
+            val values = limeValue.values.joinToString(", ") { "(byte) " + resolveValue(it) }
+            return "new byte[] { $values }"
+        }
+
         val values = limeValue.values.joinToString(", ") { resolveValue(it) }
-        return when (val limeType = limeValue.typeRef.type.actualType) {
+        return when (limeType) {
             is LimeList -> {
                 val valuesAsList = if (values.isEmpty()) "" else "Arrays.asList($values)"
                 "new ArrayList<>($valuesAsList)"

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
@@ -57,7 +57,7 @@ internal class LimeValuesValidator(private val logger: LimeLogger) {
                 logger.error(limeElement, "enumerator values can only be assigned to `enum` types")
                 return false
             }
-            is LimeValue.InitializerList -> if (actualType !is LimeGenericType) {
+            is LimeValue.InitializerList -> if (!isCollectionType(actualType)) {
                 logger.error(limeElement, "initializer list values can only be assigned to collection types")
                 return false
             }
@@ -90,7 +90,7 @@ internal class LimeValuesValidator(private val logger: LimeLogger) {
             logger.error(limeElement, "literal values cannot be assigned to non-basic types")
             return false
         }
-        if (nonLiteralTypes.contains(limeType.typeId)) {
+        if (limeType.typeId == TypeId.BLOB || limeType.typeId == TypeId.DURATION) {
             logger.error(
                 limeElement,
                 "string or numeric literal values cannot be assigned to `Blob` or `Duration` types"
@@ -108,7 +108,10 @@ internal class LimeValuesValidator(private val logger: LimeLogger) {
         return true
     }
 
-    companion object {
-        private val nonLiteralTypes = setOf(TypeId.BLOB, TypeId.DURATION)
+    private fun isCollectionType(limeType: LimeType) = when {
+        limeType is LimeGenericType -> true
+        limeType !is LimeBasicType -> false
+        limeType.typeId == TypeId.BLOB -> true
+        else -> false
     }
 }

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
@@ -114,6 +114,11 @@ class LimeValuesValidatorTest(
                 LimeValue.InitializerList(fooTypeRef, emptyList()),
                 true
             ),
+            arrayOf(
+                LimeBasicTypeRef(LimeBasicType.TypeId.BLOB),
+                LimeValue.InitializerList(fooTypeRef, emptyList()),
+                true
+            ),
             arrayOf(fooTypeRef, LimeValue.InitializerList(fooTypeRef, emptyList()), false),
             arrayOf(fooTypeRef, LimeValue.KeyValuePair(LimeValue.ZERO, LimeValue.ZERO), false),
             arrayOf(

--- a/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
@@ -117,3 +117,8 @@ struct StructWithInitializerDefaults {
     setTypeField: DefaultValues.StringSet = ["foo", "bar"]
     mapField: DefaultValues.IdToStringMap = [1: "foo", 42: "bar"]
 }
+
+struct BlobDefaults {
+    emptyList: Blob = []
+    deadBeef: Blob = [222, 173, 190, 239]
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/BlobDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/BlobDefaults.java
@@ -1,0 +1,15 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+public final class BlobDefaults {
+    @NonNull
+    public byte[] emptyList;
+    @NonNull
+    public byte[] deadBeef;
+    public BlobDefaults() {
+        this.emptyList = new byte[] {  };
+        this.deadBeef = new byte[] { (byte) 222, (byte) 173, (byte) 190, (byte) 239 };
+    }
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/BlobDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/BlobDefaults.h
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+#include <memory>
+#include <vector>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT BlobDefaults {
+    ::std::shared_ptr< ::std::vector< uint8_t > > empty_list = ::std::make_shared<::std::vector<uint8_t>>(::std::vector<uint8_t>({}));
+    ::std::shared_ptr< ::std::vector< uint8_t > > dead_beef = ::std::make_shared<::std::vector<uint8_t>>(::std::vector<uint8_t>({222, 173, 190, 239}));
+    BlobDefaults( );
+    BlobDefaults( ::std::shared_ptr< ::std::vector< uint8_t > > empty_list, ::std::shared_ptr< ::std::vector< uint8_t > > dead_beef );
+};
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/blob_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/blob_defaults.dart
@@ -1,0 +1,80 @@
+import 'dart:ffi';
+import 'dart:typed_data';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+class BlobDefaults {
+  Uint8List emptyList;
+  Uint8List deadBeef;
+  BlobDefaults._(this.emptyList, this.deadBeef);
+  BlobDefaults()
+    : emptyList = Uint8List.fromList([]), deadBeef = Uint8List.fromList([222, 173, 190, 239]);
+}
+// BlobDefaults "private" section, not exported.
+final _smokeBlobdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_BlobDefaults_create_handle'));
+final _smokeBlobdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_BlobDefaults_release_handle'));
+final _smokeBlobdefaultsGetFieldemptyList = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_BlobDefaults_get_field_emptyList'));
+final _smokeBlobdefaultsGetFielddeadBeef = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_BlobDefaults_get_field_deadBeef'));
+Pointer<Void> smokeBlobdefaultsToFfi(BlobDefaults value) {
+  final _emptyListHandle = blobToFfi(value.emptyList);
+  final _deadBeefHandle = blobToFfi(value.deadBeef);
+  final _result = _smokeBlobdefaultsCreateHandle(_emptyListHandle, _deadBeefHandle);
+  blobReleaseFfiHandle(_emptyListHandle);
+  blobReleaseFfiHandle(_deadBeefHandle);
+  return _result;
+}
+BlobDefaults smokeBlobdefaultsFromFfi(Pointer<Void> handle) {
+  final _emptyListHandle = _smokeBlobdefaultsGetFieldemptyList(handle);
+  final _deadBeefHandle = _smokeBlobdefaultsGetFielddeadBeef(handle);
+  try {
+    return BlobDefaults._(
+      blobFromFfi(_emptyListHandle),
+      blobFromFfi(_deadBeefHandle)
+    );
+  } finally {
+    blobReleaseFfiHandle(_emptyListHandle);
+    blobReleaseFfiHandle(_deadBeefHandle);
+  }
+}
+void smokeBlobdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeBlobdefaultsReleaseHandle(handle);
+// Nullable BlobDefaults
+final _smokeBlobdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_BlobDefaults_create_handle_nullable'));
+final _smokeBlobdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_BlobDefaults_release_handle_nullable'));
+final _smokeBlobdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_BlobDefaults_get_value_nullable'));
+Pointer<Void> smokeBlobdefaultsToFfiNullable(BlobDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeBlobdefaultsToFfi(value);
+  final result = _smokeBlobdefaultsCreateHandleNullable(_handle);
+  smokeBlobdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+BlobDefaults? smokeBlobdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeBlobdefaultsGetValueNullable(handle);
+  final result = smokeBlobdefaultsFromFfi(_handle);
+  smokeBlobdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeBlobdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeBlobdefaultsReleaseHandleNullable(handle);
+// End of BlobDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults/output/lime/smoke/BlobDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/output/lime/smoke/BlobDefaults.lime
@@ -1,0 +1,5 @@
+package smoke
+struct BlobDefaults {
+    emptyList: Blob = []
+    deadBeef: Blob = [222, 173, 190, 239]
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/BlobDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/BlobDefaults.swift
@@ -1,0 +1,56 @@
+//
+//
+import Foundation
+public struct BlobDefaults {
+    public var emptyList: Data
+    public var deadBeef: Data
+    public init(emptyList: Data = Data([]), deadBeef: Data = Data([222, 173, 190, 239])) {
+        self.emptyList = emptyList
+        self.deadBeef = deadBeef
+    }
+    internal init(cHandle: _baseRef) {
+        emptyList = moveFromCType(smoke_BlobDefaults_emptyList_get(cHandle))
+        deadBeef = moveFromCType(smoke_BlobDefaults_deadBeef_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> BlobDefaults {
+    return BlobDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> BlobDefaults {
+    defer {
+        smoke_BlobDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: BlobDefaults) -> RefHolder {
+    let c_emptyList = moveToCType(swiftType.emptyList)
+    let c_deadBeef = moveToCType(swiftType.deadBeef)
+    return RefHolder(smoke_BlobDefaults_create_handle(c_emptyList.ref, c_deadBeef.ref))
+}
+internal func moveToCType(_ swiftType: BlobDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_BlobDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> BlobDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_BlobDefaults_unwrap_optional_handle(handle)
+    return BlobDefaults(cHandle: unwrappedHandle) as BlobDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> BlobDefaults? {
+    defer {
+        smoke_BlobDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: BlobDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_emptyList = moveToCType(swiftType.emptyList)
+    let c_deadBeef = moveToCType(swiftType.deadBeef)
+    return RefHolder(smoke_BlobDefaults_create_optional_handle(c_emptyList.ref, c_deadBeef.ref))
+}
+internal func moveToCType(_ swiftType: BlobDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_BlobDefaults_release_optional_handle)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeBasicType.kt
@@ -54,4 +54,7 @@ class LimeBasicType(val typeId: TypeId) : LimeType(path = LimePath.EMPTY_PATH) {
 
     override val escapedName
         get() = name
+
+    override val childTypes: List<LimeTypeRef>
+        get() = if (typeId == TypeId.BLOB) listOf(LimeBasicTypeRef(TypeId.UINT8)) else emptyList()
 }


### PR DESCRIPTION
Added support for using `[...]` collection initializers with `Blob` type. The
syntax is identical to what is already supported for `List<>` and `Set<>` types.

Resolves: #1217
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
