### PR TITLE
Use `LimeReturnType.isVoid` in Dart FFI templates

### DIFF
--- a/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiHeader.mustache
@@ -81,8 +81,8 @@ _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle {{libraryName}}_{{resolveName}}_get_type_
 
 }}{{+ffiFunctionDeclaration}}
 {{#if thrownType}}
-_GLUECODIUM_FFI_EXPORT void {{>ffi/FfiFunctionName}}_return_release_handle(FfiOpaqueHandle handle);{{#isNotEq returnType.typeRef.type.name "Void"}}
-_GLUECODIUM_FFI_EXPORT {{resolveName returnType.typeRef}} {{>ffi/FfiFunctionName}}_return_get_result(FfiOpaqueHandle handle);{{/isNotEq}}
+_GLUECODIUM_FFI_EXPORT void {{>ffi/FfiFunctionName}}_return_release_handle(FfiOpaqueHandle handle);{{#unless returnType.isVoid}}
+_GLUECODIUM_FFI_EXPORT {{resolveName returnType.typeRef}} {{>ffi/FfiFunctionName}}_return_get_result(FfiOpaqueHandle handle);{{/unless}}
 _GLUECODIUM_FFI_EXPORT {{resolveName exception.errorType}} {{>ffi/FfiFunctionName}}_return_get_error(FfiOpaqueHandle handle);
 _GLUECODIUM_FFI_EXPORT bool {{>ffi/FfiFunctionName}}_return_has_error(FfiOpaqueHandle handle);
 

--- a/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiImplementation.mustache
@@ -214,13 +214,13 @@ void
     delete reinterpret_cast<{{>ffiErrorReturnType}}*>(handle);
 }
 
-{{#isNotEq returnType.typeRef.toString "Void"}}{{resolveName returnType.typeRef}}
+{{#unless returnType.isVoid}}{{resolveName returnType.typeRef}}
 {{>ffi/FfiFunctionName}}_return_get_result(FfiOpaqueHandle handle) {
     return {{>ffi/FfiInternal}}::Conversion<{{resolveName returnType.typeRef "C++"}}>::toFfi(
         reinterpret_cast<{{>ffiErrorReturnType}}*>(handle)->unsafe_value()
     );
 }
-{{/isNotEq}}
+{{/unless}}
 
 {{resolveName exception.errorType}}
 {{>ffi/FfiFunctionName}}_return_get_error(FfiOpaqueHandle handle) {
@@ -240,19 +240,19 @@ FfiOpaqueHandle
     {{>ffi/FfiInternal}}::IsolateContext _isolate_context(_isolate_id);
     auto&& _cpp_call_result = {{>ffiCallCppFunction}};
 {{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}{{!!
-}}{{#isEq returnType.typeRef.toString "Void"}}
+}}{{#if returnType.isVoid}}
     if (_cpp_call_result.value() == 0) {
         return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) {{>ffiErrorReturnType}}(true));
     }
     auto _error_code = _cpp_call_result;
-{{/isEq}}{{#isNotEq returnType.typeRef.toString "Void"}}
+{{/if}}{{#unless returnType.isVoid}}
     if (_cpp_call_result.has_value()) {
         return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) {{>ffiErrorReturnType}}(
             std::forward<{{resolveName returnType.typeRef "C++"}}>(_cpp_call_result.unsafe_value())
         ));
     }
     auto _error_code = _cpp_call_result.error();
-{{/isNotEq}}
+{{/unless}}
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) {{>ffiErrorReturnType}}(
         static_cast<{{resolveName exception.errorType "C++"}}>(_error_code.value())
     ));
@@ -269,8 +269,8 @@ FfiOpaqueHandle
 {{>ffi/FfiFunctionName}}({{#unless isStatic}}FfiOpaqueHandle _self, {{/unless}}int32_t _isolate_id{{#if parameters}}, {{/if}}{{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) {
     {{>ffi/FfiInternal}}::IsolateContext _isolate_context(_isolate_id);
-    {{#isEq returnType.typeRef.toString "Void"}}{{>ffiCallCppFunction}};{{/isEq}}{{!!
-    }}{{#isNotEq returnType.typeRef.toString "Void"}}return {{#if returnType.typeRef.attributes.optimized}}{{!!
+    {{#if returnType.isVoid}}{{>ffiCallCppFunction}};{{/if}}{{!!
+    }}{{#unless returnType.isVoid}}return {{#if returnType.typeRef.attributes.optimized}}{{!!
     }}reinterpret_cast<FfiOpaqueHandle>(
         new (std::nothrow) std::shared_ptr<{{resolveName returnType.typeRef "C++"}}>(
             new (std::nothrow) {{resolveName returnType.typeRef "C++"}}(
@@ -280,7 +280,7 @@ FfiOpaqueHandle
     );{{/if}}{{#unless returnType.typeRef.attributes.optimized}}{{!!
     }}{{>ffi/FfiInternal}}::Conversion<{{resolveName returnType.typeRef "C++"}}>::toFfi(
 {{>ffiCallCppFunction}}
-    );{{/unless}}{{/isNotEq}}
+    );{{/unless}}{{/unless}}
 }
 {{/unless}}{{/ffiFunctionBody}}{{!!
 


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>