### PR TITLE
Make "internal" fields private in Dart

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -105,7 +105,7 @@ internal class DartNameResolver(
     private fun resolveVisibility(limeVisibility: LimeVisibility) =
         when (limeVisibility) {
             LimeVisibility.PUBLIC -> ""
-            LimeVisibility.INTERNAL -> "internal$joinInfix"
+            LimeVisibility.INTERNAL -> "_"
         }
 
     private fun resolveBasicType(typeId: TypeId) =

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/internal_enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/internal_enum_defaults.dart
@@ -8,13 +8,13 @@ class InternalEnumDefaults {
   List<FooBarEnum> publicListField;
   /// @nodoc
   @internal
-  FooBarEnum internal_internalField;
+  FooBarEnum _internalField;
   /// @nodoc
   @internal
-  List<FooBarEnum> internal_internalListField;
-  InternalEnumDefaults._(this.publicField, this.publicListField, this.internal_internalField, this.internal_internalListField);
+  List<FooBarEnum> _internalListField;
+  InternalEnumDefaults._(this.publicField, this.publicListField, this._internalField, this._internalListField);
   InternalEnumDefaults()
-    : publicField = FooBarEnum.foo, publicListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz], internal_internalField = FooBarEnum.bar, internal_internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz];
+    : publicField = FooBarEnum.foo, publicListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz], _internalField = FooBarEnum.bar, _internalListField = [FooBarEnum.foo, FooBarEnum.bar, FooBarEnum.baz];
 }
 // InternalEnumDefaults "private" section, not exported.
 final _smokeInternalenumdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -44,8 +44,8 @@ final _smokeInternalenumdefaultsGetFieldinternalListField = __lib.catchArgumentE
 Pointer<Void> smokeInternalenumdefaultsToFfi(InternalEnumDefaults value) {
   final _publicFieldHandle = smokeFoobarenumToFfi(value.publicField);
   final _publicListFieldHandle = listofSmokeFoobarenumToFfi(value.publicListField);
-  final _internalFieldHandle = smokeFoobarenumToFfi(value.internal_internalField);
-  final _internalListFieldHandle = listofSmokeFoobarenumToFfi(value.internal_internalListField);
+  final _internalFieldHandle = smokeFoobarenumToFfi(value._internalField);
+  final _internalListFieldHandle = listofSmokeFoobarenumToFfi(value._internalListField);
   final _result = _smokeInternalenumdefaultsCreateHandle(_publicFieldHandle, _publicListFieldHandle, _internalFieldHandle, _internalListFieldHandle);
   smokeFoobarenumReleaseFfiHandle(_publicFieldHandle);
   listofSmokeFoobarenumReleaseFfiHandle(_publicListFieldHandle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_struct_with_internal_fields.dart
@@ -8,36 +8,36 @@ class EquatableStructWithInternalFields {
   String publicField;
   /// @nodoc
   @internal
-  String internal_internalField;
+  String _internalField;
   /// @nodoc
   @internal
-  List<String> internal_internalListField;
+  List<String> _internalListField;
   /// @nodoc
   @internal
-  Map<String, String> internal_internalMapField;
+  Map<String, String> _internalMapField;
   /// @nodoc
   @internal
-  Set<String> internal_internalSetField;
-  EquatableStructWithInternalFields(this.publicField, this.internal_internalField, this.internal_internalListField, this.internal_internalMapField, this.internal_internalSetField);
+  Set<String> _internalSetField;
+  EquatableStructWithInternalFields(this.publicField, this._internalField, this._internalListField, this._internalMapField, this._internalSetField);
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! EquatableStructWithInternalFields) return false;
     EquatableStructWithInternalFields _other = other;
     return publicField == _other.publicField &&
-        internal_internalField == _other.internal_internalField &&
-        DeepCollectionEquality().equals(internal_internalListField, _other.internal_internalListField) &&
-        DeepCollectionEquality().equals(internal_internalMapField, _other.internal_internalMapField) &&
-        DeepCollectionEquality().equals(internal_internalSetField, _other.internal_internalSetField);
+        _internalField == _other._internalField &&
+        DeepCollectionEquality().equals(_internalListField, _other._internalListField) &&
+        DeepCollectionEquality().equals(_internalMapField, _other._internalMapField) &&
+        DeepCollectionEquality().equals(_internalSetField, _other._internalSetField);
   }
   @override
   int get hashCode {
     int result = 7;
     result = 31 * result + publicField.hashCode;
-    result = 31 * result + internal_internalField.hashCode;
-    result = 31 * result + DeepCollectionEquality().hash(internal_internalListField);
-    result = 31 * result + DeepCollectionEquality().hash(internal_internalMapField);
-    result = 31 * result + DeepCollectionEquality().hash(internal_internalSetField);
+    result = 31 * result + _internalField.hashCode;
+    result = 31 * result + DeepCollectionEquality().hash(_internalListField);
+    result = 31 * result + DeepCollectionEquality().hash(_internalMapField);
+    result = 31 * result + DeepCollectionEquality().hash(_internalSetField);
     return result;
   }
 }
@@ -72,10 +72,10 @@ final _smokeEquatablestructwithinternalfieldsGetFieldinternalSetField = __lib.ca
   >('library_smoke_EquatableStructWithInternalFields_get_field_internalSetField'));
 Pointer<Void> smokeEquatablestructwithinternalfieldsToFfi(EquatableStructWithInternalFields value) {
   final _publicFieldHandle = stringToFfi(value.publicField);
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
-  final _internalListFieldHandle = foobarListofStringToFfi(value.internal_internalListField);
-  final _internalMapFieldHandle = foobarMapofStringToStringToFfi(value.internal_internalMapField);
-  final _internalSetFieldHandle = foobarSetofStringToFfi(value.internal_internalSetField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
+  final _internalListFieldHandle = foobarListofStringToFfi(value._internalListField);
+  final _internalMapFieldHandle = foobarMapofStringToStringToFfi(value._internalMapField);
+  final _internalSetFieldHandle = foobarSetofStringToFfi(value._internalSetField);
   final _result = _smokeEquatablestructwithinternalfieldsCreateHandle(_publicFieldHandle, _internalFieldHandle, _internalListFieldHandle, _internalMapFieldHandle, _internalSetFieldHandle);
   stringReleaseFfiHandle(_publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_internal_fields.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_internal_fields.dart
@@ -7,12 +7,12 @@ class FieldConstructorsInternalFields {
   int intField;
   /// @nodoc
   @internal
-  bool internal_boolField;
+  bool _boolField;
   FieldConstructorsInternalFields.withAll()
-      : stringField = "nonsense", intField = 42, internal_boolField = true;
+      : stringField = "nonsense", intField = 42, _boolField = true;
   FieldConstructorsInternalFields.withTrue(this.intField, this.stringField)
-      : internal_boolField = true;
-  FieldConstructorsInternalFields(this.internal_boolField, this.intField, this.stringField);
+      : _boolField = true;
+  FieldConstructorsInternalFields(this._boolField, this.intField, this.stringField);
 }
 // FieldConstructorsInternalFields "private" section, not exported.
 final _smokeFieldconstructorsinternalfieldsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -38,7 +38,7 @@ final _smokeFieldconstructorsinternalfieldsGetFieldboolField = __lib.catchArgume
 Pointer<Void> smokeFieldconstructorsinternalfieldsToFfi(FieldConstructorsInternalFields value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _intFieldHandle = (value.intField);
-  final _boolFieldHandle = booleanToFfi(value.internal_boolField);
+  final _boolFieldHandle = booleanToFfi(value._boolField);
   final _result = _smokeFieldconstructorsinternalfieldsCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   booleanReleaseFfiHandle(_boolFieldHandle);

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init.dart
@@ -6,10 +6,10 @@ class PublicFieldsAllInit {
   String publicField;
   /// @nodoc
   @internal
-  String internal_internalField;
-  PublicFieldsAllInit._(this.publicField, this.internal_internalField);
+  String _internalField;
+  PublicFieldsAllInit._(this.publicField, this._internalField);
   PublicFieldsAllInit()
-    : publicField = "bar", internal_internalField = "foo";
+    : publicField = "bar", _internalField = "foo";
 }
 // PublicFieldsAllInit "private" section, not exported.
 final _smokePublicfieldsallinitCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -30,7 +30,7 @@ final _smokePublicfieldsallinitGetFieldinternalField = __lib.catchArgumentError(
   >('library_smoke_PublicFieldsAllInit_get_field_internalField'));
 Pointer<Void> smokePublicfieldsallinitToFfi(PublicFieldsAllInit value) {
   final _publicFieldHandle = stringToFfi(value.publicField);
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
   final _result = _smokePublicfieldsallinitCreateHandle(_publicFieldHandle, _internalFieldHandle);
   stringReleaseFfiHandle(_publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init_pos_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_all_init_pos_defaults.dart
@@ -6,9 +6,9 @@ class PublicFieldsAllInitPosDefaults {
   String publicField;
   /// @nodoc
   @internal
-  String internal_internalField;
+  String _internalField;
   PublicFieldsAllInitPosDefaults([String publicField = "bar", String internalField = "foo"])
-    : publicField = publicField, internal_internalField = internalField;
+    : publicField = publicField, _internalField = internalField;
 }
 // PublicFieldsAllInitPosDefaults "private" section, not exported.
 final _smokePublicfieldsallinitposdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -29,7 +29,7 @@ final _smokePublicfieldsallinitposdefaultsGetFieldinternalField = __lib.catchArg
   >('library_smoke_PublicFieldsAllInitPosDefaults_get_field_internalField'));
 Pointer<Void> smokePublicfieldsallinitposdefaultsToFfi(PublicFieldsAllInitPosDefaults value) {
   final _publicFieldHandle = stringToFfi(value.publicField);
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
   final _result = _smokePublicfieldsallinitposdefaultsCreateHandle(_publicFieldHandle, _internalFieldHandle);
   stringReleaseFfiHandle(_publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_mixed_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_mixed_init.dart
@@ -7,10 +7,10 @@ class PublicFieldsMixedInit {
   String publicField2;
   /// @nodoc
   @internal
-  String internal_internalField;
-  PublicFieldsMixedInit._(this.publicField1, this.publicField2, this.internal_internalField);
+  String _internalField;
+  PublicFieldsMixedInit._(this.publicField1, this.publicField2, this._internalField);
   PublicFieldsMixedInit(String publicField2)
-    : publicField1 = "bar", publicField2 = publicField2, internal_internalField = "foo";
+    : publicField1 = "bar", publicField2 = publicField2, _internalField = "foo";
 }
 // PublicFieldsMixedInit "private" section, not exported.
 final _smokePublicfieldsmixedinitCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -36,7 +36,7 @@ final _smokePublicfieldsmixedinitGetFieldinternalField = __lib.catchArgumentErro
 Pointer<Void> smokePublicfieldsmixedinitToFfi(PublicFieldsMixedInit value) {
   final _publicField1Handle = stringToFfi(value.publicField1);
   final _publicField2Handle = stringToFfi(value.publicField2);
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
   final _result = _smokePublicfieldsmixedinitCreateHandle(_publicField1Handle, _publicField2Handle, _internalFieldHandle);
   stringReleaseFfiHandle(_publicField1Handle);
   stringReleaseFfiHandle(_publicField2Handle);

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_no_init.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_no_init.dart
@@ -6,10 +6,10 @@ class PublicFieldsNoInit {
   String publicField;
   /// @nodoc
   @internal
-  String internal_internalField;
-  PublicFieldsNoInit._(this.publicField, this.internal_internalField);
+  String _internalField;
+  PublicFieldsNoInit._(this.publicField, this._internalField);
   PublicFieldsNoInit(String publicField)
-    : publicField = publicField, internal_internalField = "foo";
+    : publicField = publicField, _internalField = "foo";
 }
 // PublicFieldsNoInit "private" section, not exported.
 final _smokePublicfieldsnoinitCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -30,7 +30,7 @@ final _smokePublicfieldsnoinitGetFieldinternalField = __lib.catchArgumentError((
   >('library_smoke_PublicFieldsNoInit_get_field_internalField'));
 Pointer<Void> smokePublicfieldsnoinitToFfi(PublicFieldsNoInit value) {
   final _publicFieldHandle = stringToFfi(value.publicField);
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
   final _result = _smokePublicfieldsnoinitCreateHandle(_publicFieldHandle, _internalFieldHandle);
   stringReleaseFfiHandle(_publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);

--- a/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_none.dart
+++ b/gluecodium/src/test/resources/smoke/internal_fields/output/dart/lib/src/smoke/public_fields_none.dart
@@ -5,10 +5,10 @@ import 'package:meta/meta.dart';
 class PublicFieldsNone {
   /// @nodoc
   @internal
-  String internal_internalField;
-  PublicFieldsNone._(this.internal_internalField);
+  String _internalField;
+  PublicFieldsNone._(this._internalField);
   PublicFieldsNone()
-    : internal_internalField = "foo";
+    : _internalField = "foo";
 }
 // PublicFieldsNone "private" section, not exported.
 final _smokePublicfieldsnoneCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -24,7 +24,7 @@ final _smokePublicfieldsnoneGetFieldinternalField = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicFieldsNone_get_field_internalField'));
 Pointer<Void> smokePublicfieldsnoneToFfi(PublicFieldsNone value) {
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
   final _result = _smokePublicfieldsnoneCreateHandle(_internalFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);
   return _result;

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
@@ -68,8 +68,8 @@ void smokePublicclassInternalenumReleaseFfiHandleNullable(Pointer<Void> handle) 
 class PublicClass_InternalStruct {
   /// @nodoc
   @internal
-  String internal_stringField;
-  PublicClass_InternalStruct(this.internal_stringField);
+  String _stringField;
+  PublicClass_InternalStruct(this._stringField);
 }
 // PublicClass_InternalStruct "private" section, not exported.
 final _smokePublicclassInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -85,7 +85,7 @@ final _smokePublicclassInternalstructGetFieldstringField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_get_field_stringField'));
 Pointer<Void> smokePublicclassInternalstructToFfi(PublicClass_InternalStruct value) {
-  final _stringFieldHandle = stringToFfi(value.internal_stringField);
+  final _stringFieldHandle = stringToFfi(value._stringField);
   final _result = _smokePublicclassInternalstructCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
@@ -134,8 +134,8 @@ void smokePublicclassInternalstructReleaseFfiHandleNullable(Pointer<Void> handle
 class PublicClass_PublicStruct {
   /// @nodoc
   @internal
-  PublicClass_InternalStruct internal_internalField;
-  PublicClass_PublicStruct(this.internal_internalField);
+  PublicClass_InternalStruct _internalField;
+  PublicClass_PublicStruct(this._internalField);
 }
 // PublicClass_PublicStruct "private" section, not exported.
 final _smokePublicclassPublicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -151,7 +151,7 @@ final _smokePublicclassPublicstructGetFieldinternalField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_get_field_internalField'));
 Pointer<Void> smokePublicclassPublicstructToFfi(PublicClass_PublicStruct value) {
-  final _internalFieldHandle = smokePublicclassInternalstructToFfi(value.internal_internalField);
+  final _internalFieldHandle = smokePublicclassInternalstructToFfi(value._internalField);
   final _result = _smokePublicclassPublicstructCreateHandle(_internalFieldHandle);
   smokePublicclassInternalstructReleaseFfiHandle(_internalFieldHandle);
   return _result;
@@ -200,11 +200,11 @@ void smokePublicclassPublicstructReleaseFfiHandleNullable(Pointer<Void> handle) 
 class PublicClass_PublicStructWithInternalDefaults {
   /// @nodoc
   @internal
-  String internal_internalField;
+  String _internalField;
   double publicField;
-  PublicClass_PublicStructWithInternalDefaults._(this.internal_internalField, this.publicField);
+  PublicClass_PublicStructWithInternalDefaults._(this._internalField, this.publicField);
   PublicClass_PublicStructWithInternalDefaults(double publicField)
-    : internal_internalField = "foo", publicField = publicField;
+    : _internalField = "foo", publicField = publicField;
 }
 // PublicClass_PublicStructWithInternalDefaults "private" section, not exported.
 final _smokePublicclassPublicstructwithinternaldefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -224,7 +224,7 @@ final _smokePublicclassPublicstructwithinternaldefaultsGetFieldpublicField = __l
     double Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField'));
 Pointer<Void> smokePublicclassPublicstructwithinternaldefaultsToFfi(PublicClass_PublicStructWithInternalDefaults value) {
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
   final _publicFieldHandle = (value.publicField);
   final _result = _smokePublicclassPublicstructwithinternaldefaultsCreateHandle(_internalFieldHandle, _publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_interface.dart
@@ -14,8 +14,8 @@ abstract class PublicInterface {
 class PublicInterface_InternalStruct {
   /// @nodoc
   @internal
-  PublicClass_InternalStruct internal_fieldOfInternalType;
-  PublicInterface_InternalStruct(this.internal_fieldOfInternalType);
+  PublicClass_InternalStruct _fieldOfInternalType;
+  PublicInterface_InternalStruct(this._fieldOfInternalType);
 }
 // PublicInterface_InternalStruct "private" section, not exported.
 final _smokePublicinterfaceInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -31,7 +31,7 @@ final _smokePublicinterfaceInternalstructGetFieldfieldOfInternalType = __lib.cat
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType'));
 Pointer<Void> smokePublicinterfaceInternalstructToFfi(PublicInterface_InternalStruct value) {
-  final _fieldOfInternalTypeHandle = smokePublicclassInternalstructToFfi(value.internal_fieldOfInternalType);
+  final _fieldOfInternalTypeHandle = smokePublicclassInternalstructToFfi(value._fieldOfInternalType);
   final _result = _smokePublicinterfaceInternalstructCreateHandle(_fieldOfInternalTypeHandle);
   smokePublicclassInternalstructReleaseFfiHandle(_fieldOfInternalTypeHandle);
   return _result;

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_struct_with_non_default_internal_field.dart
@@ -6,11 +6,11 @@ class PublicStructWithNonDefaultInternalField {
   int defaultedField;
   /// @nodoc
   @internal
-  String internal_internalField;
+  String _internalField;
   bool publicField;
-  PublicStructWithNonDefaultInternalField._(this.defaultedField, this.internal_internalField, this.publicField);
+  PublicStructWithNonDefaultInternalField._(this.defaultedField, this._internalField, this.publicField);
   PublicStructWithNonDefaultInternalField(String internalField, bool publicField)
-    : defaultedField = 42, internal_internalField = internalField, publicField = publicField;
+    : defaultedField = 42, _internalField = internalField, publicField = publicField;
 }
 // PublicStructWithNonDefaultInternalField "private" section, not exported.
 final _smokePublicstructwithnondefaultinternalfieldCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -35,7 +35,7 @@ final _smokePublicstructwithnondefaultinternalfieldGetFieldpublicField = __lib.c
   >('library_smoke_PublicStructWithNonDefaultInternalField_get_field_publicField'));
 Pointer<Void> smokePublicstructwithnondefaultinternalfieldToFfi(PublicStructWithNonDefaultInternalField value) {
   final _defaultedFieldHandle = (value.defaultedField);
-  final _internalFieldHandle = stringToFfi(value.internal_internalField);
+  final _internalFieldHandle = stringToFfi(value._internalField);
   final _publicFieldHandle = booleanToFfi(value.publicField);
   final _result = _smokePublicstructwithnondefaultinternalfieldCreateHandle(_defaultedFieldHandle, _internalFieldHandle, _publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_type_collection.dart
@@ -7,8 +7,8 @@ import 'package:meta/meta.dart';
 class InternalStruct {
   /// @nodoc
   @internal
-  String internal_stringField;
-  InternalStruct(this.internal_stringField);
+  String _stringField;
+  InternalStruct(this._stringField);
   /// @nodoc
   void fooBar() => $prototype.fooBar(this);
   /// @nodoc
@@ -39,7 +39,7 @@ class InternalStruct$Impl {
   }
 }
 Pointer<Void> smokePublictypecollectionInternalstructToFfi(InternalStruct value) {
-  final _stringFieldHandle = stringToFfi(value.internal_stringField);
+  final _stringFieldHandle = stringToFfi(value._stringField);
   final _result = _smokePublictypecollectionInternalstructCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;


### PR DESCRIPTION
Updated Dart name resolver to resolve "internal" visibility to "_". This makes
the affected elements file-private in Dart. The only remaining elements that are
affected by this are struct fields.

This prevents accidental leaks of internal APIs to public (the leaks happen due
to lack of real "internal" visibility in Dart). Making the fields private
instead of just skipping them is necessary to preserve the data in the
non-public field for language boundary transitions.

See: #1333
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>