### PR TITLE
 Remove unused import for Dart generator #1307

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Gluecodium project Release Notes
 
+### Bug fixes:
+  * Do not add unused import of cache for dart classes marked with NoCache tag.
 ## 11.1.6
 Release date: 2022-04-26
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -110,6 +110,9 @@ internal class DartDeclarationImportResolver(
         if (hasStaticFunctions(limeClass) || limeClass.properties.any { it.visibility.isInternal }) {
             result += listOf(metaPackageImport)
         }
+        if (limeClass.attributes.have(LimeAttributeType.NO_CACHE)) {
+            result.remove(tokenCacheImport)
+        }
         return result
     }
 

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -174,7 +174,7 @@ void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) {
   final _result_handle = _{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
   final _result = {{resolveName parent}}$Impl(_result_handle);
-{{#unless this.attributes.nocache}}
+{{#unless parent.attributes.nocache}}
   __lib.cacheInstance(_result_handle, _result);
 {{/unless}}
   _{{resolveName parent "Ffi"}}RegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);

--- a/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
@@ -29,7 +29,6 @@ class NoCacheClass$Impl extends __lib.NativeBase implements NoCacheClass {
   NoCacheClass make() {
     final _result_handle = _make();
     final _result = NoCacheClass$Impl(_result_handle);
-    __lib.cacheInstance(_result_handle, _result);
     _smokeNocacheclassRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }

--- a/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
@@ -1,7 +1,6 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
-import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
 abstract class NoCacheClass {
   factory NoCacheClass() => $prototype.make();


### PR DESCRIPTION
 Stop generating import of '_token_cache.dart' for classes
 marked with NoCache tag.

Signed-off-by: Rafal Parzych <rafal.parzych@here.com>
Resolves: #1307
