### PR TITLE
Always skip internal functions in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Breaking changes:
+  * Functions and properties with `internal` visibility are now unconditionally skipped in generated Dart code.
+
 ## 11.6.0
 Release date: 2022-06-23
 ### Features:

--- a/functional-tests/functional/dart/test/Properties_test.dart
+++ b/functional-tests/functional/dart/test/Properties_test.dart
@@ -21,7 +21,6 @@
 import "dart:typed_data";
 import "package:test/test.dart";
 import "package:functional/test.dart";
-import "package:functional/src/test/internal_class_with_static_property.dart";
 import "../test_suite.dart";
 
 final _testSuite = TestSuite("Properties");
@@ -85,11 +84,6 @@ void main() {
 
     expect(CachedProperties.staticCallCount, 1);
     expect(result1, Uint8List.fromList([0, 1, 2]));
-  });
-  _testSuite.test("Static internal property", () {
-    final result = InternalClassWithStaticProperty.internalfooBar;
-
-    expect(result, "foo");
   });
   _testSuite.test("Property in a nested class", () {
     final geometry = VenueGeometry();

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -25,7 +25,7 @@ abstract class {{resolveName}}{{!!
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
   factory {{resolveName parent}}{{>dart/DartConstructorName}}({{!!
   }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}{{!!
-  }}) => $prototype.{{resolveName visibility}}{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
+  }}) => $prototype.{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
 {{/constructors}}{{/set}}
 
 {{#set isInClass=true}}{{#constants}}
@@ -169,7 +169,7 @@ void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
 // End of {{resolveName}} "private" section.{{!!
 
 }}{{+dartConstructor}}
-{{resolveName parent}} {{resolveName visibility}}{{resolveName}}({{!!
+{{resolveName parent}} {{resolveName}}({{!!
 }}{{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) {
   final _result_handle = _{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}});
   final _result = {{resolveName parent}}$Impl(_result_handle);
@@ -186,7 +186,7 @@ late {{resolveName typeRef}} _{{resolveName}}Cache;
 bool _{{resolveName}}IsCached = false;
 {{#unless isStatic}}@override
 {{/unless}}
-{{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} {
+{{resolveName typeRef}} get {{resolveName}} {
   if (!_{{resolveName}}IsCached) {
     final _{{resolveName getter}}Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<{{!!
     }}{{resolveName typeRef "FfiApiTypes"}} Function({{#unless isStatic}}Pointer<Void>, {{/unless}}Int32), {{!!

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionSignature.mustache
@@ -26,8 +26,7 @@
 }}{{#unless isConstructor}}{{!!
 }}{{#if isStatic}}{{#unless ignoreStatic}}static {{/unless}}{{/if}}{{!!
 }}{{#if this.attributes.async}}Future<{{resolveName returnType}}>{{/if}}{{!!
-}}{{#unless this.attributes.async}}{{resolveName returnType}}{{/unless}} {{!!
-}}{{resolveName visibility}}{{resolveName}}({{!!
+}}{{#unless this.attributes.async}}{{resolveName returnType}}{{/unless}} {{resolveName}}({{!!
 }}{{#if addThat}}{{#unless isStatic}}{{resolveName parent}}{{#if parent.external.dart.converter}}Internal{{/if}} $that{{!!
 }}{{#if parameters}}, {{/if}}{{/unless}}{{/if}}{{!!
 }}{{/unless}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -138,10 +138,10 @@ class {{resolveName}}$Lambdas implements {{resolveName}} {
 {{/unless}}{{/each}}
 {{#each inheritedProperties properties}}{{#unless isStatic}}
   @override
-  {{resolveName typeRef}} get {{resolveName visibility}}{{resolveName}} => {{resolveName}}GetLambda();
+  {{resolveName typeRef}} get {{resolveName}} => {{resolveName}}GetLambda();
 {{#if setter}}
   @override
-  set {{resolveName visibility}}{{resolveName}}({{resolveName typeRef}} value) => {{resolveName}}SetLambda(value);
+  set {{resolveName}}({{resolveName typeRef}} value) => {{resolveName}}SetLambda(value);
 {{/if}}
 {{/unless}}{{/each}}
 }
@@ -179,7 +179,7 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}Static({{!!
   {{resolveName returnType.typeRef}}{{#unless returnType.typeRef.isNullable}}?{{/unless}} _resultObject;{{/unless}}
   try {
     {{#unless returnType.isVoid}}_resultObject = {{/unless}}{{!!
-  }}(_obj as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}}({{#parameters}}{{!!
+  }}(_obj as {{resolveName parent}}).{{resolveName}}({{#parameters}}{{!!
   }}{{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{resolveName}}){{#if iter.hasNext}}, {{/if}}{{!!
   }}{{/parameters}});{{#unless returnType.isVoid}}
     _result.value = {{#returnType}}{{#set call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}{{/returnType}}(_resultObject);{{/unless}}
@@ -201,14 +201,14 @@ int _{{resolveName parent "Ffi"}}{{resolveName}}Static({{!!
 {{#each inheritedProperties properties}}{{#unless isStatic}}
 int _{{resolveName parent "Ffi"}}{{resolveName}}GetStatic(Object _obj, Pointer<{{resolveName typeRef "FfiApiTypes"}}> _result) {
   _result.value = {{#set call="ToFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}({{!!
-  }}(_obj as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}});
+  }}(_obj as {{resolveName parent}}).{{resolveName}});
   return 0;
 }
 {{#if setter}}
 
 int _{{resolveName parent "Ffi"}}{{resolveName}}SetStatic(Object _obj, {{resolveName typeRef "FfiDartTypes"}} _value) {
   try {
-    (_obj as {{resolveName parent}}).{{resolveName visibility}}{{resolveName}} =
+    (_obj as {{resolveName parent}}).{{resolveName}} =
       {{#set call="FromFfi"}}{{>dart/DartFfiConversionCall}}{{/set}}(_value);
   } finally {
     {{#set varName="_value"}}{{>dart/DartFfiReleaseHandle}}{{/set}}

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -86,7 +86,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
   final _copiedHandle = _{{resolveName "Ffi"}}CopyHandle(handle);
   final _impl = {{resolveName}}$Impl(_copiedHandle);
   final result = {{#asFunction}}({{#parameters}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) => {{!!
-  }}_impl.{{resolveName visibility}}{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{/asFunction}};
+  }}_impl.{{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}){{/asFunction}};
   _{{resolveName "Ffi"}}RegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }

--- a/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartProperty.mustache
@@ -24,7 +24,7 @@
 {{/unless}}{{>dart/DartAttributes}}
 {{#if override}}{{#unless isStatic}}@override
 {{/unless}}{{/if}}
-{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
+{{resolveName property.typeRef}} get {{resolveName property}}{{!!
 }}{{>dart/DartFunctionBody}}
 {{/getter}}
 {{#setter}}
@@ -32,7 +32,7 @@
 {{/unless}}{{>dart/DartAttributes}}
 {{#if override}}{{#unless isStatic}}@override
 {{/unless}}{{/if}}
-set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
+set {{resolveName property}}({{resolveName property.typeRef}} value){{!!
 }}{{>dart/DartFunctionBody}}
 {{/setter}}
 {{/set}}

--- a/gluecodium/src/main/resources/templates/dart/DartRedirectImpl.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartRedirectImpl.mustache
@@ -19,5 +19,5 @@
   !
   !}}
  => {{#if isConstructor}}{{resolveName parent}}$Impl{{/if}}{{#unless isConstructor}}$prototype{{/unless}}{{!!
- }}.{{resolveName visibility}}{{resolveName}}({{#if isStruct}}{{#unless isStatic}}this{{#if parameters}}, {{/if}}{{/unless}}{{/if}}{{!!
+ }}.{{resolveName}}({{#if isStruct}}{{#unless isStatic}}this{{#if parameters}}, {{/if}}{{/unless}}{{/if}}{{!!
  }}{{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})

--- a/gluecodium/src/main/resources/templates/dart/DartRedirectProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartRedirectProperty.mustache
@@ -21,11 +21,11 @@
 {{#set property=this}}{{#getter}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}{{!!
 }}{{#if isStatic}}static {{/if}}{{!!
-}}{{resolveName property.typeRef}} get {{resolveName visibility}}{{resolveName property}}{{!!
-}}{{#if isStatic}} => $prototype.{{resolveName visibility}}{{resolveName property}}{{/if}};
+}}{{resolveName property.typeRef}} get {{resolveName property}}{{!!
+}}{{#if isStatic}} => $prototype.{{resolveName property}}{{/if}};
 {{/getter}}
 {{#setter}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}{{!!
-}}{{#if isStatic}}static {{/if}}set {{resolveName visibility}}{{resolveName property}}({{resolveName property.typeRef}} value){{!!
-}}{{#if isStatic}} { $prototype.{{resolveName visibility}}{{resolveName property}} = value; }{{/if}}{{#unless isStatic}};{{/unless}}
+}}{{#if isStatic}}static {{/if}}set {{resolveName property}}({{resolveName property.typeRef}} value){{!!
+}}{{#if isStatic}} { $prototype.{{resolveName property}} = value; }{{/if}}{{#unless isStatic}};{{/unless}}
 {{/setter}}{{/set}}

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -7,11 +7,10 @@ import 'package:meta/meta.dart';
 /// @nodoc
 @internal
 abstract class InternalClassWithComments {
-
   /// This is definitely internal
   ///
   /// @nodoc
-  void internal_doNothing();
+  void doNothing();
 }
 // InternalClassWithComments "private" section, not exported.
 final _smokeInternalclasswithcommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -28,9 +27,8 @@ final _smokeInternalclasswithcommentsReleaseHandle = __lib.catchArgumentError(()
   >('library_smoke_InternalClassWithComments_release_handle'));
 class InternalClassWithComments$Impl extends __lib.NativeBase implements InternalClassWithComments {
   InternalClassWithComments$Impl(Pointer<Void> handle) : super(handle);
-
   @override
-  void internal_doNothing() {
+  void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));
     final _handle = this.handle;
     _doNothingFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_internal.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_internal.dart
@@ -1,21 +1,12 @@
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 class FieldConstructorsInternal {
   String publicField;
   double internalField;
-  @internal
-  FieldConstructorsInternal.withAll()
-      : publicField = "foo", internalField = 42;
-  @internal
-  FieldConstructorsInternal.withFortyTwo(this.publicField)
-      : internalField = 42;
-  @internal
-  FieldConstructorsInternal.withFoo(this.internalField)
-      : publicField = "foo";
-  @internal
-  FieldConstructorsInternal(this.internalField, this.publicField);
+  FieldConstructorsInternal._(this.publicField, this.internalField);
+  FieldConstructorsInternal()
+    : publicField = "foo", internalField = 42;
 }
 // FieldConstructorsInternal "private" section, not exported.
 final _smokeFieldconstructorsinternalCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -45,9 +36,9 @@ FieldConstructorsInternal smokeFieldconstructorsinternalFromFfi(Pointer<Void> ha
   final _publicFieldHandle = _smokeFieldconstructorsinternalGetFieldpublicField(handle);
   final _internalFieldHandle = _smokeFieldconstructorsinternalGetFieldinternalField(handle);
   try {
-    return FieldConstructorsInternal(
-      (_internalFieldHandle),
-      stringFromFfi(_publicFieldHandle)
+    return FieldConstructorsInternal._(
+      stringFromFfi(_publicFieldHandle),
+      (_internalFieldHandle)
     );
   } finally {
     stringReleaseFfiHandle(_publicFieldHandle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -33,7 +33,7 @@ final _smokeClasswithinternallambdaInternalnestedlambdaCreateProxy = __lib.catch
 class ClassWithInternalLambda_InternalNestedLambda$Impl {
   final Pointer<Void> handle;
   ClassWithInternalLambda_InternalNestedLambda$Impl(this.handle);
-  bool internal_call(String p0) {
+  bool call(String p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_InternalNestedLambda_call__String'));
     final _p0Handle = stringToFfi(p0);
     final _handle = this.handle;
@@ -66,7 +66,7 @@ Pointer<Void> smokeClasswithinternallambdaInternalnestedlambdaToFfi(ClassWithInt
 ClassWithInternalLambda_InternalNestedLambda smokeClasswithinternallambdaInternalnestedlambdaFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeClasswithinternallambdaInternalnestedlambdaCopyHandle(handle);
   final _impl = ClassWithInternalLambda_InternalNestedLambda$Impl(_copiedHandle);
-  final result = (String p0) => _impl.internal_call(p0);
+  final result = (String p0) => _impl.call(p0);
   _smokeClasswithinternallambdaInternalnestedlambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class.dart
@@ -6,9 +6,8 @@ import 'package:meta/meta.dart';
 /// @nodoc
 @internal
 abstract class InternalClass {
-
   /// @nodoc
-  void internal_fooBar();
+  void fooBar();
 }
 // InternalClass "private" section, not exported.
 final _smokeInternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -25,9 +24,8 @@ final _smokeInternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.na
   >('library_smoke_InternalClass_release_handle'));
 class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
   InternalClass$Impl(Pointer<Void> handle) : super(handle);
-
   @override
-  void internal_fooBar() {
+  void fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));
     final _handle = this.handle;
     _fooBarFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -8,12 +8,11 @@ import 'package:meta/meta.dart';
 @internal
 abstract class InternalClassWithFunctions {
   /// @nodoc
-  factory InternalClassWithFunctions.make() => $prototype.internal_make();
+  factory InternalClassWithFunctions.make() => $prototype.make();
   /// @nodoc
-  factory InternalClassWithFunctions.remake(String foo) => $prototype.internal_remake(foo);
-
+  factory InternalClassWithFunctions.remake(String foo) => $prototype.remake(foo);
   /// @nodoc
-  void internal_fooBar();
+  void fooBar();
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = InternalClassWithFunctions$Impl(Pointer<Void>.fromAddress(0));
@@ -35,15 +34,14 @@ final _smokeInternalclasswithfunctionsReleaseHandle = __lib.catchArgumentError((
 @visibleForTesting
 class InternalClassWithFunctions$Impl extends __lib.NativeBase implements InternalClassWithFunctions {
   InternalClassWithFunctions$Impl(Pointer<Void> handle) : super(handle);
-
-  InternalClassWithFunctions internal_make() {
+  InternalClassWithFunctions make() {
     final _result_handle = _make();
     final _result = InternalClassWithFunctions$Impl(_result_handle);
     __lib.cacheInstance(_result_handle, _result);
     _smokeInternalclasswithfunctionsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
-  InternalClassWithFunctions internal_remake(String foo) {
+  InternalClassWithFunctions remake(String foo) {
     final _result_handle = _remake(foo);
     final _result = InternalClassWithFunctions$Impl(_result_handle);
     __lib.cacheInstance(_result_handle, _result);
@@ -51,7 +49,7 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
     return _result;
   }
   @override
-  void internal_fooBar() {
+  void fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar'));
     final _handle = this.handle;
     _fooBarFfi(_handle, __lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -7,13 +7,12 @@ import 'package:meta/meta.dart';
 /// @nodoc
 @internal
 abstract class InternalClassWithStaticProperty {
-
   /// @nodoc
   @internal
-  static String get internal_fooBar => $prototype.internal_fooBar;
+  static String get fooBar => $prototype.fooBar;
   /// @nodoc
   @internal
-  static set internal_fooBar(String value) { $prototype.internal_fooBar = value; }
+  static set fooBar(String value) { $prototype.fooBar = value; }
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = InternalClassWithStaticProperty$Impl(Pointer<Void>.fromAddress(0));
@@ -35,9 +34,8 @@ final _smokeInternalclasswithstaticpropertyReleaseHandle = __lib.catchArgumentEr
 @visibleForTesting
 class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements InternalClassWithStaticProperty {
   InternalClassWithStaticProperty$Impl(Pointer<Void> handle) : super(handle);
-
   @internal
-  String get internal_fooBar {
+  String get fooBar {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));
     final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
     try {
@@ -47,7 +45,7 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
     }
   }
   @internal
-  set internal_fooBar(String value) {
+  set fooBar(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String'));
     final _valueHandle = stringToFfi(value);
     _setFfi(__lib.LibraryContext.isolateId, _valueHandle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_interface.dart
@@ -14,9 +14,8 @@ abstract class InternalInterface {
   ) => InternalInterface$Lambdas(
     fooBarLambda,
   );
-
   /// @nodoc
-  void internal_fooBar();
+  void fooBar();
 }
 // InternalInterface "private" section, not exported.
 final _smokeInternalinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -44,16 +43,14 @@ class InternalInterface$Lambdas implements InternalInterface {
   InternalInterface$Lambdas(
     this.fooBarLambda,
   );
-
   @override
-  void internal_fooBar() =>
+  void fooBar() =>
     fooBarLambda();
 }
 class InternalInterface$Impl extends __lib.NativeBase implements InternalInterface {
   InternalInterface$Impl(Pointer<Void> handle) : super(handle);
-
   @override
-  void internal_fooBar() {
+  void fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));
     final _handle = this.handle;
     _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
@@ -61,7 +58,7 @@ class InternalInterface$Impl extends __lib.NativeBase implements InternalInterfa
 }
 int _smokeInternalinterfacefooBarStatic(Object _obj) {
   try {
-    (_obj as InternalInterface).internal_fooBar();
+    (_obj as InternalInterface).fooBar();
   } finally {
   }
   return 0;

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_property_only.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_property_only.dart
@@ -2,16 +2,7 @@ import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-import 'package:library/src/builtin_types__conversion.dart';
-import 'package:meta/meta.dart';
 abstract class InternalPropertyOnly {
-
-  /// @nodoc
-  @internal
-  String get internal_foo;
-  /// @nodoc
-  @internal
-  set internal_foo(String value);
 }
 // InternalPropertyOnly "private" section, not exported.
 final _smokeInternalpropertyonlyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -28,28 +19,6 @@ final _smokeInternalpropertyonlyReleaseHandle = __lib.catchArgumentError(() => _
   >('library_smoke_InternalPropertyOnly_release_handle'));
 class InternalPropertyOnly$Impl extends __lib.NativeBase implements InternalPropertyOnly {
   InternalPropertyOnly$Impl(Pointer<Void> handle) : super(handle);
-
-  @internal
-  @override
-  String get internal_foo {
-    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_InternalPropertyOnly_foo_get'));
-    final _handle = this.handle;
-    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return stringFromFfi(__resultHandle);
-    } finally {
-      stringReleaseFfiHandle(__resultHandle);
-    }
-  }
-  @internal
-  @override
-  set internal_foo(String value) {
-    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_InternalPropertyOnly_foo_set__String'));
-    final _valueHandle = stringToFfi(value);
-    final _handle = this.handle;
-    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
-    stringReleaseFfiHandle(_valueHandle);
-  }
 }
 Pointer<Void> smokeInternalpropertyonlyToFfi(InternalPropertyOnly value) =>
   _smokeInternalpropertyonlyCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
@@ -5,14 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 abstract class PublicClass {
-  /// @nodoc
-  PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input);
-  /// @nodoc
-  @internal
-  PublicClass_InternalStruct get internal_internalStructProperty;
-  /// @nodoc
-  @internal
-  set internal_internalStructProperty(PublicClass_InternalStruct value);
 }
 /// @nodoc
 @internal
@@ -296,40 +288,6 @@ final _smokePublicclassReleaseHandle = __lib.catchArgumentError(() => __lib.nati
   >('library_smoke_PublicClass_release_handle'));
 class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
   PublicClass$Impl(Pointer<Void> handle) : super(handle);
-  @override
-  PublicClass_InternalStruct internal_internalMethod(PublicClass_InternalStruct input) {
-    final _internalMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalMethod__InternalStruct'));
-    final _inputHandle = smokePublicclassInternalstructToFfi(input);
-    final _handle = this.handle;
-    final __resultHandle = _internalMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
-    smokePublicclassInternalstructReleaseFfiHandle(_inputHandle);
-    try {
-      return smokePublicclassInternalstructFromFfi(__resultHandle);
-    } finally {
-      smokePublicclassInternalstructReleaseFfiHandle(__resultHandle);
-    }
-  }
-  @internal
-  @override
-  PublicClass_InternalStruct get internal_internalStructProperty {
-    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_PublicClass_internalStructProperty_get'));
-    final _handle = this.handle;
-    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
-    try {
-      return smokePublicclassInternalstructFromFfi(__resultHandle);
-    } finally {
-      smokePublicclassInternalstructReleaseFfiHandle(__resultHandle);
-    }
-  }
-  @internal
-  @override
-  set internal_internalStructProperty(PublicClass_InternalStruct value) {
-    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PublicClass_internalStructProperty_set__InternalStruct'));
-    final _valueHandle = smokePublicclassInternalstructToFfi(value);
-    final _handle = this.handle;
-    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
-    smokePublicclassInternalstructReleaseFfiHandle(_valueHandle);
-  }
 }
 Pointer<Void> smokePublicclassToFfi(PublicClass value) =>
   _smokePublicclassCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_type_collection.dart
@@ -10,7 +10,7 @@ class InternalStruct {
   String internal_stringField;
   InternalStruct(this.internal_stringField);
   /// @nodoc
-  void internal_fooBar() => $prototype.internal_fooBar(this);
+  void fooBar() => $prototype.fooBar(this);
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = InternalStruct$Impl();
@@ -31,7 +31,7 @@ final _smokePublictypecollectionInternalstructGetFieldstringField = __lib.catchA
 /// @nodoc
 @visibleForTesting
 class InternalStruct$Impl {
-  void internal_fooBar(InternalStruct $that) {
+  void fooBar(InternalStruct $that) {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PublicTypeCollection_InternalStruct_fooBar'));
     final _handle = smokePublictypecollectionInternalstructToFfi($that);
     _fooBarFfi(_handle, __lib.LibraryContext.isolateId);


### PR DESCRIPTION
Updated Dart generator and templates to always skip "internal" functions,
properties, constructors, and field constructors. That prevents accidental leaks
of internal APIs to public (the leaks happen due to lack of real "internal"
visibility in Dart).

See: #1333
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>