### PR TITLE
Add support for "named constant" literals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features:
   * Added support for `@Skip(Cpp)` on constants.
+  * Added support for initializing struct fields with named constants.
 ### Bug fixes:
   * Fixed compilation issues for `@Async` functions with `throws` in C++.
   * Added missing includes/imports for struct initializers and enumerator references in C++ and Java.

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -500,10 +500,13 @@ set.
 * Example: `const FieldNames: Map<Int, String> = [1: "name", 42: "address"]`
 * Description: initializes a `Map<>` with the given key-value pairs. `[]` initializes an empty map.
 
-#### Enumerator reference
+#### Constant reference
 
-Initializes an enumeration-type constant or field with the given enumerator value, e.g. `Mode.FAST`. An enumerators can
-also be referenced by its raw value, e.g. `Mode(0)`.
+There are two subtypes of constant references:
+* *Enumerator*: initializes an enumeration-type constant or field with the given enumerator value, e.g. `Mode.FAST`. 
+An enumerators can also be referenced by its raw value, e.g. `Mode(0)`.
+* *Named constant*: initializes a constant or field of any type with the named constant of matching type (see 
+`Constant` above).
 
 ### Attributes
 

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -264,6 +264,8 @@ feature(Defaults cpp android swift dart SOURCES
     input/lime/PositionalDefaults.lime
     input/lime/PositionalEnumerators.lime
     input/lime/InternalEnumDefaults.lime
+    input/lime/FireConstants.lime
+    input/lime/ConstantDefaults.lime
 )
 
 feature(Inheritance cpp android swift dart SOURCES

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/DefaultsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/DefaultsTest.java
@@ -239,4 +239,12 @@ public final class DefaultsTest {
     assertEquals(true, result.secondFreeField);
     assertEquals("bar", result.thirdInitField);
   }
+
+  @Test
+  public void testConstantDefaults() {
+    ConstantDefaults result = new ConstantDefaults();
+
+    assertEquals(42, result.field1.intField);
+    assertEquals(-1, result.field2.intField);
+  }
 }

--- a/functional-tests/functional/dart/test/Defaults_test.dart
+++ b/functional-tests/functional/dart/test/Defaults_test.dart
@@ -111,4 +111,10 @@ void main() {
     expect(result.lastField, SomethingEnum.last);
     expect(StructWithEnums.firstConstant, SomethingEnum.reallyFirst);
   });
+  _testSuite.test("Check constant defaults", () {
+    final result = ConstantDefaults();
+
+    expect(result.field1.intField, 42);
+    expect(result.field2.intField, -2);
+  });
 }

--- a/functional-tests/functional/input/lime/ConstantDefaults.lime
+++ b/functional-tests/functional/input/lime/ConstantDefaults.lime
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+import fire.SomeStruct
+import fire.StructConstants
+
+struct ConstantDefaults {
+    field1: SomeStruct = StructConstants.dummy
+    field2: SomeStruct = StructConstants.dummy4
+}

--- a/functional-tests/functional/input/lime/FireConstants.lime
+++ b/functional-tests/functional/input/lime/FireConstants.lime
@@ -1,0 +1,36 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package fire
+
+@Swift("FireStruct")
+struct SomeStruct {
+    intField: Int
+}
+
+@Swift("FireStructConstants")
+@Dart("FireStructConstants")
+class StructConstants {
+    const dummy: SomeStruct = {42}
+    const dummy2: SomeStruct = {11}
+    const dummy3: SomeStruct = dummy2
+
+    @Skip(Swift, Dart)
+    const dummy4: SomeStruct = {-1}
+    @Skip(Cpp, Java)
+    const dummy4: SomeStruct = {-2}
+}

--- a/functional-tests/functional/swift/Tests/DefaultsTests.swift
+++ b/functional-tests/functional/swift/Tests/DefaultsTests.swift
@@ -146,6 +146,13 @@ class DefaultsTests: XCTestCase {
       XCTAssertEqual(StructWithEnums.firstConstant, SomethingEnum.reallyFirst)
     }
 
+    func testConstantDefaults() {
+      let result = ConstantDefaults()
+
+      XCTAssertEqual(result.field1.intField, 42)
+      XCTAssertEqual(result.field2.intField, -2)
+    }
+
     static var allTests = [
         ("testGetDefault", testGetDefault),
         ("testWithAllButOneDefaultFields", testWithAllButOneDefaultFields),
@@ -158,6 +165,7 @@ class DefaultsTests: XCTestCase {
         ("testCppEmptyDefaults", testCppEmptyDefaults),
         ("testSwiftInitializerDefaults", testSwiftInitializerDefaults),
         ("testCppInitializerDefaults", testCppInitializerDefaults),
-        ("testPositionalEnumeratorDefaults", testPositionalEnumeratorDefaults)
+        ("testPositionalEnumeratorDefaults", testPositionalEnumeratorDefaults),
+        ("testConstantDefaults", testConstantDefaults)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -35,7 +35,7 @@ import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeModelLoader
 import com.here.gluecodium.model.lime.LimeModelLoaderException
 import com.here.gluecodium.validator.LimeAsyncValidator
-import com.here.gluecodium.validator.LimeEnumeratorRefsValidator
+import com.here.gluecodium.validator.LimeConstantRefsValidator
 import com.here.gluecodium.validator.LimeExternalTypesValidator
 import com.here.gluecodium.validator.LimeFieldConstructorsValidator
 import com.here.gluecodium.validator.LimeFunctionsValidator
@@ -184,7 +184,7 @@ class Gluecodium(
 
     private fun getIndependentValidators(limeLogger: LimeLogger) =
         listOf<(LimeModel) -> Boolean>(
-            { LimeEnumeratorRefsValidator(limeLogger).validate(it) },
+            { LimeConstantRefsValidator(limeLogger).validate(it) },
             { LimeExternalTypesValidator(limeLogger).validate(it) },
             { LimePropertiesValidator(limeLogger).validate(it) },
             { LimeFunctionsValidator(limeLogger).validate(it) },

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -107,7 +107,8 @@ internal class DartImportResolver(
             is LimeValue.KeyValuePair -> resolveValueImports(limeValue.key) + resolveValueImports(limeValue.value)
             is LimeValue.InitializerList -> limeValue.values.flatMap { resolveValueImports(it) }
             is LimeValue.StructInitializer -> limeValue.values.flatMap { resolveValueImports(it) }
-            is LimeValue.Constant -> resolveTypeImports(limeValue.valueRef.typeRef.type, skipHelpers = true)
+            is LimeValue.Constant ->
+                resolveTypeImports(getParentElement(limeValue.valueRef.element) as LimeType, skipHelpers = true)
             else -> emptyList()
         }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolverBase.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolverBase.kt
@@ -20,16 +20,17 @@
 package com.here.gluecodium.generator.dart
 
 import com.here.gluecodium.generator.common.ImportsResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.generator.dart.DartImport.ImportType
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeType
 
 internal abstract class DartImportResolverBase(
-    private val limeReferenceMap: Map<String, LimeElement>,
+    limeReferenceMap: Map<String, LimeElement>,
     private val nameResolver: DartNameResolver,
     private val srcPath: String
-) : ImportsResolver<DartImport> {
+) : ReferenceMapBasedResolver(limeReferenceMap), ImportsResolver<DartImport> {
 
     protected fun resolveExternalImport(
         limeElement: LimeElement,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -33,6 +33,7 @@ import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.IMPORT_PATH_NAME
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
@@ -122,7 +123,7 @@ internal class DartNameResolver(
     private fun resolveValue(limeValue: LimeValue): String =
         when (limeValue) {
             is LimeValue.Literal -> resolveLiteralValue(limeValue)
-            is LimeValue.Constant -> "${resolveName(limeValue.typeRef)}.${resolveName(limeValue.valueRef.element)}"
+            is LimeValue.Constant -> resolveConstantValue(limeValue)
             is LimeValue.Special -> {
                 val specialName = when (limeValue.value) {
                     LimeValue.Special.ValueId.NAN -> "nan"
@@ -172,6 +173,12 @@ internal class DartNameResolver(
             else -> limeValue.toString()
         }
     }
+
+    private fun resolveConstantValue(limeValue: LimeValue.Constant) =
+        when (val limeElement = limeValue.valueRef.element) {
+            is LimeEnumerator -> "${resolveName(limeValue.typeRef)}.${resolveName(limeElement)}"
+            else -> resolveFullName(limeElement)
+        }
 
     private fun resolveListValue(limeValue: LimeValue.InitializerList): String {
         val limeType = limeValue.typeRef.type.actualType

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -240,7 +240,7 @@ internal class JavaNameResolver(
         return result
     }
 
-    private fun resolveFullName(limeElement: LimeNamedElement): String {
+    fun resolveFullName(limeElement: LimeNamedElement, forceDelimiter: String? = null): String {
         if (!limeElement.path.hasParent) {
             return (resolvePackageNames(limeElement) + resolveName(limeElement)).joinToString(".")
         }
@@ -252,7 +252,11 @@ internal class JavaNameResolver(
             else -> resolveFullName(getParentElement(limeElement))
         }
 
-        val delimiter = if (limeElement is LimeType) "." else "#"
+        val delimiter = when {
+            forceDelimiter != null -> forceDelimiter
+            limeElement is LimeType -> "."
+            else -> "#"
+        }
         return prefix + delimiter + resolveName(limeElement)
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -114,9 +114,9 @@ internal class SwiftNameResolver(
         when (limeValue) {
             is LimeValue.Literal -> resolveLiteralValue(limeValue)
             is LimeValue.Constant -> {
-                val enumerator = limeValue.valueRef.element
-                val enumeration = getParentElement(enumerator)
-                "${resolveReferenceName(enumeration)}.${resolveName(enumerator)}"
+                val limeElement = limeValue.valueRef.element
+                val parentElement = getParentElement(limeElement)
+                "${resolveReferenceName(parentElement)}.${resolveName(limeElement)}"
             }
             is LimeValue.Special -> {
                 val signPrefix = if (limeValue.value == LimeValue.Special.ValueId.NEGATIVE_INFINITY) "-" else ""

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeConstantRefsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeConstantRefsValidator.kt
@@ -26,10 +26,11 @@ import com.here.gluecodium.model.lime.LimeModelLoaderException
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeValue
 
-/* Validates all enumerator references by trying to resolve each one and reporting any resulting
+/**
+ * Validates all enumerator references by trying to resolve each one and reporting any resulting
  * exceptions as validation failures.
  */
-internal class LimeEnumeratorRefsValidator(private val logger: LimeLogger) :
+internal class LimeConstantRefsValidator(private val logger: LimeLogger) :
     LimeValuesVisitor<Boolean>() {
 
     fun validate(limeModel: LimeModel) = !traverseModel(limeModel).contains(false)

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValuesValidator.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeConstant
-import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeModel
@@ -53,9 +52,11 @@ internal class LimeValuesValidator(private val logger: LimeLogger) {
         val actualType = limeElement.typeRef.type.actualType
         when (limeValue) {
             is LimeValue.Literal -> if (!validateLiteral(limeElement, actualType, limeValue)) return false
-            is LimeValue.Constant -> if (actualType !is LimeEnumeration) {
-                logger.error(limeElement, "enumerator values can only be assigned to `enum` types")
-                return false
+            is LimeValue.Constant -> {
+                if (actualType.fullName != limeValue.valueRef.typeRef.type.fullName) {
+                    logger.error(limeElement, "constant value does not have a matching type")
+                    return false
+                }
             }
             is LimeValue.InitializerList -> if (!isCollectionType(actualType)) {
                 logger.error(limeElement, "initializer list values can only be assigned to collection types")

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeConstantRefsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeConstantRefsValidatorTest.kt
@@ -37,7 +37,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
-class LimeEnumeratorRefsValidatorTest {
+class LimeConstantRefsValidatorTest {
 
     private val allElements = mutableMapOf<String, LimeElement>()
     private val limeModel = LimeModel(allElements, emptyList())
@@ -51,7 +51,7 @@ class LimeEnumeratorRefsValidatorTest {
         override val typeRef = LimeBasicTypeRef.INT
     }
 
-    private val validator = LimeEnumeratorRefsValidator(mockk(relaxed = true))
+    private val validator = LimeConstantRefsValidator(mockk(relaxed = true))
 
     @Test
     fun validateFieldWithValidRef() {

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeValuesValidatorTest.kt
@@ -25,11 +25,11 @@ import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeConstantRef
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
-import com.here.gluecodium.model.lime.LimeEnumeration
-import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
@@ -68,6 +68,7 @@ class LimeValuesValidatorTest(
 
     companion object {
         private val fooTypeRef = LimeDirectTypeRef(object : LimeType(EMPTY_PATH) {})
+        private val fooType = object : LimeType(LimePath(emptyList(), listOf("foo"))) {}
 
         @JvmStatic
         @Parameterized.Parameters
@@ -88,12 +89,12 @@ class LimeValuesValidatorTest(
             arrayOf(LimeBasicTypeRef(LimeBasicType.TypeId.BLOB), LimeValue.Literal(fooTypeRef, ""), false),
             arrayOf(fooTypeRef, LimeValue.Literal(fooTypeRef, ""), false),
             arrayOf(
-                LimeDirectTypeRef(LimeEnumeration(EMPTY_PATH)),
+                LimeDirectTypeRef(fooType),
                 LimeValue.Constant(
                     fooTypeRef,
                     object : LimeConstantRef() {
-                        override val element = LimeEnumerator(EMPTY_PATH)
-                        override val typeRef = LimeBasicTypeRef.INT
+                        override val element = object : LimeNamedElement(EMPTY_PATH) {}
+                        override val typeRef = LimeDirectTypeRef(fooType)
                     }
                 ),
                 true
@@ -103,7 +104,7 @@ class LimeValuesValidatorTest(
                 LimeValue.Constant(
                     fooTypeRef,
                     object : LimeConstantRef() {
-                        override val element = LimeEnumerator(EMPTY_PATH)
+                        override val element = object : LimeNamedElement(EMPTY_PATH) {}
                         override val typeRef = LimeBasicTypeRef.INT
                     }
                 ),

--- a/gluecodium/src/test/resources/smoke/defaults_const/input/ConstantDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults_const/input/ConstantDefaults.lime
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+import fire.SomeStruct
+import fire.StructConstants
+
+struct ConstantDefaults {
+    field1: SomeStruct = StructConstants.dummy
+    field2: SomeStruct = StructConstants.dummy4
+}

--- a/gluecodium/src/test/resources/smoke/defaults_const/input/FireConstants.lime
+++ b/gluecodium/src/test/resources/smoke/defaults_const/input/FireConstants.lime
@@ -1,0 +1,33 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package fire
+
+struct SomeStruct {
+    intField: Int
+}
+
+class StructConstants {
+    const dummy: SomeStruct = {42}
+    const dummy2: SomeStruct = {11}
+    const dummy3: SomeStruct = dummy2
+
+    @Skip(Swift, Dart)
+    const dummy4: SomeStruct = {-1}
+    @Skip(Cpp, Java)
+    const dummy4: SomeStruct = {-2}
+}

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/ConstantDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/ConstantDefaults.java
@@ -1,0 +1,16 @@
+/*
+ *
+ */
+package com.example.smoke;
+import android.support.annotation.NonNull;
+import com.example.fire.SomeStruct;
+public final class ConstantDefaults {
+    @NonNull
+    public SomeStruct field1;
+    @NonNull
+    public SomeStruct field2;
+    public ConstantDefaults() {
+        this.field1 = com.example.fire.StructConstants.DUMMY;
+        this.field2 = com.example.fire.StructConstants.DUMMY4;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/ConstantDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/ConstantDefaults.h
@@ -1,0 +1,16 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "fire/SomeStruct.h"
+#include "fire/StructConstants.h"
+#include "gluecodium/ExportGluecodiumCpp.h"
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT ConstantDefaults {
+    ::fire::SomeStruct field1 = ::fire::StructConstants::DUMMY;
+    ::fire::SomeStruct field2 = ::fire::StructConstants::DUMMY4;
+    ConstantDefaults( );
+    ConstantDefaults( ::fire::SomeStruct field1, ::fire::SomeStruct field2 );
+};
+}

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/constant_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/constant_defaults.dart
@@ -1,0 +1,80 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/fire/some_struct.dart';
+import 'package:library/src/fire/struct_constants.dart';
+class ConstantDefaults {
+  SomeStruct field1;
+  SomeStruct field2;
+  ConstantDefaults._(this.field1, this.field2);
+  ConstantDefaults()
+    : field1 = StructConstants.dummy, field2 = StructConstants.dummy4;
+}
+// ConstantDefaults "private" section, not exported.
+final _smokeConstantdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_ConstantDefaults_create_handle'));
+final _smokeConstantdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ConstantDefaults_release_handle'));
+final _smokeConstantdefaultsGetFieldfield1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ConstantDefaults_get_field_field1'));
+final _smokeConstantdefaultsGetFieldfield2 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ConstantDefaults_get_field_field2'));
+Pointer<Void> smokeConstantdefaultsToFfi(ConstantDefaults value) {
+  final _field1Handle = fireSomestructToFfi(value.field1);
+  final _field2Handle = fireSomestructToFfi(value.field2);
+  final _result = _smokeConstantdefaultsCreateHandle(_field1Handle, _field2Handle);
+  fireSomestructReleaseFfiHandle(_field1Handle);
+  fireSomestructReleaseFfiHandle(_field2Handle);
+  return _result;
+}
+ConstantDefaults smokeConstantdefaultsFromFfi(Pointer<Void> handle) {
+  final _field1Handle = _smokeConstantdefaultsGetFieldfield1(handle);
+  final _field2Handle = _smokeConstantdefaultsGetFieldfield2(handle);
+  try {
+    return ConstantDefaults._(
+      fireSomestructFromFfi(_field1Handle),
+      fireSomestructFromFfi(_field2Handle)
+    );
+  } finally {
+    fireSomestructReleaseFfiHandle(_field1Handle);
+    fireSomestructReleaseFfiHandle(_field2Handle);
+  }
+}
+void smokeConstantdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeConstantdefaultsReleaseHandle(handle);
+// Nullable ConstantDefaults
+final _smokeConstantdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ConstantDefaults_create_handle_nullable'));
+final _smokeConstantdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ConstantDefaults_release_handle_nullable'));
+final _smokeConstantdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ConstantDefaults_get_value_nullable'));
+Pointer<Void> smokeConstantdefaultsToFfiNullable(ConstantDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeConstantdefaultsToFfi(value);
+  final result = _smokeConstantdefaultsCreateHandleNullable(_handle);
+  smokeConstantdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+ConstantDefaults? smokeConstantdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeConstantdefaultsGetValueNullable(handle);
+  final result = smokeConstantdefaultsFromFfi(_handle);
+  smokeConstantdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeConstantdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeConstantdefaultsReleaseHandleNullable(handle);
+// End of ConstantDefaults "private" section.

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/lime/smoke/ConstantDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/lime/smoke/ConstantDefaults.lime
@@ -1,0 +1,6 @@
+package smoke
+import fire.SomeStruct
+struct ConstantDefaults {
+    field1: SomeStruct = fire.StructConstants.dummy
+    field2: SomeStruct = fire.StructConstants.dummy4
+}

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/swift/smoke/ConstantDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/swift/smoke/ConstantDefaults.swift
@@ -1,0 +1,56 @@
+//
+//
+import Foundation
+public struct ConstantDefaults {
+    public var field1: SomeStruct
+    public var field2: SomeStruct
+    public init(field1: SomeStruct = StructConstants.dummy, field2: SomeStruct = StructConstants.dummy4) {
+        self.field1 = field1
+        self.field2 = field2
+    }
+    internal init(cHandle: _baseRef) {
+        field1 = moveFromCType(smoke_ConstantDefaults_field1_get(cHandle))
+        field2 = moveFromCType(smoke_ConstantDefaults_field2_get(cHandle))
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> ConstantDefaults {
+    return ConstantDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> ConstantDefaults {
+    defer {
+        smoke_ConstantDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ConstantDefaults) -> RefHolder {
+    let c_field1 = moveToCType(swiftType.field1)
+    let c_field2 = moveToCType(swiftType.field2)
+    return RefHolder(smoke_ConstantDefaults_create_handle(c_field1.ref, c_field2.ref))
+}
+internal func moveToCType(_ swiftType: ConstantDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ConstantDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> ConstantDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_ConstantDefaults_unwrap_optional_handle(handle)
+    return ConstantDefaults(cHandle: unwrappedHandle) as ConstantDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> ConstantDefaults? {
+    defer {
+        smoke_ConstantDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: ConstantDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_field1 = moveToCType(swiftType.field1)
+    let c_field2 = moveToCType(swiftType.field2)
+    return RefHolder(smoke_ConstantDefaults_create_optional_handle(c_field1.ref, c_field2.ref))
+}
+internal func moveToCType(_ swiftType: ConstantDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_ConstantDefaults_release_optional_handle)
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousConstantRef.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAmbiguousConstantRef.kt
@@ -38,8 +38,10 @@ class LimeAmbiguousConstantRef(
     }
 
     override val typeRef by lazy {
-        // TODO: #1355: resolve differently for a constant
-        LimeLazyTypeRef(element.path.parent.toString(), referenceMap)
+        when (val limeElement = element) {
+            is LimeConstant -> limeElement.typeRef
+            else -> LimeLazyTypeRef(limeElement.path.parent.toString(), referenceMap)
+        }
     }
 
     override fun remap(referenceMap: Map<String, LimeElement>) =


### PR DESCRIPTION
Updated name resolvers in all generators to accommodate the usage of
"named constant" references as values. Apart from slightly different
logic for name resolution, these function identically to "enumerator"
references. So no templates need updating.

Resolves: #1355
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>