### PR TITLE
Fix compilation for "overloading over inheritance"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 ### Features:
   * Added support for declaring `typealias` and `lambda` elements inside a `struct`.
   * Restored support for `internal const`.
-### Breaking changes:
+### Bug fixes:
+  * Fixed compilation issues in C++, JNI, and CBridge when "overloading over inheritance", i.e. both the child and the
+    parent types have functions with the same name (but of different signature).
+### Removed:
   * Support for `@Swift(Extension)` attribute was removed.
 
 ## 12.0.0

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -88,6 +88,7 @@ feature(MethodOverloading cpp android swift dart SOURCES
     input/src/cpp/MethodOverloads.cpp
 
     input/lime/MethodOverloads.lime
+    input/lime/InheritanceOverloads.lime
 )
 
 feature(Blob cpp android swift dart SOURCES

--- a/functional-tests/functional/input/lime/InheritanceOverloads.lime
+++ b/functional-tests/functional/input/lime/InheritanceOverloads.lime
@@ -1,0 +1,55 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface ParentInterfaceOverloads {
+    fun foo()
+    @Dart("fooInt")
+    fun foo(input: Int)
+    fun bar()
+    fun baz()
+}
+
+open class ParentClassOverloads {
+    fun foo()
+    @Dart("fooInt")
+    fun foo(input: Int)
+    fun bar()
+    fun baz()
+}
+
+interface ChildInterfaceOverloads: ParentInterfaceOverloads {
+    @Dart("fooString")
+    fun foo(input: String)
+    @Dart("barString")
+    fun bar(input: String)
+}
+
+class ChildClassFromInterfaceOverloads: ParentInterfaceOverloads {
+    @Dart("fooString")
+    fun foo(input: String)
+    @Dart("barString")
+    fun bar(input: String)
+}
+
+class ChildClassFromClassOverloads: ParentClassOverloads {
+    @Dart("fooString")
+    fun foo(input: String)
+    @Dart("barString")
+    fun bar(input: String)
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeNameResolver.kt
@@ -21,6 +21,7 @@ package com.here.gluecodium.generator.cbridge
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.generator.swift.SwiftNameRules
 import com.here.gluecodium.model.lime.LimeAttributeType
@@ -38,7 +39,6 @@ import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
-import com.here.gluecodium.model.lime.LimeSignatureResolver
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
@@ -47,7 +47,7 @@ internal class CBridgeNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val swiftNameRules: SwiftNameRules,
     private val internalPrefix: String,
-    private val signatureResolver: LimeSignatureResolver
+    private val signatureResolver: PlatformSignatureResolver
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     override fun resolveName(element: Any): String =
@@ -85,7 +85,7 @@ internal class CBridgeNameResolver(
 
     private fun getOverloadSuffix(limeFunction: LimeFunction) =
         when {
-            !signatureResolver.isOverloaded(limeFunction) -> emptyList()
+            !signatureResolver.isOverloadedInBindings(limeFunction) -> emptyList()
             limeFunction.parameters.isEmpty() -> listOf("")
             else -> signatureResolver.getSignature(limeFunction).map { mangleSignature(it) }
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/PlatformSignatureResolver.kt
@@ -22,7 +22,9 @@ package com.here.gluecodium.generator.common
 import com.here.gluecodium.common.LimeModelSkipPredicates
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeSignatureResolver
@@ -41,4 +43,16 @@ internal open class PlatformSignatureResolver(
     override fun getFunctionName(limeFunction: LimeFunction) =
         limeFunction.attributes.get(platformAttributeType, LimeAttributeValueType.NAME, String::class.java)
             ?: nameRules.getName(limeFunction)
+
+    fun isOverloadedInBindings(limeFunction: LimeFunction): Boolean {
+        if (isOverloaded(limeFunction)) return true
+
+        val container = getContainer(limeFunction) as? LimeContainerWithInheritance ?: return false
+        val inheritedFunctions =
+            if (container is LimeClass) container.interfaceInheritedFunctions else container.inheritedFunctions
+        if (inheritedFunctions.isEmpty()) return false
+
+        val functionName = getFunctionName(limeFunction)
+        return inheritedFunctions.any { getFunctionName(it) == functionName }
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppSignatureResolver.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeTypeRef
 
 internal class CppSignatureResolver(
@@ -36,4 +37,10 @@ internal class CppSignatureResolver(
             limeTypeRef.type.actualType is LimeContainerWithInheritance -> ""
             else -> "?"
         }
+
+    fun getInheritedOverloads(limeFunction: LimeFunction): List<LimeFunction> {
+        val container = getContainer(limeFunction) as? LimeContainerWithInheritance ?: return emptyList()
+        val functionName = getFunctionName(limeFunction)
+        return container.inheritedFunctions.filter { !it.isStatic }.filter { getFunctionName(it) == functionName }
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -89,7 +89,7 @@ internal class JniGeneratorPredicates(
             return typeId.isNumericType || typeId == VOID || typeId == BOOLEAN
         },
         "isOverloaded" to { limeFunction: Any ->
-            limeFunction is LimeFunction && javaSignatureResolver.isOverloaded(limeFunction)
+            limeFunction is LimeFunction && javaSignatureResolver.isOverloadedInBindings(limeFunction)
         },
         "needsOrdinalConversion" to fun(limeEnumeration: Any): Boolean {
             if (limeEnumeration !is LimeEnumeration) return false

--- a/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
@@ -46,7 +46,13 @@ public:
 {{#properties}}
 {{prefixPartial "cpp/CppProperty" "    "}}
 {{/properties}}
+{{#eval "functionUsings" fullName}}{{#if this}}
 
+{{#this}}
+    using {{resolveName "FQN"}};
+{{/this}}
+{{/if}}
+{{/eval}}
 {{/if}}
 {{#if attributes.equatable}}
 public:

--- a/gluecodium/src/test/resources/smoke/method_overloads/input/InheritanceOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/input/InheritanceOverloads.lime
@@ -1,0 +1,47 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+interface ParentInterface {
+    fun foo()
+    fun foo(input: Int)
+    fun bar()
+    fun baz()
+}
+
+open class ParentClass {
+    fun foo()
+    fun foo(input: Int)
+    fun bar()
+    fun baz()
+}
+
+interface ChildInterfaceOverloads: ParentInterface {
+    fun foo(input: String)
+    fun bar(input: String)
+}
+
+class ChildClassFromInterfaceOverloads: ParentInterface {
+    fun foo(input: String)
+    fun bar(input: String)
+}
+
+class ChildClassFromClassOverloads: ParentClass {
+    fun foo(input: String)
+    fun bar(input: String)
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_ChildClassFromInterfaceOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_ChildClassFromInterfaceOverloads.h
@@ -1,0 +1,23 @@
+/*
+ *
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassFromInterfaceOverloads_foo__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassFromInterfaceOverloads_bar__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassFromInterfaceOverloads_foo__(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassFromInterfaceOverloads_foo__I(JNIEnv* _jenv, jobject _jinstance, jint jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassFromInterfaceOverloads_bar(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildClassFromInterfaceOverloads_baz(JNIEnv* _jenv, jobject _jinstance);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_ChildInterfaceOverloadsImpl.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_ChildInterfaceOverloadsImpl.h
@@ -1,0 +1,23 @@
+/*
+ *
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildInterfaceOverloadsImpl_foo__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildInterfaceOverloadsImpl_bar__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildInterfaceOverloadsImpl_foo__(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildInterfaceOverloadsImpl_foo__I(JNIEnv* _jenv, jobject _jinstance, jint jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildInterfaceOverloadsImpl_bar(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ChildInterfaceOverloadsImpl_baz(JNIEnv* _jenv, jobject _jinstance);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_ChildClassFromInterfaceOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cbridge/include/smoke/cbridge_ChildClassFromInterfaceOverloads.h
@@ -1,0 +1,24 @@
+//
+//
+#pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "cbridge/include/BaseHandle.h"
+#include "cbridge/include/Export.h"
+#include <stdint.h>
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef smoke_ChildClassFromInterfaceOverloads_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT const void* smoke_ChildClassFromInterfaceOverloads_get_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_remove_swift_object_from_wrapper_cache(_baseRef handle);
+_GLUECODIUM_C_EXPORT void* smoke_ChildClassFromInterfaceOverloads_get_typed(_baseRef handle);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_foo_String(_baseRef _instance, _baseRef input);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_bar_String(_baseRef _instance, _baseRef input);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_foo_(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_foo_Int(_baseRef _instance, int32_t input);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_bar(_baseRef _instance);
+_GLUECODIUM_C_EXPORT void smoke_ChildClassFromInterfaceOverloads_baz(_baseRef _instance);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromClassOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromClassOverloads.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentClass.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ChildClassFromClassOverloads: public ::smoke::ParentClass {
+public:
+    ChildClassFromClassOverloads();
+    virtual ~ChildClassFromClassOverloads() = 0;
+public:
+    virtual void foo( const ::std::string& input ) = 0;
+    virtual void bar( const ::std::string& input ) = 0;
+    using ::smoke::ParentClass::foo;
+    using ::smoke::ParentClass::bar;
+};
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromInterfaceOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromInterfaceOverloads.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentInterface.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ChildClassFromInterfaceOverloads: public ::smoke::ParentInterface {
+public:
+    ChildClassFromInterfaceOverloads();
+    virtual ~ChildClassFromInterfaceOverloads() = 0;
+public:
+    virtual void foo( const ::std::string& input ) = 0;
+    virtual void bar( const ::std::string& input ) = 0;
+    using ::smoke::ParentInterface::foo;
+    using ::smoke::ParentInterface::bar;
+};
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildInterfaceOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildInterfaceOverloads.h
@@ -1,0 +1,20 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "smoke/ParentInterface.h"
+#include <string>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT ChildInterfaceOverloads: public ::smoke::ParentInterface {
+public:
+    ChildInterfaceOverloads();
+    virtual ~ChildInterfaceOverloads() = 0;
+public:
+    virtual void foo( const ::std::string& input ) = 0;
+    virtual void bar( const ::std::string& input ) = 0;
+    using ::smoke::ParentInterface::foo;
+    using ::smoke::ParentInterface::bar;
+};
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/ChildClassFromInterfaceOverloads.swift
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/swift/smoke/ChildClassFromInterfaceOverloads.swift
@@ -1,0 +1,114 @@
+//
+//
+import Foundation
+public class ChildClassFromInterfaceOverloads: ParentInterface {
+    let c_instance : _baseRef
+    init(cChildClassFromInterfaceOverloads: _baseRef) {
+        guard cChildClassFromInterfaceOverloads != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cChildClassFromInterfaceOverloads
+    }
+    deinit {
+        smoke_ChildClassFromInterfaceOverloads_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_ChildClassFromInterfaceOverloads_release_handle(c_instance)
+    }
+    public func foo() -> Void {
+        smoke_ChildClassFromInterfaceOverloads_foo_(self.c_instance)
+    }
+    public func foo(input: Int32) -> Void {
+        let c_input = moveToCType(input)
+        smoke_ChildClassFromInterfaceOverloads_foo_Int(self.c_instance, c_input.ref)
+    }
+    public func bar() -> Void {
+        smoke_ChildClassFromInterfaceOverloads_bar(self.c_instance)
+    }
+    public func baz() -> Void {
+        smoke_ChildClassFromInterfaceOverloads_baz(self.c_instance)
+    }
+    public func foo(input: String) -> Void {
+        let c_input = moveToCType(input)
+        smoke_ChildClassFromInterfaceOverloads_foo_String(self.c_instance, c_input.ref)
+    }
+    public func bar(input: String) -> Void {
+        let c_input = moveToCType(input)
+        smoke_ChildClassFromInterfaceOverloads_bar_String(self.c_instance, c_input.ref)
+    }
+}
+@_cdecl("_CBridgeInitsmoke_ChildClassFromInterfaceOverloads")
+internal func _CBridgeInitsmoke_ChildClassFromInterfaceOverloads(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = ChildClassFromInterfaceOverloads(cChildClassFromInterfaceOverloads: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+internal func getRef(_ ref: ChildClassFromInterfaceOverloads?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_ChildClassFromInterfaceOverloads_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_ChildClassFromInterfaceOverloads_release_handle)
+        : RefHolder(handle_copy)
+}
+extension ChildClassFromInterfaceOverloads: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+extension ChildClassFromInterfaceOverloads: Hashable {
+    /// :nodoc:
+    public static func == (lhs: ChildClassFromInterfaceOverloads, rhs: ChildClassFromInterfaceOverloads) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+internal func ChildClassFromInterfaceOverloads_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterfaceOverloads {
+    if let swift_pointer = smoke_ChildClassFromInterfaceOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterfaceOverloads {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ChildClassFromInterfaceOverloads_get_typed(smoke_ChildClassFromInterfaceOverloads_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildClassFromInterfaceOverloads {
+        smoke_ChildClassFromInterfaceOverloads_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ChildClassFromInterfaceOverloads_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterfaceOverloads {
+    if let swift_pointer = smoke_ChildClassFromInterfaceOverloads_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ChildClassFromInterfaceOverloads {
+        smoke_ChildClassFromInterfaceOverloads_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_ChildClassFromInterfaceOverloads_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? ChildClassFromInterfaceOverloads {
+        smoke_ChildClassFromInterfaceOverloads_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+internal func ChildClassFromInterfaceOverloads_copyFromCType(_ handle: _baseRef) -> ChildClassFromInterfaceOverloads? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ChildClassFromInterfaceOverloads_moveFromCType(handle) as ChildClassFromInterfaceOverloads
+}
+internal func ChildClassFromInterfaceOverloads_moveFromCType(_ handle: _baseRef) -> ChildClassFromInterfaceOverloads? {
+    guard handle != 0 else {
+        return nil
+    }
+    return ChildClassFromInterfaceOverloads_moveFromCType(handle) as ChildClassFromInterfaceOverloads
+}
+internal func copyToCType(_ swiftClass: ChildClassFromInterfaceOverloads) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ChildClassFromInterfaceOverloads) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+internal func copyToCType(_ swiftClass: ChildClassFromInterfaceOverloads?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+internal func moveToCType(_ swiftClass: ChildClassFromInterfaceOverloads?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}


### PR DESCRIPTION
Fixed varios compilation issues when "overloading over inheritance". For
C++, adding a `using` directive for the parent functions in the child
class. For JNI and CBridge, adding a signature suffix to the C
functions.

For Dart FFI no changes, since it has this logic in place already, due
to overloading being absent from the Dart language as a concept
entirely.

Resolves: #1401
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>
