### PR TITLE
Include classes and interfaces in topological sorting in C++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
   * Removed redundant visibility propagation for nested elements, except where required by language specifics.
+  * Fixed declaration ordering for lambdas in C++.
 
 ## 13.2.0
 Release date: 2022-08-19

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -391,10 +391,15 @@ feature(Durations cpp android swift dart SOURCES
 feature(StructsWithCompanion cpp android swift dart SOURCES
     input/src/cpp/StructsWithMethods.cpp
     input/src/cpp/StructsWithConstants.cpp
-    input/src/cpp/StructsWithMethodsDeclarationOrder.cpp
 
     input/lime/StructsWithMethods.lime
     input/lime/StructsWithConstants.lime
+)
+
+feature(DeclarationOrder cpp android swift dart SOURCES
+    input/src/cpp/StructsWithMethodsDeclarationOrder.cpp
+
+    input/lime/OrderWithInterface.lime
     input/lime/StructsWithMethodsDeclarationOrder.lime
 )
 

--- a/functional-tests/functional/input/lime/OrderWithInterface.lime
+++ b/functional-tests/functional/input/lime/OrderWithInterface.lime
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+interface InterfaceInInterface {
+    lambda SomeLambda = (FooChecker) -> Void
+    interface FooChecker {}
+}
+
+struct ClassInStruct {
+    lambda SomeLambda = (FooChecker) -> Void
+    class FooChecker {}
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/TopologicalSort.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/TopologicalSort.kt
@@ -54,8 +54,7 @@ internal class TopologicalSort(private val elements: List<LimeNamedElement>) {
 
             sortedElements.add(nextElement)
 
-            // As dependency to "nextElement" is now fulfilled we must remove it from elements
-            // dependencies.
+            // As dependency to "nextElement" is now fulfilled we must remove it from elements dependencies.
             for (name in fullNames) {
                 dependencies[name]?.remove(nextElement.fullName)
             }

--- a/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
@@ -28,17 +28,16 @@ public:
 
 {{#if enumerations typeAliases structs constants classes interfaces lambdas logic="or"}}
 public:
-{{#sort enumerations lambdas typeAliases structs constants}}
+{{#sort enumerations lambdas typeAliases structs constants classes interfaces}}
 {{#instanceOf this "LimeEnumeration"}}{{prefixPartial "cpp/CppEnumeration" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeLambda"}}{{prefixPartial "cpp/CppLambda" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeTypeAlias"}}{{prefixPartial "cpp/CppTypeAlias" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeStruct"}}{{prefixPartial "cpp/CppStruct" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeConstant"}}{{#set constant=this storageQualifier="static"}}{{#constant}}{{!!
-}}{{prefixPartial "cpp/CppConstant" "    "}}{{/constant}}{{/set}}{{/instanceOf}}
+}}{{prefixPartial "cpp/CppConstant" "    "}}{{/constant}}{{/set}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeClass"}}{{prefixPartial "cpp/CppClass" "    "}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeInterface"}}{{prefixPartial "cpp/CppClass" "    "}}{{/instanceOf}}
 {{/sort}}
-{{#each classes interfaces}}
-{{prefixPartial "cpp/CppClass" "    "}}
-{{/each}}
 {{/if}}
 {{#if functions properties logic="or"}}
 public:

--- a/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStruct.mustache
@@ -21,19 +21,17 @@
 {{#unless external.cpp}}
 {{>cpp/CppDocComment}}
 struct {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}} {
-{{#sort structs constants enumerations lambdas typeAliases}}
+{{#sort structs constants enumerations lambdas typeAliases classes interfaces}}
 {{#instanceOf this "LimeEnumeration"}}{{prefixPartial "cpp/CppEnumeration" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeLambda"}}{{prefixPartial "cpp/CppLambda" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeTypeAlias"}}{{prefixPartial "cpp/CppTypeAlias" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeStruct"}}{{prefixPartial "cpp/CppStruct" "    "}}{{/instanceOf}}{{!!
 }}{{#instanceOf this "LimeConstant"}}{{#set constant=this storageQualifier="static"}}{{#constant}}{{!!
-}}{{prefixPartial "cpp/CppConstant" "    "}}{{/constant}}{{/set}}{{/instanceOf}}
+}}{{prefixPartial "cpp/CppConstant" "    "}}{{/constant}}{{/set}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeClass"}}{{prefixPartial "cpp/CppClass" "    "}}{{/instanceOf}}{{!!
+}}{{#instanceOf this "LimeInterface"}}{{prefixPartial "cpp/CppClass" "    "}}{{/instanceOf}}
 {{/sort}}
-{{#each classes interfaces}}
-{{prefixPartial "cpp/CppClass" "    "}}
-{{/each}}{{!!
-
-}}{{#if attributes.cpp.accessors}}
+{{#if attributes.cpp.accessors}}
 private:
 {{#fields}}
     {{resolveName typeRef}} {{resolveName}}{{#defaultValue}} = {{resolveName}}{{/defaultValue}};

--- a/gluecodium/src/test/resources/smoke/declaration_order/input/OrderWithInterface.lime
+++ b/gluecodium/src/test/resources/smoke/declaration_order/input/OrderWithInterface.lime
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2022 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+interface InterfaceInInterface {
+    lambda SomeLambda = (FooChecker) -> Void
+    interface FooChecker {}
+}
+
+struct ClassInStruct {
+    lambda SomeLambda = (FooChecker) -> Void
+    class FooChecker {}
+}

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/ClassInStruct.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/ClassInStruct.h
@@ -1,0 +1,18 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include <functional>
+#include <memory>
+namespace smoke {
+struct _GLUECODIUM_CPP_EXPORT ClassInStruct {
+    class _GLUECODIUM_CPP_EXPORT FooChecker {
+    public:
+        FooChecker();
+        virtual ~FooChecker() = 0;
+    };
+    using SomeLambda = ::std::function<void(const ::std::shared_ptr< ::smoke::ClassInStruct::FooChecker >&)>;
+};
+}

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/InterfaceInInterface.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/InterfaceInInterface.h
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------------------------------
+//
+//
+// -------------------------------------------------------------------------------------------------
+#pragma once
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/TypeRepository.h"
+#include <functional>
+#include <memory>
+namespace smoke {
+class _GLUECODIUM_CPP_EXPORT InterfaceInInterface {
+public:
+    InterfaceInInterface();
+    virtual ~InterfaceInInterface() = 0;
+public:
+    class _GLUECODIUM_CPP_EXPORT FooChecker {
+    public:
+        FooChecker();
+        virtual ~FooChecker() = 0;
+    };
+    using SomeLambda = ::std::function<void(const ::std::shared_ptr< ::smoke::InterfaceInInterface::FooChecker >&)>;
+};
+}


### PR DESCRIPTION
Updated C++ templates to include classes and interfaces in the
topological sorting of the nested elements. This fixes the issue where
the declaration order of nested elements led to uncompilable C++ code.

Added smoke and functional tests.

Resolves: #1467
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>