### PR TITLE
Relax validation restrictions for `@Equatable` structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Removed:
+  * Removed all validation restrictions on `@Equatable` structs.
+
 ## 11.4.0
 Release date: 2022-06-16
 ### Removed:

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeStructsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeStructsValidator.kt
@@ -21,14 +21,11 @@ package com.here.gluecodium.validator
 
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.model.lime.LimeAttributeType
-import com.here.gluecodium.model.lime.LimeContainer
-import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeStruct
 
 /**
- * Validates equatable structs to ensure their fields have equatable types. Validates structs with
- * instance functions to ensure they have fields.
+ * Validates structs with instance functions to ensure they have fields.
  *
  * With [strictMode] enabled, there are additional validations: a struct must have explicit constructors defined if
  * * either it is `@Immutable`,
@@ -38,9 +35,6 @@ internal class LimeStructsValidator(private val logger: LimeLogger, private val 
 
     fun validate(limeModel: LimeModel): Boolean {
         val allStructs = limeModel.referenceMap.values.filterIsInstance<LimeStruct>()
-        val equatableValidationResults = allStructs
-            .filter { it.attributes.have(LimeAttributeType.EQUATABLE) }
-            .map { validateEquatable(it) }
         val constrValidationResults = allStructs.map { validateConstructability(it) }
         val strictValidationResults =
             when {
@@ -48,29 +42,7 @@ internal class LimeStructsValidator(private val logger: LimeLogger, private val 
                 else -> emptyList()
             }
 
-        return !(equatableValidationResults + constrValidationResults + strictValidationResults).contains(false)
-    }
-
-    private fun validateEquatable(limeStruct: LimeStruct): Boolean {
-        val nonEquatableFieldTypes = limeStruct.childTypes.asSequence()
-            .map { it.type }
-            .filterNot { it is LimeContainerWithInheritance }
-            .filterNot { it.attributes.have(LimeAttributeType.EQUATABLE) }
-
-        return when {
-            limeStruct.fields.isEmpty() -> {
-                logger.error(limeStruct, "an equatable struct should have at least one field")
-                false
-            }
-            nonEquatableFieldTypes.any { it is LimeContainer } -> {
-                logger.error(
-                    limeStruct,
-                    "fields of non-equatable types are not supported for equatable structs"
-                )
-                false
-            }
-            else -> true
-        }
+        return !(constrValidationResults + strictValidationResults).contains(false)
     }
 
     private fun validateConstructability(limeStruct: LimeStruct): Boolean {

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeStructsValidatorTest.kt
@@ -19,16 +19,10 @@
 
 package com.here.gluecodium.validator
 
-import com.here.gluecodium.model.lime.LimeAttributeType
-import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
-import com.here.gluecodium.model.lime.LimeContainerWithInheritance
-import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
-import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
-import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
 import com.here.gluecodium.model.lime.LimeStruct
@@ -45,76 +39,7 @@ class LimeStructsValidatorTest {
     private val allElements = mutableMapOf<String, LimeElement>()
     private val limeModel = LimeModel(allElements, emptyList())
 
-    private val equatableAttributes =
-        LimeAttributes.Builder().addAttribute(LimeAttributeType.EQUATABLE).build()
-
     private val validator = LimeStructsValidator(mockk(relaxed = true), strictMode = false)
-
-    @Test
-    fun validateEquatableWithBasicType() {
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeBasicTypeRef.INT)
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertTrue(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithEnumType() {
-        val limeEnum = LimeEnumeration(EMPTY_PATH)
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeEnum))
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertTrue(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithArrayType() {
-        val limeArray = LimeList(LimeBasicTypeRef.INT)
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeArray))
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertTrue(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithEquatableStructType() {
-        val otherStruct = LimeStruct(EMPTY_PATH, attributes = equatableAttributes)
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(otherStruct))
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertTrue(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithNonEquatableStructType() {
-        val otherStruct = LimeStruct(EMPTY_PATH)
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(otherStruct))
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertFalse(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithContainerType() {
-        val limeContainer = object : LimeContainerWithInheritance(EMPTY_PATH) {}
-        val limeField = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeContainer))
-        allElements[""] =
-            LimeStruct(EMPTY_PATH, attributes = equatableAttributes, fields = listOf(limeField))
-
-        assertTrue(validator.validate(limeModel))
-    }
-
-    @Test
-    fun validateEquatableWithNoFields() {
-        allElements[""] = LimeStruct(EMPTY_PATH, attributes = equatableAttributes)
-
-        assertFalse(validator.validate(limeModel))
-    }
 
     @Test
     fun validateConstructabilityWithNothing() {


### PR DESCRIPTION
Removed all validation restrictions for `@Equatable` structs. Some corner cases
could still produce uncompilable code (no-fields structs, fields of `exception`
type, etc.). But these corner cases have no real-world usage. And they will not
"leak" into incorrect runtime behavior, but will still be caught at code
compilation.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>