### PR TITLE
Add support for enumerator aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+  * Added support for enumerator aliases.
+
 ## 11.2.0
 Release date: 2022-05-24
 ### Features:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -284,8 +284,9 @@ struct Options {
 * Can be a free-standing element at file level or can be placed in: class, interface, types, struct.
 * Description: declares an enumeration type in the parent type:
   * an enumeration can have any number of enumerators, but at least one enumerator is required.
-  * an enumerator can have a default value associated with it (optionally). Only integer values are
-  currently supported. For more details on values and literals see `Values and Literals` below.
+  * an enumerator can have a value associated with it (optionally). The value can be either an integer or another
+  enumerator from the same enumeration (also known as "enumerator alias"). For more details on values and literals see
+  `Values and Literals` below.
 
 #### Exception
 

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -168,6 +168,7 @@ feature(Enums cpp android swift dart SOURCES
     input/src/cpp/EnumsTypeCollection.cpp
 
     input/lime/Enums.lime
+    input/lime/EnumeratorAlias.lime
     input/lime/EnumsTypeCollection.lime
 )
 

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/EnumsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/EnumsTest.java
@@ -19,6 +19,7 @@
 package com.here.android.test;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 
 import android.os.Build;
 import com.here.android.RobolectricApplication;
@@ -80,5 +81,35 @@ public class EnumsTest {
 
     assertEquals(InternalErrorTypeCollection.ERROR_NONE, result.type);
     assertEquals(message, result.message);
+  }
+
+  @Test
+  public void compareAliasInJava() {
+    assertEquals(EnumWithAlias.ONE, EnumWithAlias.FIRST);
+  }
+
+  @Test
+  public void compareAliasFromCpp() {
+    EnumWithAlias value = UseEnumWithAlias.getFirst();
+
+    assertEquals(EnumWithAlias.ONE, value);
+  }
+
+  @Test
+  public void compareAliasToTargetCpp() {
+    EnumWithAlias value = EnumWithAlias.FIRST;
+
+    boolean result = UseEnumWithAlias.compareToOne(value);
+
+    assertTrue(result);
+  }
+
+  @Test
+  public void compareAliasToAliasCpp() {
+    EnumWithAlias value = EnumWithAlias.FIRST;
+
+    boolean result = UseEnumWithAlias.compareToFirst(value);
+
+    assertTrue(result);
   }
 }

--- a/functional-tests/functional/dart/test/Enums_test.dart
+++ b/functional-tests/functional/dart/test/Enums_test.dart
@@ -71,4 +71,26 @@ void main() {
 
     expect(result, EnumStartsWithOne.first);
   });
+  _testSuite.test("Compare alias in Dart", () {
+    expect(EnumWithAlias.first, EnumWithAlias.one);
+  });
+  _testSuite.test("Compare alias from C++", () {
+    final value = UseEnumWithAlias.getFirst();
+
+    expect(value, EnumWithAlias.one);
+  });
+  _testSuite.test("Compare alias to target in C++", () {
+    final value = EnumWithAlias.first;
+
+    final result = UseEnumWithAlias.compareToOne(value);
+
+    expect(result, isTrue);
+  });
+  _testSuite.test("Compare alias to alias in C++", () {
+    final value = EnumWithAlias.first;
+
+    final result = UseEnumWithAlias.compareToFirst(value);
+
+    expect(result, isTrue);
+  });
 }

--- a/functional-tests/functional/input/lime/EnumeratorAlias.lime
+++ b/functional-tests/functional/input/lime/EnumeratorAlias.lime
@@ -1,0 +1,39 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+enum EnumWithAlias {
+    ONE = 2,
+    TWO,
+    THREE,
+    FIRST = ONE
+}
+
+enum EnumWithAliasWithDeprecated {
+    @Deprecated
+    ONE = 2,
+    TWO,
+    THREE,
+    FIRST = ONE
+}
+
+class UseEnumWithAlias {
+    static fun compareToOne(input: EnumWithAlias): Boolean
+    static fun compareToFirst(input: EnumWithAlias): Boolean
+    static fun getFirst(): EnumWithAlias
+}

--- a/functional-tests/functional/input/src/cpp/Enums.cpp
+++ b/functional-tests/functional/input/src/cpp/Enums.cpp
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/Enums.h"
+#include "test/UseEnumWithAlias.h"
 
 namespace
 {
@@ -59,4 +60,20 @@ Enums::flip_enum_starts_with_one(const test::EnumStartsWithOne input)
         ? test::EnumStartsWithOne::SECOND
         : test::EnumStartsWithOne::FIRST;
 }
-}  // namespace test
+
+// UseEnumWithAlias
+
+bool
+UseEnumWithAlias::compare_to_one(const test::EnumWithAlias input) {
+    return input == test::EnumWithAlias::ONE;
+}
+
+bool
+UseEnumWithAlias::compare_to_first(const test::EnumWithAlias input) {
+    return input == test::EnumWithAlias::FIRST;
+}
+
+test::EnumWithAlias
+UseEnumWithAlias::get_first() { return test::EnumWithAlias::FIRST; }
+
+}

--- a/functional-tests/functional/swift/Tests/EnumsTests.swift
+++ b/functional-tests/functional/swift/Tests/EnumsTests.swift
@@ -74,12 +74,42 @@ class EnumsTests: XCTestCase {
         XCTAssertEqual(result, value)
     }
 
+    func testAliasInSwift() {
+        XCTAssertEqual(EnumWithAlias.first, EnumWithAlias.one)
+    }
+
+    func testAliasFromCpp() {
+        let value = UseEnumWithAlias.getFirst()
+
+        XCTAssertEqual(value, EnumWithAlias.one)
+    }
+
+    func testAliasToTargetCpp() {
+        let value = EnumWithAlias.first
+
+        let result = UseEnumWithAlias.compareToOne(input: value)
+
+        XCTAssertTrue(result)
+    }
+
+    func testAliasToAlias() {
+        let value = EnumWithAlias.first
+
+        let result = UseEnumWithAlias.compareToFirst(input: value)
+
+        XCTAssertTrue(result)
+    }
+
     static var allTests = [
         ("testFlipEnumValue", testFlipEnumValue),
         ("testExtractEnumFromStruct", testExtractEnumFromStruct),
         ("testCreateStructWithEnumInside", testCreateStructWithEnumInside),
         ("testCaseIterable", testCaseIterable),
         ("testCaseIterableWithDeprecated", testCaseIterableWithDeprecated),
-        ("testCodableWithDeprecated", testCodableWithDeprecated)
+        ("testCodableWithDeprecated", testCodableWithDeprecated),
+        ("testAliasInSwift", testAliasInSwift),
+        ("testAliasFromCpp", testAliasFromCpp),
+        ("testAliasToTargetCpp", testAliasToTargetCpp),
+        ("testAliasToAlias", testAliasToAlias)
     ]
 }

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -20,11 +20,23 @@
   !}}
 {{#unlessPredicate "skipDeclaration"}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-enum {{resolveName}}{{#if external.dart.converter}}Internal{{/if}} {
+{{#if aliasEnumerators}}
+class {{>enumName}} {
+  final int index;
+  const {{>enumName}}._(this.index);
+
+{{#set enumeration=this}}{{#enumerators}}
+{{prefixPartial "enhancedEnumerator" "  "}}
+{{/enumerators}}{{/set}}
+}
+{{/if}}{{!!
+}}{{#unless aliasEnumerators}}
+enum {{>enumName}} {
 {{#enumerators}}
 {{prefixPartial "dart/DartEnumerator" "    "}}
 {{/enumerators}}
 }
+{{/unless}}
 {{/unlessPredicate}}
 
 // {{resolveName}} "private" section, not exported.
@@ -34,10 +46,10 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
   final value = {{external.dart.converter}}.convertToInternal(valueExternal);
 {{/if}}
   switch (value) {
-{{#set parent=this}}{{#enumerators}}
+{{#set parent=this}}{{#uniqueEnumerators}}
   case {{resolveName parent "" "ref"}}{{#if external.dart.converter}}Internal{{/if}}.{{resolveName}}:
     return {{value}};
-{{/enumerators}}{{/set}}
+{{/uniqueEnumerators}}{{/set}}
   default:
     throw StateError("Invalid enum value $value for {{resolveName}} enum.");
   }
@@ -45,14 +57,14 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
 
 {{resolveName this "" "ref"}} {{resolveName "Ffi"}}FromFfi(int handle) {
   switch (handle) {
-{{#set parent=this}}{{#enumerators}}
+{{#set parent=this}}{{#uniqueEnumerators}}
   case {{value}}:
 {{#if external.dart.converter}}
     return {{external.dart.converter}}.convertFromInternal({{resolveName parent}}Internal.{{resolveName}});
 {{/if}}{{#unless external.dart.converter}}
     return {{resolveName parent "" "ref"}}.{{resolveName}};
 {{/unless}}
-{{/enumerators}}{{/set}}
+{{/uniqueEnumerators}}{{/set}}
   default:
     throw StateError("Invalid numeric value $handle for {{resolveName}} enum.");
   }
@@ -62,4 +74,11 @@ void {{resolveName "Ffi"}}ReleaseFfiHandle(int handle) {}
 
 {{>dart/DartNullableTypeConversion}}
 
-// End of {{resolveName}} "private" section.
+// End of {{resolveName}} "private" section.{{!!
+
+}}{{+enumName}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{/enumName}}{{!!
+
+}}{{+enhancedEnumerator}}{{!!
+}}{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
+static const {{resolveName}} = {{#if isAlias}}{{resolveName explicitValue}}{{/if}}{{!!
+}}{{#unless isAlias}}{{#enumeration}}{{>enumName}}{{/enumeration}}._({{iter.position}}){{/unless}};{{/enhancedEnumerator}}

--- a/gluecodium/src/main/resources/templates/java/JavaEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaEnumeration.mustache
@@ -20,8 +20,13 @@
   !}}
 {{>java/JavaDocComment}}{{>java/JavaAttributes}}
 {{resolveName visibility}}enum {{resolveName}} {
-{{joinPartial enumerators "java/JavaEnumerator" ",
-"}}{{#if enumerators}};{{/if}}
+{{joinPartial uniqueEnumerators "java/JavaEnumerator" ",
+"}}{{#if uniqueEnumerators}};{{/if}}{{#if aliasEnumerators}}
+
+{{#set enumeration=this}}{{#aliasEnumerators}}
+{{>java/JavaEnumerator}}
+{{/aliasEnumerators}}{{/set}}
+{{/if}}
 
     {{resolveName visibility}}final int value;
 

--- a/gluecodium/src/main/resources/templates/java/JavaEnumerator.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaEnumerator.mustache
@@ -21,4 +21,6 @@
 {{#if comment}}
 {{prefixPartial "java/JavaDocComment" "    "}}{{/if}}{{!!
 }}{{prefixPartial "java/JavaAttributes" "    "}}{{!!
-}}    {{resolveName}}({{resolveName value}})
+}}{{#if isAlias}}    {{resolveName visibility}}final static {{resolveName enumeration}} {{resolveName}}{{!!
+}} = {{resolveName value}};{{/if}}{{!!
+}}{{#unless isAlias}}    {{resolveName}}({{resolveName value}}){{/unless}}

--- a/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
@@ -77,11 +77,11 @@ convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}} _ninput)
     auto& javaClass = CachedJavaClass<{{resolveName "C++ FQN"}}>::java_class;
     const char* enumeratorName = nullptr;
     switch(_ninput) {
-{{#enumerators}}
+{{#enumerators}}{{#unless isAlias}}
         case({{resolveName enum "C++ FQN"}}::{{resolveName "C++"}}):
             enumeratorName = "{{resolveName}}";
             break;
-{{/enumerators}}
+{{/unless}}{{/enumerators}}
     }
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "L{{resolveName this "" "ref"}};");
 {{#unless external.java.converter}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftEnumDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftEnumDefinition.mustache
@@ -20,8 +20,11 @@
   !}}
 {{#unlessPredicate "skipDeclaration"}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
 {{>swift/TypeVisibility}} enum {{resolveName}}{{#if external.swift.converter}}_internal{{/if}} : UInt32, CaseIterable, Codable {
-{{#enumerators}}{{prefixPartial "enumerator" "    "}}
-{{/enumerators}}{{!!
+{{#uniqueEnumerators}}{{prefixPartial "enumerator" "    "}}
+{{/uniqueEnumerators}}{{#if aliasEnumerators}}
+
+{{#aliasEnumerators}}{{prefixPartial "enumerator" "    "}}
+{{/aliasEnumerators}}{{/if}}{{!!
 }}{{#ifPredicate "hasDeprecatedEnumerators"}}
     {{resolveName visibility}} static var allCases: [{{resolveName}}] {
         return [{{#enumerators}}.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/enumerators}}]
@@ -39,10 +42,10 @@
         let container = try decoder.container(keyedBy: Key.self)
         let rawValue = try container.decode(Int.self, forKey: .rawValue)
         switch rawValue {
-{{#enumerators}}
+{{#uniqueEnumerators}}
         case {{iter.position}}:
             self = .{{resolveName}} 
-{{/enumerators}}
+{{/uniqueEnumerators}}
         default:
             throw CodingError.unknownValue
         }
@@ -51,14 +54,15 @@
     {{resolveName visibility}} func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: Key.self)
         switch self {
-{{#enumerators}}
+{{#uniqueEnumerators}}
         case .{{resolveName}}:
             try container.encode({{iter.position}}, forKey: .rawValue)
-{{/enumerators}}
+{{/uniqueEnumerators}}
         }
     }
 {{/ifPredicate}}
 }
 {{/unlessPredicate}}{{!!
 }}{{+enumerator}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
-case {{resolveName}}{{#if explicitValue}} = {{resolveName explicitValue}}{{/if}}{{/enumerator}}
+{{#if isAlias}}{{resolveName visibility}} static let {{resolveName}} = {{resolveName explicitValue}}{{/if}}{{!!
+}}{{#unless isAlias}}case {{resolveName}}{{#if explicitValue}} = {{resolveName explicitValue}}{{/if}}{{/unless}}{{/enumerator}}

--- a/gluecodium/src/test/resources/smoke/enums/input/EnumeratorAlias.lime
+++ b/gluecodium/src/test/resources/smoke/enums/input/EnumeratorAlias.lime
@@ -1,0 +1,33 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+enum EnumWithAlias {
+    ONE = 2,
+    TWO,
+    THREE,
+    FIRST = ONE
+}
+
+enum EnumWithAliasWithDeprecated {
+    @Deprecated
+    ONE = 2,
+    TWO,
+    THREE,
+    FIRST = ONE
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/EnumWithAlias.java
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/com/example/smoke/EnumWithAlias.java
@@ -1,0 +1,14 @@
+/*
+ *
+ */
+package com.example.smoke;
+public enum EnumWithAlias {
+    ONE(2),
+    TWO(3),
+    THREE(4);
+    public final static EnumWithAlias FIRST = EnumWithAlias.ONE;
+    public final int value;
+    EnumWithAlias(final int value) {
+        this.value = value;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_EnumWithAlias__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_EnumWithAlias__Conversion.cpp
@@ -1,0 +1,51 @@
+/*
+ *
+ */
+#include "com_example_smoke_EnumWithAlias__Conversion.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+namespace gluecodium
+{
+namespace jni
+{
+::smoke::EnumWithAlias
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::EnumWithAlias*)
+{
+    return ::smoke::EnumWithAlias(
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+}
+::gluecodium::optional<::smoke::EnumWithAlias>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::gluecodium::optional<::smoke::EnumWithAlias>*)
+{
+    return _jinput
+        ? ::gluecodium::optional<::smoke::EnumWithAlias>(convert_from_jni(_jenv, _jinput, (::smoke::EnumWithAlias*)nullptr))
+        : ::gluecodium::optional<::smoke::EnumWithAlias>{};
+}
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/EnumWithAlias", com_example_smoke_EnumWithAlias, ::smoke::EnumWithAlias)
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::EnumWithAlias _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::EnumWithAlias>::java_class;
+    const char* enumeratorName = nullptr;
+    switch(_ninput) {
+        case(::smoke::EnumWithAlias::ONE):
+            enumeratorName = "ONE";
+            break;
+        case(::smoke::EnumWithAlias::TWO):
+            enumeratorName = "TWO";
+            break;
+        case(::smoke::EnumWithAlias::THREE):
+            enumeratorName = "THREE";
+            break;
+    }
+    jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/EnumWithAlias;");
+    return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
+}
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::gluecodium::optional<::smoke::EnumWithAlias> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAlias.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAlias.h
@@ -1,0 +1,15 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <cstdint>
+namespace smoke {
+enum class EnumWithAlias {
+    ONE = 2,
+    TWO,
+    THREE,
+    FIRST = ::smoke::EnumWithAlias::ONE
+};
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_with_alias.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_with_alias.dart
@@ -1,0 +1,66 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+class EnumWithAlias {
+  final int index;
+  const EnumWithAlias._(this.index);
+
+  static const one = EnumWithAlias._(0);
+  static const two = EnumWithAlias._(1);
+  static const three = EnumWithAlias._(2);
+  static const first = EnumWithAlias.one;
+}
+// EnumWithAlias "private" section, not exported.
+int smokeEnumwithaliasToFfi(EnumWithAlias value) {
+  switch (value) {
+  case EnumWithAlias.one:
+    return 2;
+  case EnumWithAlias.two:
+    return 3;
+  case EnumWithAlias.three:
+    return 4;
+  default:
+    throw StateError("Invalid enum value $value for EnumWithAlias enum.");
+  }
+}
+EnumWithAlias smokeEnumwithaliasFromFfi(int handle) {
+  switch (handle) {
+  case 2:
+    return EnumWithAlias.one;
+  case 3:
+    return EnumWithAlias.two;
+  case 4:
+    return EnumWithAlias.three;
+  default:
+    throw StateError("Invalid numeric value $handle for EnumWithAlias enum.");
+  }
+}
+void smokeEnumwithaliasReleaseFfiHandle(int handle) {}
+final _smokeEnumwithaliasCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_EnumWithAlias_create_handle_nullable'));
+final _smokeEnumwithaliasReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_EnumWithAlias_release_handle_nullable'));
+final _smokeEnumwithaliasGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_EnumWithAlias_get_value_nullable'));
+Pointer<Void> smokeEnumwithaliasToFfiNullable(EnumWithAlias? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeEnumwithaliasToFfi(value);
+  final result = _smokeEnumwithaliasCreateHandleNullable(_handle);
+  smokeEnumwithaliasReleaseFfiHandle(_handle);
+  return result;
+}
+EnumWithAlias? smokeEnumwithaliasFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeEnumwithaliasGetValueNullable(handle);
+  final result = smokeEnumwithaliasFromFfi(_handle);
+  smokeEnumwithaliasReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeEnumwithaliasReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeEnumwithaliasReleaseHandleNullable(handle);
+// End of EnumWithAlias "private" section.

--- a/gluecodium/src/test/resources/smoke/enums/output/lime/smoke/EnumWithAlias.lime
+++ b/gluecodium/src/test/resources/smoke/enums/output/lime/smoke/EnumWithAlias.lime
@@ -1,0 +1,7 @@
+package smoke
+enum EnumWithAlias {
+    ONE = 2,
+    TWO,
+    THREE,
+    FIRST = EnumWithAlias.ONE
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumWithAlias.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumWithAlias.swift
@@ -1,0 +1,39 @@
+//
+//
+import Foundation
+public enum EnumWithAlias : UInt32, CaseIterable, Codable {
+    case one = 2
+    case two
+    case three
+    public static let first = EnumWithAlias.one
+}
+internal func copyToCType(_ swiftEnum: EnumWithAlias) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumWithAlias) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: EnumWithAlias?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumWithAlias?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> EnumWithAlias {
+    return EnumWithAlias(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> EnumWithAlias {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> EnumWithAlias? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EnumWithAlias(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> EnumWithAlias? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumWithAliasWithDeprecated.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumWithAliasWithDeprecated.swift
@@ -1,0 +1,74 @@
+//
+//
+import Foundation
+public enum EnumWithAliasWithDeprecated : UInt32, CaseIterable, Codable {
+    @available(*, deprecated)
+    case one = 2
+    case two
+    case three
+    public static let first = EnumWithAliasWithDeprecated.one
+    public static var allCases: [EnumWithAliasWithDeprecated] {
+        return [.one, .two, .three, .first]
+    }
+    public enum Key: CodingKey {
+        case rawValue
+    }
+    public enum CodingError: Error {
+        case unknownValue
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: Key.self)
+        let rawValue = try container.decode(Int.self, forKey: .rawValue)
+        switch rawValue {
+        case 0:
+            self = .one
+        case 1:
+            self = .two
+        case 2:
+            self = .three
+        default:
+            throw CodingError.unknownValue
+        }
+    }
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: Key.self)
+        switch self {
+        case .one:
+            try container.encode(0, forKey: .rawValue)
+        case .two:
+            try container.encode(1, forKey: .rawValue)
+        case .three:
+            try container.encode(2, forKey: .rawValue)
+        }
+    }
+}
+internal func copyToCType(_ swiftEnum: EnumWithAliasWithDeprecated) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumWithAliasWithDeprecated) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: EnumWithAliasWithDeprecated?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumWithAliasWithDeprecated?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> EnumWithAliasWithDeprecated {
+    return EnumWithAliasWithDeprecated(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> EnumWithAliasWithDeprecated {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> EnumWithAliasWithDeprecated? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EnumWithAliasWithDeprecated(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> EnumWithAliasWithDeprecated? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -472,7 +472,7 @@ internal class AntlrLimeModelBuilder(
             path = currentPath,
             comment = parseStructuredComment(ctx.docComment(), ctx).description,
             attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
-            explicitValue = ctx.literalConstant()?.let { convertLiteralConstant(LimeBasicTypeRef.INT, it) },
+            explicitValue = ctx.literalConstant()?.let { convertEnumeratorValue(it) },
             previous = siblings.lastOrNull()
         )
 
@@ -676,6 +676,15 @@ internal class AntlrLimeModelBuilder(
             '`' -> text.drop(1).dropLast(1)
             else -> text
         }
+    }
+
+    private fun convertEnumeratorValue(ctx: LimeParser.LiteralConstantContext): LimeValue {
+        val typeRef = when {
+            ctx.enumeratorRef() != null ->
+                LimeLazyTypeRef(currentPath.parent.toString(), referenceResolver.referenceMap)
+            else -> LimeBasicTypeRef.INT
+        }
+        return convertLiteralConstant(typeRef, ctx)
     }
 
     private fun getComment(

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumeration.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumeration.kt
@@ -26,4 +26,11 @@ class LimeEnumeration(
     attributes: LimeAttributes? = null,
     external: LimeExternalDescriptor? = null,
     val enumerators: List<LimeEnumerator> = emptyList()
-) : LimeType(path, visibility, comment, attributes, external)
+) : LimeType(path, visibility, comment, attributes, external) {
+
+    val aliasEnumerators
+        get() = enumerators.filter { it.isAlias }
+
+    val uniqueEnumerators
+        get() = enumerators.filter { !it.isAlias }
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumerator.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumerator.kt
@@ -29,6 +29,9 @@ class LimeEnumerator(
     val value
         get() = explicitValue ?: computeValue()
 
+    val isAlias
+        get() = explicitValue is LimeValue.Enumerator
+
     private fun computeValue(): LimeValue =
         previous?.value?.toString()?.toIntOrNull()?.let {
             LimeValue.Literal(LimeBasicTypeRef.INT, (it + 1).toString())


### PR DESCRIPTION
Added support for enumerator aliases when declaring enumerators inside an
enumeration in LIME IDL. In target languages these are represented as:
* enumerator aliases in C++
* static constants on enums in Java and Swift
* static constants on pseudo-enums in Dart

In Dart, static constants on regular enums are not supported before Dart 2.17.
Gluecodium Dart generator currently targets Dart 2.13. So enums with aliases are
converted into pseudo-enum classes in Dart generated code instead. These classes
are functionally equivalent to regular enums.

Added smoke and functional tests.

Resolves: #1334
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>