### PR TITLE
Refactor LimeSignatureResolver

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftSignatureResolver.kt
@@ -30,10 +30,11 @@ internal class SwiftSignatureResolver(
     nameRules: SwiftNameRules,
     activeTags: Set<String>
 ) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.SWIFT, nameRules, activeTags) {
+
     fun isOverloadingConstructor(limeFunction: LimeFunction): Boolean {
         val container = getContainer(limeFunction) ?: return false
-        val overloads = getOwnAndParentFunctions(container).filter { it.isConstructor }
-        return hasSignatureClash(limeFunction, overloads)
+        val allFunctions = getOwnFunctions(container) + getParentFunctions(container)
+        return hasSignatureClash(limeFunction, allFunctions.filter { it.isConstructor })
     }
 
     override fun getParameterSignature(limeParameter: LimeParameter) =

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeSignatureResolver.kt
@@ -59,11 +59,10 @@ open class LimeSignatureResolver(private val referenceMap: Map<String, LimeEleme
         return getOwnFunctions(parentElement).filter { getFunctionName(it) == functionName }
     }
 
-    protected fun getOwnAndParentFunctions(limeContainer: LimeContainer): List<LimeFunction> {
+    protected fun getParentFunctions(limeContainer: LimeContainer): List<LimeFunction> {
         val parentTypes = (limeContainer as? LimeContainerWithInheritance)?.parents ?: emptyList()
-        val parentFunctions =
-            parentTypes.mapNotNull { it.type.actualType as? LimeContainer }.flatMap { getOwnAndParentFunctions(it) }
-        return parentFunctions + getOwnFunctions(limeContainer)
+        return parentTypes.mapNotNull { it.type.actualType as? LimeContainer }
+            .flatMap { getOwnFunctions(it) + getParentFunctions(it) }
     }
 
     protected open fun getOwnFunctions(limeContainer: LimeContainer) =


### PR DESCRIPTION
Refactored `LimeSignatureResolver.getOwnAndParentFunctions()` into
`getParentFunctions()` instead.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>