### PR TITLE
Revert "Remove support for visibility modifiers on constants (#1377)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features:
   * Added support for declaring `typealias` and `lambda` elements inside a `struct`.
+  * Restored support for `internal const`.
 ### Breaking changes:
   * Support for `@Swift(Extension)` attribute was removed.
 

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -105,7 +105,7 @@ such a prefix is considered `public`. The visibility prefix, if present, should 
 
 * Example: `internal static property secretDelegate: ProcessorDelegate? { get set }`
 * List of element kinds that can have a visibility prefix: class, interface, types, function, constructor, property, 
-struct, struct field, enumeration, exception, type alias, lambda, consstant.
+struct, struct field, enumeration, exception, type alias, lambda, constant.
 * Visibility prefix has no effect on C++ generated code.
 * `open` and `open internal` are currently only supported for classes. Both mean the class can be
 inherited from (see `Inheritance` below).

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -104,8 +104,8 @@ Most elements can be prefixed with a visibility prefix. Possible visibility pref
 such a prefix is considered `public`. The visibility prefix, if present, should precede the rest of the declaration.
 
 * Example: `internal static property secretDelegate: ProcessorDelegate? { get set }`
-* List of element kinds that can have a visibility prefix: class, interface, types, function,
-constructor, property, struct, struct field, enumeration, exception, type alias, lambda.
+* List of element kinds that can have a visibility prefix: class, interface, types, function, constructor, property, 
+struct, struct field, enumeration, exception, type alias, lambda, consstant.
 * Visibility prefix has no effect on C++ generated code.
 * `open` and `open internal` are currently only supported for classes. Both mean the class can be
 inherited from (see `Inheritance` below).

--- a/functional-tests/functional/input/lime/JavaExternalTypes.lime
+++ b/functional-tests/functional/input/lime/JavaExternalTypes.lime
@@ -118,5 +118,5 @@ struct VeryBoolean {
 
 struct UseJavaExternalConst {
     stringField: String
-    const defaultTruth: VeryBoolean = {true}
+    internal const defaultTruth: VeryBoolean = {true}
 }

--- a/gluecodium/src/main/resources/templates/dart/DartConstant.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartConstant.mustache
@@ -19,4 +19,4 @@
   !
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
-{{#if isInClass}}static {{/if}}final {{resolveName typeRef}} {{resolveName}} = {{resolveName value}};
+{{#if isInClass}}static {{/if}}final {{resolveName typeRef}} {{resolveName visibility}}{{resolveName}} = {{resolveName value}};

--- a/gluecodium/src/main/resources/templates/java/JavaConstant.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaConstant.mustache
@@ -19,4 +19,4 @@
   !
   !}}
 {{>java/JavaDocComment}}{{>java/JavaAttributes}}
-public static final {{resolveName typeRef}} {{resolveName}} = {{resolveName value}};
+{{resolveName visibility}}static final {{resolveName typeRef}} {{resolveName}} = {{resolveName value}};

--- a/gluecodium/src/main/resources/templates/swift/SwiftConstant.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftConstant.mustache
@@ -19,4 +19,4 @@
   !
   !}}
 {{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
-public static let {{resolveName}}: {{resolveName typeRef}} = {{resolveName value}}
+{{resolveName visibility}} static let {{resolveName}}: {{resolveName typeRef}} = {{resolveName value}}

--- a/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/JavaExternalTypes.lime
@@ -99,5 +99,5 @@ struct JavaExternalCtor {
 
 struct UseJavaExternalConst {
     stringField: String
-    const defaultTruth: JavaExternalCtor = {"foo"}
+    internal const defaultTruth: JavaExternalCtor = {"foo"}
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalConst.java
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/com/example/smoke/UseJavaExternalConst.java
@@ -4,7 +4,7 @@
 package com.example.smoke;
 import android.support.annotation.NonNull;
 public final class UseJavaExternalConst {
-    public static final com.example.Foo DEFAULT_TRUTH = new com.example.Foo("foo");
+    static final com.example.Foo DEFAULT_TRUTH = new com.example.Foo("foo");
     @NonNull
     public String stringField;
     public UseJavaExternalConst(@NonNull final String stringField) {

--- a/lime-loader/src/main/antlr/LimeParser.g4
+++ b/lime-loader/src/main/antlr/LimeParser.g4
@@ -122,7 +122,7 @@ enumerator
     ;
 
 constant
-    : docComment* annotation* 'const' NewLine* simpleId NewLine* ':' NewLine* typeRef NewLine*
+    : docComment* annotation* visibility? 'const' NewLine* simpleId NewLine* ':' NewLine* typeRef NewLine*
       '=' NewLine* literalConstant NewLine+
     ;
 

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -483,7 +483,7 @@ internal class AntlrLimeModelBuilder(
     }
 
     override fun enterConstant(ctx: LimeParser.ConstantContext) {
-        pushPathAndVisibility(ctx.simpleId(), null)
+        pushPathAndVisibility(ctx.simpleId(), ctx.visibility())
     }
 
     override fun exitConstant(ctx: LimeParser.ConstantContext) {
@@ -491,6 +491,7 @@ internal class AntlrLimeModelBuilder(
         val limeElement = LimeConstant(
             path = currentPath,
             comment = parseStructuredComment(ctx.docComment(), ctx).description,
+            visibility = currentVisibility,
             attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
             typeRef = limeTypeRef,
             value = convertLiteralConstant(limeTypeRef, ctx.literalConstant())

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
@@ -228,6 +228,7 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
         limeConstant.run {
             LimeConstant(
                 path = path,
+                visibility = visibility,
                 comment = comment,
                 attributes = attributes,
                 typeRef = typeRef,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeConstant.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeConstant.kt
@@ -21,8 +21,9 @@ package com.here.gluecodium.model.lime
 
 class LimeConstant(
     path: LimePath,
+    visibility: LimeVisibility = LimeVisibility.PUBLIC,
     comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
     typeRef: LimeTypeRef,
     val value: LimeValue
-) : LimeTypedElement(path, LimeVisibility.PUBLIC, comment, attributes, typeRef = typeRef)
+) : LimeTypedElement(path, visibility, comment, attributes, typeRef = typeRef)


### PR DESCRIPTION
This reverts commit 00ae8efd93286fa7353f3fe2eec6404d85046b9c.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>