### PR TITLE
Use own CBridge functions in a child class in Swift

### DIFF
--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeClassHeader.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeClassHeader.mustache
@@ -49,17 +49,12 @@ _GLUECODIUM_C_EXPORT const void* {{resolveName}}_get_swift_object_from_cache(_ba
 {{/unless}}
 {{/instanceOf}}
 
-{{#functions}}{{#ifPredicate "shouldRetain"}}
-_GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
-{{/ifPredicate}}{{/functions}}
-{{#properties}}{{#ifPredicate "shouldRetain"}}
-{{#getter}}
-_GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
-{{/getter}}
-{{#setter}}
-_GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
-{{/setter}}
-{{/ifPredicate}}{{/properties}}
+{{#functions}}{{>cbridgeFunction}}{{/functions}}
+{{#properties}}{{>cbridgeProperty}}{{/properties}}
+{{#set isInherited=true container=this}}
+{{#container.interfaceInheritedFunctions}}{{>cbridgeFunction}}{{/container.interfaceInheritedFunctions}}
+{{#container.interfaceInheritedProperties}}{{>cbridgeProperty}}{{/container.interfaceInheritedProperties}}
+{{/set}}
 
 {{#each classes interfaces}}
 {{>cbridge/CBridgeClassHeader}}
@@ -67,4 +62,17 @@ _GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
 
 {{#lambdas}}
 {{>cbridge/CBridgeLambdaHeader}}
-{{/lambdas}}
+{{/lambdas}}{{!!
+
+}}{{+cbridgeFunction}}{{#ifPredicate "shouldRetain"}}
+_GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
+{{/ifPredicate}}{{/cbridgeFunction}}{{!!
+
+}}{{+cbridgeProperty}}{{#ifPredicate "shouldRetain"}}
+{{#getter}}
+_GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
+{{/getter}}
+{{#setter}}
+_GLUECODIUM_C_EXPORT {{>cbridge/CBridgeFunctionSignature}};
+{{/setter}}
+{{/ifPredicate}}{{/cbridgeProperty}}

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeClassImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeClassImpl.mustache
@@ -88,18 +88,12 @@ uint64_t {{resolveName}}_hash(_baseRef handle) {
 {{/if}}
 
 {{#set selfType=this}}
-{{#functions}}{{#ifPredicate "shouldRetain"}}
-{{>cbridge/CBridgeFunctionDefinition}}
-{{/ifPredicate}}{{/functions}}
-{{#properties}}{{#ifPredicate "shouldRetain"}}
-{{#getter}}
-{{>cbridge/CBridgeFunctionDefinition}}
-{{/getter}}
-{{#setter}}
-{{>cbridge/CBridgeFunctionDefinition}}
-{{/setter}}
-{{/ifPredicate}}{{/properties}}
-{{/set}}
+{{#functions}}{{>cbridgeFunction}}{{/functions}}
+{{#properties}}{{>cbridgeProperty}}{{/properties}}
+{{#set isInherited=true container=selfType}}
+{{#container.interfaceInheritedFunctions}}{{>cbridgeFunction}}{{/container.interfaceInheritedFunctions}}
+{{#container.interfaceInheritedProperties}}{{>cbridgeProperty}}{{/container.interfaceInheritedProperties}}
+{{/set}}{{/set}}
 
 {{#instanceOf this "LimeInterface"}}
 {{>cbridge/CBridgeCppProxy}}
@@ -115,4 +109,17 @@ uint64_t {{resolveName}}_hash(_baseRef handle) {
 
 {{#lambdas}}
 {{>cbridge/CBridgeLambdaImpl}}
-{{/lambdas}}
+{{/lambdas}}{{!!
+
+}}{{+cbridgeFunction}}{{#ifPredicate "shouldRetain"}}
+{{>cbridge/CBridgeFunctionDefinition}}
+{{/ifPredicate}}{{/cbridgeFunction}}{{!!
+
+}}{{+cbridgeProperty}}{{#ifPredicate "shouldRetain"}}
+{{#getter}}
+{{>cbridge/CBridgeFunctionDefinition}}
+{{/getter}}
+{{#setter}}
+{{>cbridge/CBridgeFunctionDefinition}}
+{{/setter}}
+{{/ifPredicate}}{{/cbridgeProperty}}

--- a/gluecodium/src/main/resources/templates/cbridge/CBridgeFunctionSignature.mustache
+++ b/gluecodium/src/main/resources/templates/cbridge/CBridgeFunctionSignature.mustache
@@ -19,5 +19,6 @@
   !
   !}}
 {{#if thrownType}}{{resolveName}}_result{{/if}}{{#unless thrownType}}{{resolveName returnType}}{{/unless}} {{!!
-}}{{resolveName}}({{#unless isStatic}}_baseRef _instance{{#if parameters}}, {{/if}}{{/unless}}{{!!
+}}{{#if isInherited}}{{resolveName container}}_{{resolveName this "" "ref"}}{{/if}}{{!!
+}}{{#unless isInherited}}{{resolveName}}{{/unless}}({{#unless isStatic}}_baseRef _instance{{#if parameters}}, {{/if}}{{/unless}}{{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})

--- a/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
+++ b/gluecodium/src/main/resources/templates/swift/CommonClassParts.mustache
@@ -22,11 +22,11 @@
 {{>swift/SwiftConstant}}
 {{/constants}}
 {{#if this.parentInterfaces}}
-{{#if this.interfaceInheritedProperties}}
-{{#this.interfaceInheritedProperties}}
+{{#if this.interfaceInheritedProperties}}{{#set isInherited=true container=this}}
+{{#container.interfaceInheritedProperties}}
 {{>swift/SwiftProperty}}
-{{/this.interfaceInheritedProperties}}
-{{/if}}{{#unless this.interfaceInheritedProperties}}
+{{/container.interfaceInheritedProperties}}
+{{/set}}{{/if}}{{#unless this.interfaceInheritedProperties}}
 {{#inheritedProperties}}
 {{>swift/SwiftProperty}}
 {{/inheritedProperties}}
@@ -70,11 +70,11 @@ deinit {
 {{/structs}}{{/unless}}{{!!
 
 }}{{#if this.parentInterfaces}}
-{{#if this.interfaceInheritedFunctions}}
-{{#this.interfaceInheritedFunctions}}
+{{#if this.interfaceInheritedFunctions}}{{#set isInherited=true container=this}}
+{{#container.interfaceInheritedFunctions}}
 {{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}
-{{/this.interfaceInheritedFunctions}}
-{{/if}}{{#unless this.interfaceInheritedFunctions}}
+{{/container.interfaceInheritedFunctions}}
+{{/set}}{{/if}}{{#unless this.interfaceInheritedFunctions}}
 {{#inheritedFunctions}}
 {{>swift/SwiftFunctionSignature}} {{prefixPartial "swift/SwiftFunctionBody" "" skipFirstLine=true}}
 {{/inheritedFunctions}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftFunctionBody.mustache
@@ -44,7 +44,9 @@
 }{{!!
 
 }}{{+delegateCall}}{{!!
-}}{{resolveName "CBridge"}}({{#unless isStatic}}{{#if selfIsStruct}}c_self_handle.ref{{#if parameters}}, {{/if}}{{/if}}{{!!
+}}{{#if isInherited}}{{resolveName container "CBridge"}}_{{resolveName this "CBridge" "ref"}}{{/if}}{{!!
+}}{{#unless isInherited}}{{resolveName "CBridge"}}{{/unless}}{{!!
+}}({{#unless isStatic}}{{#if selfIsStruct}}c_self_handle.ref{{#if parameters}}, {{/if}}{{/if}}{{!!
 }}{{#unless selfIsStruct}}self.c_instance{{#if parameters}}, {{/if}}{{/unless}}{{/unless}}{{!!
 }}{{#parameters}}c_{{resolveName}}.ref{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{!!
 }}{{/delegateCall}}{{!!

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/include/smoke/cbridge_ChildClassFromInterface.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/include/smoke/cbridge_ChildClassFromInterface.h
@@ -1,0 +1,21 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterface_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_ChildClassFromInterface_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_ChildClassFromInterface_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterface_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterface_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void* smoke_ChildClassFromInterface_get_typed(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterface_childClassMethod(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterface_rootMethod(_baseRef _instance);
+_GLUECODIUM_C_EXPORT _baseRef smoke_ChildClassFromInterface_rootProperty_get(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterface_rootProperty_set(_baseRef _instance, _baseRef value);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cbridge/src/smoke/cbridge_ChildClassFromInterface.cpp
@@ -47,3 +47,12 @@ void* smoke_ChildClassFromInterface_get_typed(_baseRef handle) {
 void smoke_ChildClassFromInterface_childClassMethod(_baseRef _instance) {
     return get_pointer<::std::shared_ptr< ::smoke::ChildClassFromInterface >>(_instance)->get()->child_class_method();
 }
+void smoke_ChildClassFromInterface_rootMethod(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::ChildClassFromInterface >>(_instance)->get()->root_method();
+}
+_baseRef smoke_ChildClassFromInterface_rootProperty_get(_baseRef _instance) {
+    return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::ChildClassFromInterface >>(_instance)->get()->get_root_property());
+}
+void smoke_ChildClassFromInterface_rootProperty_set(_baseRef _instance, _baseRef value) {
+    return get_pointer<::std::shared_ptr< ::smoke::ChildClassFromInterface >>(_instance)->get()->set_root_property(Conversion<::std::string>::toCpp(value));
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/swift/smoke/ChildClassFromInterface.swift
@@ -4,12 +4,12 @@ import Foundation
 public class ChildClassFromInterface: ParentInterface {
     public var rootProperty: String {
         get {
-            let c_result_handle = smoke_ParentInterface_rootProperty_get(self.c_instance)
+            let c_result_handle = smoke_ChildClassFromInterface_rootProperty_get(self.c_instance)
             return moveFromCType(c_result_handle)
         }
         set {
             let c_value = moveToCType(newValue)
-            smoke_ParentInterface_rootProperty_set(self.c_instance, c_value.ref)
+            smoke_ChildClassFromInterface_rootProperty_set(self.c_instance, c_value.ref)
         }
     }
     let c_instance : _baseRef
@@ -24,7 +24,7 @@ public class ChildClassFromInterface: ParentInterface {
         smoke_ChildClassFromInterface_release_handle(c_instance)
     }
     public func rootMethod() -> Void {
-        smoke_ParentInterface_rootMethod(self.c_instance)
+        smoke_ChildClassFromInterface_rootMethod(self.c_instance)
     }
     public func childClassMethod() -> Void {
         smoke_ChildClassFromInterface_childClassMethod(self.c_instance)

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/FirstParentIsClassClass.swift
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/swift/smoke/FirstParentIsClassClass.swift
@@ -4,12 +4,12 @@ import Foundation
 public class FirstParentIsClassClass: ParentClass, ParentNarrowOne {
     public var parentPropertyOne: String {
         get {
-            let c_result_handle = smoke_ParentNarrowOne_parentPropertyOne_get(self.c_instance)
+            let c_result_handle = smoke_FirstParentIsClassClass_parentPropertyOne_get(self.c_instance)
             return moveFromCType(c_result_handle)
         }
         set {
             let c_value = moveToCType(newValue)
-            smoke_ParentNarrowOne_parentPropertyOne_set(self.c_instance, c_value.ref)
+            smoke_FirstParentIsClassClass_parentPropertyOne_set(self.c_instance, c_value.ref)
         }
     }
     public var childProperty: String {
@@ -26,7 +26,7 @@ public class FirstParentIsClassClass: ParentClass, ParentNarrowOne {
         super.init(cParentClass: cFirstParentIsClassClass)
     }
     public func parentFunctionOne() -> Void {
-        smoke_ParentNarrowOne_parentFunctionOne(self.c_instance)
+        smoke_FirstParentIsClassClass_parentFunctionOne(self.c_instance)
     }
     public func childFunction() -> Void {
         smoke_FirstParentIsClassClass_childFunction(self.c_instance)


### PR DESCRIPTION
Updated Swift and CBridge templates to generate dedicated bindings for functions
in a class inherited from an interface. Previous implementation reused bindings
of the parent inteface, which let to compilation errors if that interface was
placed in a separate Swift framework.

Added smoke tests. Existing "inheritance" functional tests are covering this
scenario already and are passing.

See: #1312
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>