### PR TITLE
Don't use `types` in "namerules" tests

### DIFF
--- a/functional-tests/namerules/input/lime/NameRules.lime
+++ b/functional-tests/namerules/input/lime/NameRules.lime
@@ -17,23 +17,21 @@
 
 package namerules
 
-types HelloWorldParcelable {
-    @Serializable
-    struct State {
-        dimension: Dimension
-        orientation: Orientation
-    }
+@Serializable
+struct State {
+    dimension: Dimension
+    orientation: Orientation
+}
 
-    @Serializable
-    struct Dimension {
-        width: Int
-        height: Int
-    }
+@Serializable
+struct Dimension {
+    width: Int
+    height: Int
+}
 
-    enum Orientation {
-        PORTRAIT,
-        LANDSCAPE
-    }
+enum Orientation {
+    PORTRAIT,
+    LANDSCAPE
 }
 
 class CustomNameRules {


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>