### PR TITLE
Fix compilation for `@Async` + `@Cpp(Name)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixes compilation issue for the combination of `@Async` and `@Cpp(Name)` attributes.
+
 ## 11.2.1
 Release date: 2022-05-24
 ### Features:

--- a/functional-tests/functional/input/lime/Async.lime
+++ b/functional-tests/functional/input/lime/Async.lime
@@ -50,3 +50,10 @@ struct AsyncStruct {
     @Async
     static fun asyncStatic(input: Boolean)
 }
+
+@Skip(Java, Swift)
+class AsyncRenamed {
+    @Async
+    @Cpp("callDispose")
+    fun dispose()
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartAsyncHelpers.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartAsyncHelpers.kt
@@ -20,6 +20,7 @@
 package com.here.gluecodium.generator.dart
 
 import com.here.gluecodium.model.lime.LimeAttributeType.ASYNC
+import com.here.gluecodium.model.lime.LimeAttributeType.CPP
 import com.here.gluecodium.model.lime.LimeAttributeType.DART
 import com.here.gluecodium.model.lime.LimeAttributeValueType.NAME
 import com.here.gluecodium.model.lime.LimeAttributes
@@ -33,7 +34,6 @@ import com.here.gluecodium.model.lime.LimeLambdaParameter
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimeTypeHelper
-import com.here.gluecodium.model.lime.LimeVisibility
 
 internal object DartAsyncHelpers {
     class AsyncHelpersGroup(
@@ -82,7 +82,6 @@ internal object DartAsyncHelpers {
 
         return LimeLambda(
             limeFunction.path.parent.child(limeFunction.name + COMPLETER_LAMBDA, limeFunction.path.disambiguator),
-            LimeVisibility.INTERNAL,
             attributes = LimeAttributes.Builder().addAttribute(DART, NAME, functionName + COMPLETER_LAMBDA).build(),
             parameters = parameters
         )
@@ -95,9 +94,11 @@ internal object DartAsyncHelpers {
             typeRef = LimeDirectTypeRef(asyncLambda),
             attributes = LimeAttributes.Builder().addAttribute(DART, NAME, "_completerLambda").build(),
         )
+        val attributes = LimeAttributes.Builder().addAttribute(DART, NAME, "_$functionName$ASYNC_FUNCTION")
+        limeFunction.attributes.get(CPP, NAME)?.let { attributes.addAttribute(CPP, NAME, it) }
         return LimeFunction(
             path,
-            attributes = LimeAttributes.Builder().addAttribute(DART, NAME, "_$functionName$ASYNC_FUNCTION").build(),
+            attributes = attributes.build(),
             parameters = listOf(lambdaParameter) + limeFunction.parameters,
             isStatic = limeFunction.isStatic
         )

--- a/gluecodium/src/test/resources/smoke/async/input/Async.lime
+++ b/gluecodium/src/test/resources/smoke/async/input/Async.lime
@@ -49,3 +49,10 @@ struct AsyncStruct {
     @Async
     static fun asyncStatic(input: Boolean)
 }
+
+@Skip(Java, Swift)
+class AsyncRenamed {
+    @Async
+    @Cpp("callDispose")
+    fun dispose()
+}

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncRenamed.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncRenamed.h
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <functional>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT AsyncRenamed {
+public:
+    AsyncRenamed();
+    virtual ~AsyncRenamed() = 0;
+public:
+    virtual void callDispose( std::function<void()> _completer_callback ) = 0;
+    virtual void callDispose(  ) = 0;
+};
+}

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncRenamed.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncRenamed.cpp
@@ -1,0 +1,104 @@
+#include "ffi_smoke_AsyncRenamed.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "smoke/AsyncRenamed.h"
+#include <memory>
+#include <memory>
+#include <new>
+class smoke_AsyncRenamed_DisposeCompleterlambda_Proxy {
+public:
+    smoke_AsyncRenamed_DisposeCompleterlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
+        : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
+    }
+    ~smoke_AsyncRenamed_DisposeCompleterlambda_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncRenamed_DisposeCompleterlambda");
+        auto dart_persistent_handle_local = dart_persistent_handle;
+        auto deleter = [dart_persistent_handle_local]() {
+            Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
+        };
+        if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
+            deleter();
+        } else {
+            gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
+        }
+    }
+    smoke_AsyncRenamed_DisposeCompleterlambda_Proxy(const smoke_AsyncRenamed_DisposeCompleterlambda_Proxy&) = delete;
+    smoke_AsyncRenamed_DisposeCompleterlambda_Proxy& operator=(const smoke_AsyncRenamed_DisposeCompleterlambda_Proxy&) = delete;
+    void
+    operator()() {
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
+        ); });
+    }
+private:
+    const uint64_t token;
+    const int32_t isolate_id;
+    const Dart_PersistentHandle dart_persistent_handle;
+    const FfiOpaqueHandle f0;
+    inline void dispatch(std::function<void()>&& callback) const
+    {
+        gluecodium::ffi::IsolateContext::is_current(isolate_id)
+            ? callback()
+            : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
+    }
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+library_smoke_AsyncRenamed_dispose__dispose__completerLambda(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle Completerlambda) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::AsyncRenamed>>::toCpp(_self)).callDispose(
+        gluecodium::ffi::Conversion<std::function<void()>>::toCpp(Completerlambda)
+    );
+}
+void
+library_smoke_AsyncRenamed_DisposeCompleterlambda_call(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    gluecodium::ffi::Conversion<::std::function<void()>>::toCpp(_self).operator()();
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_AsyncRenamed_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::AsyncRenamed>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_AsyncRenamed_release_handle(handle);
+}
+void
+library_smoke_AsyncRenamed_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_AsyncRenamed_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_AsyncRenamed_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::AsyncRenamed>(
+            *reinterpret_cast<std::shared_ptr<smoke::AsyncRenamed>*>(handle)
+        )
+    );
+}
+void
+library_smoke_AsyncRenamed_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::AsyncRenamed>*>(handle);
+}
+void
+library_smoke_AsyncRenamed_DisposeCompleterlambda_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<::std::function<void()>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_AsyncRenamed_DisposeCompleterlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncRenamed_DisposeCompleterlambda_Proxy>(token, isolate_id, "smoke_AsyncRenamed_DisposeCompleterlambda");
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_AsyncRenamed_DisposeCompleterlambda_Proxy>(token, isolate_id, dart_handle, f0);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncRenamed_DisposeCompleterlambda", cached_proxy);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new ::std::function<void()>(
+            std::bind(&smoke_AsyncRenamed_DisposeCompleterlambda_Proxy::operator(), cached_proxy)
+        )
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/smoke.dart
@@ -1,0 +1,4 @@
+export 'src/smoke/async_class.dart' show AsyncClass, AsyncClass$Impl;
+export 'src/smoke/async_renamed.dart' show AsyncRenamed;
+export 'src/smoke/async_struct.dart' show AsyncStruct, AsyncStruct$Impl;
+export 'src/smoke/throw_me_exception.dart' show ThrowMeException;

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
@@ -173,8 +173,6 @@ AsyncClass? smokeAsyncclassFromFfiNullable(Pointer<Void> handle) =>
 void smokeAsyncclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAsyncclassReleaseHandle(handle);
 // End of AsyncClass "private" section.
-/// @nodoc
-@internal
 typedef AsyncClass_asyncVoid__completerLambda = void Function();
 // AsyncClass_asyncVoid__completerLambda "private" section, not exported.
 final _smokeAsyncclassAsyncvoidcompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -188,7 +186,7 @@ final _smokeAsyncclassAsyncvoidcompleterlambdaCreateProxy = __lib.catchArgumentE
 class AsyncClass_asyncVoid__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncVoid__completerLambda$Impl(this.handle);
-  void internal_asyncVoid__completerLambda() {
+  void asyncVoid__completerLambda() {
     final _asyncVoid__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncClass_AsyncvoidCompleterlambda_call'));
     final _handle = this.handle;
     _asyncVoid__completerLambdaFfi(_handle, __lib.LibraryContext.isolateId);
@@ -211,8 +209,6 @@ Pointer<Void> smokeAsyncclassAsyncvoidcompleterlambdaToFfi(AsyncClass_asyncVoid_
 void smokeAsyncclassAsyncvoidcompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncvoidcompleterlambdaReleaseHandle(handle);
 // End of AsyncClass_asyncVoid__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncClass_asyncVoidThrows__completerLambda = void Function(bool, String);
 // AsyncClass_asyncVoidThrows__completerLambda "private" section, not exported.
 final _smokeAsyncclassAsyncvoidthrowscompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -226,7 +222,7 @@ final _smokeAsyncclassAsyncvoidthrowscompleterlambdaCreateProxy = __lib.catchArg
 class AsyncClass_asyncVoidThrows__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncVoidThrows__completerLambda$Impl(this.handle);
-  void internal_asyncVoidThrows__completerLambda(bool p0, String p1) {
+  void asyncVoidThrows__completerLambda(bool p0, String p1) {
     final _asyncVoidThrows__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_AsyncClass_AsyncvoidthrowsCompleterlambda_call__Boolean_String'));
     final _p0Handle = booleanToFfi(p0);
     final _p1Handle = stringToFfi(p1);
@@ -255,8 +251,6 @@ Pointer<Void> smokeAsyncclassAsyncvoidthrowscompleterlambdaToFfi(AsyncClass_asyn
 void smokeAsyncclassAsyncvoidthrowscompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncvoidthrowscompleterlambdaReleaseHandle(handle);
 // End of AsyncClass_asyncVoidThrows__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncClass_asyncInt__completerLambda = void Function(int);
 // AsyncClass_asyncInt__completerLambda "private" section, not exported.
 final _smokeAsyncclassAsyncintcompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -270,7 +264,7 @@ final _smokeAsyncclassAsyncintcompleterlambdaCreateProxy = __lib.catchArgumentEr
 class AsyncClass_asyncInt__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncInt__completerLambda$Impl(this.handle);
-  void internal_asyncInt__completerLambda(int p0) {
+  void asyncInt__completerLambda(int p0) {
     final _asyncInt__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncClass_AsyncintCompleterlambda_call__Int'));
     final _p0Handle = (p0);
     final _handle = this.handle;
@@ -294,8 +288,6 @@ Pointer<Void> smokeAsyncclassAsyncintcompleterlambdaToFfi(AsyncClass_asyncInt__c
 void smokeAsyncclassAsyncintcompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncintcompleterlambdaReleaseHandle(handle);
 // End of AsyncClass_asyncInt__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncClass_asyncIntThrows__completerLambda = void Function(bool, int, String);
 // AsyncClass_asyncIntThrows__completerLambda "private" section, not exported.
 final _smokeAsyncclassAsyncintthrowscompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -309,7 +301,7 @@ final _smokeAsyncclassAsyncintthrowscompleterlambdaCreateProxy = __lib.catchArgu
 class AsyncClass_asyncIntThrows__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncIntThrows__completerLambda$Impl(this.handle);
-  void internal_asyncIntThrows__completerLambda(bool p0, int p1, String p2) {
+  void asyncIntThrows__completerLambda(bool p0, int p1, String p2) {
     final _asyncIntThrows__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, int, Pointer<Void>)>('library_smoke_AsyncClass_AsyncintthrowsCompleterlambda_call__Boolean_Int_String'));
     final _p0Handle = booleanToFfi(p0);
     final _p1Handle = (p1);
@@ -339,8 +331,6 @@ Pointer<Void> smokeAsyncclassAsyncintthrowscompleterlambdaToFfi(AsyncClass_async
 void smokeAsyncclassAsyncintthrowscompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncintthrowscompleterlambdaReleaseHandle(handle);
 // End of AsyncClass_asyncIntThrows__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncClass_asyncStatic__completerLambda = void Function();
 // AsyncClass_asyncStatic__completerLambda "private" section, not exported.
 final _smokeAsyncclassAsyncstaticcompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -354,7 +344,7 @@ final _smokeAsyncclassAsyncstaticcompleterlambdaCreateProxy = __lib.catchArgumen
 class AsyncClass_asyncStatic__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncStatic__completerLambda$Impl(this.handle);
-  void internal_asyncStatic__completerLambda() {
+  void asyncStatic__completerLambda() {
     final _asyncStatic__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncClass_AsyncstaticCompleterlambda_call'));
     final _handle = this.handle;
     _asyncStatic__completerLambdaFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
@@ -1,0 +1,95 @@
+import 'dart:async';
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+abstract class AsyncRenamed {
+  Future<void> dispose();
+}
+// AsyncRenamed "private" section, not exported.
+final _smokeAsyncrenamedRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_AsyncRenamed_register_finalizer'));
+final _smokeAsyncrenamedCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_AsyncRenamed_copy_handle'));
+final _smokeAsyncrenamedReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AsyncRenamed_release_handle'));
+class AsyncRenamed$Impl extends __lib.NativeBase implements AsyncRenamed {
+  AsyncRenamed$Impl(Pointer<Void> handle) : super(handle);
+  @override
+  Future<void> dispose() {
+    final $completer = Completer<void>();
+    _dispose__async(() {
+      $completer.complete();
+    });
+    return $completer.future;
+  }
+  void _dispose__async(AsyncRenamed_dispose__completerLambda _completerLambda) {
+    final __dispose__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AsyncRenamed_dispose__dispose__completerLambda'));
+    final __completerLambdaHandle = smokeAsyncrenamedDisposecompleterlambdaToFfi(_completerLambda);
+    final _handle = this.handle;
+    __dispose__asyncFfi(_handle, __lib.LibraryContext.isolateId, __completerLambdaHandle);
+    smokeAsyncrenamedDisposecompleterlambdaReleaseFfiHandle(__completerLambdaHandle);
+  }
+}
+Pointer<Void> smokeAsyncrenamedToFfi(AsyncRenamed value) =>
+  _smokeAsyncrenamedCopyHandle((value as __lib.NativeBase).handle);
+AsyncRenamed smokeAsyncrenamedFromFfi(Pointer<Void> handle) {
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is AsyncRenamed) return instance;
+  final _copiedHandle = _smokeAsyncrenamedCopyHandle(handle);
+  final result = AsyncRenamed$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeAsyncrenamedRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeAsyncrenamedReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeAsyncrenamedReleaseHandle(handle);
+Pointer<Void> smokeAsyncrenamedToFfiNullable(AsyncRenamed? value) =>
+  value != null ? smokeAsyncrenamedToFfi(value) : Pointer<Void>.fromAddress(0);
+AsyncRenamed? smokeAsyncrenamedFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeAsyncrenamedFromFfi(handle) : null;
+void smokeAsyncrenamedReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeAsyncrenamedReleaseHandle(handle);
+// End of AsyncRenamed "private" section.
+typedef AsyncRenamed_dispose__completerLambda = void Function();
+// AsyncRenamed_dispose__completerLambda "private" section, not exported.
+final _smokeAsyncrenamedDisposecompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_AsyncRenamed_DisposeCompleterlambda_release_handle'));
+final _smokeAsyncrenamedDisposecompleterlambdaCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer)
+  >('library_smoke_AsyncRenamed_DisposeCompleterlambda_create_proxy'));
+class AsyncRenamed_dispose__completerLambda$Impl {
+  final Pointer<Void> handle;
+  AsyncRenamed_dispose__completerLambda$Impl(this.handle);
+  void dispose__completerLambda() {
+    final _dispose__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncRenamed_DisposeCompleterlambda_call'));
+    final _handle = this.handle;
+    _dispose__completerLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+  }
+}
+int _smokeAsyncrenamedDisposecompleterlambdadispose__completerLambdaStatic(Object _obj) {
+  try {
+    (_obj as AsyncRenamed_dispose__completerLambda)();
+  } finally {
+  }
+  return 0;
+}
+Pointer<Void> smokeAsyncrenamedDisposecompleterlambdaToFfi(AsyncRenamed_dispose__completerLambda value) =>
+  _smokeAsyncrenamedDisposecompleterlambdaCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncrenamedDisposecompleterlambdadispose__completerLambdaStatic, __lib.unknownError)
+  );
+void smokeAsyncrenamedDisposecompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeAsyncrenamedDisposecompleterlambdaReleaseHandle(handle);
+// End of AsyncRenamed_dispose__completerLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_struct.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_struct.dart
@@ -200,8 +200,6 @@ AsyncStruct? smokeAsyncstructFromFfiNullable(Pointer<Void> handle) {
 void smokeAsyncstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAsyncstructReleaseHandleNullable(handle);
 // End of AsyncStruct "private" section.
-/// @nodoc
-@internal
 typedef AsyncStruct_asyncVoid__completerLambda = void Function();
 // AsyncStruct_asyncVoid__completerLambda "private" section, not exported.
 final _smokeAsyncstructAsyncvoidcompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -215,7 +213,7 @@ final _smokeAsyncstructAsyncvoidcompleterlambdaCreateProxy = __lib.catchArgument
 class AsyncStruct_asyncVoid__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncStruct_asyncVoid__completerLambda$Impl(this.handle);
-  void internal_asyncVoid__completerLambda() {
+  void asyncVoid__completerLambda() {
     final _asyncVoid__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncStruct_AsyncvoidCompleterlambda_call'));
     final _handle = this.handle;
     _asyncVoid__completerLambdaFfi(_handle, __lib.LibraryContext.isolateId);
@@ -238,8 +236,6 @@ Pointer<Void> smokeAsyncstructAsyncvoidcompleterlambdaToFfi(AsyncStruct_asyncVoi
 void smokeAsyncstructAsyncvoidcompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncvoidcompleterlambdaReleaseHandle(handle);
 // End of AsyncStruct_asyncVoid__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncStruct_asyncVoidThrows__completerLambda = void Function(bool, String);
 // AsyncStruct_asyncVoidThrows__completerLambda "private" section, not exported.
 final _smokeAsyncstructAsyncvoidthrowscompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -253,7 +249,7 @@ final _smokeAsyncstructAsyncvoidthrowscompleterlambdaCreateProxy = __lib.catchAr
 class AsyncStruct_asyncVoidThrows__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncStruct_asyncVoidThrows__completerLambda$Impl(this.handle);
-  void internal_asyncVoidThrows__completerLambda(bool p0, String p1) {
+  void asyncVoidThrows__completerLambda(bool p0, String p1) {
     final _asyncVoidThrows__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8, Pointer<Void>), void Function(Pointer<Void>, int, int, Pointer<Void>)>('library_smoke_AsyncStruct_AsyncvoidthrowsCompleterlambda_call__Boolean_String'));
     final _p0Handle = booleanToFfi(p0);
     final _p1Handle = stringToFfi(p1);
@@ -282,8 +278,6 @@ Pointer<Void> smokeAsyncstructAsyncvoidthrowscompleterlambdaToFfi(AsyncStruct_as
 void smokeAsyncstructAsyncvoidthrowscompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncvoidthrowscompleterlambdaReleaseHandle(handle);
 // End of AsyncStruct_asyncVoidThrows__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncStruct_asyncInt__completerLambda = void Function(int);
 // AsyncStruct_asyncInt__completerLambda "private" section, not exported.
 final _smokeAsyncstructAsyncintcompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -297,7 +291,7 @@ final _smokeAsyncstructAsyncintcompleterlambdaCreateProxy = __lib.catchArgumentE
 class AsyncStruct_asyncInt__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncStruct_asyncInt__completerLambda$Impl(this.handle);
-  void internal_asyncInt__completerLambda(int p0) {
+  void asyncInt__completerLambda(int p0) {
     final _asyncInt__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncStruct_AsyncintCompleterlambda_call__Int'));
     final _p0Handle = (p0);
     final _handle = this.handle;
@@ -321,8 +315,6 @@ Pointer<Void> smokeAsyncstructAsyncintcompleterlambdaToFfi(AsyncStruct_asyncInt_
 void smokeAsyncstructAsyncintcompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncintcompleterlambdaReleaseHandle(handle);
 // End of AsyncStruct_asyncInt__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncStruct_asyncIntThrows__completerLambda = void Function(bool, int, String);
 // AsyncStruct_asyncIntThrows__completerLambda "private" section, not exported.
 final _smokeAsyncstructAsyncintthrowscompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -336,7 +328,7 @@ final _smokeAsyncstructAsyncintthrowscompleterlambdaCreateProxy = __lib.catchArg
 class AsyncStruct_asyncIntThrows__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncStruct_asyncIntThrows__completerLambda$Impl(this.handle);
-  void internal_asyncIntThrows__completerLambda(bool p0, int p1, String p2) {
+  void asyncIntThrows__completerLambda(bool p0, int p1, String p2) {
     final _asyncIntThrows__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8, Int32, Pointer<Void>), void Function(Pointer<Void>, int, int, int, Pointer<Void>)>('library_smoke_AsyncStruct_AsyncintthrowsCompleterlambda_call__Boolean_Int_String'));
     final _p0Handle = booleanToFfi(p0);
     final _p1Handle = (p1);
@@ -366,8 +358,6 @@ Pointer<Void> smokeAsyncstructAsyncintthrowscompleterlambdaToFfi(AsyncStruct_asy
 void smokeAsyncstructAsyncintthrowscompleterlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncintthrowscompleterlambdaReleaseHandle(handle);
 // End of AsyncStruct_asyncIntThrows__completerLambda "private" section.
-/// @nodoc
-@internal
 typedef AsyncStruct_asyncStatic__completerLambda = void Function();
 // AsyncStruct_asyncStatic__completerLambda "private" section, not exported.
 final _smokeAsyncstructAsyncstaticcompleterlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -381,7 +371,7 @@ final _smokeAsyncstructAsyncstaticcompleterlambdaCreateProxy = __lib.catchArgume
 class AsyncStruct_asyncStatic__completerLambda$Impl {
   final Pointer<Void> handle;
   AsyncStruct_asyncStatic__completerLambda$Impl(this.handle);
-  void internal_asyncStatic__completerLambda() {
+  void asyncStatic__completerLambda() {
     final _asyncStatic__completerLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncStruct_AsyncstaticCompleterlambda_call'));
     final _handle = this.handle;
     _asyncStatic__completerLambdaFfi(_handle, __lib.LibraryContext.isolateId);


### PR DESCRIPTION
Updated DartAsyncHelper to preserve `@Cpp(Name)` on the async helper function as
well. This solves the related compilation issue.

Also removed `internal` visibility from the async helper lambdas. They are not
exposed to public anyway because they are not put into the "exports" file. But
`@internal` attribute in Dart can cause compilation issues if proper imports are
missing.

Added smoke tests for both issues. Added functional test for the attributes
combination issue.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
