### PR TITLE
Make non-empty Map literals compatible with Android API level 21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Gluecodium project Release Notes
 
 ## Unreleased
+### Bug fixes:
+  * Fixed Java compilation issue for non-empty `Map<>` initializers under Android API level 21.
 ### Removed:
   * Support for `types` declaration was removed.
   * Support for `@Cpp(External*)` attributes was removed.

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -133,6 +133,11 @@ internal class JavaGenerator : Generator {
             GeneratedFile.SourceSet.COMMON
         )
         resultFiles += GeneratedFile(
+            TemplateEngine.render("java/HashMapBuilder", internalPackageList),
+            "$nativeBasePath/HashMapBuilder.java",
+            GeneratedFile.SourceSet.COMMON
+        )
+        resultFiles += GeneratedFile(
             TemplateEngine.render("java/Duration", internalPackageList),
             "$nativeBasePath/time/Duration.java",
             GeneratedFile.SourceSet.COMMON

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaImportResolver.kt
@@ -54,6 +54,7 @@ internal class JavaImportResolver(
 ) : ImportsResolver<JavaImport> {
     val nativeBaseImport = JavaImport(internalPackages, "NativeBase")
     private val abstractNativeListImport = JavaImport(internalPackages, "AbstractNativeList")
+    private val hashMapBuilderImport = JavaImport(internalPackages, "HashMapBuilder")
     private val durationImport = JavaImport(internalPackages + "time", "Duration")
 
     override fun resolveElementImports(limeElement: LimeElement): List<JavaImport> =
@@ -116,8 +117,7 @@ internal class JavaImportResolver(
             is LimeList -> listOfNotNull(arrayListImport, arraysImport.takeIf { hasValues })
             is LimeSet -> listOfNotNull(arraysImport.takeIf { hasValues }) +
                 if (limeType.elementType.type.actualType is LimeEnumeration) enumSetImport else hashSetImport
-            is LimeMap ->
-                listOfNotNull(hashMapImport, streamImport.takeIf { hasValues }, collectorsImport.takeIf { hasValues })
+            is LimeMap -> listOfNotNull(hashMapImport, hashMapBuilderImport.takeIf { hasValues })
             else -> emptyList()
         }
     }
@@ -169,7 +169,6 @@ internal class JavaImportResolver(
 
     companion object {
         private val javaUtilPackage = listOf("java", "util")
-        private val javaUtilStreamPackage = javaUtilPackage + "stream"
         private val androidOsPackage = listOf("android", "os")
 
         private val listImport = JavaImport(javaUtilPackage, "List")
@@ -181,9 +180,6 @@ internal class JavaImportResolver(
         private val enumSetImport = JavaImport(javaUtilPackage, "EnumSet")
         private val hashMapImport = JavaImport(javaUtilPackage, "HashMap")
         private val arraysImport = JavaImport(javaUtilPackage, "Arrays")
-
-        private val streamImport = JavaImport(javaUtilStreamPackage, "Stream")
-        private val collectorsImport = JavaImport(javaUtilStreamPackage, "Collectors")
 
         private val parcelableImport = JavaImport(androidOsPackage, "Parcelable")
         private val parcelImport = JavaImport(androidOsPackage, "Parcel")

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameResolver.kt
@@ -114,7 +114,7 @@ internal class JavaNameResolver(
     private fun resolveAccessorName(element: Any, rule: JavaNameRules.(LimeTypedElement) -> String) =
         (element as? LimeTypedElement)?.let { javaNameRules.rule(it) }
 
-    private fun resolveTypeRef(limeTypeRef: LimeTypeRef, needsBoxing: Boolean = false): String {
+    internal fun resolveTypeRef(limeTypeRef: LimeTypeRef, needsBoxing: Boolean = false): String {
         val limeType = limeTypeRef.type.actualType
         val externalName = limeType.external?.java?.get(NAME_NAME)
         return when {

--- a/gluecodium/src/main/resources/templates/java/HashMapBuilder.mustache
+++ b/gluecodium/src/main/resources/templates/java/HashMapBuilder.mustache
@@ -1,0 +1,65 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2022 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+/*
+ * Copyright (C) 2016-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package {{join this delimiter="."}};
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @hidden
+ */
+public final class HashMapBuilder<K, V> {
+    private Map<K, V> map = new HashMap<>();
+
+    /**
+     * @hidden
+     */
+    public HashMapBuilder<K, V> put(K key, V value) {
+        map.put(key, value);
+        return this;
+    }
+
+    /**
+     * @hidden
+     */
+    public Map<K, V> build() {
+        return map;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/CollectionConstants.java
+++ b/gluecodium/src/test/resources/smoke/constants/output/android/com/example/smoke/CollectionConstants.java
@@ -2,6 +2,7 @@
  *
  */
 package com.example.smoke;
+import com.example.HashMapBuilder;
 import com.example.NativeBase;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -11,13 +12,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 public final class CollectionConstants extends NativeBase {
     public static final List<String> LIST_CONSTANT = new ArrayList<>(Arrays.asList("foo", "bar"));
     public static final Set<String> SET_CONSTANT = new HashSet<>(Arrays.asList("foo", "bar"));
-    public static final Map<String, String> MAP_CONSTANT = new HashMap<>(Stream.of(new AbstractMap.SimpleEntry<>("foo", "bar")).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-    public static final Map<List<String>, Set<String>> MIXED_CONSTANT = new HashMap<>(Stream.of(new AbstractMap.SimpleEntry<>(new ArrayList<>(Arrays.asList("foo")), new HashSet<>(Arrays.asList("bar")))).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    public static final Map<String, String> MAP_CONSTANT = new HashMapBuilder<String, String>().put("foo", "bar").build();
+    public static final Map<List<String>, Set<String>> MIXED_CONSTANT = new HashMapBuilder<List<String>, Set<String>>().put(new ArrayList<>(Arrays.asList("foo")), new HashSet<>(Arrays.asList("bar"))).build();
     /**
      * For internal use only.
      * @hidden

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/HashMapBuilder.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/HashMapBuilder.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016-2022 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.example;
+import java.util.HashMap;
+import java.util.Map;
+/**
+ * @hidden
+ */
+public final class HashMapBuilder<K, V> {
+    private Map<K, V> map = new HashMap<>();
+    /**
+     * @hidden
+     */
+    public HashMapBuilder<K, V> put(K key, V value) {
+        map.put(key, value);
+        return this;
+    }
+    /**
+     * @hidden
+     */
+    public Map<K, V> build() {
+        return map;
+    }
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithInitializerDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/StructWithInitializerDefaults.java
@@ -3,6 +3,7 @@
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
+import com.example.HashMapBuilder;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,8 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 public final class StructWithInitializerDefaults {
     @NonNull
     public List<Integer> intsField;
@@ -26,6 +25,6 @@ public final class StructWithInitializerDefaults {
         this.intsField = new ArrayList<>(Arrays.asList(4, -2, 42));
         this.floatsField = new ArrayList<>(Arrays.asList(3.14f, Float.NEGATIVE_INFINITY));
         this.setTypeField = new HashSet<>(Arrays.asList("foo", "bar"));
-        this.mapField = new HashMap<>(Stream.of(new AbstractMap.SimpleEntry<>(1L, "foo"), new AbstractMap.SimpleEntry<>(42L, "bar")).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        this.mapField = new HashMapBuilder<Long, String>().put(1L, "foo").put(42L, "bar").build();
     }
 }

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaults.java
@@ -3,6 +3,7 @@
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
+import com.example.HashMapBuilder;
 import com.example.fire.Enum1;
 import com.example.fire.Enum2;
 import com.example.fire.Enum3;
@@ -15,8 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 public final class EnumCollectionDefaults {
     @NonNull
     public List<Enum1> listField;
@@ -27,6 +26,6 @@ public final class EnumCollectionDefaults {
     public EnumCollectionDefaults() {
         this.listField = new ArrayList<>(Arrays.asList(Enum1.DISABLED));
         this.setField = new EnumSet<>(Arrays.asList(Enum2.DISABLED));
-        this.mapField = new HashMap<>(Stream.of(new AbstractMap.SimpleEntry<>(Enum3.DISABLED, Enum4.DISABLED)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        this.mapField = new HashMapBuilder<Enum3, Enum4>().put(Enum3.DISABLED, Enum4.DISABLED).build();
     }
 }

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaultsExternal.java
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaultsExternal.java
@@ -3,6 +3,7 @@
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
+import com.example.HashMapBuilder;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,8 +12,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 public final class EnumCollectionDefaultsExternal {
     @NonNull
     public List<foo.AlienEnum1> listField;
@@ -23,6 +22,6 @@ public final class EnumCollectionDefaultsExternal {
     public EnumCollectionDefaultsExternal() {
         this.listField = new ArrayList<>(Arrays.asList(foo.AlienEnum1.DISABLED));
         this.setField = new EnumSet<>(Arrays.asList(foo.AlienEnum2.DISABLED));
-        this.mapField = new HashMap<>(Stream.of(new AbstractMap.SimpleEntry<>(foo.AlienEnum3.DISABLED, foo.AlienEnum4.DISABLED)).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+        this.mapField = new HashMapBuilder<foo.AlienEnum3, foo.AlienEnum4>().put(foo.AlienEnum3.DISABLED, foo.AlienEnum4.DISABLED).build();
     }
 }


### PR DESCRIPTION
Updated JavaValueResolver and templates to generate non-empty Map initializer
literals without using any Java 8 features. This makes the code compatible with
Android API level 21.

Updated smoke tests. The functional tests pass without change.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>