### PR TITLE
Add missing includes for parents of nested types in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added support for Markdown tables in documentation comments.
+### Bug fixes:
+  * Fixed C++ compilation issue with missing includes for inheritance parents of nested types.
 
 ## 11.1.5
 Release date: 2022-04-07

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -423,6 +423,7 @@ feature(Nesting cpp android swift dart SOURCES
     input/lime/NestedContainers.lime
     input/lime/NestedClassWithProperty.lime
     input/lime/NestingInStruct.lime
+    input/lime/NestedInheritance.lime
 )
 
 feature(Lambdas cpp android swift dart SOURCES

--- a/functional-tests/functional/input/lime/NestedInheritance.lime
+++ b/functional-tests/functional/input/lime/NestedInheritance.lime
@@ -1,0 +1,24 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface MyParentInterface { }
+
+class MyOuterClass {
+    class MyNestedImplementation: MyParentInterface { }
+}

--- a/gluecodium/src/test/resources/smoke/nesting/input/NestedInheritance.lime
+++ b/gluecodium/src/test/resources/smoke/nesting/input/NestedInheritance.lime
@@ -1,0 +1,24 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+interface MyParentInterface { }
+
+class MyOuterClass {
+    class MyNestedImplementation: MyParentInterface { }
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/MyOuterClass.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/MyOuterClass.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/MyParentInterface.h"
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT MyOuterClass {
+public:
+    MyOuterClass();
+    virtual ~MyOuterClass() = 0;
+public:
+    class _GLUECODIUM_CPP_EXPORT MyNestedImplementation: public ::smoke::MyParentInterface {
+    public:
+        MyNestedImplementation();
+        virtual ~MyNestedImplementation() = 0;
+    };
+};
+}


### PR DESCRIPTION
Updated CppHeaderIncludesCollector to collect parent includes (and other
"additional") includes for nested types, instead of for just outer types as
before. Added smoke and functional compilation tests as regression tests.

Resolves: #1302
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>