### PR TITLE
Fix `Set<Enum>` initializers in Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Features:
   * Added support for per-platform visibility attributes (e.g. `@Java(Internal)`, etc.).
   * Added a `null` check in Dart for non-nullable class and interface usages.
+### Bug fixes:
+  * Fixed Java compilation issue for enum set literals.
 ### Removed:
   * The LIME generator was removed. 
 

--- a/functional-tests/functional/input/lime/SetType.lime
+++ b/functional-tests/functional/input/lime/SetType.lime
@@ -68,3 +68,14 @@ class SomePointerEquatableClass {
     )
     property id: String { get }
 }
+
+struct EnumSetDefaults {
+    enum TriState {
+        OFF,
+        ON,
+        BROKEN
+    }
+
+    emptyDefault: Set<TriState> = []
+    nonEmptyDefault: Set<TriState> = [TriState.OFF, TriState.BROKEN]
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaValueResolver.kt
@@ -89,9 +89,18 @@ internal class JavaValueResolver(private val nameResolver: JavaNameResolver) {
             }
             is LimeSet -> {
                 val values = limeValue.values.joinToString(", ") { resolveValue(it) }
-                val implName = if (limeType.elementType.type.actualType is LimeEnumeration) "EnumSet" else "HashSet"
-                val valuesAsList = if (values.isEmpty()) "" else "Arrays.asList($values)"
-                "new $implName<>($valuesAsList)"
+                if (limeType.elementType.type.actualType is LimeEnumeration) {
+                    when {
+                        values.isEmpty() -> {
+                            val typeName = nameResolver.resolveTypeRef(limeType.elementType, needsBoxing = true)
+                            "EnumSet.noneOf($typeName.class)"
+                        }
+                        else -> "EnumSet.of($values)"
+                    }
+                } else {
+                    val valuesAsList = if (values.isEmpty()) "" else "Arrays.asList($values)"
+                    "new HashSet<>($valuesAsList)"
+                }
             }
             is LimeMap -> when {
                 limeValue.values.isEmpty() -> "new HashMap<>()"

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaults.java
@@ -25,7 +25,7 @@ public final class EnumCollectionDefaults {
     public Map<Enum3, Enum4> mapField;
     public EnumCollectionDefaults() {
         this.listField = new ArrayList<>(Arrays.asList(Enum1.DISABLED));
-        this.setField = new EnumSet<>(Arrays.asList(Enum2.DISABLED));
+        this.setField = EnumSet.of(Enum2.DISABLED);
         this.mapField = new HashMapBuilder<Enum3, Enum4>().put(Enum3.DISABLED, Enum4.DISABLED).build();
     }
 }

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaultsExternal.java
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/android/com/example/smoke/EnumCollectionDefaultsExternal.java
@@ -21,7 +21,7 @@ public final class EnumCollectionDefaultsExternal {
     public Map<foo.AlienEnum3, foo.AlienEnum4> mapField;
     public EnumCollectionDefaultsExternal() {
         this.listField = new ArrayList<>(Arrays.asList(foo.AlienEnum1.DISABLED));
-        this.setField = new EnumSet<>(Arrays.asList(foo.AlienEnum2.DISABLED));
+        this.setField = EnumSet.of(foo.AlienEnum2.DISABLED);
         this.mapField = new HashMapBuilder<foo.AlienEnum3, foo.AlienEnum4>().put(foo.AlienEnum3.DISABLED, foo.AlienEnum4.DISABLED).build();
     }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/EnumSets.java
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/com/example/smoke/EnumSets.java
@@ -7,10 +7,10 @@ import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.Set;
 public final class EnumSets {
-    public static final Set<GenericTypesWithCompoundTypes.SomeEnum> ENUM_SET_CONST = new EnumSet<>(Arrays.asList(GenericTypesWithCompoundTypes.SomeEnum.FOO, GenericTypesWithCompoundTypes.SomeEnum.BAR));
+    public static final Set<GenericTypesWithCompoundTypes.SomeEnum> ENUM_SET_CONST = EnumSet.of(GenericTypesWithCompoundTypes.SomeEnum.FOO, GenericTypesWithCompoundTypes.SomeEnum.BAR);
     @NonNull
     public Set<GenericTypesWithCompoundTypes.SomeEnum> enumSetField;
     public EnumSets() {
-        this.enumSetField = new EnumSet<>();
+        this.enumSetField = EnumSet.noneOf(GenericTypesWithCompoundTypes.SomeEnum.class);
     }
 }


### PR DESCRIPTION
Updated JavaValueResolver to generate correct value initializers for empty and
non-empty enum sets.

Updated smoke tests. Added functional tests.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>