### PR TITLE
Fix compilation issue for `exception` + enumerator alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue in C++ when throwing an exception with an enum which has an enumerator alias.
+
 ## 11.2.2
 Release date: 2022-05-25
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/EnumeratorAlias.lime
+++ b/functional-tests/functional/input/lime/EnumeratorAlias.lime
@@ -33,6 +33,8 @@ enum EnumWithAliasWithDeprecated {
     FIRST = ONE
 }
 
+exception Alias(EnumWithAlias)
+
 class UseEnumWithAlias {
     static fun compareToOne(input: EnumWithAlias): Boolean
     static fun compareToFirst(input: EnumWithAlias): Boolean

--- a/gluecodium/src/main/resources/templates/cpp/CppImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppImplementation.mustache
@@ -48,10 +48,10 @@ make_error_code( {{resolveName "FQN"}} value ) noexcept
         {
             switch( {{resolveName "FQN"}}( condition ) )
             {
-            {{#enumerators}}
+            {{#uniqueEnumerators}}
             case( {{resolveName "FQN"}} ):
                 return "{{resolveName "FQN"}}";
-            {{/enumerators}}
+            {{/uniqueEnumerators}}
             }
             return "Unknown enum value";
         }

--- a/gluecodium/src/test/resources/smoke/enums/input/EnumeratorAlias.lime
+++ b/gluecodium/src/test/resources/smoke/enums/input/EnumeratorAlias.lime
@@ -32,3 +32,5 @@ enum EnumWithAliasWithDeprecated {
     THREE,
     FIRST = ONE
 }
+
+exception Alias(EnumWithAlias)

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAlias.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAlias.h
@@ -5,6 +5,7 @@
 #pragma once
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
+#include <system_error>
 namespace smoke {
 enum class EnumWithAlias {
     ONE = 2,
@@ -13,4 +14,10 @@ enum class EnumWithAlias {
     FIRST = ::smoke::EnumWithAlias::ONE,
     THE_BEST = ::smoke::EnumWithAlias::FIRST
 };
+_GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::EnumWithAlias value ) noexcept;
+}
+namespace std
+{
+template <>
+struct is_error_code_enum< ::smoke::EnumWithAlias > : public std::true_type { };
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/src/smoke/EnumWithAlias.cpp
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/src/smoke/EnumWithAlias.cpp
@@ -1,0 +1,38 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#include "smoke/EnumWithAlias.h"
+#include <string>
+namespace smoke {
+std::error_code
+make_error_code( ::smoke::EnumWithAlias value ) noexcept
+{
+    class EnumWithAliasErrorCategory: public ::std::error_category
+    {
+    public:
+        ~EnumWithAliasErrorCategory( ) override = default;
+        const char*
+        name( ) const noexcept override
+        {
+            return "EnumWithAliasErrorCategory";
+        }
+        std::string
+        message( int condition ) const override
+        {
+            switch( ::smoke::EnumWithAlias( condition ) )
+            {
+            case( ::smoke::EnumWithAlias::ONE ):
+                return "::smoke::EnumWithAlias::ONE";
+            case( ::smoke::EnumWithAlias::TWO ):
+                return "::smoke::EnumWithAlias::TWO";
+            case( ::smoke::EnumWithAlias::THREE ):
+                return "::smoke::EnumWithAlias::THREE";
+            }
+            return "Unknown enum value";
+        }
+    };
+    static EnumWithAliasErrorCategory category{};
+    return std::error_code( static_cast<int>( value ), category );
+}
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumeration.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeEnumeration.kt
@@ -28,9 +28,11 @@ class LimeEnumeration(
     val enumerators: List<LimeEnumerator> = emptyList()
 ) : LimeType(path, visibility, comment, attributes, external) {
 
+    @Suppress("unused")
     val aliasEnumerators
         get() = enumerators.filter { it.isAlias }
 
+    @Suppress("unused")
     val uniqueEnumerators
         get() = enumerators.filter { !it.isAlias }
 }


### PR DESCRIPTION
Updated CppImplementation.mustache template to avoid generating `case`
statements for enumerator aliases. This fixes a C++ compilation issue
when an enumeration with an aliases enumerator is used as a payload for
an exception.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
