### PR TITLE
Document internal architecture in more detail, part 2

### DIFF
--- a/docs/internal/architecture.md
+++ b/docs/internal/architecture.md
@@ -52,15 +52,15 @@ Code generators
 ---------------
 
 Currently, Gluecodium can generate code for the following platforms and languages:
-* C++: mostly headers, with classes and interfaces both represented by abstract classes. Some minimal implementation
-files are generated too, where required for initialization. The generated abstract classes are designed to be manually
-implemented by concrete classes, providing the business logic.
-* Android: Java files with some elements from Android APIs, plus JNI C/C++ files as Java-to-C++ bindings. Not compilable
-for non-Android Java environment.
-* Swift: Swift files, plus Objective-C-compatible C/C++ bindings (nicknamed "CBridge" internally). Compilable both for
-iOS and as cross-platform Swift executable.
-* Dart: Dart files, plus Dart FFI C/C++ bindings. Compilable both for Flutter framework and as cross-platform Dart
-executable.
+* [C++](generators/cpp.md): mostly headers, with classes and interfaces both represented by abstract classes. Some
+minimal implementation files are generated too, where required for initialization. The generated abstract classes are
+designed to be manually implemented by concrete classes, providing the business logic.
+* [Android](generators/java.md): Java files with some elements from Android APIs, plus JNI C/C++ files as Java-to-C++
+bindings. Not compilable for non-Android Java environment.
+* [Swift](generators/swift.md): Swift files, plus Objective-C-compatible C/C++ bindings (nicknamed "CBridge"
+internally). Compilable both for iOS and as cross-platform Swift executable.
+* [Dart](generators/dart.md): Dart files, plus Dart FFI C/C++ bindings. Compilable both for Flutter framework and as
+cross-platform Dart executable.
 * LIME IDL: generates LIME IDL files. Can be used to migrate IDL files from older LIME syntax to newer one, or to
 convert the definitions written in some other IDL to LIME, if a corresponding loader is provided. Currently, only used
 for testing purposes internally.

--- a/docs/internal/generators.md
+++ b/docs/internal/generators.md
@@ -1,0 +1,51 @@
+General outline of generators
+=============================
+
+This document describes the general ideas shared by all code generators in Gluecodium project.
+
+High-level structure
+--------------------
+Each generator takes the LIME model (model tree + reference map) as an input and produces a set of (in-memory) code
+files as an output. Most generators (all but C++) produce two distinct sets of output code files: API files in the
+"target" languages and bindings files in C/C++.
+
+For each generator, the initial steps before the actual code generation are:
+* filter the model to account for `@Skip` and `@EnableIf` generator-specific attributes.
+* perform the [generator-specific validation](validation.md#generator-specific-validation).
+
+Mustache templates
+------------------
+LIME model tree is transformed into the output code through application of
+[Mustache templates](https://mustache.github.io/). The templates are rendered with the
+[Trimou engine](http://trimou.org/) that extends the Mustache syntax on its own and also allows extending the syntax
+even further with custom handlers.
+
+Most generators (all but C++) have two distinct sets of templates: one for API files, one for bindings files. 
+
+Name resolvers
+--------------
+One kind of the custom handlers for the templating engine is "name resolvers". These are responsible for transforming
+LIME element names into actual names suitable for the generated code in the target language. There are more than one
+name resolver per generator, even more than one per output language. Different parts of code require different
+"decorations" of the same name: short name, fully qualified name, mangled name, etc. Some parts of code also need names
+from other languages: e.g. bindings name for a function is different from its C++ name, but both are present in the
+bindings code.
+
+Import/include resolvers
+------------------------
+Another kind of resolvers, not accessible directly from templates, but still present in every generator, are
+import/include resolvers. C++ code or bindings code use includes, all other languages have their own imports system.
+For each generated file, the appropriate imports/includes (to be placed at the top of the file) are collected based on
+the LIME definition in question and based on the types the definition refers to.
+
+Documentation processors
+------------------------
+Each generator also has its own "documentation processor". LIME documentation comments use Markdown for the markup
+syntax. Most target languages (except Java) support Markdown as well. However, there are slight variation in each, and
+their documentation tags are different. So producing valid documentation in the target language still requires some
+additional processing. Gluecodium uses [Flexmark library](https://github.com/vsch/flexmark-java) to parse and process
+Markdown documentation.
+
+Documentation processors are also responsible for resolving documentation links, i.e. converting
+`[core.MyClass.NestedInterface]` from LIME names to names and syntax in the target language. See
+[Reference resolution](reference_resolution.md#documentation-references) for more detail.

--- a/docs/internal/generators/cpp.md
+++ b/docs/internal/generators/cpp.md
@@ -1,0 +1,4 @@
+C++ generator internal architecture
+===================================
+
+TODO #1297

--- a/docs/internal/generators/dart.md
+++ b/docs/internal/generators/dart.md
@@ -1,0 +1,4 @@
+Dart generator internal architecture
+===================================
+
+TODO #1297

--- a/docs/internal/generators/java.md
+++ b/docs/internal/generators/java.md
@@ -1,0 +1,4 @@
+Android generator internal architecture
+===================================
+
+TODO #1297

--- a/docs/internal/generators/swift.md
+++ b/docs/internal/generators/swift.md
@@ -1,0 +1,4 @@
+Swift generator internal architecture
+===================================
+
+TODO #1297

--- a/docs/internal/validation.md
+++ b/docs/internal/validation.md
@@ -1,0 +1,47 @@
+LIME model validation
+=====================
+
+This document describes the approach to LIME model validation in Gluecodium project.
+
+General approach
+----------------
+"Validation" in the context of LIME model means checking the model tree for correctness. The purpose of validation is to
+"fail fast" before the actual code generation has begun. Among other benefits, this allows to provide the error
+description in the terms of LIME model, so that it could be found and fixed in the source IDL file(s).
+
+Validation messages are output to the log. Most validation messages are "errors": no code generation follows if any
+validation errors are detected. A few validation messages are "warnings": the code generation can proceed, but may
+produce broken or inefficient code. Individual validation warnings could be selectively elevated to "errors" with
+`-werror` command line parameter.
+
+Imports validation
+------------------
+LIME IDL import statements are not represented as model elements, so they need to be validated as early as possible.
+Ambiguous imports (i.e. those ending with the same name) prevent the model tree from being constructed. Therefore, they
+are handled _during_ the tree construction and are considered unrecoverable parsing errors.
+
+Unresolved imports (i.e. those with no corresponding element found in the tree) are validated immediately after the
+model tree is created, still in the loader module. Similarly to later stages of model tree validations, these are
+reported to the log.
+
+Semantic validation
+-------------------
+Semantic validation checks the LIME model for general correctness, disregarding any generator-specific requirements.
+This validation step is performed by the main `Gluecodium` class, after the model tree is loaded, but before the tree is
+passed to any individual generator.
+
+This step consists of three sub-steps:
+1. Type reference validation (`LimeTypeRefsValidator` class) walks over each and every late-bound type reference and
+tries to resolve it. Resolution failures are reported as validation errors.
+2. Type-reference-dependent validation groups all validators that access any type references during their own validation
+and thus require all type references to be resolved correctly. If step #1 fails, none of the step #2 validators are run.
+3. Independent validation groups all validators that _do not_ access any type references and thus can function
+regardless of step #1 results.
+
+Generator-specific validation
+-----------------------------
+This type of validation, as the name suggests, checks the LIME model for correctness specific to the individual
+generator. The exact set of checks varies, but each generator always has its own validation logic for function
+overloads. All languages place some restrictions on function overloading, but no two sets of those restrictions are
+exactly the same. Moreover, type mapping from IDL types into language types could introduce signature ambiguity where
+none is apparent from the IDL definition alone.

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeTypeRefTargetValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeTypeRefTargetValidator.kt
@@ -31,7 +31,6 @@ import com.here.gluecodium.model.lime.LimeTypesCollection
 /**
  * Validate against:
  * * Referring to type collections directly.
- * * Referring to non-enum types from exception types.
  * * Referring to exception types from anywhere but the `throws` clause.
  */
 internal class LimeTypeRefTargetValidator(private val logger: LimeLogger) :


### PR DESCRIPTION
Added internal architecture documentation for the validators and for the
general outline of generator structure.

Fixed typos in some documentation comments.

See: #1297
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>