### PR TITLE
Document internal architecture in more detail, part 1

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -33,20 +33,34 @@ The loader produces a `LimeModel` as an output. The model consists of the LIME m
 
 The main class also discovers available generators (implementers of `Generator` interface) through the same
 ServiceLoader mechanism. From the list of the available generators it selects a subset based on the command line
-options. Each generator is initialized with generator options (part of command line options) and then it generated
+options. Each generator is initialized with generator options (part of command line options) and then it generates
 output code based on the options, and the in-memory LIME model. The contents of the generated files are also in-memory.
 The main class is responsible for taking this output and committing it to the file system.
 
 LIME IDL loader
 ---------------
 
-LIME IDL loader module is decoupled from the main Gluecodium code. The only point of communication between them is a
-single-function interface `LimeModelLoader`, implemented by LIME IDL loader and exposed (made discoverable) though Java
-Service Loader mechanism.
+[LIME IDL loader](lime_loader.md) module is decoupled from the main Gluecodium code. The only point of communication
+between them is a single-function interface `LimeModelLoader`, implemented by LIME IDL loader and exposed (made
+discoverable) though Java Service Loader mechanism.
 
 There is no manually-written code for parsing LIME IDL files. Instead, the parser is generated at compile time by ANTLR
-parser-generator library based on the grammar definition for LIME IDL language (`LimeParser.g4`). The output of the
-parser is an abstract syntax tree (AST) in ANTLR in-memory format. This syntax tree is converted to LIME model tree by
-`AntlrLimeModelBuilder` class.
+parser-generator library based on the grammar definition for LIME IDL language. The output of the parser is an abstract
+syntax tree (AST) in ANTLR in-memory format. This syntax tree is then converted to LIME model tree.
 
-There's also a secondary parser for parsing LIME IDL documentation comments ("LimeDoc", `LimedocParser.g4`).
+Code generators
+---------------
+
+Currently, Gluecodium can generate code for the following platforms and languages:
+* C++: mostly headers, with classes and interfaces both represented by abstract classes. Some minimal implementation
+files are generated too, where required for initialization. The generated abstract classes are designed to be manually
+implemented by concrete classes, providing the business logic.
+* Android: Java files with some elements from Android APIs, plus JNI C/C++ files as Java-to-C++ bindings. Not compilable
+for non-Android Java environment.
+* Swift: Swift files, plus Objective-C-compatible C/C++ bindings (nicknamed "CBridge" internally). Compilable both for
+iOS and as cross-platform Swift executable.
+* Dart: Dart files, plus Dart FFI C/C++ bindings. Compilable both for Flutter framework and as cross-platform Dart
+executable.
+* LIME IDL: generates LIME IDL files. Can be used to migrate IDL files from older LIME syntax to newer one, or to
+convert the definitions written in some other IDL to LIME, if a corresponding loader is provided. Currently, only used
+for testing purposes internally.

--- a/docs/internal/lime_loader.md
+++ b/docs/internal/lime_loader.md
@@ -1,0 +1,53 @@
+LIME IDL loader
+===============
+
+This document describes the general internal structure of LIME IDL loader module of Gluecodium project.
+
+Decoupling
+----------
+LIME IDL loader module is decoupled from most of the Gluecodium code. It uses the LIME model tree classes from the "LIME
+runtime" module, but it is not "aware" of the rest of the code (i.e. generators). The main `Gluecodim` class discovers
+the loader through Java's innate
+[ServiceLoader mechanism](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html). The loader implements
+a single-function interface `LimeModelLoader`. The main class calls this single function, `loadModel()`, passing the
+lists of source file and getting the `LimeModel` as a result.
+
+LimeModel class
+---------------
+
+`LimeModel` class contains all model-data obtained from the loader:
+* a name-to-element "[reference map](reference_resolution.md)", that is used in the resolution of late-bound references,
+as well as of documentation references, and of nesting relationships.
+* a list of individual model trees, each corresponding to a model element declared in the top scope of an IDL file.
+* a list of auxiliary model tree. No code is generated for auxiliary elements themselves, but they still can be referred
+to by the "normal" elements.
+* a map of element-to-file names, used exclusively for error reporting.
+
+File parsing
+------------
+
+There is no manually-written code for parsing LIME IDL files. Instead, the parser is generated at compile time by [ANTLR
+parser-generator library](https://www.antlr.org/about.html), based on the grammar definition for LIME IDL language
+(check the "*.g4" files for grisly EBNF details). The grammar of LIME is inspired by Kotlin (mostly) and Swift (a bit).
+But it is significantly simpler than either of those, as LIME IDL only contains definitions (`class Foo {}`), but not
+statements (`String bar = Foo.doStuff()`).
+
+The output of the (auto-generated) LIME parser is an abstract syntax tree (AST) in ANTLR in-memory format. The AST is
+"walked" by an (also auto-generated) tree-walker visitor, that invokes the methods of `AntlrLimeModelBuilder` class
+corresponding to each model element. The AST is walked "down" first (from root to leaves), setting up the context where
+needed, and then "up", creating LIME model elements on the way.
+
+Any documentation comments encountered by this process are treated as plain string at first. They are parsed separately
+by a similar, if smaller, process with `AntlrLimedocBuilder` class.
+
+Syntax errors
+-------------
+
+Parsing errors are thrown as `ParseCancellationException`. There is no code that catches and handles those, letting them
+propagate to the top and abort the execution, as most parsing errors are unrecoverable.
+
+Import statements are not represented as model elements, so they need to be validated early. Ambiguous imports (i.e.
+those ending with the same name) are considered unrecoverable and thus are handled similarly to parsing errors.
+
+Unresolved imports (i.e. those with no corresponding element found in the tree) are validated at the end the parsing
+process. Similarly to later stages of model tree validations, these are reported to the log.

--- a/docs/internal/reference_resolution.md
+++ b/docs/internal/reference_resolution.md
@@ -1,0 +1,93 @@
+Reference resolution
+====================
+
+This document describes the details of resolving of different kinds references that are found in the LIME model.
+
+Why references?
+---------------
+LIME model represents all declarations from the IDL files as elements in the model tree. These elements are immutable
+and thus have to contain all related data at the moment of creation. However, the order of creation of these elements is
+not guaranteed. So when a function parameter (or return value, or a struct field, etc.) refers to a type, the element
+representing that type might not be created yet. Or, worse yet, there might be a cyclic reference of some kind, i.e.
+A refers to B, while B refers to A. Therefore, resolving a (textual) reference to an element has to be postponed until
+after the whole model tree is created.
+
+In the model tree itself this is represented by element references. Mostly these are descendants of the `LimeTypeRef`
+abstract class. There are also `LimeEnumeratorRef` and `LimeFieldRef`.
+
+Direct references
+-----------------
+Some type references do not require any delayed-resolution handling. These are references to basic (built-in) type, like
+`String`, `Int`, or `Date`. References to generic types(`List`, `Set`, and `Map`)  themselves could also be resolved
+directly. However, the generic types also contain at least one nested type reference, representing the type parameter of
+the generic. These nested references are normal type references, and thus could also be either direct, or late-bound.
+
+Reference map
+-------------
+Resolution of all late-bound references is done through a simple mechanism called "reference map". The map itself is a
+simple Kotlin `Map<String, LimeElement>`. Each key is a "full path": a dot-concatenated list of nested declarations,
+uniquely identifying the element that is the mapped value. For situations where some ambiguity can be expected (e.g.
+functions overloading), an additional "disambiguation suffix" is appended to the path. For example, given the following
+declaration
+```kotlin
+package core
+
+class MyClass {
+    interface NestedInterface {}
+    fun doSomething(value: Int)
+    fun doSomething(value: String): Boolean
+}
+```
+the full path of "core.MyClass.NestedInterface" uniquely identifies the interface element in the declaration. And the
+full path "core.MyClass.doSomething.value:1" uniquely identifies the parameter of the second overload of the function.
+Notably, even if the possible ambiguity is at the "core.MyClass.doSomething" level, the ":1" suffix is still added at
+the very end. This works, because there can be no more than one ambiguity per path, and it allows for a uniform string
+representation of paths.
+
+The reference map is mutable (appendable) for the whole duration of model tree creation. It becomes immutable when the
+tree is fully created.
+
+Late-bound references
+---------------------
+There are several kinds of late-bound references. All of them utilize the Kotlin `by lazy` mechanism to delay the
+resolution until the first "read" access.
+* _Ambiguous type reference_: a type reference where some ambiguity is expected due to the effect of `import`
+statements. This is by far the most common kind of late-bound reference in a usual model tree. The logic for ambiguity
+resolution is isolated in a standalone helper `LimeAmbiguityResolver`. For the details of the algorithm, please refer to
+the documentation of `LimeAmbiguityResolver` itself.
+* _Lazy type reference_: a simple late-bound reference where no ambiguity is expected. Only used for self-references,
+i.e. to refer to the type in the process of creation of the element, corresponding to it. Only occurs in the return
+types of constructor declarations.
+* _Positional type reference_: a late-bound reference where the name of the type is not known, but the type needs to be
+computed by the position of the reference in the list of its siblings. Occurs in struct initializer literals, or in 
+collection initializer literals.
+* _Ambiguous enumerator reference_: same as "ambiguous type reference" above, but referring to an enumerator (a single
+member of an `enum` enumeration). Occurs in enumerator literals.
+* _Positional enumerator reference_: same as "positional type reference" above, but referring to an enumerator. Occurs
+in "raw" enumerator literals, e.g. `const myConst: MyEnum = MyEnum(2)`.
+* _Lazy field reference_: a simple late-bound reference to a struct field. Occurs in field constructor declarations.
+
+Documentation references
+------------------------
+Textual references to an element (e.g `[core.MyClass.NestedInterface]`) in LIME documentation comments are also resolved
+through the reference map. Only the disambiguation syntax differs: documentation references use function signatures to
+explicitly disambiguate between different function overloads. Compared to numerical suffixes, this syntax is more
+human-readable. It is also stable with regard to reordering, adding, or removing declarations in the IDL file (numerical
+suffixes don't need to be stable, only to be unique within a single Gluecodium execution).
+
+Nesting relationships
+---------------------
+The reference map is also used to resolve the nesting relationships in some algorithms. I.e. in
+```kotlin
+package core
+
+class MyClass {
+    interface NestedInterface {}
+    fun doSomething(value: Int)
+    fun doSomething(value: String): Boolean
+}
+```
+given an element with the "path" of "core.MyClass.doSomething" (with or without the disambiguation suffix), another
+element can be found by omitting the last section of the path ("core.MyClass") and then using that as a key for the
+reference map. Such "nesting parent" look-ups are used in various generator algorithms: import/include resolution,
+fully qualified name resolution, etc.

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguityResolver.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguityResolver.kt
@@ -21,7 +21,7 @@ package com.here.gluecodium.model.lime
 
 object LimeAmbiguityResolver {
     /**
-     * Resolves an ambiguous reference to a type, represented by [relativePath]. The ambiguity is
+     * Resolves an ambiguous reference to an element, represented by [relativePath]. The ambiguity is
      * resolved with the following logic:
      * * for each import in [imports], try to match the last component of the import to the first
      * component of the [relativePath]. If it matches, try to resolve it into an actual element
@@ -29,8 +29,7 @@ object LimeAmbiguityResolver {
      * * if import resolution fails, try appending [relativePath] to each parent path in
      * [parentPaths] and try resolving the combined path to an actual element through [referenceMap].
      * * if both approaches fail, the reference is invalid: a [LimeModelLoaderException] is thrown.
-     * * if more than one type is found, the reference is ambiguous: a [LimeModelLoaderException] is
-     * thrown.
+     * * if more than one match is found, the reference is ambiguous: a [LimeModelLoaderException] is thrown.
      */
     inline fun <reified T : LimeNamedElement> resolve(
         relativePath: List<String>,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousTypeRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousTypeRef.kt
@@ -23,7 +23,7 @@ package com.here.gluecodium.model.lime
  * An ambiguous reference to a type, represented by [relativePath]. The ambiguity is resolved
  * through the [LimeAmbiguityResolver].
  *
- * The resolution logic is "lazy": if it succeed on the first call then the result is stored and the
+ * The resolution logic is "lazy": if it succeeds on the first call then the result is stored and the
  * stored result is used on subsequent calls instead.
  */
 class LimeAmbiguousTypeRef(

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyTypeRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyTypeRef.kt
@@ -22,7 +22,7 @@ package com.here.gluecodium.model.lime
 /**
  * A delayed-resolution reference to a type, represented by [elementFullName]. The name is resolved
  * into an actual type through the [referenceMap] on the first call. The resolution logic is "lazy":
- * if it succeed on the first call then the result is stored and the stored result is used on
+ * if it succeeds on the first call then the result is stored and the stored result is used on
  * subsequent calls instead.
  */
 class LimeLazyTypeRef(


### PR DESCRIPTION
Added internal architecture documentation for the LIME loader module and for the
late-bound references resolution mechanisms in the LIME model tree.

Added a brief description of generators to "internal/architecture.md".

Fixed typos in some documentation comments.

See: #1297