### PR TITLE
Add support for `@Swift(OptionSet)` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features:
   * Added support for per-platform visibility attributes (e.g. `@Java(Internal)`, etc.).
   * Added a `null` check in Dart for non-nullable class and interface usages.
+  * Added support for `@Swift(OptionSet)` attribute.
 ### Bug fixes:
   * Fixed Java compilation issue for enum set literals.
 ### Removed:

--- a/docs/lime_attributes.md
+++ b/docs/lime_attributes.md
@@ -94,6 +94,9 @@ generated code. _Attribute_ does not need to be prepended with `@`. _Attribute_ 
 literals, their enclosing quotes need to be backslash-escaped, as in the example.
 * **ParameterDefaults**: marks a "field constructor" of a struct to have field default values as parameter defaults
 in Swift, for those fields that are listed in the "filed constructor's" signature.
+* **OptionSet**: marks an enumeration to be generated in Swift as a `struct` implementing the `OptionSet` protocol.
+Additionally, for each enum `MyEnum` marked as such, any usage of `Set<MyEnum>` will be replaced by `MyEnum` itself in
+Swift, per the `OptionSet` usage pattern.
 * **Public** or **Internal**: marks an element to have the corresponding visibility in Swift, disregarding any "global"
 visibility modifiers the element might have.
 

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -170,6 +170,7 @@ feature(Enums cpp android swift dart SOURCES
 
     input/lime/Enums.lime
     input/lime/EnumeratorAlias.lime
+    input/lime/EnumOptionSet.lime
     input/lime/EnumsTypeCollection.lime
 )
 

--- a/functional-tests/functional/input/lime/EnumOptionSet.lime
+++ b/functional-tests/functional/input/lime/EnumOptionSet.lime
@@ -1,0 +1,41 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Swift(OptionSet)
+enum EnumOptionSet {
+    ONE = 1,
+    TWO = 2,
+    THREE = 4
+}
+
+@Swift(OptionSet)
+enum EnumOptionSetComments {
+    ONE = 1,
+    @Deprecated
+    TWO = 2,
+    // Foo bar
+    THREE = 4
+}
+
+struct UseEnumOptionSet {
+    setField: Set<EnumOptionSet>
+    setFieldEmpty: Set<EnumOptionSet> = []
+    setFieldValue: Set<EnumOptionSet> = [EnumOptionSet.ONE, EnumOptionSet.THREE]
+    static fun roundTrip(input: Set<EnumOptionSet>): Set<EnumOptionSet>
+}

--- a/functional-tests/functional/input/src/cpp/Enums.cpp
+++ b/functional-tests/functional/input/src/cpp/Enums.cpp
@@ -19,7 +19,9 @@
 // -------------------------------------------------------------------------------------------------
 
 #include "test/Enums.h"
+#include "test/UseEnumOptionSet.h"
 #include "test/UseEnumWithAlias.h"
+#include <unordered_set>
 
 namespace
 {
@@ -30,7 +32,7 @@ flip_enum( const ::test::Enums::InternalError val )
                ? ::test::Enums::InternalError::ERROR_FATAL
                : ::test::Enums::InternalError::ERROR_NONE;
 }
-}  // namespace
+}
 
 namespace test
 {
@@ -75,5 +77,14 @@ UseEnumWithAlias::compare_to_first(const test::EnumWithAlias input) {
 
 test::EnumWithAlias
 UseEnumWithAlias::get_first() { return test::EnumWithAlias::FIRST; }
+
+// UseEnumOptionSet
+
+std::unordered_set<test::EnumOptionSet, lorem_ipsum::test::hash<test::EnumOptionSet>>
+UseEnumOptionSet::round_trip(
+    const std::unordered_set<test::EnumOptionSet, lorem_ipsum::test::hash<test::EnumOptionSet>>& input
+) {
+    return input;
+}
 
 }

--- a/functional-tests/functional/swift/Tests/EnumsTests.swift
+++ b/functional-tests/functional/swift/Tests/EnumsTests.swift
@@ -104,6 +104,26 @@ class EnumsTests: XCTestCase {
         XCTAssertTrue(result)
     }
 
+    func testEnumOptionSet() {
+        let value: EnumOptionSet = [.one, .three]
+
+        XCTAssertEqual(value.rawValue, 5)
+    }
+
+    func testEnumOptionSetDefault() {
+        let value = UseEnumOptionSet(setField: []).setFieldValue
+
+        XCTAssertEqual(value.rawValue, 5)
+    }
+
+    func testEnumOptionSetRoundTrip() {
+        let value: EnumOptionSet = [.one, .three]
+
+        let result = UseEnumOptionSet.roundTrip(input: value)
+
+        XCTAssertEqual(result.rawValue, 5)
+    }
+
     static var allTests = [
         ("testFlipEnumValue", testFlipEnumValue),
         ("testExtractEnumFromStruct", testExtractEnumFromStruct),
@@ -115,6 +135,9 @@ class EnumsTests: XCTestCase {
         ("testDoubleAliasInSwift", testDoubleAliasInSwift),
         ("testAliasFromCpp", testAliasFromCpp),
         ("testAliasToTargetCpp", testAliasToTargetCpp),
-        ("testAliasToAlias", testAliasToAlias)
+        ("testAliasToAlias", testAliasToAlias),
+        ("testEnumOptionSet", testEnumOptionSet),
+        ("testEnumOptionSetDefault", testEnumOptionSetDefault),
+        ("testEnumOptionSetRoundTrip", testEnumOptionSetRoundTrip)
     ]
 }

--- a/functional-tests/scripts/valgrind_suppressions
+++ b/functional-tests/scripts/valgrind_suppressions
@@ -49,6 +49,14 @@
    fun:*
 }
 {
+   instantiateGenericMetadata 2
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:__swift_instantiateGenericMetadata
+}
+{
    allocateGenericValueMetadata
 
    Memcheck:Leak
@@ -312,4 +320,3 @@
    fun:__swift_instantiateConcreteTypeFromMangledName
    fun:*
 }
-

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -25,6 +25,8 @@ import com.here.gluecodium.generator.common.CommentsProcessor
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
 import com.here.gluecodium.model.lime.LimeAttributeType.OPTIMIZED
+import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
+import com.here.gluecodium.model.lime.LimeAttributeValueType.OPTION_SET
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeClass
@@ -32,6 +34,7 @@ import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeConstant
 import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeException
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
@@ -178,7 +181,14 @@ internal class SwiftNameResolver(
         when (limeType) {
             is LimeList -> "[${resolveName(limeType.elementType)}]"
             is LimeMap -> "[${resolveName(limeType.keyType)}: ${resolveName(limeType.valueType)}]"
-            is LimeSet -> "Set<${resolveName(limeType.elementType)}>"
+            is LimeSet -> {
+                val actualType = limeType.elementType.type.actualType
+                val elementTypeName = resolveName(limeType.elementType)
+                when {
+                    actualType is LimeEnumeration && actualType.attributes.have(SWIFT, OPTION_SET) -> elementTypeName
+                    else -> "Set<$elementTypeName>"
+                }
+            }
             else -> throw GluecodiumExecutionException("Unsupported element type ${limeType.javaClass.name}")
         }
 

--- a/gluecodium/src/main/resources/templates/swift/EnumOptionSetDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/EnumOptionSetDefinition.mustache
@@ -1,0 +1,43 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2022 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{>swift/TypeVisibility}} struct {{resolveName}}{{#if external.swift.converter}}_internal{{/if}} : OptionSet, CaseIterable, Codable {
+    public let rawValue: UInt32
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+{{#set enum=this}}{{#enumerators}}
+{{prefixPartial "optionSetEnumerator" "    "}}
+{{/enumerators}}{{/set}}
+
+    {{resolveName "visibility"}} static var allCases: [{{resolveName}}] {
+        return [{{#enumerators}}.{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/enumerators}}]
+    }
+}
+{{!!
+
+}}{{+optionSetEnumerator}}
+{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
+{{resolveName "visibility"}} static let {{resolveName}} = {{!!
+}}{{#if isAlias}}{{resolveName explicitValue}}{{/if}}{{!!
+}}{{#unless isAlias}}{{resolveName enum}}(rawValue: {{resolveName explicitValue}}){{/unless}}
+{{/optionSetEnumerator}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftEnumConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftEnumConversion.mustache
@@ -67,7 +67,9 @@
 {{#if external.swift.converter}}
     return {{external.swift.converter}}.convertFromInternal({{resolveName this "" "ref"}}_internal(rawValue: cValue)!)
 {{/if}}{{#unless external.swift.converter}}
-    return {{resolveName this "" "ref"}}(rawValue: {{#ifPredicate "skipDeclaration"}}UInt({{/ifPredicate}}cValue{{#ifPredicate "skipDeclaration"}}){{/ifPredicate}})!
+    return {{resolveName this "" "ref"}}(rawValue: {{!!
+    }}{{#ifPredicate "skipDeclaration"}}UInt({{/ifPredicate}}cValue{{!!
+    }}{{#ifPredicate "skipDeclaration"}}){{/ifPredicate}}){{#unless attributes.swift.optionSet}}!{{/unless}}
 {{/unless}}
 }
 {{>swift/ConversionVisibility}} func moveFromCType(_ cValue: UInt32) -> {{resolveName this "" "ref"}} {
@@ -81,7 +83,9 @@
 {{#if external.swift.converter}}
     return {{external.swift.converter}}.convertFromInternal({{resolveName this "" "ref"}}_internal(rawValue: uint32_t_value_get(handle))!)
 {{/if}}{{#unless external.swift.converter}}
-    return {{resolveName this "" "ref"}}(rawValue: {{#ifPredicate "skipDeclaration"}}UInt({{/ifPredicate}}uint32_t_value_get(handle){{#ifPredicate "skipDeclaration"}}){{/ifPredicate}})!
+    return {{resolveName this "" "ref"}}(rawValue: {{!!
+    }}{{#ifPredicate "skipDeclaration"}}UInt({{/ifPredicate}}uint32_t_value_get(handle){{!!
+    }}{{#ifPredicate "skipDeclaration"}}){{/ifPredicate}}){{#unless attributes.swift.optionSet}}!{{/unless}}
 {{/unless}}
 }
 {{>swift/ConversionVisibility}} func moveFromCType(_ handle: _baseRef) -> {{resolveName this "" "ref"}}? {

--- a/gluecodium/src/main/resources/templates/swift/SwiftEnumDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftEnumDefinition.mustache
@@ -18,7 +18,10 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#unlessPredicate "skipDeclaration"}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
+{{#unlessPredicate "skipDeclaration"}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{#if attributes.swift.optionSet}}
+{{>swift/EnumOptionSetDefinition}}
+{{/if}}{{!!
+}}{{#unless attributes.swift.optionSet}}
 {{>swift/TypeVisibility}} enum {{resolveName}}{{#if external.swift.converter}}_internal{{/if}} : UInt32, CaseIterable, Codable {
 {{#uniqueEnumerators}}{{prefixPartial "enumerator" "    "}}
 {{/uniqueEnumerators}}{{#if aliasEnumerators}}
@@ -62,7 +65,9 @@
     }
 {{/ifPredicate}}
 }
+{{/unless}}
 {{/unlessPredicate}}{{!!
+
 }}{{+enumerator}}{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
 {{#if isAlias}}{{resolveName "visibility"}} static let {{resolveName}} = {{resolveName explicitValue}}{{/if}}{{!!
 }}{{#unless isAlias}}case {{resolveName}}{{#if explicitValue}} = {{resolveName explicitValue}}{{/if}}{{/unless}}{{/enumerator}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftSets.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftSets.mustache
@@ -27,7 +27,8 @@ import Foundation
 import {{this}}
 {{/imports}}
 
-{{#collections}}
+{{#collections}}{{!!
+}}{{#set isOptionSet=elementType.type.actualType.attributes.swift.optionSet collection=this}}{{#collection}}
 internal func {{>functionPrefix}}copyFromCType(_ handle: _baseRef) -> {{resolveName}} {
     var result: {{resolveName}} = []
     let iterator_handle = {{resolveName "CBridge"}}_iterator(handle)
@@ -48,7 +49,11 @@ internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveN
 
 internal func {{>functionPrefix}}copyToCType(_ swiftSet: {{resolveName}}) -> RefHolder {
     let handle = {{resolveName "CBridge"}}_create_handle()
+{{#if isOptionSet}}
+    for item in {{elementType}}.allCases.filter({ swiftSet.contains($0) }) {
+{{/if}}{{#unless isOptionSet}}
     for item in swiftSet {
+{{/unless}}
         let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
         {{resolveName "CBridge"}}_insert(handle, _item.ref)
     }
@@ -68,7 +73,11 @@ internal func {{>functionPrefix}}copyToCType(_ swiftSet: {{resolveName}}?) -> Re
     }
     let optionalHandle = {{resolveName "CBridge"}}_create_optional_handle()
     let handle = {{resolveName "CBridge"}}_unwrap_optional_handle(optionalHandle)
+{{#if isOptionSet}}
+    for item in {{elementType}}.allCases.filter({ swiftSet.contains($0) }) {
+{{/if}}{{#unless isOptionSet}}
     for item in swiftSet {
+{{/unless}}
         let _item = {{#set typeRef=elementType}}{{>swift/ConversionPrefixTo}}{{/set}}moveToCType(item)
         {{resolveName "CBridge"}}_insert(handle, _item.ref)
     }
@@ -94,7 +103,7 @@ internal func {{>functionPrefix}}moveFromCType(_ handle: _baseRef) -> {{resolveN
     return {{>functionPrefix}}copyFromCType(handle)
 }
 
-{{/collections}}{{!!
+{{/collection}}{{/set}}{{/collections}}{{!!
 
 }}{{+functionPrefix}}{{#ifPredicate "hasCppTypeAttribute"}}{{resolveName "CBridge"}}{{/ifPredicate}}{{!!
 }}{{#unlessPredicate "hasCppTypeAttribute"}}{{internalPrefix}}{{!!

--- a/gluecodium/src/test/resources/smoke/enums/input/EnumOptionSet.lime
+++ b/gluecodium/src/test/resources/smoke/enums/input/EnumOptionSet.lime
@@ -1,0 +1,41 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Swift(OptionSet)
+enum EnumOptionSet {
+    ONE = 1,
+    TWO = 2,
+    THREE = 4
+}
+
+@Swift(OptionSet)
+enum EnumOptionSetComments {
+    ONE = 1,
+    @Deprecated
+    TWO = 2,
+    // Foo bar
+    THREE = 4
+}
+
+struct UseEnumOptionSet {
+    setField: Set<EnumOptionSet>
+    setFieldEmpty: Set<EnumOptionSet> = []
+    setFieldValue: Set<EnumOptionSet> = [EnumOptionSet.ONE, EnumOptionSet.THREE]
+    static fun roundTrip(input: Set<EnumOptionSet>): Set<EnumOptionSet>
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/Sets.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/Sets.swift
@@ -1,0 +1,58 @@
+//
+//
+import Foundation
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EnumOptionSet {
+    var result: EnumOptionSet = []
+    let iterator_handle = foobar_SetOf_smoke_EnumOptionSet_iterator(handle)
+    while foobar_SetOf_smoke_EnumOptionSet_iterator_is_valid(handle, iterator_handle) {
+        result.insert(copyFromCType(foobar_SetOf_smoke_EnumOptionSet_iterator_get(iterator_handle)))
+        foobar_SetOf_smoke_EnumOptionSet_iterator_increment(iterator_handle)
+    }
+    foobar_SetOf_smoke_EnumOptionSet_iterator_release_handle(iterator_handle)
+    return result
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EnumOptionSet {
+    defer {
+        foobar_SetOf_smoke_EnumOptionSet_release_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}
+internal func foobar_copyToCType(_ swiftSet: EnumOptionSet) -> RefHolder {
+    let handle = foobar_SetOf_smoke_EnumOptionSet_create_handle()
+    for item in EnumOptionSet.allCases.filter({ swiftSet.contains($0) }) {
+        let _item = moveToCType(item)
+        foobar_SetOf_smoke_EnumOptionSet_insert(handle, _item.ref)
+    }
+    return RefHolder(handle)
+}
+internal func foobar_moveToCType(_ swiftSet: EnumOptionSet) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftSet).ref, release: foobar_SetOf_smoke_EnumOptionSet_release_handle)
+}
+internal func foobar_copyToCType(_ swiftSet: EnumOptionSet?) -> RefHolder {
+    guard let swiftSet = swiftSet else {
+        return RefHolder(0)
+    }
+    let optionalHandle = foobar_SetOf_smoke_EnumOptionSet_create_optional_handle()
+    let handle = foobar_SetOf_smoke_EnumOptionSet_unwrap_optional_handle(optionalHandle)
+    for item in EnumOptionSet.allCases.filter({ swiftSet.contains($0) }) {
+        let _item = moveToCType(item)
+        foobar_SetOf_smoke_EnumOptionSet_insert(handle, _item.ref)
+    }
+    return RefHolder(optionalHandle)
+}
+internal func foobar_moveToCType(_ swiftType: EnumOptionSet?) -> RefHolder {
+    return RefHolder(ref: foobar_copyToCType(swiftType).ref, release: foobar_SetOf_smoke_EnumOptionSet_release_optional_handle)
+}
+internal func foobar_copyFromCType(_ handle: _baseRef) -> EnumOptionSet? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = foobar_SetOf_smoke_EnumOptionSet_unwrap_optional_handle(handle)
+    return foobar_copyFromCType(unwrappedHandle) as EnumOptionSet
+}
+internal func foobar_moveFromCType(_ handle: _baseRef) -> EnumOptionSet? {
+    defer {
+        foobar_SetOf_smoke_EnumOptionSet_release_optional_handle(handle)
+    }
+    return foobar_copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumOptionSet.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumOptionSet.swift
@@ -1,0 +1,45 @@
+//
+//
+import Foundation
+public struct EnumOptionSet : OptionSet, CaseIterable, Codable {
+    public let rawValue: UInt32
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+    public static let one = EnumOptionSet(rawValue: 1)
+    public static let two = EnumOptionSet(rawValue: 2)
+    public static let three = EnumOptionSet(rawValue: 4)
+    public static var allCases: [EnumOptionSet] {
+        return [.one, .two, .three]
+    }
+}
+internal func copyToCType(_ swiftEnum: EnumOptionSet) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumOptionSet) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: EnumOptionSet?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumOptionSet?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> EnumOptionSet {
+    return EnumOptionSet(rawValue: cValue)
+}
+internal func moveFromCType(_ cValue: UInt32) -> EnumOptionSet {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> EnumOptionSet? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EnumOptionSet(rawValue: uint32_t_value_get(handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> EnumOptionSet? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumOptionSetComments.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/EnumOptionSetComments.swift
@@ -1,0 +1,47 @@
+//
+//
+import Foundation
+public struct EnumOptionSetComments : OptionSet, CaseIterable, Codable {
+    public let rawValue: UInt32
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+    public static let one = EnumOptionSetComments(rawValue: 1)
+    @available(*, deprecated)
+    public static let two = EnumOptionSetComments(rawValue: 2)
+    /// Foo bar
+    public static let three = EnumOptionSetComments(rawValue: 4)
+    public static var allCases: [EnumOptionSetComments] {
+        return [.one, .two, .three]
+    }
+}
+internal func copyToCType(_ swiftEnum: EnumOptionSetComments) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumOptionSetComments) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+internal func copyToCType(_ swiftEnum: EnumOptionSetComments?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: EnumOptionSetComments?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+internal func copyFromCType(_ cValue: UInt32) -> EnumOptionSetComments {
+    return EnumOptionSetComments(rawValue: cValue)
+}
+internal func moveFromCType(_ cValue: UInt32) -> EnumOptionSetComments {
+    return copyFromCType(cValue)
+}
+internal func copyFromCType(_ handle: _baseRef) -> EnumOptionSetComments? {
+    guard handle != 0 else {
+        return nil
+    }
+    return EnumOptionSetComments(rawValue: uint32_t_value_get(handle))
+}
+internal func moveFromCType(_ handle: _baseRef) -> EnumOptionSetComments? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/UseEnumOptionSet.swift
+++ b/gluecodium/src/test/resources/smoke/enums/output/swift/smoke/UseEnumOptionSet.swift
@@ -1,0 +1,66 @@
+//
+//
+import Foundation
+public struct UseEnumOptionSet {
+    public var setField: EnumOptionSet
+    public var setFieldEmpty: EnumOptionSet
+    public var setFieldValue: EnumOptionSet
+    public init(setField: EnumOptionSet, setFieldEmpty: EnumOptionSet = [], setFieldValue: EnumOptionSet = [EnumOptionSet.one, EnumOptionSet.three]) {
+        self.setField = setField
+        self.setFieldEmpty = setFieldEmpty
+        self.setFieldValue = setFieldValue
+    }
+    internal init(cHandle: _baseRef) {
+        setField = foobar_moveFromCType(smoke_UseEnumOptionSet_setField_get(cHandle))
+        setFieldEmpty = foobar_moveFromCType(smoke_UseEnumOptionSet_setFieldEmpty_get(cHandle))
+        setFieldValue = foobar_moveFromCType(smoke_UseEnumOptionSet_setFieldValue_get(cHandle))
+    }
+    public static func roundTrip(input: EnumOptionSet) -> EnumOptionSet {
+        let c_input = foobar_moveToCType(input)
+        let c_result_handle = smoke_UseEnumOptionSet_roundTrip(c_input.ref)
+        return foobar_moveFromCType(c_result_handle)
+    }
+}
+internal func copyFromCType(_ handle: _baseRef) -> UseEnumOptionSet {
+    return UseEnumOptionSet(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> UseEnumOptionSet {
+    defer {
+        smoke_UseEnumOptionSet_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: UseEnumOptionSet) -> RefHolder {
+    let c_setField = foobar_moveToCType(swiftType.setField)
+    let c_setFieldEmpty = foobar_moveToCType(swiftType.setFieldEmpty)
+    let c_setFieldValue = foobar_moveToCType(swiftType.setFieldValue)
+    return RefHolder(smoke_UseEnumOptionSet_create_handle(c_setField.ref, c_setFieldEmpty.ref, c_setFieldValue.ref))
+}
+internal func moveToCType(_ swiftType: UseEnumOptionSet) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_UseEnumOptionSet_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> UseEnumOptionSet? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_UseEnumOptionSet_unwrap_optional_handle(handle)
+    return UseEnumOptionSet(cHandle: unwrappedHandle) as UseEnumOptionSet
+}
+internal func moveFromCType(_ handle: _baseRef) -> UseEnumOptionSet? {
+    defer {
+        smoke_UseEnumOptionSet_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+internal func copyToCType(_ swiftType: UseEnumOptionSet?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_setField = foobar_moveToCType(swiftType.setField)
+    let c_setFieldEmpty = foobar_moveToCType(swiftType.setFieldEmpty)
+    let c_setFieldValue = foobar_moveToCType(swiftType.setFieldValue)
+    return RefHolder(smoke_UseEnumOptionSet_create_optional_handle(c_setField.ref, c_setFieldEmpty.ref, c_setFieldValue.ref))
+}
+internal func moveToCType(_ swiftType: UseEnumOptionSet?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_UseEnumOptionSet_release_optional_handle)
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -83,7 +83,7 @@ internal object AntlrLimeConverter {
         }
 
         annotationValues.forEach {
-            val valueType = convertAnnotationValueType(it, attributeType) ?: return@forEach
+            val valueType = convertAnnotationValueType(it, attributeType)
             val rawValue = convertAnnotationValue(it)
             val value = when {
                 attributeType == LimeAttributeType.DEPRECATED -> {
@@ -159,7 +159,7 @@ internal object AntlrLimeConverter {
     private fun convertAnnotationValueType(
         ctx: LimeParser.AnnotationValueContext,
         attributeType: LimeAttributeType
-    ): LimeAttributeValueType? {
+    ): LimeAttributeValueType {
         val id = ctx.simpleId()?.text ?: return (
             attributeType.defaultValueType
                 ?: throw LimeLoadingException("Attribute type $attributeType does not support values")
@@ -177,6 +177,7 @@ internal object AntlrLimeConverter {
             "Internal" -> LimeAttributeValueType.INTERNAL
             "Label" -> LimeAttributeValueType.LABEL
             "Message" -> LimeAttributeValueType.MESSAGE
+            "OptionSet" -> LimeAttributeValueType.OPTION_SET
             "ParameterDefaults" -> LimeAttributeValueType.PARAMETER_DEFAULTS
             "PositionalDefaults" -> LimeAttributeValueType.POSITIONAL_DEFAULTS
             "Public" -> LimeAttributeValueType.PUBLIC

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -32,6 +32,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     INTERNAL("Internal"),
     LABEL("Label"),
     MESSAGE("Message"),
+    OPTION_SET("OptionSet"),
     PARAMETER_DEFAULTS("ParameterDefaults"),
     POSITIONAL_DEFAULTS("PositionalDefaults"),
     PUBLIC("Public"),


### PR DESCRIPTION
Added support for `@Swift(OptionSet)` attribute. An enum marked with this
attribute is generated as a Swift `struct` conforming to `OptionSet` protocol.
Moreover, for each such enum `Foo`, any LIME usage of `Set<Foo>` will be `Foo`
itself in Swift, per the use pattern for `OptionSet`.

Resolves: #1197
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>