### PR TITLE
Add support for `@Swift(ParameterDefaults)` on field constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for `@Swift(ParameterDefaults)` attribute on field constructors.
+
 ## 11.1.4
 Release date: 2022-04-06
 ### Bug fixes:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -584,6 +584,8 @@ element is skipped (not generated). Custom tags are case-insensitive.
   generated code. _Attribute_ does not need to be prepended with `@`. _Attribute_ can contain parameters, e.g.
   `@Swift(Attribute="available(*, deprecated, message: \"It's deprecated.\")")`. If some of the parameters are string
   literals, their enclosing quotes need to be backslash-escaped, as in the example.
+  * **ParameterDefaults**: marks a "field constructor" of a struct to have field default values as parameter defaults
+  in Swift, for those fields that are listed in the "filed constructor's" signature.
 * **@Dart**: marks an element with Dart-specific behaviors:
   * \[**Name** **=**\] **"**_ElementName_**"**: marks an element to have a distinct name in Dart. This is the default
   specification for this attribute.

--- a/functional-tests/functional/input/lime/FieldConstructors.lime
+++ b/functional-tests/functional/input/lime/FieldConstructors.lime
@@ -118,3 +118,17 @@ struct FieldConstructorsWithLabels {
     field constructor(@Swift(Label="value") intField, @Swift(Label="_") boolField)
     field constructor(stringField, @Swift(Label="value") intField, @Swift(Label="_") boolField)
 }
+
+@Skip(Java, Dart)
+struct FieldConstructorsParameterDefaults {
+    stringField: String = "nonsense"
+    intField: Int
+    boolField: Boolean = true
+
+    @Swift(ParameterDefaults)
+    field constructor(intField)
+    @Swift(ParameterDefaults)
+    field constructor(intField, boolField)
+    @Swift(ParameterDefaults)
+    field constructor(stringField, intField, boolField)
+}

--- a/functional-tests/functional/swift/Tests/FieldConstructorsTests.swift
+++ b/functional-tests/functional/swift/Tests/FieldConstructorsTests.swift
@@ -79,6 +79,22 @@ class FieldConstructorsTests: XCTestCase {
         XCTAssertEqual(result.boolField, false)
     }
 
+    func testParameterDefaultsClash() {
+        let result = FieldConstructorsParameterDefaults(intField: 7)
+
+        XCTAssertEqual(result.stringField, "nonsense")
+        XCTAssertEqual(result.intField, 7)
+        XCTAssertEqual(result.boolField, true)
+    }
+
+    func testParameterDefaultsNoClash() {
+        let result = FieldConstructorsParameterDefaults(stringField: "foo", intField: 7)
+
+        XCTAssertEqual(result.stringField, "foo")
+        XCTAssertEqual(result.intField, 7)
+        XCTAssertEqual(result.boolField, true)
+    }
+
     static var allTests = [
         ("testPartialDefaults2", testPartialDefaults2),
         ("testPartialDefaults3", testPartialDefaults3),
@@ -86,6 +102,8 @@ class FieldConstructorsTests: XCTestCase {
         ("testAllDefaults1", testAllDefaults1),
         ("testImmutableNoClash", testImmutableNoClash),
         ("testImmutableWithClash", testImmutableWithClash),
-        ("testLabels", testLabels)
+        ("testLabels", testLabels),
+        ("testParameterDefaultsClash", testParameterDefaultsClash),
+        ("testParameterDefaultsNoClash", testParameterDefaultsNoClash)
     ]
 }

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructConstructors.mustache
@@ -56,8 +56,9 @@
     @available(*, deprecated{{#if message}}, message: "{{#resolveName message}}{{escape this}}{{/resolveName}}"{{/if}}){{/attributes.deprecated}}
 {{prefixPartial "swift/SwiftAttributes" "    "}}
     {{>swift/TypeVisibility}} init({{!!
-    }}{{#fieldRefs}}{{#if attributes.swift.label}}{{attributes.swift.label}} {{/if}}{{!!
-    }}{{#field}}{{>ctorParameter}}{{#if iter.hasNext}}, {{/if}}{{/field}}{{/fieldRefs}}) {
+    }}{{#set fieldCtor=this}}{{#fieldCtor}}{{#fieldRefs}}{{#if attributes.swift.label}}{{attributes.swift.label}} {{/if}}{{!!
+    }}{{#field}}{{>ctorParameter}}{{#if fieldCtor.attributes.swift.parameterDefaults defaultValue}} = {{resolveName defaultValue}}{{/if}}{{!!
+    }}{{#if iter.hasNext}}, {{/if}}{{/field}}{{/fieldRefs}}{{/fieldCtor}}{{/set}}) {
 {{#fields}}
         self.{{resolveName}} = {{resolveName}}
 {{/fields}}

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
@@ -112,3 +112,17 @@ struct FieldConstructorsWithLabels {
     field constructor(@Swift(Label="value") intField, @Swift(Label="_") boolField)
     field constructor(stringField, @Swift(Label="value") intField, @Swift(Label="_") boolField)
 }
+
+@Skip(Java, Dart)
+struct FieldConstructorsParameterDefaults {
+    stringField: String = "nonsense"
+    intField: Int
+    boolField: Boolean = true
+
+    @Swift(ParameterDefaults)
+    field constructor(intField)
+    @Swift(ParameterDefaults)
+    field constructor(intField, boolField)
+    @Swift(ParameterDefaults)
+    field constructor(stringField, intField, boolField)
+}

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsParameterDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsParameterDefaults.swift
@@ -1,0 +1,71 @@
+//
+//
+import Foundation
+public struct FieldConstructorsParameterDefaults {
+    public var stringField: String
+    public var intField: Int32
+    public var boolField: Bool
+    public init(intField: Int32) {
+        self.intField = intField
+        self.stringField = "nonsense"
+        self.boolField = true
+    }
+    public init(intField: Int32, boolField: Bool = true) {
+        self.intField = intField
+        self.boolField = boolField
+        self.stringField = "nonsense"
+    }
+    public init(stringField: String = "nonsense", intField: Int32, boolField: Bool = true) {
+        self.stringField = stringField
+        self.intField = intField
+        self.boolField = boolField
+    }
+    internal init(cHandle: _baseRef) {
+        stringField = moveFromCType(smoke_FieldConstructorsParameterDefaults_stringField_get(cHandle))
+        intField = moveFromCType(smoke_FieldConstructorsParameterDefaults_intField_get(cHandle))
+        boolField = moveFromCType(smoke_FieldConstructorsParameterDefaults_boolField_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsParameterDefaults {
+    return FieldConstructorsParameterDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsParameterDefaults {
+    defer {
+        smoke_FieldConstructorsParameterDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsParameterDefaults) -> RefHolder {
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_FieldConstructorsParameterDefaults_create_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsParameterDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsParameterDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsParameterDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_FieldConstructorsParameterDefaults_unwrap_optional_handle(handle)
+    return FieldConstructorsParameterDefaults(cHandle: unwrappedHandle) as FieldConstructorsParameterDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsParameterDefaults? {
+    defer {
+        smoke_FieldConstructorsParameterDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: FieldConstructorsParameterDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_stringField = moveToCType(swiftType.stringField)
+    let c_intField = moveToCType(swiftType.intField)
+    let c_boolField = moveToCType(swiftType.boolField)
+    return RefHolder(smoke_FieldConstructorsParameterDefaults_create_optional_handle(c_stringField.ref, c_intField.ref, c_boolField.ref))
+}
+internal func moveToCType(_ swiftType: FieldConstructorsParameterDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsParameterDefaults_release_optional_handle)
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -196,6 +196,7 @@ internal object AntlrLimeConverter {
             "FunctionName" -> LimeAttributeValueType.FUNCTION_NAME
             "Label" -> LimeAttributeValueType.LABEL
             "Message" -> LimeAttributeValueType.MESSAGE
+            "ParameterDefaults" -> LimeAttributeValueType.PARAMETER_DEFAULTS
             "PositionalDefaults" -> LimeAttributeValueType.POSITIONAL_DEFAULTS
             "Ref" -> LimeAttributeValueType.REF
             "Skip" -> LimeAttributeValueType.SKIP

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -32,6 +32,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     FUNCTION_NAME("FunctionName"),
     LABEL("Label"),
     MESSAGE("Message"),
+    PARAMETER_DEFAULTS("ParameterDefaults"),
     POSITIONAL_DEFAULTS("PositionalDefaults"),
     REF("Ref"),
     SKIP("Skip"),


### PR DESCRIPTION
Added support for `@Swift(ParameterDefaults)` attribute on field constructors.
With this attribute, field default values are used as parameter default values
of the constructor (but only for fields that are excplicitly included in the
field constructor's signature).

Resolves: #1286
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>