### PR TITLE
Add `private` visibility to LIME model

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -219,7 +219,7 @@ internal class DartGenerator : Generator {
         val nonExternalTypes = allTypes.filter { it.external?.dart == null }
         val freeConstants = (rootElement as? LimeTypesCollection)?.constants ?: emptyList()
         val allSymbols =
-            (nonExternalTypes + freeConstants).filter { it !is LimeTypesCollection && !it.visibility.isInternal }
+            (nonExternalTypes + freeConstants).filter { it !is LimeTypesCollection && it.visibility.isPublic }
         if (allSymbols.isNotEmpty()) {
             val allNames = allSymbols.map { dartNameResolver.resolveName(it) }
             val testNames = allSymbols

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -102,8 +102,9 @@ internal class DartNameResolver(
 
     private fun resolveVisibility(limeVisibility: LimeVisibility) =
         when (limeVisibility) {
+            LimeVisibility.PUBLIC -> ""
             LimeVisibility.INTERNAL -> "internal$joinInfix"
-            else -> ""
+            LimeVisibility.PRIVATE -> "_"
         }
 
     private fun resolveBasicType(typeId: TypeId) =

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -107,7 +107,12 @@ internal class JavaNameResolver(
         return commentsProcessor.process(commentedElement.fullName, commentText, limeToJavaNames, limeLogger)
     }
 
-    private fun resolveVisibility(limeVisibility: LimeVisibility) = if (limeVisibility.isInternal) "" else "public "
+    private fun resolveVisibility(limeVisibility: LimeVisibility) =
+        when (limeVisibility) {
+            LimeVisibility.PUBLIC -> "public "
+            LimeVisibility.INTERNAL -> ""
+            LimeVisibility.PRIVATE -> "private "
+        }
 
     private fun resolveAccessorName(element: Any, rule: JavaNameRules.(LimeTypedElement) -> String) =
         (element as? LimeTypedElement)?.let { javaNameRules.rule(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -87,7 +87,11 @@ internal class SwiftNameResolver(
         }
 
     private fun resolveVisibility(limeVisibility: LimeVisibility) =
-        if (limeVisibility.isInternal) "internal" else "public"
+        when (limeVisibility) {
+            LimeVisibility.PUBLIC -> "public"
+            LimeVisibility.INTERNAL -> "internal"
+            LimeVisibility.PRIVATE -> "fileprivate"
+        }
 
     private fun resolveBasicType(typeId: TypeId) =
         when (typeId) {

--- a/gluecodium/src/main/resources/templates/swift/ConversionVisibility.mustache
+++ b/gluecodium/src/main/resources/templates/swift/ConversionVisibility.mustache
@@ -18,4 +18,4 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#if this.visibility.isInternal}}internal{{/if}}{{#unless this.visibility.isInternal}}{{conversionVisibility}}{{/unless}}
+{{#unless this.visibility.isPublic}}internal{{/unless}}{{#if this.visibility.isPublic}}{{conversionVisibility}}{{/if}}

--- a/lime-loader/src/main/antlr/LimeLexer.g4
+++ b/lime-loader/src/main/antlr/LimeLexer.g4
@@ -73,6 +73,7 @@ Lambda: 'lambda' ;
 Narrow: 'narrow' ;
 Open: 'open' ;
 Package: 'package' ;
+Private: 'private' ;
 Property: 'property' ;
 Public: 'public' ;
 Set: 'set' ;

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeStruct.kt
@@ -60,7 +60,7 @@ class LimeStruct(
 
     @Suppress("unused")
     val publicFields
-        get() = fields.filter { !it.visibility.isInternal }
+        get() = fields.filter { it.visibility.isPublic }
 
     val internalFields
         get() = fields.filter { it.visibility.isInternal }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeVisibility.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeVisibility.kt
@@ -20,11 +20,20 @@
 package com.here.gluecodium.model.lime
 
 enum class LimeVisibility(
-    private val tag: String,
-    val isInternal: Boolean = false
+    private val tag: String
 ) {
     PUBLIC(""),
-    INTERNAL("internal ", isInternal = true);
+    INTERNAL("internal "),
+    PRIVATE("private ");
+
+    val isPublic
+        get() = this == PUBLIC
+
+    val isInternal
+        get() = this == INTERNAL
+
+    val isPrivate
+        get() = this == PRIVATE
 
     override fun toString() = tag
 }


### PR DESCRIPTION
Added `LimeVisibility.PRIVATE` and associated flags to LIME model. Updated
usages of existing `isInternal` to new flags, where appropriate.

The actual implementation of syntax and output language support will be in a
separate commit.

See: #1333
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>