### PR TITLE
Fix issues with `@Dart(Skip)` + `@Async` on overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed compilation issue in Dart when combining function overloads with `@Async` and `@Skip(Dart)`.
+
 ## 11.2.3
 Release date: 2022-05-30
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -487,7 +487,9 @@ feature(NoCache android swift dart SOURCES
 )
 
 feature(Async cpp dart SOURCES
-    input/src/cpp/Async.cpp
+    input/src/cpp/AsyncClass.cpp
+    input/src/cpp/AsyncStruct.cpp
+    input/src/cpp/AsyncWithSkips.cpp
 
     input/lime/Async.lime
 )

--- a/functional-tests/functional/input/lime/Async.lime
+++ b/functional-tests/functional/input/lime/Async.lime
@@ -57,3 +57,11 @@ class AsyncRenamed {
     @Cpp("callDispose")
     fun dispose()
 }
+
+class AsyncWithSkips {
+    @Skip(Swift) @Skip(Dart)
+    static fun make_shared_instance(androidContext: String)
+
+    @Skip(Java) @Async
+    static fun make_shared_instance()
+}

--- a/functional-tests/functional/input/src/cpp/AsyncClass.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncClass.cpp
@@ -19,15 +19,12 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/AsyncClass.h"
-#include "test/AsyncStruct.h"
 #include <memory>
 #include <string>
 
 namespace test
 {
 using namespace lorem_ipsum::test;
-
-// AsyncClass
 
 class AsyncClassImpl: public AsyncClass {
 public:
@@ -96,7 +93,7 @@ AsyncClassImpl::async_int_throws(
 Return<int32_t, std::string>
 AsyncClassImpl::async_int_throws(const bool) { return Return<int32_t, std::string>(0); }
 
-// AsyncClass static functions
+// Static functions
 
 std::shared_ptr<AsyncClass>
 AsyncClass::create() { return std::make_shared<AsyncClassImpl>(); }
@@ -108,63 +105,5 @@ AsyncClass::async_static(std::function<void()> completer_callback, const bool) {
 
 void
 AsyncClass::async_static(const bool) {}
-
-// AsyncStruct
-
-void
-AsyncStruct::async_void(std::function<void()> completer_callback, const bool) const {
-    completer_callback();
-}
-
-void
-AsyncStruct::async_void(const bool) const {}
-
-void
-AsyncStruct::async_void_throws(
-    std::function<void(bool, std::string)> completer_callback,
-    const bool should_throw
-) const {
-    if (should_throw) {
-        completer_callback(false, "boom");
-    } else {
-        completer_callback(true, "");
-    }
-}
-
-Return<void, std::string>
-AsyncStruct::async_void_throws(const bool) const { return Return<void, std::string>(false); }
-
-void
-AsyncStruct::async_int(std::function<void(int32_t)> completer_callback, const bool) const {
-    completer_callback(42);
-}
-
-int32_t
-AsyncStruct::async_int(const bool) const { return 0; }
-
-void
-AsyncStruct::async_int_throws(
-    std::function<void(bool, int32_t, std::string)> completer_callback,
-    const bool should_throw
-) const {
-    if (should_throw) {
-        completer_callback(false, 0, "boom");
-    } else {
-        completer_callback(true, 42, "");
-    }
-}
-
-Return<int32_t, std::string>
-AsyncStruct::async_int_throws(const bool) const { return Return<int32_t, std::string>(0); }
-
-// AsyncStruct static functions
-
-void
-AsyncStruct::async_static(std::function<void()> completer_callback, const bool) {
-    completer_callback();
-}
-
-void
-AsyncStruct::async_static(const bool) {}
 
 }

--- a/functional-tests/functional/input/src/cpp/AsyncStruct.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncStruct.cpp
@@ -1,0 +1,85 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2022 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License") override;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/AsyncStruct.h"
+#include <memory>
+#include <string>
+
+namespace test
+{
+using namespace lorem_ipsum::test;
+
+void
+AsyncStruct::async_void(std::function<void()> completer_callback, const bool) const {
+    completer_callback();
+}
+
+void
+AsyncStruct::async_void(const bool) const {}
+
+void
+AsyncStruct::async_void_throws(
+    std::function<void(bool, std::string)> completer_callback,
+    const bool should_throw
+) const {
+    if (should_throw) {
+        completer_callback(false, "boom");
+    } else {
+        completer_callback(true, "");
+    }
+}
+
+Return<void, std::string>
+AsyncStruct::async_void_throws(const bool) const { return Return<void, std::string>(false); }
+
+void
+AsyncStruct::async_int(std::function<void(int32_t)> completer_callback, const bool) const {
+    completer_callback(42);
+}
+
+int32_t
+AsyncStruct::async_int(const bool) const { return 0; }
+
+void
+AsyncStruct::async_int_throws(
+    std::function<void(bool, int32_t, std::string)> completer_callback,
+    const bool should_throw
+) const {
+    if (should_throw) {
+        completer_callback(false, 0, "boom");
+    } else {
+        completer_callback(true, 42, "");
+    }
+}
+
+Return<int32_t, std::string>
+AsyncStruct::async_int_throws(const bool) const { return Return<int32_t, std::string>(0); }
+
+// Static functions
+
+void
+AsyncStruct::async_static(std::function<void()> completer_callback, const bool) {
+    completer_callback();
+}
+
+void
+AsyncStruct::async_static(const bool) {}
+
+}

--- a/functional-tests/functional/input/src/cpp/AsyncWithSkips.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncWithSkips.cpp
@@ -1,0 +1,39 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2022 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License") override;
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/AsyncWithSkips.h"
+#include <memory>
+#include <string>
+
+namespace test
+{
+
+void
+AsyncWithSkips::make_shared_instance(std::function<void()> completer_callback) {
+    completer_callback();
+}
+
+void
+AsyncWithSkips::make_shared_instance() {}
+
+void
+AsyncWithSkips::make_shared_instance(const std::string& android_context) {}
+
+}

--- a/gluecodium/src/test/resources/smoke/async/input/Async.lime
+++ b/gluecodium/src/test/resources/smoke/async/input/Async.lime
@@ -56,3 +56,11 @@ class AsyncRenamed {
     @Cpp("callDispose")
     fun dispose()
 }
+
+class AsyncWithSkips {
+    @Skip(Swift) @Skip(Dart)
+    static fun make_shared_instance(androidContext: String)
+
+    @Skip(Java) @Async
+    static fun make_shared_instance()
+}

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncWithSkips.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncWithSkips.h
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium\ExportGluecodiumCpp.h"
+#include <functional>
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT AsyncWithSkips {
+public:
+    AsyncWithSkips();
+    virtual ~AsyncWithSkips() = 0;
+public:
+    static void make_shared_instance( const ::std::string& android_context );
+    static void make_shared_instance( std::function<void()> _completer_callback );
+    static void make_shared_instance(  );
+};
+}

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncWithSkips.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncWithSkips.cpp
@@ -1,0 +1,104 @@
+#include "ffi_smoke_AsyncWithSkips.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "smoke/AsyncWithSkips.h"
+#include <memory>
+#include <memory>
+#include <new>
+class smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy {
+public:
+    smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
+        : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
+    }
+    ~smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy() {
+        gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda");
+        auto dart_persistent_handle_local = dart_persistent_handle;
+        auto deleter = [dart_persistent_handle_local]() {
+            Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
+        };
+        if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
+            deleter();
+        } else {
+            gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
+        }
+    }
+    smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy(const smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy&) = delete;
+    smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy& operator=(const smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy&) = delete;
+    void
+    operator()() {
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
+        ); });
+    }
+private:
+    const uint64_t token;
+    const int32_t isolate_id;
+    const Dart_PersistentHandle dart_persistent_handle;
+    const FfiOpaqueHandle f0;
+    inline void dispatch(std::function<void()>&& callback) const
+    {
+        gluecodium::ffi::IsolateContext::is_current(isolate_id)
+            ? callback()
+            : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
+    }
+};
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+library_smoke_AsyncWithSkips_makeSharedInstance__make_shared_instance__completerLambda(int32_t _isolate_id, FfiOpaqueHandle Completerlambda) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    smoke::AsyncWithSkips::make_shared_instance(
+        gluecodium::ffi::Conversion<std::function<void()>>::toCpp(Completerlambda)
+    );
+}
+void
+library_smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_call(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    gluecodium::ffi::Conversion<::std::function<void()>>::toCpp(_self).operator()();
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_AsyncWithSkips_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::AsyncWithSkips>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_AsyncWithSkips_release_handle(handle);
+}
+void
+library_smoke_AsyncWithSkips_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_AsyncWithSkips_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_AsyncWithSkips_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::AsyncWithSkips>(
+            *reinterpret_cast<std::shared_ptr<smoke::AsyncWithSkips>*>(handle)
+        )
+    );
+}
+void
+library_smoke_AsyncWithSkips_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::AsyncWithSkips>*>(handle);
+}
+void
+library_smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<::std::function<void()>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+    auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy>(token, isolate_id, "smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda");
+    if (!cached_proxy) {
+        cached_proxy = std::make_shared<smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy>(token, isolate_id, dart_handle, f0);
+        gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda", cached_proxy);
+    }
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new ::std::function<void()>(
+            std::bind(&smoke_AsyncWithSkips_MakeSharedInstanceCompleterlambda_Proxy::operator(), cached_proxy)
+        )
+    );
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/smoke.dart
@@ -1,4 +1,5 @@
 export 'src/smoke/async_class.dart' show AsyncClass, AsyncClass$Impl;
 export 'src/smoke/async_renamed.dart' show AsyncRenamed;
 export 'src/smoke/async_struct.dart' show AsyncStruct, AsyncStruct$Impl;
+export 'src/smoke/async_with_skips.dart' show AsyncWithSkips, AsyncWithSkips$Impl;
 export 'src/smoke/throw_me_exception.dart' show ThrowMeException;


### PR DESCRIPTION
Updated injection of "async helpers" into the reference map in Dart generator to
also inject these with "ambiguous" keys. This resolves the issues when using
`@Async` on a function, some overloads of which are skipped.

Resolves: #1349
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>