### PR TITLE
Revert "Remove support for `types` keyword (#1411)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Gluecodium project Release Notes
 
-## Unreleased
-### Removed:
-  * Support for `types` declaration was removed.
-
 ## 12.1.0
 Release date: 2022-06-29
 ### Features:

--- a/docs/lime_idl.md
+++ b/docs/lime_idl.md
@@ -59,7 +59,7 @@ interface ProcessorDelegate: com.example.utils.GenericDelegate {
     fun onProcessorEvent(message: String)
 }
 
-struct ProcessorHelperTypes {
+types ProcessorHelperTypes {
     typealias Timestamp = Date
 
     const DefaultOptions: SomeImportantProcessor.Options = {flagOption = true, uintOption = 42, {}}
@@ -104,7 +104,7 @@ Most elements can be prefixed with a visibility prefix. Possible visibility pref
 such a prefix is considered `public`. The visibility prefix, if present, should precede the rest of the declaration.
 
 * Example: `internal static property secretDelegate: ProcessorDelegate? { get set }`
-* List of element kinds that can have a visibility prefix: class, interface, function, constructor, property, 
+* List of element kinds that can have a visibility prefix: class, interface, types, function, constructor, property, 
 struct, struct field, enumeration, exception, type alias, lambda, constant.
 * Visibility prefix has no effect on C++ generated code.
 * `open` and `open internal` are currently only supported for classes. Both mean the class can be
@@ -122,7 +122,7 @@ attribute name that follows.
 ### File-level declarations
 
 There are three kinds of file-level declarations: package, import or element declaration. The
-following element types can be placed at the top level: `class`, `interface`, `struct`,
+following element types can be placed at the top level: `class`, `interface`, `types`, `struct`,
 `enum`, `exception`, `typealias`, `lambda`. All other declarations can only be placed as child elements to
 some other element.
 
@@ -144,16 +144,17 @@ immediately after the package declaration.
 
 #### Container-type elements
 
-* Syntax: (**class** | **interface**) *ElementName*\[**:** *ParentName*\] **{**
+* Syntax: (**class** | **interface** | **types**) *ElementName*\[**:** *ParentName*\] **{**
 *child-elements-declarations...* **}**
 * Example: `class SomeImportantProcessor { ... }`
 * Example: `interface ProcessorDelegate: GenericDelegate { ... }`
 * Description: declares a container-type language element:
   * **class** corresponds to a class declaration in the output languages.
   * **interface** corresponds to an interface (protocol) declaration in the output languages.
+  * **types** declares a loose collection of elements, most of which become free-standing elements
   in the output languages.
 * Classes and interfaces can be free-standing elements at file level or can be placed in another
-class, interface, or struct.
+class, interface, or struct. `types` declaration can be only placed at file level.
 
 #### Inheritance
 
@@ -263,7 +264,7 @@ struct Options {
     additionalOptions: List<String> = {}
 }
 ```
-* Can be a free-standing element at file level or can be placed in: class, interface, struct.
+* Can be a free-standing element at file level or can be placed in: class, interface, types, struct.
 * Description: declares a struct type (data type) in the parent type:
   * a struct can have any number of fields, but at least one field is required.
   * a struct field can have a default value associated with it (optionally). For more details on
@@ -277,7 +278,7 @@ struct Options {
 * where *enumerators-list* is a comma-separated list of enumerators, each enumerator declared as
 *EnumeratorName* \[**=** *EnumeratorValue*\]
 * Example: `enum Mode { SLOW, FAST, CHEAP }`
-* Can be a free-standing element at file level or can be placed in: class, interface, struct.
+* Can be a free-standing element at file level or can be placed in: class, interface, types, struct.
 * Description: declares an enumeration type in the parent type:
   * an enumeration can have any number of enumerators, but at least one enumerator is required.
   * an enumerator can have a value associated with it (optionally). The value can be either an integer or another
@@ -288,7 +289,7 @@ struct Options {
 
 * Syntax: **exception** *ExceptionName*__(__*ErrorTypeName*__)__
 * Example: `exception SomethingWrong(ErrorType)`
-* Can be a free-standing element at file level or can be placed in: class, interface, struct.
+* Can be a free-standing element at file level or can be placed in: class, interface, types, struct.
 * Description: declares an exception (error) type in the parent type:
   * an exception has an error-value type associated with it.
   * an exception type cannot be used as a regular type, it can only be used in a `throws` clause of
@@ -298,7 +299,7 @@ struct Options {
 
 * Syntax: **const** *ConstantName*__:__ *ConstantType* **=** *ValueLiteral*
 * Example: `const DefaultOptions: Options = {true, 42, {}}`
-* Can be placed in: class, struct
+* Can be placed in: class, types, struct
 * Description: declares a constant in the parent type. For more details on values and literals see
 `Values and Literals` below.
 
@@ -570,6 +571,10 @@ element is skipped (not generated). Custom tags are case-insensitive.
   This is the default specification for this attribute.
   * **Label** **=** **"**_LabelName_**"**: marks a parameter of a function or a constructor to have a distinct argument
   label in Swift.
+  * **Extension**: marks a type collection (`types`) to be generated as Swift extension. The primary
+  use case for this is adding nested types into a pre-existing Swift type (i.e. non-generated).
+  Extending a generated type is also possible, but requires usage of `Name` attribute to avoid name
+  clashes on other platforms.
   * **Skip** \[**=** **"**_CustomTag_**"** \]: marks an element to be skipped (not generated) in Swift. Can be applied to
   any element except for enumerators. Optionally, if custom tag is specified, the element is only skipped if that tag
   was defined (see `@Skip` above).

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cbridge/CBridgeImplIncludeResolver.kt
@@ -42,6 +42,7 @@ import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypedElement
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import java.io.File
 
 internal class CBridgeImplIncludeResolver(private val cppIncludeResolver: CppIncludeResolver) :
@@ -49,7 +50,7 @@ internal class CBridgeImplIncludeResolver(private val cppIncludeResolver: CppInc
 
     override fun resolveElementImports(limeElement: LimeElement) =
         when (limeElement) {
-            is LimeConstant -> emptyList()
+            is LimeTypesCollection, is LimeConstant -> emptyList()
             is LimeTypeRef -> resolveTypeRefIncludes(limeElement)
             is LimeReturnType -> resolveTypeRefIncludes(limeElement.typeRef)
             is LimeLambdaParameter -> resolveTypeRefIncludes(limeElement.typeRef)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameCache.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameCache.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.SETTER_NA
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import java.util.HashMap
 
 internal class CppNameCache(
@@ -80,8 +81,14 @@ internal class CppNameCache(
     }
 
     private fun resolveNames(limeElement: LimeNamedElement): NamesCacheEntry {
-        val parentPath = limeElement.path.parent
-        val parentElement = limeReferenceMap[parentPath.toString()] as? LimeNamedElement
+        var parentPath = limeElement.path.parent
+        var parentElement = limeReferenceMap[parentPath.toString()] as? LimeNamedElement
+        if (parentElement is LimeTypesCollection) {
+            // A type collection doesn't correspond to any named entity in C++ generated code.
+            // So skip it and use the parent namespace instead.
+            parentPath = parentPath.parent
+            parentElement = null
+        }
 
         val parentFullName: String
         var parentIsExternal = false

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartDeclarationImportResolver.kt
@@ -34,6 +34,7 @@ import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypesCollection
 
 internal class DartDeclarationImportResolver(
     limeReferenceMap: Map<String, LimeElement>,
@@ -54,7 +55,9 @@ internal class DartDeclarationImportResolver(
     override fun resolveElementImports(limeElement: LimeElement): List<DartImport> {
         if (limeElement !is LimeNamedElement) return emptyList()
 
-        if (limeElement is LimeException || limeElement is LimeTypeAlias || limeElement is LimeConstant) return emptyList()
+        if (limeElement is LimeTypesCollection || limeElement is LimeException || limeElement is LimeTypeAlias ||
+            limeElement is LimeConstant
+        ) return emptyList()
 
         return when {
             limeElement is LimeLambda -> listOf(tokenCacheImport)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -74,6 +74,7 @@ import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import java.util.logging.Logger
 
 internal class DartGenerator : Generator {
@@ -224,7 +225,9 @@ internal class DartGenerator : Generator {
 
         val allTypes = LimeTypeHelper.getAllTypes(rootElement).filterNot { it is LimeTypeAlias }
         val nonExternalTypes = allTypes.filter { it.external?.dart == null }
-        val allSymbols = nonExternalTypes.filter { it.visibility.isPublic }
+        val freeConstants = (rootElement as? LimeTypesCollection)?.constants ?: emptyList()
+        val allSymbols =
+            (nonExternalTypes + freeConstants).filter { it !is LimeTypesCollection && it.visibility.isPublic }
         if (allSymbols.isNotEmpty()) {
             val allNames = allSymbols.map { dartNameResolver.resolveName(it) }
             val testNames = allSymbols
@@ -521,6 +524,7 @@ internal class DartGenerator : Generator {
 
     private fun selectTemplate(limeElement: LimeNamedElement) =
         when (limeElement) {
+            is LimeTypesCollection -> "dart/DartTypes"
             is LimeClass -> "dart/DartClass"
             is LimeInterface -> "dart/DartInterface"
             is LimeStruct -> "dart/DartStruct"

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -51,6 +51,7 @@ import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
 import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.model.lime.LimeValue
 import com.here.gluecodium.model.lime.LimeValue.Duration.TimeUnit
 import com.here.gluecodium.model.lime.LimeVisibility
@@ -230,6 +231,7 @@ internal class DartNameResolver(
         val parentType = if (limeType.path.hasParent) getParentElement(limeType) as? LimeType else null
         return when (parentType) {
             null -> listOf(typeName)
+            is LimeTypesCollection -> listOf(typeName)
             else -> listOf(resolveTypeName(parentType), typeName)
         }.joinToString(joinInfix)
     }
@@ -311,7 +313,7 @@ internal class DartNameResolver(
     private fun buildDuplicateNames() =
         limeReferenceMap.values
             .filterIsInstance<LimeType>()
-            .filterNot { it is LimeTypeAlias || it is LimeGenericType || it is LimeBasicType }
+            .filterNot { it is LimeTypesCollection || it is LimeTypeAlias || it is LimeGenericType || it is LimeBasicType }
             .filter { it.external?.dart == null }
             .groupBy { resolveTypeName(it) }
             .filterValues { it.size > 1 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
@@ -43,6 +43,7 @@ import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeTypesCollection
 
 internal class FfiCppIncludeResolver(
     limeReferenceMap: Map<String, LimeElement>,
@@ -54,7 +55,7 @@ internal class FfiCppIncludeResolver(
     override fun resolveElementImports(limeElement: LimeElement): List<Include> =
         when (limeElement) {
             is LimeTypeRef -> getTypeRefIncludes(limeElement)
-            is LimeException, is LimeTypeAlias, is LimeConstant -> emptyList()
+            is LimeTypesCollection, is LimeException, is LimeTypeAlias, is LimeConstant -> emptyList()
             is LimeInterface -> getTypeIncludes(limeElement) + getThrownTypeIncludes(limeElement) +
                 getContainerIncludes(limeElement) + proxyIncludes
             is LimeContainer -> getTypeIncludes(limeElement) + getContainerIncludes(limeElement)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
@@ -43,6 +43,7 @@ import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeTypedElement
+import com.here.gluecodium.model.lime.LimeTypesCollection
 
 internal class JniNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
@@ -124,7 +125,7 @@ internal class JniNameResolver(
         val elementName = javaNameRules.getName(limeElement)
         val parentElement = if (limeElement.path.hasParent) getParentElement(limeElement) else null
         return when (parentElement) {
-            null -> listOf(elementName)
+            null, is LimeTypesCollection -> listOf(elementName)
             else -> resolveNestedNames(parentElement) + elementName
         }
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/lime/LimeGenerator.kt
@@ -35,6 +35,7 @@ import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
+import com.here.gluecodium.model.lime.LimeTypesCollection
 
 internal class LimeGenerator : Generator {
 
@@ -74,6 +75,7 @@ internal class LimeGenerator : Generator {
         when (limeElement) {
             is LimeClass -> "lime/LimeClass"
             is LimeInterface -> "lime/LimeInterface"
+            is LimeTypesCollection -> "lime/LimeTypesCollection"
             is LimeStruct -> "lime/LimeStruct"
             is LimeEnumeration -> "lime/LimeEnumeration"
             is LimeTypeAlias -> "lime/LimeTypeAlias"

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -52,6 +52,7 @@ import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeHelper
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.validator.LimeOverloadsValidator
 import java.util.logging.Logger
 
@@ -264,6 +265,7 @@ internal class SwiftGenerator : Generator {
             is LimeStruct -> "swift/SwiftStructDefinition"
             is LimeClass -> "swift/SwiftClassDefinition"
             is LimeInterface -> "swift/SwiftInterfaceDefinition"
+            is LimeTypesCollection -> "swift/SwiftTypesDefinition"
             else -> null
         }
 
@@ -275,6 +277,7 @@ internal class SwiftGenerator : Generator {
             is LimeStruct -> "swift/SwiftStructConversion"
             is LimeClass -> "swift/SwiftClassConversion"
             is LimeInterface -> "swift/SwiftClassConversion"
+            is LimeTypesCollection -> null
             else -> null
         }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeTypeRefTargetValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeTypeRefTargetValidator.kt
@@ -26,6 +26,7 @@ import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeTypesCollection
 
 /**
  * Validate against:
@@ -40,6 +41,14 @@ internal class LimeTypeRefTargetValidator(private val logger: LimeLogger) :
     override fun visitTypeRef(parentElement: LimeNamedElement, limeTypeRef: LimeTypeRef?): Boolean {
         val referredType = limeTypeRef?.type?.actualType
         return when {
+            referredType is LimeTypesCollection -> {
+                logger.error(
+                    parentElement,
+                    "refers to `types` container ${referredType.fullName} " +
+                        "which cannot be used as a type itself."
+                )
+                false
+            }
             referredType is LimeException &&
                 (
                     parentElement !is LimeFunction ||

--- a/gluecodium/src/main/resources/templates/cpp/CppTypes.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppTypes.mustache
@@ -1,0 +1,28 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#sort enumerations lambdas typeAliases structs constants}}
+{{#instanceOf this "LimeEnumeration"}}{{>cpp/CppEnumeration}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeLambda"}}{{>cpp/CppLambda}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeTypeAlias"}}{{>cpp/CppTypeAlias}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeStruct"}}{{>cpp/CppStruct}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeConstant"}}{{#set constant=this storageQualifier="extern" needsExport=true}}{{#constant}}{{!!
+}}{{>cpp/CppConstant}}{{/constant}}{{/set}}{{/instanceOf}}
+{{/sort}}

--- a/gluecodium/src/main/resources/templates/cpp/CppTypesImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppTypesImpl.mustache
@@ -1,0 +1,29 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#enumerations}}
+{{>cpp/CppEnumerationImpl}}
+{{/enumerations}}
+{{#structs}}
+{{>cpp/CppStructImpl}}
+{{/structs}}
+{{#constants}}
+const {{resolveName typeRef}} {{resolveName}} = {{resolveName value}};
+{{/constants}}

--- a/gluecodium/src/main/resources/templates/dart/DartTypes.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartTypes.mustache
@@ -1,0 +1,32 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#enumerations}}
+{{>dart/DartEnumeration}}
+{{/enumerations}}
+{{#exceptions}}
+{{>dart/DartException}}
+{{/exceptions}}
+{{#structs}}
+{{>dart/DartStruct}}
+{{/structs}}
+{{#constants}}
+{{>dart/DartConstant}}
+{{/constants}}

--- a/gluecodium/src/main/resources/templates/java/JavaConstantsWrapper.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaConstantsWrapper.mustache
@@ -1,0 +1,25 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>java/JavaDocComment}}
+{{resolveName visibility}}final class {{resolveName}} {
+{{#constants}}{{prefixPartial "java/JavaConstant" "    "}}
+{{/constants}}
+}

--- a/gluecodium/src/main/resources/templates/lime/LimeTypesCollection.mustache
+++ b/gluecodium/src/main/resources/templates/lime/LimeTypesCollection.mustache
@@ -1,0 +1,24 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>lime/LimeDocumentation}}
+{{visibility}}types {{escapedName}} {
+{{>lime/LimeContainerContents}}
+}

--- a/gluecodium/src/main/resources/templates/swift/SwiftTypesDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftTypesDefinition.mustache
@@ -1,0 +1,52 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#typeAliases}}
+{{>swift/SwiftTypeAlias}}
+{{/typeAliases}}
+{{#exceptions}}
+{{>swift/SwiftException}}
+{{/exceptions}}
+
+{{#lambdas}}
+{{>swift/SwiftLambdaDefinition}}
+
+{{>swift/SwiftLambdaConversion}}
+{{/lambdas}}
+
+{{#enumerations}}
+{{>swift/SwiftEnumDefinition}}
+
+{{>swift/SwiftEnumConversion}}
+{{/enumerations}}
+
+{{#structs}}
+{{>swift/SwiftStructDefinition}}
+
+{{>swift/SwiftStructConversion}}
+{{/structs}}
+
+{{#if constants}}
+{{resolveName visibility}} struct {{resolveName}} {
+{{#constants}}
+{{prefixPartial "swift/SwiftConstant" "    "}}
+{{/constants}}
+}
+{{/if}}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeTypeRefTargetValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeTypeRefTargetValidatorTest.kt
@@ -31,6 +31,7 @@ import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeThrownType
 import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import io.mockk.mockk
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -52,6 +53,14 @@ class LimeTypeRefTargetValidatorTest {
         allElements[""] = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeClass))
 
         assertTrue(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateTypesReference() {
+        val limeTypesCollection = LimeTypesCollection(EMPTY_PATH)
+        allElements[""] = LimeField(EMPTY_PATH, typeRef = LimeDirectTypeRef(limeTypesCollection))
+
+        assertFalse(validator.validate(limeModel))
     }
 
     @Test

--- a/lime-loader/src/main/antlr/LimeLexer.g4
+++ b/lime-loader/src/main/antlr/LimeLexer.g4
@@ -80,6 +80,7 @@ Static: 'static' ;
 Struct: 'struct' ;
 Throws: 'throws' ;
 TypeAlias: 'typealias' ;
+Types: 'types' ;
 
 // Predefined types
 

--- a/lime-loader/src/main/antlr/LimeParser.g4
+++ b/lime-loader/src/main/antlr/LimeParser.g4
@@ -23,7 +23,7 @@ options { tokenVocab = LimeLexer; }
 
 limeFile
     : NewLine* packageHeader importHeader
-      (container |  struct | enumeration | typealias | exception | lambda)+ EOF
+      (container | types | struct | enumeration | typealias | exception | lambda)+ EOF
     ;
 
 packageHeader
@@ -43,6 +43,11 @@ container
       simpleId NewLine* parentTypes? '{' NewLine* externalDescriptor?
       ((function | constructor | property | struct | enumeration | constant | typealias |
       exception | lambda | container) NewLine*)* '}' NewLine+
+    ;
+
+types
+    : docComment* annotation* visibility? 'types' NewLine* simpleId NewLine*
+      '{' NewLine* ((struct | enumeration | constant | typealias | exception) NewLine*)* '}' NewLine+
     ;
 
 parentTypes

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -51,6 +51,7 @@ import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeThrownType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.model.lime.LimeValue
 import com.here.gluecodium.model.lime.LimeValue.Special.ValueId
 import com.here.gluecodium.model.lime.LimeVisibility
@@ -163,6 +164,26 @@ internal class AntlrLimeModelBuilder(
                 isNarrow = ctx.Narrow() != null
             )
         }
+
+        storeResultAndPopStacks(limeElement)
+    }
+
+    override fun enterTypes(ctx: LimeParser.TypesContext) {
+        pushPathAndVisibility(ctx.simpleId(), ctx.visibility())
+    }
+
+    override fun exitTypes(ctx: LimeParser.TypesContext) {
+        val limeElement = LimeTypesCollection(
+            path = currentPath,
+            visibility = currentVisibility,
+            comment = parseStructuredComment(ctx.docComment(), ctx).description,
+            attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
+            structs = getPreviousResults(LimeStruct::class.java),
+            enumerations = getPreviousResults(LimeEnumeration::class.java),
+            constants = getPreviousResults(LimeConstant::class.java),
+            typeAliases = getPreviousResults(LimeTypeAlias::class.java),
+            exceptions = getPreviousResults(LimeException::class.java)
+        )
 
         storeResultAndPopStacks(limeElement)
     }

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
@@ -35,6 +35,7 @@ import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimePositionalEnumeratorRef
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypesCollection
 import com.here.gluecodium.model.lime.LimeValue
 
 /**
@@ -103,6 +104,7 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
         when (element) {
             is LimeClass -> filterClass(element)
             is LimeInterface -> filterInterface(element)
+            is LimeTypesCollection -> filterTypesCollection(element)
             is LimeStruct -> filterStruct(element)
             is LimeEnumeration -> filterEnum(element)
             else -> element
@@ -158,6 +160,21 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
                 lambdas = lambdas.filter(predicate),
                 parents = parents.map { it.remap(referenceMap) },
                 isNarrow = isNarrow
+            )
+        }.also { remap(it) }
+
+    private fun filterTypesCollection(limeTypes: LimeTypesCollection) =
+        limeTypes.run {
+            LimeTypesCollection(
+                path = path,
+                visibility = visibility,
+                comment = comment,
+                attributes = attributes,
+                structs = structs.filter(predicate).map { filterStruct(it) },
+                enumerations = enumerations.filter(predicate).map { filterEnum(it) },
+                constants = constants.filter(predicate).map { filterConstant(it) },
+                typeAliases = typeAliases.filter(predicate),
+                exceptions = exceptions.filter(predicate)
             )
         }.also { remap(it) }
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypeHelper.kt
@@ -44,6 +44,8 @@ object LimeTypeHelper {
                 limeElement.constants + limeElement.structs +
                     limeElement.classes + limeElement.interfaces
                 ).flatMap { getAllValues(it) }
+            is LimeTypesCollection ->
+                (limeElement.constants + limeElement.structs).flatMap { getAllValues(it) }
             is LimeStruct ->
                 (limeElement.constants + limeElement.fields).flatMap { getAllValues(it) }
             else -> emptyList()

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypesCollection.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeTypesCollection.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016-2019 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.model.lime
+
+class LimeTypesCollection(
+    path: LimePath,
+    visibility: LimeVisibility = LimeVisibility.PUBLIC,
+    comment: LimeComment = LimeComment(),
+    attributes: LimeAttributes? = null,
+    structs: List<LimeStruct> = emptyList(),
+    enumerations: List<LimeEnumeration> = emptyList(),
+    constants: List<LimeConstant> = emptyList(),
+    typeAliases: List<LimeTypeAlias> = emptyList(),
+    exceptions: List<LimeException> = emptyList()
+) : LimeContainer(
+    path = path,
+    visibility = visibility,
+    comment = comment,
+    attributes = attributes,
+    structs = structs,
+    enumerations = enumerations,
+    constants = constants,
+    typeAliases = typeAliases,
+    exceptions = exceptions
+)


### PR DESCRIPTION
Temporarily revert the `types` support removal, so that it does not get into the
next release.

This reverts commit 8dca1db080d4ebeac855fb042c39122f40697b4b.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>