### PR TITLE
Add `null` check in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features:
   * Added support for per-platform visibility attributes (e.g. `@Java(Internal)`, etc.).
+  * Added a `null` check in Dart for non-nullable class and interface usages.
 ### Removed:
   * The LIME generator was removed. 
 

--- a/functional-tests/functional/dart/test/Nullable_test.dart
+++ b/functional-tests/functional/dart/test/Nullable_test.dart
@@ -285,4 +285,7 @@ void main() {
 
     expect(result, {7: "Foo"});
   });
+  _testSuite.test("Non-null constraint broken", () {
+    expect(NonNullConstraintBroken.getNull, throwsStateError);
+  });
 }

--- a/functional-tests/functional/input/lime/NullableInstances.lime
+++ b/functional-tests/functional/input/lime/NullableInstances.lime
@@ -49,3 +49,8 @@ class NullablePayload {
     fun poke(): Boolean
     constructor create()
 }
+
+class NonNullConstraintBroken {
+    // Returns a `null` value even though the return type is explicitly non-nullable.
+    static fun getNull(): NullablePayload
+}

--- a/functional-tests/functional/input/src/cpp/NullableInstances.cpp
+++ b/functional-tests/functional/input/src/cpp/NullableInstances.cpp
@@ -19,6 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "NullablePayloadImpl.h"
+#include "test/NonNullConstraintBroken.h"
 #include "test/NullableInstanceListener.h"
 #include "test/NullableStatic.h"
 
@@ -73,4 +74,8 @@ NullablePayload::create( )
 {
     return std::make_shared< NullablePayloadImpl >( );
 }
-}  // namespace test
+
+std::shared_ptr<NullablePayload>
+NonNullConstraintBroken::get_null() { return {}; }
+
+}

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -132,6 +132,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
   _{{resolveName "Ffi"}}CopyHandle((value as __lib.NativeBase).handle);
 
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
 {{#unless this.attributes.nocache}}
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is {{resolveName}}) return instance;

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -245,6 +245,7 @@ Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) {
 }
 
 {{resolveName}} {{resolveName "Ffi"}}FromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
 {{#unless this.attributes.nocache}}
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is {{resolveName}}) return instance;

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
@@ -132,6 +132,7 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
 Pointer<Void> smokeAsyncclassToFfi(AsyncClass value) =>
   _smokeAsyncclassCopyHandle((value as __lib.NativeBase).handle);
 AsyncClass smokeAsyncclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AsyncClass) return instance;
   final _copiedHandle = _smokeAsyncclassCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
@@ -40,6 +40,7 @@ class AsyncRenamed$Impl extends __lib.NativeBase implements AsyncRenamed {
 Pointer<Void> smokeAsyncrenamedToFfi(AsyncRenamed value) =>
   _smokeAsyncrenamedCopyHandle((value as __lib.NativeBase).handle);
 AsyncRenamed smokeAsyncrenamedFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AsyncRenamed) return instance;
   final _copiedHandle = _smokeAsyncrenamedCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -64,6 +64,7 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
 Pointer<Void> smokeAttributesclassToFfi(AttributesClass value) =>
   _smokeAttributesclassCopyHandle((value as __lib.NativeBase).handle);
 AttributesClass smokeAttributesclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesClass) return instance;
   final _copiedHandle = _smokeAttributesclassCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -129,6 +129,7 @@ Pointer<Void> smokeAttributesinterfaceToFfi(AttributesInterface value) {
   return result;
 }
 AttributesInterface smokeAttributesinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesInterface) return instance;
   final _typeIdHandle = _smokeAttributesinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -134,6 +134,7 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
 Pointer<Void> smokeAttributeswithcommentsToFfi(AttributesWithComments value) =>
   _smokeAttributeswithcommentsCopyHandle((value as __lib.NativeBase).handle);
 AttributesWithComments smokeAttributeswithcommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesWithComments) return instance;
   final _copiedHandle = _smokeAttributeswithcommentsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -133,6 +133,7 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
 Pointer<Void> smokeAttributeswithdeprecatedToFfi(AttributesWithDeprecated value) =>
   _smokeAttributeswithdeprecatedCopyHandle((value as __lib.NativeBase).handle);
 AttributesWithDeprecated smokeAttributeswithdeprecatedFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesWithDeprecated) return instance;
   final _copiedHandle = _smokeAttributeswithdeprecatedCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -75,6 +75,7 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
 Pointer<Void> smokeMultipleattributesdartToFfi(MultipleAttributesDart value) =>
   _smokeMultipleattributesdartCopyHandle((value as __lib.NativeBase).handle);
 MultipleAttributesDart smokeMultipleattributesdartFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MultipleAttributesDart) return instance;
   final _copiedHandle = _smokeMultipleattributesdartCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -41,6 +41,7 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
 Pointer<Void> smokeSpecialattributesToFfi(SpecialAttributes value) =>
   _smokeSpecialattributesCopyHandle((value as __lib.NativeBase).handle);
 SpecialAttributes smokeSpecialattributesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SpecialAttributes) return instance;
   final _copiedHandle = _smokeSpecialattributesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -156,6 +156,7 @@ class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
 Pointer<Void> smokeBasictypesToFfi(BasicTypes value) =>
   _smokeBasictypesCopyHandle((value as __lib.NativeBase).handle);
 BasicTypes smokeBasictypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is BasicTypes) return instance;
   final _copiedHandle = _smokeBasictypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -517,6 +517,7 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
 Pointer<Void> smokeCommentsToFfi(Comments value) =>
   _smokeCommentsCopyHandle((value as __lib.NativeBase).handle);
 Comments smokeCommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Comments) return instance;
   final _copiedHandle = _smokeCommentsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -538,6 +538,7 @@ Pointer<Void> smokeCommentsinterfaceToFfi(CommentsInterface value) {
   return result;
 }
 CommentsInterface smokeCommentsinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsInterface) return instance;
   final _typeIdHandle = _smokeCommentsinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -195,6 +195,7 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
 Pointer<Void> smokeCommentslinksToFfi(CommentsLinks value) =>
   _smokeCommentslinksCopyHandle((value as __lib.NativeBase).handle);
 CommentsLinks smokeCommentslinksFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsLinks) return instance;
   final _copiedHandle = _smokeCommentslinksCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
@@ -50,6 +50,7 @@ class CommentsMarkdown$Impl extends __lib.NativeBase implements CommentsMarkdown
 Pointer<Void> smokeCommentsmarkdownToFfi(CommentsMarkdown value) =>
   _smokeCommentsmarkdownCopyHandle((value as __lib.NativeBase).handle);
 CommentsMarkdown smokeCommentsmarkdownFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsMarkdown) return instance;
   final _copiedHandle = _smokeCommentsmarkdownCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table.dart
@@ -30,6 +30,7 @@ class CommentsTable$Impl extends __lib.NativeBase implements CommentsTable {
 Pointer<Void> smokeCommentstableToFfi(CommentsTable value) =>
   _smokeCommentstableCopyHandle((value as __lib.NativeBase).handle);
 CommentsTable smokeCommentstableFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsTable) return instance;
   final _copiedHandle = _smokeCommentstableCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table_links.dart
@@ -30,6 +30,7 @@ class CommentsTableLinks$Impl extends __lib.NativeBase implements CommentsTableL
 Pointer<Void> smokeCommentstablelinksToFfi(CommentsTableLinks value) =>
   _smokeCommentstablelinksCopyHandle((value as __lib.NativeBase).handle);
 CommentsTableLinks smokeCommentstablelinksFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsTableLinks) return instance;
   final _copiedHandle = _smokeCommentstablelinksCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/ctor_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/ctor_links.dart
@@ -46,6 +46,7 @@ class CtorLinks_SingleCtor$Impl extends __lib.NativeBase implements CtorLinks_Si
 Pointer<Void> smokeCtorlinksSinglectorToFfi(CtorLinks_SingleCtor value) =>
   _smokeCtorlinksSinglectorCopyHandle((value as __lib.NativeBase).handle);
 CtorLinks_SingleCtor smokeCtorlinksSinglectorFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CtorLinks_SingleCtor) return instance;
   final _copiedHandle = _smokeCtorlinksSinglectorCopyHandle(handle);
@@ -122,6 +123,7 @@ class CtorLinks_OverloadedCtors$Impl extends __lib.NativeBase implements CtorLin
 Pointer<Void> smokeCtorlinksOverloadedctorsToFfi(CtorLinks_OverloadedCtors value) =>
   _smokeCtorlinksOverloadedctorsCopyHandle((value as __lib.NativeBase).handle);
 CtorLinks_OverloadedCtors smokeCtorlinksOverloadedctorsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CtorLinks_OverloadedCtors) return instance;
   final _copiedHandle = _smokeCtorlinksOverloadedctorsCopyHandle(handle);
@@ -158,6 +160,7 @@ class CtorLinks$Impl extends __lib.NativeBase implements CtorLinks {
 Pointer<Void> smokeCtorlinksToFfi(CtorLinks value) =>
   _smokeCtorlinksCopyHandle((value as __lib.NativeBase).handle);
 CtorLinks smokeCtorlinksFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CtorLinks) return instance;
   final _copiedHandle = _smokeCtorlinksCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -328,6 +328,7 @@ Pointer<Void> smokeDeprecationcommentsToFfi(DeprecationComments value) {
   return result;
 }
 DeprecationComments smokeDeprecationcommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DeprecationComments) return instance;
   final _typeIdHandle = _smokeDeprecationcommentsGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -258,6 +258,7 @@ Pointer<Void> smokeDeprecationcommentsonlyToFfi(DeprecationCommentsOnly value) {
   return result;
 }
 DeprecationCommentsOnly smokeDeprecationcommentsonlyFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DeprecationCommentsOnly) return instance;
   final _typeIdHandle = _smokeDeprecationcommentsonlyGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -340,6 +340,7 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
 Pointer<Void> smokeExcludedcommentsToFfi(ExcludedComments value) =>
   _smokeExcludedcommentsCopyHandle((value as __lib.NativeBase).handle);
 ExcludedComments smokeExcludedcommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExcludedComments) return instance;
   final _copiedHandle = _smokeExcludedcommentsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -44,6 +44,7 @@ Pointer<Void> smokeExcludedcommentsinterfaceToFfi(ExcludedCommentsInterface valu
   return result;
 }
 ExcludedCommentsInterface smokeExcludedcommentsinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExcludedCommentsInterface) return instance;
   final _typeIdHandle = _smokeExcludedcommentsinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -316,6 +316,7 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
 Pointer<Void> smokeExcludedcommentsonlyToFfi(ExcludedCommentsOnly value) =>
   _smokeExcludedcommentsonlyCopyHandle((value as __lib.NativeBase).handle);
 ExcludedCommentsOnly smokeExcludedcommentsonlyFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExcludedCommentsOnly) return instance;
   final _copiedHandle = _smokeExcludedcommentsonlyCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -35,6 +35,7 @@ class InternalClassWithComments$Impl extends __lib.NativeBase implements Interna
 Pointer<Void> smokeInternalclasswithcommentsToFfi(InternalClassWithComments value) =>
   _smokeInternalclasswithcommentsCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithComments smokeInternalclasswithcommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClassWithComments) return instance;
   final _copiedHandle = _smokeInternalclasswithcommentsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -131,6 +131,7 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
 Pointer<Void> smokeMapsceneToFfi(MapScene value) =>
   _smokeMapsceneCopyHandle((value as __lib.NativeBase).handle);
 MapScene smokeMapsceneFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MapScene) return instance;
   final _copiedHandle = _smokeMapsceneCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -72,6 +72,7 @@ class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineCommen
 Pointer<Void> smokeMultilinecommentsToFfi(MultiLineComments value) =>
   _smokeMultilinecommentsCopyHandle((value as __lib.NativeBase).handle);
 MultiLineComments smokeMultilinecommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MultiLineComments) return instance;
   final _copiedHandle = _smokeMultilinecommentsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -226,6 +226,7 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
 Pointer<Void> smokePlatformcommentsToFfi(PlatformComments value) =>
   _smokePlatformcommentsCopyHandle((value as __lib.NativeBase).handle);
 PlatformComments smokePlatformcommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PlatformComments) return instance;
   final _copiedHandle = _smokePlatformcommentsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
@@ -24,6 +24,7 @@ class PlatformCommentsLineBreaks$Impl extends __lib.NativeBase implements Platfo
 Pointer<Void> smokePlatformcommentslinebreaksToFfi(PlatformCommentsLineBreaks value) =>
   _smokePlatformcommentslinebreaksCopyHandle((value as __lib.NativeBase).handle);
 PlatformCommentsLineBreaks smokePlatformcommentslinebreaksFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PlatformCommentsLineBreaks) return instance;
   final _copiedHandle = _smokePlatformcommentslinebreaksCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -76,6 +76,7 @@ class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
 Pointer<Void> smokeUnicodecommentsToFfi(UnicodeComments value) =>
   _smokeUnicodecommentsCopyHandle((value as __lib.NativeBase).handle);
 UnicodeComments smokeUnicodecommentsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UnicodeComments) return instance;
   final _copiedHandle = _smokeUnicodecommentsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -29,6 +29,7 @@ class CollectionConstants$Impl extends __lib.NativeBase implements CollectionCon
 Pointer<Void> smokeCollectionconstantsToFfi(CollectionConstants value) =>
   _smokeCollectionconstantsCopyHandle((value as __lib.NativeBase).handle);
 CollectionConstants smokeCollectionconstantsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CollectionConstants) return instance;
   final _copiedHandle = _smokeCollectionconstantsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -87,6 +87,7 @@ class ConstantsInterface$Impl extends __lib.NativeBase implements ConstantsInter
 Pointer<Void> smokeConstantsinterfaceToFfi(ConstantsInterface value) =>
   _smokeConstantsinterfaceCopyHandle((value as __lib.NativeBase).handle);
 ConstantsInterface smokeConstantsinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ConstantsInterface) return instance;
   final _copiedHandle = _smokeConstantsinterfaceCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -164,6 +164,7 @@ class StructConstants$Impl extends __lib.NativeBase implements StructConstants {
 Pointer<Void> smokeStructconstantsToFfi(StructConstants value) =>
   _smokeStructconstantsCopyHandle((value as __lib.NativeBase).handle);
 StructConstants smokeStructconstantsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is StructConstants) return instance;
   final _copiedHandle = _smokeStructconstantsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -212,6 +212,7 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
 Pointer<Void> smokeConstructorsToFfi(Constructors value) =>
   _smokeConstructorsCopyHandle((value as __lib.NativeBase).handle);
 Constructors smokeConstructorsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Constructors) return instance;
   final _typeIdHandle = _smokeConstructorsGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -44,6 +44,7 @@ class SingleNamedConstructor$Impl extends __lib.NativeBase implements SingleName
 Pointer<Void> smokeSinglenamedconstructorToFfi(SingleNamedConstructor value) =>
   _smokeSinglenamedconstructorCopyHandle((value as __lib.NativeBase).handle);
 SingleNamedConstructor smokeSinglenamedconstructorFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SingleNamedConstructor) return instance;
   final _copiedHandle = _smokeSinglenamedconstructorCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -44,6 +44,7 @@ class SingleNamelessConstructor$Impl extends __lib.NativeBase implements SingleN
 Pointer<Void> smokeSinglenamelessconstructorToFfi(SingleNamelessConstructor value) =>
   _smokeSinglenamelessconstructorCopyHandle((value as __lib.NativeBase).handle);
 SingleNamelessConstructor smokeSinglenamelessconstructorFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SingleNamelessConstructor) return instance;
   final _copiedHandle = _smokeSinglenamelessconstructorCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -171,6 +171,7 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
 Pointer<Void> smokeDatesToFfi(Dates value) =>
   _smokeDatesCopyHandle((value as __lib.NativeBase).handle);
 Dates smokeDatesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Dates) return instance;
   final _copiedHandle = _smokeDatesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
@@ -143,6 +143,7 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
 Pointer<Void> smokeDatessteadyToFfi(DatesSteady value) =>
   _smokeDatessteadyCopyHandle((value as __lib.NativeBase).handle);
 DatesSteady smokeDatessteadyFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DatesSteady) return instance;
   final _copiedHandle = _smokeDatessteadyCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -551,6 +551,7 @@ class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
 Pointer<Void> smokeDefaultvaluesToFfi(DefaultValues value) =>
   _smokeDefaultvaluesCopyHandle((value as __lib.NativeBase).handle);
 DefaultValues smokeDefaultvaluesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DefaultValues) return instance;
   final _copiedHandle = _smokeDefaultvaluesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
@@ -302,6 +302,7 @@ class EnumDefaults$Impl extends __lib.NativeBase implements EnumDefaults {
 Pointer<Void> smokeEnumdefaultsToFfi(EnumDefaults value) =>
   _smokeEnumdefaultsCopyHandle((value as __lib.NativeBase).handle);
 EnumDefaults smokeEnumdefaultsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnumDefaults) return instance;
   final _copiedHandle = _smokeEnumdefaultsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
@@ -305,6 +305,7 @@ class EnumDefaultsExternal$Impl extends __lib.NativeBase implements EnumDefaults
 Pointer<Void> smokeEnumdefaultsexternalToFfi(EnumDefaultsExternal value) =>
   _smokeEnumdefaultsexternalCopyHandle((value as __lib.NativeBase).handle);
 EnumDefaultsExternal smokeEnumdefaultsexternalFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnumDefaultsExternal) return instance;
   final _copiedHandle = _smokeEnumdefaultsexternalCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
@@ -139,6 +139,7 @@ class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMill
 Pointer<Void> smokeDurationmillisecondsToFfi(DurationMilliseconds value) =>
   _smokeDurationmillisecondsCopyHandle((value as __lib.NativeBase).handle);
 DurationMilliseconds smokeDurationmillisecondsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DurationMilliseconds) return instance;
   final _copiedHandle = _smokeDurationmillisecondsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
@@ -139,6 +139,7 @@ class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
 Pointer<Void> smokeDurationsecondsToFfi(DurationSeconds value) =>
   _smokeDurationsecondsCopyHandle((value as __lib.NativeBase).handle);
 DurationSeconds smokeDurationsecondsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DurationSeconds) return instance;
   final _copiedHandle = _smokeDurationsecondsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -266,6 +266,7 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
 Pointer<Void> smokeEnumsToFfi(Enums value) =>
   _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
 Enums smokeEnumsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Enums) return instance;
   final _copiedHandle = _smokeEnumsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -51,6 +51,7 @@ Pointer<Void> smokeEquatableinterfaceToFfi(EquatableInterface value) {
   return result;
 }
 EquatableInterface smokeEquatableinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EquatableInterface) return instance;
   final _typeIdHandle = _smokeEquatableinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -312,6 +312,7 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
 Pointer<Void> smokeErrorsToFfi(Errors value) =>
   _smokeErrorsCopyHandle((value as __lib.NativeBase).handle);
 Errors smokeErrorsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Errors) return instance;
   final _copiedHandle = _smokeErrorsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -406,6 +406,7 @@ Pointer<Void> smokeErrorsinterfaceToFfi(ErrorsInterface value) {
   return result;
 }
 ErrorsInterface smokeErrorsinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ErrorsInterface) return instance;
   final _typeIdHandle = _smokeErrorsinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -113,6 +113,7 @@ class Class$Impl extends __lib.NativeBase implements Class {
 Pointer<Void> packageClassToFfi(Class value) =>
   _packageClassCopyHandle((value as __lib.NativeBase).handle);
 Class packageClassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Class) return instance;
   final _typeIdHandle = _packageClassGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -42,6 +42,7 @@ Pointer<Void> packageInterfaceToFfi(Interface value) {
   return result;
 }
 Interface packageInterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Interface) return instance;
   final _typeIdHandle = _packageInterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -148,6 +148,7 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
 Pointer<Void> smokeEnumsToFfi(Enums value) =>
   _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
 Enums smokeEnumsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Enums) return instance;
   final _copiedHandle = _smokeEnumsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -160,6 +160,7 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
 Pointer<Void> smokeExternalclassToFfi(ExternalClass value) =>
   _smokeExternalclassCopyHandle((value as __lib.NativeBase).handle);
 ExternalClass smokeExternalclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExternalClass) return instance;
   final _copiedHandle = _smokeExternalclassCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -209,6 +209,7 @@ Pointer<Void> smokeExternalinterfaceToFfi(ExternalInterface value) {
   return result;
 }
 ExternalInterface smokeExternalinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExternalInterface) return instance;
   final _typeIdHandle = _smokeExternalinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -209,6 +209,7 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
 Pointer<Void> smokeStructsToFfi(Structs value) =>
   _smokeStructsCopyHandle((value as __lib.NativeBase).handle);
 Structs smokeStructsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Structs) return instance;
   final _copiedHandle = _smokeStructsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_generics.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_generics.dart
@@ -42,6 +42,7 @@ class UseDartExternalGenerics$Impl extends __lib.NativeBase implements UseDartEx
 Pointer<Void> smokeUsedartexternalgenericsToFfi(UseDartExternalGenerics value) =>
   _smokeUsedartexternalgenericsCopyHandle((value as __lib.NativeBase).handle);
 UseDartExternalGenerics smokeUsedartexternalgenericsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseDartExternalGenerics) return instance;
   final _copiedHandle = _smokeUsedartexternalgenericsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -85,6 +85,7 @@ class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExter
 Pointer<Void> smokeUsedartexternaltypesToFfi(UseDartExternalTypes value) =>
   _smokeUsedartexternaltypesCopyHandle((value as __lib.NativeBase).handle);
 UseDartExternalTypes smokeUsedartexternaltypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseDartExternalTypes) return instance;
   final _copiedHandle = _smokeUsedartexternaltypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
@@ -90,6 +90,7 @@ class OuterName$Impl extends __lib.NativeBase implements OuterName {
 Pointer<Void> smokeOuternameToFfi(OuterName value) =>
   _smokeOuternameCopyHandle((value as __lib.NativeBase).handle);
 OuterName smokeOuternameFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterName) return instance;
   final _copiedHandle = _smokeOuternameCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
@@ -38,6 +38,7 @@ class UseInnerName$Impl extends __lib.NativeBase implements UseInnerName {
 Pointer<Void> smokeUseinnernameToFfi(UseInnerName value) =>
   _smokeUseinnernameCopyHandle((value as __lib.NativeBase).handle);
 UseInnerName smokeUseinnernameFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseInnerName) return instance;
   final _copiedHandle = _smokeUseinnernameCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -257,6 +257,7 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
 Pointer<Void> smokeGenerictypeswithbasictypesToFfi(GenericTypesWithBasicTypes value) =>
   _smokeGenerictypeswithbasictypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithBasicTypes smokeGenerictypeswithbasictypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is GenericTypesWithBasicTypes) return instance;
   final _copiedHandle = _smokeGenerictypeswithbasictypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -377,6 +377,7 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
 Pointer<Void> smokeGenerictypeswithcompoundtypesToFfi(GenericTypesWithCompoundTypes value) =>
   _smokeGenerictypeswithcompoundtypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithCompoundTypes smokeGenerictypeswithcompoundtypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is GenericTypesWithCompoundTypes) return instance;
   final _copiedHandle = _smokeGenerictypeswithcompoundtypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -124,6 +124,7 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
 Pointer<Void> smokeGenerictypeswithgenerictypesToFfi(GenericTypesWithGenericTypes value) =>
   _smokeGenerictypeswithgenerictypesCopyHandle((value as __lib.NativeBase).handle);
 GenericTypesWithGenericTypes smokeGenerictypeswithgenerictypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is GenericTypesWithGenericTypes) return instance;
   final _copiedHandle = _smokeGenerictypeswithgenerictypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -91,6 +91,7 @@ class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList
 Pointer<Void> smokeUseoptimizedlistToFfi(UseOptimizedList value) =>
   _smokeUseoptimizedlistCopyHandle((value as __lib.NativeBase).handle);
 UseOptimizedList smokeUseoptimizedlistFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseOptimizedList) return instance;
   final _copiedHandle = _smokeUseoptimizedlistCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -39,6 +39,7 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
 Pointer<Void> smokeChildclassfromclassToFfi(ChildClassFromClass value) =>
   _smokeChildclassfromclassCopyHandle((value as __lib.NativeBase).handle);
 ChildClassFromClass smokeChildclassfromclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildClassFromClass) return instance;
   final _typeIdHandle = _smokeChildclassfromclassGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -62,6 +62,7 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
 Pointer<Void> smokeChildclassfrominterfaceToFfi(ChildClassFromInterface value) =>
   _smokeChildclassfrominterfaceCopyHandle((value as __lib.NativeBase).handle);
 ChildClassFromInterface smokeChildclassfrominterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildClassFromInterface) return instance;
   final _typeIdHandle = _smokeChildclassfrominterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
@@ -32,6 +32,7 @@ class ChildClassWithImports$Impl extends ParentClassWithImports$Impl implements 
 Pointer<Void> smokeChildclasswithimportsToFfi(ChildClassWithImports value) =>
   _smokeChildclasswithimportsCopyHandle((value as __lib.NativeBase).handle);
 ChildClassWithImports smokeChildclasswithimportsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildClassWithImports) return instance;
   final _typeIdHandle = _smokeChildclasswithimportsGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -143,6 +143,7 @@ Pointer<Void> smokeChildinterfaceToFfi(ChildInterface value) {
   return result;
 }
 ChildInterface smokeChildinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildInterface) return instance;
   final _typeIdHandle = _smokeChildinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -62,6 +62,7 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
 Pointer<Void> smokeChildwithparentclassreferencesToFfi(ChildWithParentClassReferences value) =>
   _smokeChildwithparentclassreferencesCopyHandle((value as __lib.NativeBase).handle);
 ChildWithParentClassReferences smokeChildwithparentclassreferencesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildWithParentClassReferences) return instance;
   final _typeIdHandle = _smokeChildwithparentclassreferencesGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -59,6 +59,7 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
 Pointer<Void> smokeParentclassToFfi(ParentClass value) =>
   _smokeParentclassCopyHandle((value as __lib.NativeBase).handle);
 ParentClass smokeParentclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ParentClass) return instance;
   final _typeIdHandle = _smokeParentclassGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -124,6 +124,7 @@ Pointer<Void> smokeParentinterfaceToFfi(ParentInterface value) {
   return result;
 }
 ParentInterface smokeParentinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ParentInterface) return instance;
   final _typeIdHandle = _smokeParentinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -52,6 +52,7 @@ class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
 Pointer<Void> smokeSimpleclassToFfi(SimpleClass value) =>
   _smokeSimpleclassCopyHandle((value as __lib.NativeBase).handle);
 SimpleClass smokeSimpleclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SimpleClass) return instance;
   final _copiedHandle = _smokeSimpleclassCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -111,6 +111,7 @@ Pointer<Void> smokeSimpleinterfaceToFfi(SimpleInterface value) {
   return result;
 }
 SimpleInterface smokeSimpleinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SimpleInterface) return instance;
   final _typeIdHandle = _smokeSimpleinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -135,6 +135,7 @@ class ClassWithInternalLambda$Impl extends __lib.NativeBase implements ClassWith
 Pointer<Void> smokeClasswithinternallambdaToFfi(ClassWithInternalLambda value) =>
   _smokeClasswithinternallambdaCopyHandle((value as __lib.NativeBase).handle);
 ClassWithInternalLambda smokeClasswithinternallambdaFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ClassWithInternalLambda) return instance;
   final _copiedHandle = _smokeClasswithinternallambdaCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -504,6 +504,7 @@ class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
 Pointer<Void> smokeLambdasToFfi(Lambdas value) =>
   _smokeLambdasCopyHandle((value as __lib.NativeBase).handle);
 Lambdas smokeLambdasFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Lambdas) return instance;
   final _copiedHandle = _smokeLambdasCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -211,6 +211,7 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
 Pointer<Void> smokeLambdaswithstructuredtypesToFfi(LambdasWithStructuredTypes value) =>
   _smokeLambdaswithstructuredtypesCopyHandle((value as __lib.NativeBase).handle);
 LambdasWithStructuredTypes smokeLambdaswithstructuredtypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LambdasWithStructuredTypes) return instance;
   final _copiedHandle = _smokeLambdaswithstructuredtypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -260,6 +260,7 @@ Pointer<Void> smokeCalculatorlistenerToFfi(CalculatorListener value) {
   return result;
 }
 CalculatorListener smokeCalculatorlistenerFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CalculatorListener) return instance;
   final _typeIdHandle = _smokeCalculatorlistenerGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -159,6 +159,7 @@ Pointer<Void> smokeInterfacewithstaticToFfi(InterfaceWithStatic value) {
   return result;
 }
 InterfaceWithStatic smokeInterfacewithstaticFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InterfaceWithStatic) return instance;
   final _typeIdHandle = _smokeInterfacewithstaticGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -492,6 +492,7 @@ Pointer<Void> smokeListenerwithpropertiesToFfi(ListenerWithProperties value) {
   return result;
 }
 ListenerWithProperties smokeListenerwithpropertiesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ListenerWithProperties) return instance;
   final _typeIdHandle = _smokeListenerwithpropertiesGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -371,6 +371,7 @@ Pointer<Void> smokeListenerswithreturnvaluesToFfi(ListenersWithReturnValues valu
   return result;
 }
 ListenersWithReturnValues smokeListenerswithreturnvaluesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ListenersWithReturnValues) return instance;
   final _typeIdHandle = _smokeListenerswithreturnvaluesGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -126,6 +126,7 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
 Pointer<Void> smokeLocalesToFfi(Locales value) =>
   _smokeLocalesCopyHandle((value as __lib.NativeBase).handle);
 Locales smokeLocalesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Locales) return instance;
   final _copiedHandle = _smokeLocalesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -239,6 +239,7 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
 Pointer<Void> smokeMethodoverloadsToFfi(MethodOverloads value) =>
   _smokeMethodoverloadsCopyHandle((value as __lib.NativeBase).handle);
 MethodOverloads smokeMethodoverloadsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MethodOverloads) return instance;
   final _copiedHandle = _smokeMethodoverloadsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -75,6 +75,7 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
 Pointer<Void> smokeSpecialnamesToFfi(SpecialNames value) =>
   _smokeSpecialnamesCopyHandle((value as __lib.NativeBase).handle);
 SpecialNames smokeSpecialnamesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SpecialNames) return instance;
   final _copiedHandle = _smokeSpecialnamesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
@@ -84,6 +84,7 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
 Pointer<Void> smokeFirstparentisclassclassToFfi(FirstParentIsClassClass value) =>
   _smokeFirstparentisclassclassCopyHandle((value as __lib.NativeBase).handle);
 FirstParentIsClassClass smokeFirstparentisclassclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is FirstParentIsClassClass) return instance;
   final _typeIdHandle = _smokeFirstparentisclassclassGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
@@ -250,6 +250,7 @@ Pointer<Void> smokeFirstparentisinterfaceinterfaceToFfi(FirstParentIsInterfaceIn
   return result;
 }
 FirstParentIsInterfaceInterface smokeFirstparentisinterfaceinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is FirstParentIsInterfaceInterface) return instance;
   final _typeIdHandle = _smokeFirstparentisinterfaceinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
@@ -117,6 +117,7 @@ Pointer<Void> smokeParentnarrowoneToFfi(ParentNarrowOne value) {
   return result;
 }
 ParentNarrowOne smokeParentnarrowoneFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ParentNarrowOne) return instance;
   final _typeIdHandle = _smokeParentnarrowoneGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -181,6 +181,7 @@ class LevelOne_LevelTwo_LevelThree$Impl extends __lib.NativeBase implements Leve
 Pointer<Void> smokeLeveloneLeveltwoLevelthreeToFfi(LevelOne_LevelTwo_LevelThree value) =>
   _smokeLeveloneLeveltwoLevelthreeCopyHandle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo_LevelThree smokeLeveloneLeveltwoLevelthreeFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LevelOne_LevelTwo_LevelThree) return instance;
   final _copiedHandle = _smokeLeveloneLeveltwoLevelthreeCopyHandle(handle);
@@ -218,6 +219,7 @@ class LevelOne_LevelTwo$Impl extends __lib.NativeBase implements LevelOne_LevelT
 Pointer<Void> smokeLeveloneLeveltwoToFfi(LevelOne_LevelTwo value) =>
   _smokeLeveloneLeveltwoCopyHandle((value as __lib.NativeBase).handle);
 LevelOne_LevelTwo smokeLeveloneLeveltwoFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LevelOne_LevelTwo) return instance;
   final _copiedHandle = _smokeLeveloneLeveltwoCopyHandle(handle);
@@ -255,6 +257,7 @@ class LevelOne$Impl extends __lib.NativeBase implements LevelOne {
 Pointer<Void> smokeLeveloneToFfi(LevelOne value) =>
   _smokeLeveloneCopyHandle((value as __lib.NativeBase).handle);
 LevelOne smokeLeveloneFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LevelOne) return instance;
   final _copiedHandle = _smokeLeveloneCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -45,6 +45,7 @@ class OuterClass_InnerClass$Impl extends __lib.NativeBase implements OuterClass_
 Pointer<Void> smokeOuterclassInnerclassToFfi(OuterClass_InnerClass value) =>
   _smokeOuterclassInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClass_InnerClass smokeOuterclassInnerclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClass_InnerClass) return instance;
   final _copiedHandle = _smokeOuterclassInnerclassCopyHandle(handle);
@@ -140,6 +141,7 @@ Pointer<Void> smokeOuterclassInnerinterfaceToFfi(OuterClass_InnerInterface value
   return result;
 }
 OuterClass_InnerInterface smokeOuterclassInnerinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClass_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterclassInnerinterfaceGetTypeId(handle);
@@ -195,6 +197,7 @@ class OuterClass$Impl extends __lib.NativeBase implements OuterClass {
 Pointer<Void> smokeOuterclassToFfi(OuterClass value) =>
   _smokeOuterclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClass smokeOuterclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClass) return instance;
   final _copiedHandle = _smokeOuterclassCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -46,6 +46,7 @@ class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase impleme
 Pointer<Void> smokeOuterclasswithinheritanceInnerclassToFfi(OuterClassWithInheritance_InnerClass value) =>
   _smokeOuterclasswithinheritanceInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance_InnerClass smokeOuterclasswithinheritanceInnerclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClassWithInheritance_InnerClass) return instance;
   final _copiedHandle = _smokeOuterclasswithinheritanceInnerclassCopyHandle(handle);
@@ -141,6 +142,7 @@ Pointer<Void> smokeOuterclasswithinheritanceInnerinterfaceToFfi(OuterClassWithIn
   return result;
 }
 OuterClassWithInheritance_InnerInterface smokeOuterclasswithinheritanceInnerinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClassWithInheritance_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterclasswithinheritanceInnerinterfaceGetTypeId(handle);
@@ -200,6 +202,7 @@ class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterCl
 Pointer<Void> smokeOuterclasswithinheritanceToFfi(OuterClassWithInheritance value) =>
   _smokeOuterclasswithinheritanceCopyHandle((value as __lib.NativeBase).handle);
 OuterClassWithInheritance smokeOuterclasswithinheritanceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClassWithInheritance) return instance;
   final _typeIdHandle = _smokeOuterclasswithinheritanceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -50,6 +50,7 @@ class OuterInterface_InnerClass$Impl extends __lib.NativeBase implements OuterIn
 Pointer<Void> smokeOuterinterfaceInnerclassToFfi(OuterInterface_InnerClass value) =>
   _smokeOuterinterfaceInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterInterface_InnerClass smokeOuterinterfaceInnerclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterInterface_InnerClass) return instance;
   final _copiedHandle = _smokeOuterinterfaceInnerclassCopyHandle(handle);
@@ -145,6 +146,7 @@ Pointer<Void> smokeOuterinterfaceInnerinterfaceToFfi(OuterInterface_InnerInterfa
   return result;
 }
 OuterInterface_InnerInterface smokeOuterinterfaceInnerinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterInterface_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterinterfaceInnerinterfaceGetTypeId(handle);
@@ -236,6 +238,7 @@ Pointer<Void> smokeOuterinterfaceToFfi(OuterInterface value) {
   return result;
 }
 OuterInterface smokeOuterinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterInterface) return instance;
   final _typeIdHandle = _smokeOuterinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -198,6 +198,7 @@ class OuterStruct_InnerClass$Impl extends __lib.NativeBase implements OuterStruc
 Pointer<Void> smokeOuterstructInnerclassToFfi(OuterStruct_InnerClass value) =>
   _smokeOuterstructInnerclassCopyHandle((value as __lib.NativeBase).handle);
 OuterStruct_InnerClass smokeOuterstructInnerclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterStruct_InnerClass) return instance;
   final _copiedHandle = _smokeOuterstructInnerclassCopyHandle(handle);
@@ -287,6 +288,7 @@ Pointer<Void> smokeOuterstructInnerinterfaceToFfi(OuterStruct_InnerInterface val
   return result;
 }
 OuterStruct_InnerInterface smokeOuterstructInnerinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterStruct_InnerInterface) return instance;
   final _typeIdHandle = _smokeOuterstructInnerinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -72,6 +72,7 @@ class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
 Pointer<Void> smokeUsefreetypesToFfi(UseFreeTypes value) =>
   _smokeUsefreetypesCopyHandle((value as __lib.NativeBase).handle);
 UseFreeTypes smokeUsefreetypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseFreeTypes) return instance;
   final _copiedHandle = _smokeUsefreetypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
@@ -47,6 +47,7 @@ class NoCacheClass$Impl extends __lib.NativeBase implements NoCacheClass {
 Pointer<Void> smokeNocacheclassToFfi(NoCacheClass value) =>
   _smokeNocacheclassCopyHandle((value as __lib.NativeBase).handle);
 NoCacheClass smokeNocacheclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final _copiedHandle = _smokeNocacheclassCopyHandle(handle);
   final result = NoCacheClass$Impl(_copiedHandle);
   _smokeNocacheclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);

--- a/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_interface.dart
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_interface.dart
@@ -69,6 +69,7 @@ Pointer<Void> smokeNocacheinterfaceToFfi(NoCacheInterface value) {
   return result;
 }
 NoCacheInterface smokeNocacheinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final _typeIdHandle = _smokeNocacheinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -777,6 +777,7 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
 Pointer<Void> smokeNullableToFfi(Nullable value) =>
   _smokeNullableCopyHandle((value as __lib.NativeBase).handle);
 Nullable smokeNullableFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Nullable) return instance;
   final _copiedHandle = _smokeNullableCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -108,6 +108,7 @@ class NestedPackages$Impl extends __lib.NativeBase implements NestedPackages {
 Pointer<Void> smokeOffNestedpackagesToFfi(NestedPackages value) =>
   _smokeOffNestedpackagesCopyHandle((value as __lib.NativeBase).handle);
 NestedPackages smokeOffNestedpackagesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is NestedPackages) return instance;
   final _copiedHandle = _smokeOffNestedpackagesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -79,6 +79,7 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
 Pointer<Void> smokePlatformnamesinterfaceToFfi(weeInterface value) =>
   _smokePlatformnamesinterfaceCopyHandle((value as __lib.NativeBase).handle);
 weeInterface smokePlatformnamesinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is weeInterface) return instance;
   final _copiedHandle = _smokePlatformnamesinterfaceCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -75,6 +75,7 @@ Pointer<Void> smokePlatformnameslistenerToFfi(weeListener value) {
   return result;
 }
 weeListener smokePlatformnameslistenerFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is weeListener) return instance;
   final _typeIdHandle = _smokePlatformnameslistenerGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -67,6 +67,7 @@ class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties
 Pointer<Void> smokeCachedpropertiesToFfi(CachedProperties value) =>
   _smokeCachedpropertiesCopyHandle((value as __lib.NativeBase).handle);
 CachedProperties smokeCachedpropertiesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CachedProperties) return instance;
   final _copiedHandle = _smokeCachedpropertiesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -335,6 +335,7 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
 Pointer<Void> smokePropertiesToFfi(Properties value) =>
   _smokePropertiesCopyHandle((value as __lib.NativeBase).handle);
 Properties smokePropertiesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Properties) return instance;
   final _copiedHandle = _smokePropertiesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -158,6 +158,7 @@ Pointer<Void> smokePropertiesinterfaceToFfi(PropertiesInterface value) {
   return result;
 }
 PropertiesInterface smokePropertiesinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PropertiesInterface) return instance;
   final _typeIdHandle = _smokePropertiesinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -66,6 +66,7 @@ class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
 Pointer<Void> smokeEnableifenabledToFfi(EnableIfEnabled value) =>
   _smokeEnableifenabledCopyHandle((value as __lib.NativeBase).handle);
 EnableIfEnabled smokeEnableifenabledFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnableIfEnabled) return instance;
   final _copiedHandle = _smokeEnableifenabledCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -25,6 +25,7 @@ class EnableIfSkipped$Impl extends __lib.NativeBase implements EnableIfSkipped {
 Pointer<Void> smokeEnableifskippedToFfi(EnableIfSkipped value) =>
   _smokeEnableifskippedCopyHandle((value as __lib.NativeBase).handle);
 EnableIfSkipped smokeEnableifskippedFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnableIfSkipped) return instance;
   final _copiedHandle = _smokeEnableifskippedCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
@@ -94,6 +94,7 @@ Pointer<Void> smokeEnabletagsindartToFfi(EnableTagsInDart value) {
   return result;
 }
 EnableTagsInDart smokeEnabletagsindartFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnableTagsInDart) return instance;
   final _typeIdHandle = _smokeEnabletagsindartGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -201,6 +201,7 @@ Pointer<Void> smokeInheritfromskippedToFfi(InheritFromSkipped value) {
   return result;
 }
 InheritFromSkipped smokeInheritfromskippedFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InheritFromSkipped) return instance;
   final _typeIdHandle = _smokeInheritfromskippedGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enable_parameters.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enable_parameters.dart
@@ -33,6 +33,7 @@ class SkipEnableParameters$Impl extends __lib.NativeBase implements SkipEnablePa
 Pointer<Void> smokeSkipenableparametersToFfi(SkipEnableParameters value) =>
   _smokeSkipenableparametersCopyHandle((value as __lib.NativeBase).handle);
 SkipEnableParameters smokeSkipenableparametersFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipEnableParameters) return instance;
   final _copiedHandle = _smokeSkipenableparametersCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -56,6 +56,7 @@ class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
 Pointer<Void> smokeSkipfunctionsToFfi(SkipFunctions value) =>
   _smokeSkipfunctionsCopyHandle((value as __lib.NativeBase).handle);
 SkipFunctions smokeSkipfunctionsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipFunctions) return instance;
   final _copiedHandle = _smokeSkipfunctionsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -211,6 +211,7 @@ Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
   return result;
 }
 SkipProxy smokeSkipproxyFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipProxy) return instance;
   final _typeIdHandle = _smokeSkipproxyGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_setter.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_setter.dart
@@ -69,6 +69,7 @@ Pointer<Void> smokeSkipsetterToFfi(SkipSetter value) {
   return result;
 }
 SkipSetter smokeSkipsetterFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipSetter) return instance;
   final _typeIdHandle = _smokeSkipsetterGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
@@ -72,6 +72,7 @@ Pointer<Void> smokeSkiptagsindartToFfi(SkipTagsInDart value) {
   return result;
 }
 SkipTagsInDart smokeSkiptagsindartFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipTagsInDart) return instance;
   final _typeIdHandle = _smokeSkiptagsindartGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -25,6 +25,7 @@ class SkipTagsOnly$Impl extends __lib.NativeBase implements SkipTagsOnly {
 Pointer<Void> smokeSkiptagsonlyToFfi(SkipTagsOnly value) =>
   _smokeSkiptagsonlyCopyHandle((value as __lib.NativeBase).handle);
 SkipTagsOnly smokeSkiptagsonlyFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipTagsOnly) return instance;
   final _copiedHandle = _smokeSkiptagsonlyCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -154,6 +154,7 @@ class SkipTypes$Impl extends __lib.NativeBase implements SkipTypes {
 Pointer<Void> smokeSkiptypesToFfi(SkipTypes value) =>
   _smokeSkiptypesCopyHandle((value as __lib.NativeBase).handle);
 SkipTypes smokeSkiptypesFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipTypes) return instance;
   final _copiedHandle = _smokeSkiptypesCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -776,6 +776,7 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
 Pointer<Void> smokeStructsToFfi(Structs value) =>
   _smokeStructsCopyHandle((value as __lib.NativeBase).handle);
 Structs smokeStructsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Structs) return instance;
   final _copiedHandle = _smokeStructsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -247,6 +247,7 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
 Pointer<Void> smokeTypedefsToFfi(TypeDefs value) =>
   _smokeTypedefsCopyHandle((value as __lib.NativeBase).handle);
 TypeDefs smokeTypedefsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is TypeDefs) return instance;
   final _copiedHandle = _smokeTypedefsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class.dart
@@ -32,6 +32,7 @@ class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
 Pointer<Void> smokeInternalclassToFfi(InternalClass value) =>
   _smokeInternalclassCopyHandle((value as __lib.NativeBase).handle);
 InternalClass smokeInternalclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClass) return instance;
   final _copiedHandle = _smokeInternalclassCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -69,6 +69,7 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
 Pointer<Void> smokeInternalclasswithfunctionsToFfi(InternalClassWithFunctions value) =>
   _smokeInternalclasswithfunctionsCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithFunctions smokeInternalclasswithfunctionsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClassWithFunctions) return instance;
   final _copiedHandle = _smokeInternalclasswithfunctionsCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -50,6 +50,7 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
 Pointer<Void> smokeInternalclasswithstaticpropertyToFfi(InternalClassWithStaticProperty value) =>
   _smokeInternalclasswithstaticpropertyCopyHandle((value as __lib.NativeBase).handle);
 InternalClassWithStaticProperty smokeInternalclasswithstaticpropertyFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClassWithStaticProperty) return instance;
   final _copiedHandle = _smokeInternalclasswithstaticpropertyCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_interface.dart
@@ -72,6 +72,7 @@ Pointer<Void> smokeInternalinterfaceToFfi(InternalInterface value) {
   return result;
 }
 InternalInterface smokeInternalinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalInterface) return instance;
   final _typeIdHandle = _smokeInternalinterfaceGetTypeId(handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_property_only.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/internal_property_only.dart
@@ -23,6 +23,7 @@ class InternalPropertyOnly$Impl extends __lib.NativeBase implements InternalProp
 Pointer<Void> smokeInternalpropertyonlyToFfi(InternalPropertyOnly value) =>
   _smokeInternalpropertyonlyCopyHandle((value as __lib.NativeBase).handle);
 InternalPropertyOnly smokeInternalpropertyonlyFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalPropertyOnly) return instance;
   final _copiedHandle = _smokeInternalpropertyonlyCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_class.dart
@@ -286,6 +286,7 @@ class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
 Pointer<Void> smokePublicclassToFfi(PublicClass value) =>
   _smokePublicclassCopyHandle((value as __lib.NativeBase).handle);
 PublicClass smokePublicclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PublicClass) return instance;
   final _copiedHandle = _smokePublicclassCopyHandle(handle);

--- a/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_internal/output/dart/lib/src/smoke/public_interface.dart
@@ -107,6 +107,7 @@ Pointer<Void> smokePublicinterfaceToFfi(PublicInterface value) {
   return result;
 }
 PublicInterface smokePublicinterfaceFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PublicInterface) return instance;
   final _typeIdHandle = _smokePublicinterfaceGetTypeId(handle);


### PR DESCRIPTION
Added a `null` check in Dart for non-nullable class and interface
usages. This would produce a meaningful Dart crash stack when the
underlying C++ function violates the "non-null" constraint.

Added a functional test. Updated smoke tests.

Resolves: #1458
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>