### PR TITLE
Add `LimePath.toAmbiguousString()` function

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -280,22 +280,19 @@ internal class CppNameResolver(
         val result = limeReferenceMap.values
             .filterIsInstance<LimeNamedElement>()
             .filterNot { it is LimeProperty || it is LimeException || it is LimeBasicType || it is LimeParameter }
-            .associateBy({ it.fullName }, { getFullyQualifiedReference(it) })
+            .associateBy({ it.path.toAmbiguousString() }, { getFullyQualifiedReference(it) })
             .toMutableMap()
 
         result += limeReferenceMap.values.filterIsInstance<LimeException>()
-            .associateBy({ it.fullName }, { resolveName(it.errorType) })
+            .associateBy({ it.path.toAmbiguousString() }, { resolveName(it.errorType) })
         result += limeReferenceMap.values.filterIsInstance<LimeParameter>()
             .associateBy({ it.fullName }, { resolveName(it) })
 
         val functions = limeReferenceMap.values.filterIsInstance<LimeFunction>()
-        result += functions.associateBy(
-            { it.path.withSuffix("").toString() },
-            { getFullyQualifiedReference(it) }
-        )
+        result += functions.associateBy({ it.path.toAmbiguousString() }, { getFullyQualifiedReference(it) })
         result += functions.associateBy(
             { function ->
-                function.path.withSuffix("").toString() + function.parameters
+                function.path.toAmbiguousString() + function.parameters
                     .joinToString(prefix = "(", postfix = ")", separator = ",") { it.typeRef.toString() }
             },
             { getFullyQualifiedReference(it) }
@@ -303,15 +300,15 @@ internal class CppNameResolver(
 
         val properties = limeReferenceMap.values.filterIsInstance<LimeProperty>()
         result += properties.associateBy(
-            { it.fullName },
+            { it.path.toAmbiguousString() },
             { nameCache.getFullyQualifiedGetterName(it) }
         )
         result += properties.associateBy(
-            { it.fullName + ".get" },
+            { it.path.toAmbiguousString() + ".get" },
             { nameCache.getFullyQualifiedGetterName(it) }
         )
         result += properties.filter { it.setter != null }.associateBy(
-            { it.fullName + ".set" },
+            { it.path.toAmbiguousString() + ".set" },
             { nameCache.getFullyQualifiedSetterName(it) }
         )
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -233,11 +233,11 @@ internal class SwiftNameResolver(
         val result = limeReferenceMap.values
             .filterIsInstance<LimeNamedElement>()
             .filterNot { it is LimeParameter }
-            .associateBy({ it.fullName }, { resolveFullName(it) })
+            .associateBy({ it.path.toAmbiguousString() }, { resolveFullName(it) })
             .toMutableMap()
 
         limeReferenceMap.values.filterIsInstance<LimeFunction>().forEach { function ->
-            val ambiguousKey = function.path.withSuffix("").toString()
+            val ambiguousKey = function.path.toAmbiguousString()
             val functionCommentRef = resolveCommentRef(function, signatureResolver)
             result[ambiguousKey] = functionCommentRef
 
@@ -249,8 +249,9 @@ internal class SwiftNameResolver(
         }
 
         val properties = limeReferenceMap.values.filterIsInstance<LimeProperty>()
-        result += properties.associateBy({ it.fullName + ".get" }, { resolveFullName(it) })
-        result += properties.filter { it.setter != null }.associateBy({ it.fullName + ".set" }, { resolveFullName(it) })
+        result += properties.associateBy({ it.path.toAmbiguousString() + ".get" }, { resolveFullName(it) })
+        result += properties.filter { it.setter != null }
+            .associateBy({ it.path.toAmbiguousString() + ".set" }, { resolveFullName(it) })
 
         return result
     }

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -585,7 +585,7 @@ internal class AntlrLimeModelBuilder(
     }
 
     private fun storeResultAndPopStacks(limeFunction: LimeFunction) {
-        val ambiguousKey = limeFunction.path.withSuffix("").toString()
+        val ambiguousKey = limeFunction.path.toAmbiguousString()
         referenceResolver.registerElement(ambiguousKey, limeFunction)
         storeResultAndPopStacks(limeFunction as LimeNamedElement)
     }

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
@@ -66,7 +66,7 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
             if (!result) {
                 droppedElements += it.fullName
                 if (it.path.disambiguator.isNotEmpty()) {
-                    droppedElements += it.path.withSuffix("").toString()
+                    droppedElements += it.path.toAmbiguousString()
                 }
             }
         }
@@ -108,7 +108,7 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
     private fun <T : LimeNamedElement> remap(element: T) {
         referenceMap[element.fullName] = element
         if (element.path.disambiguator.isNotEmpty()) {
-            referenceMap.replace(element.path.withSuffix("").toString(), element)
+            referenceMap.replace(element.path.toAmbiguousString(), element)
         }
     }
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePath.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimePath.kt
@@ -60,8 +60,9 @@ data class LimePath(
 
     fun withSuffix(disambiguator: String) = LimePath(head, tail, disambiguator)
 
-    override fun toString() = (head + tail).joinToString(separator = ".") +
-        if (disambiguator.isNotEmpty()) ":$disambiguator" else ""
+    fun toAmbiguousString() = (head + tail).joinToString(separator = ".")
+
+    override fun toString() = toAmbiguousString() + if (disambiguator.isNotEmpty()) ":$disambiguator" else ""
 
     override fun compareTo(other: LimePath) = toString().compareTo(other.toString())
 


### PR DESCRIPTION
Added `toAmbiguousString()` function to `LimePath` class. The function creates a
string representation of the path where the disambiguation suffix is omitted.

Updated resolution logic for reference links in documentation comments to use
this new functions instead of `LimeNamedElement.fullName` in most places. For
the current implementation, it is just a refactoring, with no change of
functionality.

However, this refactoring decouples the link resolution logic from the
assumption that most paths don't have a suffix. With the assumption removed, a
new implementation can be done that introduces disambiguation suffixes for any
element, not just the functions as before.

See: #1313
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>