### PR TITLE
Use own FFI functions in a child class in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Gluecodium project Release Notes
 
+## Unreleased
 ### Bug fixes:
-  * Do not add unused import of cache for dart classes marked with NoCache tag.
+  * Removed unused import in Dart for `@NoCache` attribute.
+  * Fixed compilation issues in Swift and Dart when inheriting from an interface between separate libraries.
+
 ## 11.1.6
 Release date: 2022-04-26
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiNameResolver.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.generator.ffi
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -33,6 +34,7 @@ import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.lime.LimeType
@@ -40,10 +42,10 @@ import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal class FfiNameResolver(
-    private val limeReferenceMap: Map<String, LimeElement>,
+    limeReferenceMap: Map<String, LimeElement>,
     private val nameRules: NameRules,
     private val internalPrefix: String
-) : NameResolver {
+) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     private val signatureResolver = FfiSignatureResolver(limeReferenceMap, this)
 
@@ -58,6 +60,17 @@ internal class FfiNameResolver(
             else ->
                 throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
         }
+
+    // Narrow usage: for the short name of a function in a class/interface
+    override fun resolveReferenceName(element: Any): String? {
+        if (element !is LimeFunction) return null
+        val parentElement = getParentElement(element)
+        val functionName = mangleName(nameRules.getName(element))
+        return when (parentElement) {
+            is LimeProperty -> mangleName(nameRules.getName(parentElement)) + "_$functionName"
+            else -> functionName
+        }
+    }
 
     private fun getTypeRefName(limeTypeRef: LimeTypeRef): String {
         val limeType = limeTypeRef.type.actualType

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -109,22 +109,21 @@ class {{resolveName}}$Impl extends {{#if this.parentClass}}{{resolveName this.pa
 {{#unless isStatic}}  @override
 {{/unless}}
 {{prefixPartial "dart/DartFunction" "  "}}
-{{/functions}}{{#if container.parentInterfaces}}
-{{#inheritedFunctions}}
+{{/functions}}
+{{#set isInherited=true}}{{#container.interfaceInheritedFunctions}}
 {{#unless isStatic}}  @override
 {{/unless}}
 {{prefixPartial "dart/DartFunction" "  "}}
-{{/inheritedFunctions}}{{/if}}
+{{/container.interfaceInheritedFunctions}}{{/set}}
 {{#set override=true skipDocs=true}}{{#properties}}{{#if attributes.cached}}
 {{prefixPartial "dartCachedProperty" "  "}}
 {{/if}}{{#unless attributes.cached}}
 {{prefixPartial "dart/DartProperty" "  "}}
 {{/unless}}{{/properties}}
-{{#if container.parentInterfaces}}
-{{#inheritedProperties}}
+{{#set isInherited=true}}{{#container.interfaceInheritedProperties}}
 {{prefixPartial "dart/DartProperty" "  "}}
-{{/inheritedProperties}}
-{{/if}}{{/set}}{{/set}}
+{{/container.interfaceInheritedProperties}}{{/set}}
+{{/set}}{{/set}}
 {{#if attributes.equatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}
 }

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -20,7 +20,7 @@
   !}}
  {
   final _{{resolveName}}Ffi = __lib.catchArgumentError(() => {{!!
-  }}__lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{libraryName}}_{{resolveName "FfiSnakeCase"}}'));
+  }}__lib.nativeLibrary.lookupFunction<{{>ffiApi}}, {{>ffiDart}}>('{{>dart/DartFunctionFfiName}}'));
 {{#parameters}}
   final _{{resolveName}}Handle = {{#set call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}});
 {{/parameters}}{{#unless isStatic}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
@@ -22,20 +22,20 @@
 final _{{resolveName}}ReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_return_release_handle'));
+  >('{{>dart/DartFunctionFfiName}}_return_release_handle'));
 {{#unless returnType.isVoid}}
 final _{{resolveName}}ReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName returnType.typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName returnType.typeRef "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_return_get_result'));
+  >('{{>dart/DartFunctionFfiName}}_return_get_result'));
 {{/unless}}
 final _{{resolveName}}ReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName exception.errorType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName exception.errorType "FfiDartTypes"}} Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_return_get_error'));
+  >('{{>dart/DartFunctionFfiName}}_return_get_error'));
 final _{{resolveName}}ReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
-  >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_return_has_error'));
+  >('{{>dart/DartFunctionFfiName}}_return_has_error'));
 
 {{/if}}

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionFfiName.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionFfiName.mustache
@@ -1,0 +1,23 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2022 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{libraryName}}_{{!!
+}}{{#if isInherited}}{{resolveName container "FfiSnakeCase"}}_{{resolveName this "FfiSnakeCase" "ref"}}{{/if}}{{!!
+}}{{#unless isInherited}}{{resolveName "FfiSnakeCase"}}{{/unless}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiFunctionName.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiFunctionName.mustache
@@ -1,0 +1,23 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2022 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{libraryName}}_{{!!
+}}{{#if isInherited}}{{resolveName container}}_{{resolveName this "" "ref"}}{{/if}}{{!!
+}}{{#unless isInherited}}{{resolveName ""}}{{/unless}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
@@ -81,13 +81,13 @@ _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_get_type_
 
 }}{{+ffiFunctionDeclaration}}
 {{#if thrownType}}
-_GLUECODIUM_FFI_EXPORT void {{libraryName}}_{{resolveName}}_return_release_handle(FfiOpaqueHandle handle);{{#isNotEq returnType.typeRef.type.name "Void"}}
-_GLUECODIUM_FFI_EXPORT {{resolveName returnType.typeRef}} {{libraryName}}_{{resolveName}}_return_get_result(FfiOpaqueHandle handle);{{/isNotEq}}
-_GLUECODIUM_FFI_EXPORT {{resolveName exception.errorType}} {{libraryName}}_{{resolveName}}_return_get_error(FfiOpaqueHandle handle);
-_GLUECODIUM_FFI_EXPORT bool {{libraryName}}_{{resolveName}}_return_has_error(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void {{>ffi/FfiFunctionName}}_return_release_handle(FfiOpaqueHandle handle);{{#isNotEq returnType.typeRef.type.name "Void"}}
+_GLUECODIUM_FFI_EXPORT {{resolveName returnType.typeRef}} {{>ffi/FfiFunctionName}}_return_get_result(FfiOpaqueHandle handle);{{/isNotEq}}
+_GLUECODIUM_FFI_EXPORT {{resolveName exception.errorType}} {{>ffi/FfiFunctionName}}_return_get_error(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT bool {{>ffi/FfiFunctionName}}_return_has_error(FfiOpaqueHandle handle);
 
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle{{/if}}{{!!
-}}{{#unless thrownType}}_GLUECODIUM_FFI_EXPORT {{resolveName returnType.typeRef}}{{/unless}} {{libraryName}}_{{resolveName}}({{!!
+}}{{#unless thrownType}}_GLUECODIUM_FFI_EXPORT {{resolveName returnType.typeRef}}{{/unless}} {{>ffi/FfiFunctionName}}({{!!
 }}{{#unless isStatic}}FfiOpaqueHandle _self, {{/unless}}int32_t _isolate_id{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/ffiFunctionDeclaration}}{{!!
@@ -97,19 +97,15 @@ _GLUECODIUM_FFI_EXPORT bool {{libraryName}}_{{resolveName}}_are_equal(FfiOpaqueH
 {{/ffiEqualityFunctionDeclaration}}{{!!
 
 }}{{+ffiClassHeader}}
-{{#functions}}{{#ifPredicate "shouldRetain"}}
-{{>ffiFunctionDeclaration}}
-{{/ifPredicate}}{{/functions}}
-{{#properties}}{{#ifPredicate "shouldRetain"}}{{#getter}}
-{{>ffiFunctionDeclaration}}
-{{/getter}}{{#setter}}
-{{>ffiFunctionDeclaration}}
-{{/setter}}
-{{/ifPredicate}}{{/properties}}
+{{#functions}}{{>ffiFunction}}{{/functions}}
+{{#properties}}{{>ffiProperty}}{{/properties}}
+{{#set isInherited=true container=this}}
+{{#container.interfaceInheritedFunctions}}{{>ffiFunction}}{{/container.interfaceInheritedFunctions}}
+{{#container.interfaceInheritedProperties}}{{>ffiProperty}}{{/container.interfaceInheritedProperties}}
+{{/set}}
+
 {{#structs}}
-{{#functions}}{{#ifPredicate "shouldRetain"}}
-{{>ffiFunctionDeclaration}}
-{{/ifPredicate}}{{/functions}}
+{{#functions}}{{>ffiFunction}}{{/functions}}
 {{/structs}}
 {{#this.lambdas}}{{#asFunction}}
 {{>ffiFunctionDeclaration}}
@@ -117,4 +113,15 @@ _GLUECODIUM_FFI_EXPORT bool {{libraryName}}_{{resolveName}}_are_equal(FfiOpaqueH
 {{#each classes interfaces}}
 {{>ffiClassHeader}}
 {{/each}}
-{{/ffiClassHeader}}
+{{/ffiClassHeader}}{{!!
+
+}}{{+ffiFunction}}{{#ifPredicate "shouldRetain"}}
+{{>ffiFunctionDeclaration}}
+{{/ifPredicate}}{{/ffiFunction}}{{!!
+
+}}{{+ffiProperty}}{{#ifPredicate "shouldRetain"}}{{#getter}}
+{{>ffiFunctionDeclaration}}
+{{/getter}}{{#setter}}
+{{>ffiFunctionDeclaration}}
+{{/setter}}
+{{/ifPredicate}}{{/ffiProperty}}

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -208,14 +208,14 @@ void
 
 {{/ffiStructReleaseAndGetters}}{{!!
 
-}}{{+ffiFunction}}{{#if thrownType}}
+}}{{+ffiFunctionBody}}{{#if thrownType}}
 void
-{{libraryName}}_{{resolveName}}_return_release_handle(FfiOpaqueHandle handle) {
+{{>ffi/FfiFunctionName}}_return_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<{{>ffiErrorReturnType}}*>(handle);
 }
 
 {{#isNotEq returnType.typeRef.toString "Void"}}{{resolveName returnType.typeRef}}
-{{libraryName}}_{{resolveName}}_return_get_result(FfiOpaqueHandle handle) {
+{{>ffi/FfiFunctionName}}_return_get_result(FfiOpaqueHandle handle) {
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName returnType.typeRef "C++"}}>::toFfi(
         reinterpret_cast<{{>ffiErrorReturnType}}*>(handle)->unsafe_value()
     );
@@ -223,19 +223,19 @@ void
 {{/isNotEq}}
 
 {{resolveName exception.errorType}}
-{{libraryName}}_{{resolveName}}_return_get_error(FfiOpaqueHandle handle) {
+{{>ffi/FfiFunctionName}}_return_get_error(FfiOpaqueHandle handle) {
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName exception.errorType "C++"}}>::toFfi(
         reinterpret_cast<{{>ffiErrorReturnType}}*>(handle)->error()
     );
 }
 
 bool
-{{libraryName}}_{{resolveName}}_return_has_error(FfiOpaqueHandle handle) {
+{{>ffi/FfiFunctionName}}_return_has_error(FfiOpaqueHandle handle) {
     return !reinterpret_cast<{{>ffiErrorReturnType}}*>(handle)->has_value();
 }
 
 FfiOpaqueHandle
-{{libraryName}}_{{resolveName}}({{#unless isStatic}}FfiOpaqueHandle _self, {{/unless}}int32_t _isolate_id{{#if parameters}}, {{/if}}{{!!
+{{>ffi/FfiFunctionName}}({{#unless isStatic}}FfiOpaqueHandle _self, {{/unless}}int32_t _isolate_id{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) {
     {{>ffi/FfiInternal}}::IsolateContext _isolate_context(_isolate_id);
     auto&& _cpp_call_result = {{>ffiCallCppFunction}};
@@ -266,7 +266,7 @@ FfiOpaqueHandle
 
 }}{{#unless thrownType}}
 {{resolveName returnType.typeRef}}
-{{libraryName}}_{{resolveName}}({{#unless isStatic}}FfiOpaqueHandle _self, {{/unless}}int32_t _isolate_id{{#if parameters}}, {{/if}}{{!!
+{{>ffi/FfiFunctionName}}({{#unless isStatic}}FfiOpaqueHandle _self, {{/unless}}int32_t _isolate_id{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) {
     {{>ffi/FfiInternal}}::IsolateContext _isolate_context(_isolate_id);
     {{#isEq returnType.typeRef.toString "Void"}}{{>ffiCallCppFunction}};{{/isEq}}{{!!
@@ -282,7 +282,7 @@ FfiOpaqueHandle
 {{>ffiCallCppFunction}}
     );{{/unless}}{{/isNotEq}}
 }
-{{/unless}}{{/ffiFunction}}{{!!
+{{/unless}}{{/ffiFunctionBody}}{{!!
 
 }}{{+selfReferenceConversion}}{{#instanceOf parent "LimeStruct"}}{{!!
 }}{{>ffi/FfiInternal}}::Conversion<{{resolveName parent "C++"}}>::toCpp(_self){{/instanceOf}}{{#notInstanceOf parent "LimeStruct"}}{{!!
@@ -324,22 +324,18 @@ bool
 {{/ffiEqualityFunction}}{{!!
 
 }}{{+ffiClassImpl}}
-{{#set parent=this}}{{#functions}}{{#ifPredicate "shouldRetain"}}
-{{>ffiFunction}}
-{{/ifPredicate}}{{/functions}}
-{{#properties}}{{#ifPredicate "shouldRetain"}}{{#getter}}
-{{>ffiFunction}}
-{{/getter}}{{#setter}}
-{{>ffiFunction}}
-{{/setter}}
-{{/ifPredicate}}{{/properties}}{{/set}}
+{{#set parent=this container=this}}{{#functions}}{{>ffiFunction}}{{/functions}}
+{{#properties}}{{>ffiProperty}}{{/properties}}
+{{#set isInherited=true}}
+{{#container.interfaceInheritedFunctions}}{{>ffiFunction}}{{/container.interfaceInheritedFunctions}}
+{{#container.interfaceInheritedProperties}}{{>ffiProperty}}{{/container.interfaceInheritedProperties}}
+{{/set}}{{/set}}
+
 {{#structs}}
-{{#set parent=this}}{{#functions}}{{#ifPredicate "shouldRetain"}}
-{{>ffiFunction}}
-{{/ifPredicate}}{{/functions}}{{/set}}
+{{#set parent=this}}{{#functions}}{{>ffiFunction}}{{/functions}}{{/set}}
 {{/structs}}
 {{#this.lambdas}}{{#set parent=this}}{{#asFunction}}
-{{>ffiFunction}}
+{{>ffiFunctionBody}}
 {{/asFunction}}{{/set}}{{/this.lambdas}}
 {{#each classes interfaces}}
 {{>ffiClassImpl}}
@@ -357,4 +353,15 @@ bool
 {{/if}}{{#unless external.cpp.setterName}}
     _result->{{resolveName "C++"}} = {{>ffiFieldToCpp}};
 {{/unless}}{{/unless}}
-{{/ffiSetCppField}}
+{{/ffiSetCppField}}{{!!
+
+}}{{+ffiFunction}}{{#ifPredicate "shouldRetain"}}
+{{>ffiFunctionBody}}
+{{/ifPredicate}}{{/ffiFunction}}{{!!
+
+}}{{+ffiProperty}}{{#ifPredicate "shouldRetain"}}{{#getter}}
+{{>ffiFunctionBody}}
+{{/getter}}{{#setter}}
+{{>ffiFunctionBody}}
+{{/setter}}
+{{/ifPredicate}}{{/ffiProperty}}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromInterface.cpp
@@ -1,0 +1,69 @@
+#include "ffi_smoke_ChildClassFromInterface.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/ChildClassFromInterface.h"
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+library_smoke_ChildClassFromInterface_childClassMethod(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::ChildClassFromInterface>>::toCpp(_self)).child_class_method();
+}
+void
+library_smoke_ChildClassFromInterface_rootMethod(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::ChildClassFromInterface>>::toCpp(_self)).root_method();
+}
+FfiOpaqueHandle
+library_smoke_ChildClassFromInterface_rootProperty_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<std::string>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::ChildClassFromInterface>>::toCpp(_self)).get_root_property()
+    );
+}
+void
+library_smoke_ChildClassFromInterface_rootProperty_set(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle value) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+            (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::ChildClassFromInterface>>::toCpp(_self)).set_root_property(
+            gluecodium::ffi::Conversion<std::string>::toCpp(value)
+        );
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_ChildClassFromInterface_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::ChildClassFromInterface>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_ChildClassFromInterface_release_handle(handle);
+}
+void
+library_smoke_ChildClassFromInterface_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_ChildClassFromInterface_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_ChildClassFromInterface_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::ChildClassFromInterface>(
+            *reinterpret_cast<std::shared_ptr<smoke::ChildClassFromInterface>*>(handle)
+        )
+    );
+}
+void
+library_smoke_ChildClassFromInterface_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::ChildClassFromInterface>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ChildClassFromInterface_get_type_id(FfiOpaqueHandle handle) {
+    const auto& type_id = ::gluecodium::get_type_repository().get_id(reinterpret_cast<std::shared_ptr<smoke::ChildClassFromInterface>*>(handle)->get());
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::string(type_id));
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromInterface.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/ffi/ffi_smoke_ChildClassFromInterface.h
@@ -7,6 +7,9 @@
 extern "C" {
 #endif
 _GLUECODIUM_FFI_EXPORT void library_smoke_ChildClassFromInterface_childClassMethod(FfiOpaqueHandle _self, int32_t _isolate_id);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ChildClassFromInterface_rootMethod(FfiOpaqueHandle _self, int32_t _isolate_id);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ChildClassFromInterface_rootProperty_get(FfiOpaqueHandle _self, int32_t _isolate_id);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ChildClassFromInterface_rootProperty_set(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle value);
 _GLUECODIUM_FFI_EXPORT void library_smoke_ChildClassFromInterface_register_finalizer(
     FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle);
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ChildClassFromInterface_copy_handle(FfiOpaqueHandle handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -6,7 +6,6 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 abstract class ChildClassFromInterface implements ParentInterface {
-
   void childClassMethod();
 }
 // ChildClassFromInterface "private" section, not exported.
@@ -28,7 +27,6 @@ final _smokeChildclassfrominterfaceGetTypeId = __lib.catchArgumentError(() => __
   >('library_smoke_ChildClassFromInterface_get_type_id'));
 class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClassFromInterface {
   ChildClassFromInterface$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));
@@ -37,13 +35,13 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
   }
   @override
   void rootMethod() {
-    final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
+    final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_rootMethod'));
     final _handle = this.handle;
     _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
   String get rootProperty {
-    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_rootProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -54,7 +52,7 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
   }
   @override
   set rootProperty(String value) {
-    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ChildClassFromInterface_rootProperty_set'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -8,7 +8,6 @@ import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
 abstract class ChildWithParentClassReferences implements ParentWithClassReferences {
-
 }
 // ChildWithParentClassReferences "private" section, not exported.
 final _smokeChildwithparentclassreferencesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -29,10 +28,9 @@ final _smokeChildwithparentclassreferencesGetTypeId = __lib.catchArgumentError((
   >('library_smoke_ChildWithParentClassReferences_get_type_id'));
 class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements ChildWithParentClassReferences {
   ChildWithParentClassReferences$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   ChildClassFromClass classFunction() {
-    final _classFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classFunction'));
+    final _classFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ChildWithParentClassReferences_classFunction'));
     final _handle = this.handle;
     final __resultHandle = _classFunctionFfi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -43,7 +41,7 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
   }
   @override
   ParentClass get classProperty {
-    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentWithClassReferences_classProperty_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ChildWithParentClassReferences_classProperty_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -54,7 +52,7 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
   }
   @override
   set classProperty(ParentClass value) {
-    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentWithClassReferences_classProperty_set__ParentClass'));
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ChildWithParentClassReferences_classProperty_set'));
     final _valueHandle = smokeParentclassToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
@@ -7,7 +7,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_narrow_one.dart';
 abstract class FirstParentIsClassClass implements ParentClass, ParentNarrowOne {
-
   void childFunction();
   String get childProperty;
   set childProperty(String value);
@@ -31,7 +30,6 @@ final _smokeFirstparentisclassclassGetTypeId = __lib.catchArgumentError(() => __
   >('library_smoke_FirstParentIsClassClass_get_type_id'));
 class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstParentIsClassClass {
   FirstParentIsClassClass$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   void childFunction() {
     final _childFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_childFunction'));
@@ -39,14 +37,8 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
     _childFunctionFfi(_handle, __lib.LibraryContext.isolateId);
   }
   @override
-  void parentFunction() {
-    final _parentFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_parentFunction'));
-    final _handle = this.handle;
-    _parentFunctionFfi(_handle, __lib.LibraryContext.isolateId);
-  }
-  @override
   void parentFunctionOne() {
-    final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentFunctionOne'));
+    final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_parentFunctionOne'));
     final _handle = this.handle;
     _parentFunctionOneFfi(_handle, __lib.LibraryContext.isolateId);
   }
@@ -70,27 +62,8 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
     stringReleaseFfiHandle(_valueHandle);
   }
   @override
-  String get parentProperty {
-    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentClass_parentProperty_get'));
-    final _handle = this.handle;
-    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return stringFromFfi(__resultHandle);
-    } finally {
-      stringReleaseFfiHandle(__resultHandle);
-    }
-  }
-  @override
-  set parentProperty(String value) {
-    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentClass_parentProperty_set__String'));
-    final _valueHandle = stringToFfi(value);
-    final _handle = this.handle;
-    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
-    stringReleaseFfiHandle(_valueHandle);
-  }
-  @override
   String get parentPropertyOne {
-    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentPropertyOne_get'));
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_parentPropertyOne_get'));
     final _handle = this.handle;
     final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
     try {
@@ -101,7 +74,7 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
   }
   @override
   set parentPropertyOne(String value) {
-    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentNarrowOne_parentPropertyOne_set__String'));
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_FirstParentIsClassClass_parentPropertyOne_set'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);


### PR DESCRIPTION
Updated Dart and FFI templates to generate dedicated bindings for functions
in a class inherited from an interface. Previous implementation reused bindings
of the parent interface, which let to compilation errors if that interface was
placed in a separate Dart library.

Added smoke tests. Existing "inheritance" functional tests are covering this
scenario already and are passing.

Resolves: #1312
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>