### PR TITLE
Reduce visibility propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Removed redundant visibility propagation for nested elements, except where required by language specifics.
+
 ## 13.2.0
 Release date: 2022-08-19
 ### Features:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGenerator.kt
@@ -133,7 +133,7 @@ internal class DartGenerator : Generator {
             "FfiSnakeCase" to ffiNameResolver,
             "FfiApiTypes" to FfiApiTypeNameResolver(),
             "FfiDartTypes" to FfiDartTypeNameResolver(),
-            "visibility" to DartVisibilityResolver()
+            "visibility" to DartVisibilityResolver(dartFilteredModel.referenceMap)
         )
         val ffiCppNameResolver = FfiCppNameResolver(ffiReferenceMap, cppNameRules, rootNamespace, internalNamespace)
         val ffiResolvers = mapOf(
@@ -574,7 +574,6 @@ internal class DartGenerator : Generator {
                 limeElement !is LimeFunction && limeElement !is LimeProperty && limeElement !is LimeFieldConstructor ->
                     false
                 limeElement.attributes.have(DART, LimeAttributeValueType.PUBLIC) -> false
-                CommonGeneratorPredicates.isInternal(getParentElement(limeElement), DART) -> false
                 else -> CommonGeneratorPredicates.isInternal(limeElement, DART)
             }
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartVisibilityResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartVisibilityResolver.kt
@@ -22,14 +22,27 @@ package com.here.gluecodium.generator.dart
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.DART
+import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeType
 
-internal class DartVisibilityResolver : NameResolver {
+internal class DartVisibilityResolver(limeReferenceMap: Map<String, LimeElement>) :
+    ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
 
     override fun resolveName(element: Any): String =
         when (element) {
-            is LimeNamedElement -> if (CommonGeneratorPredicates.isInternal(element, DART)) "_" else ""
+            // Dart has no type nesting, so all types are "outside" and have to check for an internal outer type.
+            is LimeType -> {
+                val isInternal = generateSequence(element) {
+                    limeReferenceMap[it.path.parent.toString()] as? LimeType
+                }.any { CommonGeneratorPredicates.isInternal(it, DART) }
+                getVisibilityPrefix(isInternal)
+            }
+            is LimeNamedElement -> getVisibilityPrefix(CommonGeneratorPredicates.isInternal(element, DART))
             else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
         }
+
+    private fun getVisibilityPrefix(isInternal: Boolean) = if (isInternal) "_" else ""
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGenerator.kt
@@ -134,7 +134,7 @@ internal class SwiftGenerator : Generator {
             "" to swiftNameResolver,
             "CBridge" to cbridgeNameResolver,
             "mangled" to SwiftMangledNameResolver(swiftNameResolver),
-            "visibility" to SwiftVisibilityResolver()
+            "visibility" to SwiftVisibilityResolver(swiftFilteredModel.referenceMap)
         )
         val predicates = SwiftGeneratorPredicates(nameRules, swiftSignatureResolver)
         val descendantInterfaces = LimeTypeHelper.collectDescendantInterfaces(swiftFilteredModel.topElements)

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -7,7 +7,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 abstract class InternalClassWithComments {
   /// This is definitely internal
   ///
-  /// @nodoc
   void doNothing();
 }
 // InternalClassWithComments "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/expose_internals/output/swift/smoke/ExposeInternalStruct.swift
+++ b/gluecodium/src/test/resources/smoke/expose_internals/output/swift/smoke/ExposeInternalStruct.swift
@@ -2,7 +2,7 @@
 //
 import Foundation
 internal struct ExposeInternalStruct {
-    internal var field: String
+    public var field: String
     internal init(field: String) {
         self.field = field
     }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/input/VisibilityInternal.lime
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/input/VisibilityInternal.lime
@@ -83,13 +83,6 @@ internal class InternalClassWithStaticProperty {
 }
 
 @Skip(Java, Swift)
-struct DontExportInDart {
-    struct DoExportInDart {
-        stringField: String
-    }
-}
-
-@Skip(Java, Swift)
 class InternalPropertyOnly {
     internal property foo: String
 }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/InternalClass.java
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/InternalClass.java
@@ -17,5 +17,5 @@ final class InternalClass extends NativeBase {
         });
     }
     private static native void disposeNativeHandle(long nativeHandle);
-    native void fooBar();
+    public native void fooBar();
 }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/PublicClass.java
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/PublicClass.java
@@ -15,7 +15,7 @@ public final class PublicClass extends NativeBase {
     }
     static final class InternalStruct {
         @NonNull
-        String stringField;
+        public String stringField;
         InternalStruct(@NonNull final String stringField) {
             this.stringField = stringField;
         }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/PublicInterface.java
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/PublicInterface.java
@@ -1,13 +1,12 @@
 /*
  *
-
  */
 package com.example.smoke;
 import android.support.annotation.NonNull;
 public interface PublicInterface {
     static final class InternalStruct {
         @NonNull
-        PublicClass.InternalStruct fieldOfInternalType;
+        public PublicClass.InternalStruct fieldOfInternalType;
         InternalStruct(@NonNull final PublicClass.InternalStruct fieldOfInternalType) {
             this.fieldOfInternalType = fieldOfInternalType;
         }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/PublicTypeCollection.java
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/android/com/example/smoke/PublicTypeCollection.java
@@ -10,6 +10,6 @@ public final class PublicTypeCollection {
         InternalStruct(@NonNull final String stringField) {
             this.stringField = stringField;
         }
-        native void fooBar();
+        public native void fooBar();
     }
 }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/smoke.dart
@@ -1,4 +1,3 @@
-export 'src/smoke/dont_export_in_dart.dart' show DontExportInDart, DontExportInDart_DoExportInDart;
 export 'src/smoke/internal_property_only.dart' show InternalPropertyOnly;
 export 'src/smoke/public_class.dart' show PublicClass, PublicClass_PublicStruct, PublicClass_PublicStructWithInternalDefaults;
 export 'src/smoke/public_interface.dart' show PublicInterface;

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 /// @nodoc
 abstract class InternalClass {
-  /// @nodoc
   void fooBar();
 }
 // InternalClass "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -6,11 +6,8 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// @nodoc
 abstract class InternalClassWithFunctions {
-  /// @nodoc
   factory InternalClassWithFunctions.make() => $prototype.make();
-  /// @nodoc
   factory InternalClassWithFunctions.remake(String foo) => $prototype.remake(foo);
-  /// @nodoc
   void fooBar();
   /// @nodoc
   @visibleForTesting

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -6,9 +6,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 /// @nodoc
 abstract class InternalClassWithStaticProperty {
-  /// @nodoc
   static String get fooBar => $prototype.fooBar;
-  /// @nodoc
   static set fooBar(String value) { $prototype.fooBar = value; }
   /// @nodoc
   @visibleForTesting

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_interface.dart
@@ -12,7 +12,6 @@ abstract class InternalInterface {
   ) => InternalInterface$Lambdas(
     fooBarLambda,
   );
-  /// @nodoc
   void fooBar();
 }
 // InternalInterface "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
@@ -63,9 +63,8 @@ void smokePublicclassInternalenumReleaseFfiHandleNullable(Pointer<Void> handle) 
 // End of PublicClass_InternalEnum "private" section.
 /// @nodoc
 class PublicClass_InternalStruct {
-  /// @nodoc
-  String _stringField;
-  PublicClass_InternalStruct(this._stringField);
+  String stringField;
+  PublicClass_InternalStruct(this.stringField);
 }
 // PublicClass_InternalStruct "private" section, not exported.
 final _smokePublicclassInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -81,7 +80,7 @@ final _smokePublicclassInternalstructGetFieldstringField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_get_field_stringField'));
 Pointer<Void> smokePublicclassInternalstructToFfi(PublicClass_InternalStruct value) {
-  final _stringFieldHandle = stringToFfi(value._stringField);
+  final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokePublicclassInternalstructCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_interface.dart
@@ -9,9 +9,8 @@ abstract class PublicInterface {
 }
 /// @nodoc
 class PublicInterface_InternalStruct {
-  /// @nodoc
-  PublicClass_InternalStruct _fieldOfInternalType;
-  PublicInterface_InternalStruct(this._fieldOfInternalType);
+  PublicClass_InternalStruct fieldOfInternalType;
+  PublicInterface_InternalStruct(this.fieldOfInternalType);
 }
 // PublicInterface_InternalStruct "private" section, not exported.
 final _smokePublicinterfaceInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -27,7 +26,7 @@ final _smokePublicinterfaceInternalstructGetFieldfieldOfInternalType = __lib.cat
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType'));
 Pointer<Void> smokePublicinterfaceInternalstructToFfi(PublicInterface_InternalStruct value) {
-  final _fieldOfInternalTypeHandle = smokePublicclassInternalstructToFfi(value._fieldOfInternalType);
+  final _fieldOfInternalTypeHandle = smokePublicclassInternalstructToFfi(value.fieldOfInternalType);
   final _result = _smokePublicinterfaceInternalstructCreateHandle(_fieldOfInternalTypeHandle);
   smokePublicclassInternalstructReleaseFfiHandle(_fieldOfInternalTypeHandle);
   return _result;

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_type_collection.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_type_collection.dart
@@ -9,7 +9,6 @@ class PublicTypeCollection_InternalStruct {
   /// @nodoc
   String _stringField;
   PublicTypeCollection_InternalStruct(this._stringField);
-  /// @nodoc
   void fooBar() => $prototype.fooBar(this);
   /// @nodoc
   @visibleForTesting

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/InternalClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/InternalClass.swift
@@ -13,7 +13,7 @@ internal class InternalClass {
         smoke_InternalClass_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_InternalClass_release_handle(c_instance)
     }
-    internal func fooBar() -> Void {
+    public func fooBar() -> Void {
         smoke_InternalClass_fooBar(self.c_instance)
     }
 }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/InternalInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/InternalInterface.swift
@@ -16,7 +16,7 @@ internal class _InternalInterface: InternalInterface {
         smoke_InternalInterface_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_InternalInterface_release_handle(c_instance)
     }
-    internal func fooBar() -> Void {
+    public func fooBar() -> Void {
         smoke_InternalInterface_fooBar(self.c_instance)
     }
 }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/PublicClass.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/PublicClass.swift
@@ -31,7 +31,7 @@ public class PublicClass {
         case bar
     }
     internal struct InternalStruct {
-        internal var stringField: String
+        public var stringField: String
         internal init(stringField: String) {
             self.stringField = stringField
         }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/PublicInterface.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/PublicInterface.swift
@@ -17,7 +17,7 @@ internal class _PublicInterface: PublicInterface {
     }
 }
 internal struct InternalStruct {
-    internal var fieldOfInternalType: PublicClass.InternalStruct
+    public var fieldOfInternalType: PublicClass.InternalStruct
     internal init(fieldOfInternalType: PublicClass.InternalStruct) {
         self.fieldOfInternalType = fieldOfInternalType
     }

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/PublicTypeCollection.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/swift/smoke/PublicTypeCollection.swift
@@ -10,7 +10,7 @@ public struct PublicTypeCollection {
         internal init(cHandle: _baseRef) {
             stringField = moveFromCType(smoke_PublicTypeCollection_InternalStruct_stringField_get(cHandle))
         }
-        internal func fooBar() -> Void {
+        public func fooBar() -> Void {
             let c_self_handle = moveToCType(self)
             smoke_PublicTypeCollection_InternalStruct_fooBar(c_self_handle.ref)
         }


### PR DESCRIPTION
Removed the logic for propagating visibility from outer to inner elements from
the AntlrLimeModel builder. For most languages, marking the inner elements
"internal" is redundant if the outer element is already marked.

Added visibility propagation on case-by-case basis where needed:
* in Dart for nested types, as there is no nesting in Dart
* in Swift for types nested inside interfaces, as there is no nesting inside
Swift protocols

For both cases, the propagation affects types only. Non-type elements are not
affected.

This both simplifies the visibility logic, and ensures that "global" and
"per-platform" visibilities are handled in the same way.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>