### PR TITLE
Upgrade ANTLR to 4.10.1

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -192,6 +192,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - name: Install JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Breaking changes:
+  * Minimum Java version for running Gluecodium is now Java 11.
+
 ## 13.2.1
 Release date: 2022-08-22
 ### Bug fixes:

--- a/docs/internal/development_tools.md
+++ b/docs/internal/development_tools.md
@@ -9,7 +9,7 @@ Required tools for Gluecodium itself
 * [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - for downloading Gluecodium repository source
   code and for committing the changes to the repository.
 * [Java JDK](https://openjdk.java.net/install/index.html) - for running Gluecodium itself, as well as its unit and
-  integration tests. Java 8 is guaranteed to work, regardless of the JDK vendor. Any version above that may or may not
+  integration tests. Java 11 is guaranteed to work, regardless of the JDK vendor. Any version above that may or may not
   have issues.
 
 Required tools for Gluecodium functional tests

--- a/gluecodium/build.gradle
+++ b/gluecodium/build.gradle
@@ -25,23 +25,23 @@ dependencies {
     implementation project(":lime-loader")
 
     compileOnly 'com.android.tools:annotations:25.3.0'
-    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.guava:guava:31.1-jre'
     implementation 'com.natpryce:konfig:1.6.10.0'
-    implementation 'com.vladsch.flexmark:flexmark:0.62.2'
-    implementation 'com.vladsch.flexmark:flexmark-ext-tables:0.62.2'
-    implementation 'com.vladsch.flexmark:flexmark-util:0.62.2'
-    implementation 'commons-cli:commons-cli:1.4'
-    implementation 'org.apache.logging.log4j:log4j-core:2.16.0'
+    implementation 'com.vladsch.flexmark:flexmark:0.64.0'
+    implementation 'com.vladsch.flexmark:flexmark-ext-tables:0.64.0'
+    implementation 'com.vladsch.flexmark:flexmark-util:0.64.0'
+    implementation 'commons-cli:commons-cli:1.5.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.18.0'
     implementation 'org.jetbrains.kotlin:kotlin-reflect:1.6.21'
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'
-    implementation 'org.jetbrains:annotations:13.0'
-    implementation 'org.slf4j:slf4j-api:1.7.31'
-    implementation 'org.slf4j:slf4j-log4j12:1.7.31'
-    implementation 'org.trimou:trimou-core:2.5.0.Final'
+    implementation 'org.jetbrains:annotations:23.0.0'
+    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation 'org.slf4j:slf4j-log4j12:1.7.36'
+    implementation 'org.trimou:trimou-core:2.5.1.Final'
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.2'
-    testImplementation 'io.mockk:mockk:1.12.2'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.5'
+    testImplementation 'io.mockk:mockk:1.12.5'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommentsProcessor.kt
@@ -29,12 +29,11 @@ import com.vladsch.flexmark.util.ast.NodeVisitor
 import com.vladsch.flexmark.util.ast.VisitHandler
 import com.vladsch.flexmark.util.data.DataHolder
 import com.vladsch.flexmark.util.data.DataSet
-import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
+import com.vladsch.flexmark.util.sequence.CharSubSequence
 
 /**
  * Parse Markdown comments and process links.
  */
-@Suppress("DEPRECATION")
 abstract class CommentsProcessor(
     private val renderer: IRender,
     private val werror: Boolean,
@@ -79,7 +78,7 @@ abstract class CommentsProcessor(
         }
         val codeBlockHandler = VisitHandler(Code::class.java) {
             if (it.text.toString() == standardNullReference) {
-                it.text = BasedSequenceImpl.of(nullReference)
+                it.text = CharSubSequence.of(nullReference)
             }
         }
         val autoLinkHandler = VisitHandler(AutoLink::class.java) { processAutoLink(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/DoxygenCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/DoxygenCommentsProcessor.kt
@@ -22,18 +22,17 @@ package com.here.gluecodium.generator.cpp
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
-import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
+import com.vladsch.flexmark.util.sequence.CharSubSequence
 
-@Suppress("DEPRECATION")
 internal class DoxygenCommentsProcessor(werror: Boolean) : CommentsProcessor(Formatter.builder().build(), werror) {
 
     override fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String) {
-        linkNode.reference = BasedSequenceImpl.of(linkReference)
+        linkNode.reference = CharSubSequence.of(linkReference)
         // Doxygen documentation claims that \link classname Alternative title \endlink is the
         // correct way to have a link with alternative title, however it only works for a small
         // subset of possible link types. Rely on autolinking instead and just remove the link
         // markers.
-        linkNode.referenceOpeningMarker = BasedSequenceImpl.of("")
-        linkNode.referenceClosingMarker = BasedSequenceImpl.of("")
+        linkNode.referenceOpeningMarker = CharSubSequence.of("")
+        linkNode.referenceClosingMarker = CharSubSequence.of("")
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartCommentsProcessor.kt
@@ -22,15 +22,14 @@ package com.here.gluecodium.generator.dart
 import com.here.gluecodium.generator.common.CommentsProcessor
 import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
-import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
+import com.vladsch.flexmark.util.sequence.CharSubSequence
 
-@Suppress("DEPRECATION")
 internal class DartCommentsProcessor(werror: Boolean) : CommentsProcessor(Formatter.builder().build(), werror) {
 
     override fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String) {
-        linkNode.reference = BasedSequenceImpl.of(linkReference)
-        linkNode.referenceOpeningMarker = BasedSequenceImpl.of("[")
-        linkNode.referenceClosingMarker = BasedSequenceImpl.of("]")
+        linkNode.reference = CharSubSequence.of(linkReference)
+        linkNode.referenceOpeningMarker = CharSubSequence.of("[")
+        linkNode.referenceClosingMarker = CharSubSequence.of("]")
         linkNode.firstChild?.unlink()
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaDocProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaDocProcessor.kt
@@ -28,12 +28,11 @@ import com.vladsch.flexmark.html.HtmlRenderer
 import com.vladsch.flexmark.parser.Parser
 import com.vladsch.flexmark.util.data.DataHolder
 import com.vladsch.flexmark.util.data.MutableDataSet
-import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
+import com.vladsch.flexmark.util.sequence.CharSubSequence
 
 /**
  * Parse Markdown comments and output JavaDoc
  */
-@Suppress("DEPRECATION")
 internal class JavaDocProcessor(werror: Boolean, private val referenceMap: Map<String, LimeElement>) :
     CommentsProcessor(HtmlRenderer.builder(flexmarkOptions).build(), werror, flexmarkOptions) {
 
@@ -41,9 +40,9 @@ internal class JavaDocProcessor(werror: Boolean, private val referenceMap: Map<S
         val limeElement = referenceMap[fullNameToPathKey(limeFullName)]
         linkNode.chars = if (limeElement is LimeParameter) {
             val shortReference = linkReference.split("#").last()
-            BasedSequenceImpl.of("{@code $shortReference}")
+            CharSubSequence.of("{@code $shortReference}")
         } else {
-            BasedSequenceImpl.of("{@link $linkReference}")
+            CharSubSequence.of("{@link $linkReference}")
         }
         linkNode.firstChild?.unlink()
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftCommentsProcessor.kt
@@ -25,23 +25,22 @@ import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.parser.ParserEmulationProfile
 import com.vladsch.flexmark.util.data.MutableDataSet
-import com.vladsch.flexmark.util.sequence.BasedSequenceImpl
+import com.vladsch.flexmark.util.sequence.CharSubSequence
 
 /**
  * Parse markdown comments and process links
  */
-@Suppress("DEPRECATION")
 class SwiftCommentsProcessor(werror: Boolean) : CommentsProcessor(Formatter.builder(formatterOptions).build(), werror) {
 
     override fun processLink(linkNode: LinkRef, linkReference: String, limeFullName: String) {
-        linkNode.reference = BasedSequenceImpl.of(linkReference)
-        linkNode.referenceOpeningMarker = BasedSequenceImpl.of("`")
-        linkNode.referenceClosingMarker = BasedSequenceImpl.of("`")
+        linkNode.reference = CharSubSequence.of(linkReference)
+        linkNode.referenceOpeningMarker = CharSubSequence.of("`")
+        linkNode.referenceClosingMarker = CharSubSequence.of("`")
         linkNode.firstChild?.unlink()
     }
 
     override fun processAutoLink(linkNode: AutoLink) {
-        linkNode.chars = BasedSequenceImpl.of(linkNode.chars.trim('<', '>'))
+        linkNode.chars = CharSubSequence.of(linkNode.chars.trim('<', '>'))
     }
 
     override val nullReference = "nil"

--- a/lime-loader/build.gradle
+++ b/lime-loader/build.gradle
@@ -3,14 +3,14 @@ plugins {
 }
 
 dependencies {
-    antlr "org.antlr:antlr4:4.9.1"
+    antlr "org.antlr:antlr4:4.10.1"
     api project(":lime-runtime")
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'
-    implementation "org.antlr:antlr4-runtime:4.9.1"
+    implementation "org.antlr:antlr4-runtime:4.10.1"
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.2'
-    testImplementation 'io.mockk:mockk:1.12.2'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.5'
+    testImplementation 'io.mockk:mockk:1.12.5'
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/lime-runtime/build.gradle
+++ b/lime-runtime/build.gradle
@@ -19,10 +19,10 @@
 
 dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'
-    compileOnly 'org.jetbrains:annotations:13.0'
+    compileOnly 'org.jetbrains:annotations:23.0.0'
 
-    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.2'
-    testImplementation 'io.mockk:mockk:1.12.2'
+    testImplementation 'io.mockk:mockk-dsl-jvm:1.12.5'
+    testImplementation 'io.mockk:mockk:1.12.5'
     testImplementation 'junit:junit:4.13.2'
 }
 


### PR DESCRIPTION
Upgrading ANTLR library to 4.10.1 brings at least 10% performance improvements,
as measured on the smoke tests.

Also upgraded other dependencies.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>