### PR TITLE
Fix redundant `@override` in Dart interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 ### Features:
   * Added support for `@Internal` attribute.
+### Bug fixes:
+  * Removed redundant `@override` in Dart for static functions in interfaces.
 ### Breaking changes:
   * Minimum Java version for running Gluecodium is now Java 11.
 

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -156,8 +156,8 @@ class {{resolveName}}$Impl extends __lib.NativeBase implements {{resolveName}} {
   {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
 
 {{#set ignoreStatic=true}}{{#set parent=this}}{{#each inheritedFunctions functions}}
-  @override
-{{prefixPartial "dart/DartFunction" "  "}}
+{{#unless isStatic}}  @override
+{{/unless}}{{prefixPartial "dart/DartFunction" "  "}}
 {{/each}}{{/set}}
 {{#each inheritedProperties properties}}
 {{prefixPartial "dart/DartProperty" "  "}}

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -318,7 +318,6 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
       stringReleaseFfiHandle(__resultHandle);
     }
   }
-  @override
   void methodWithPayloadError() {
     final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError'));
     final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
@@ -333,7 +332,6 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
     }
     _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
   }
-  @override
   String methodWithPayloadErrorAndReturnValue() {
     final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue'));
     final __callResultHandle = _methodWithPayloadErrorAndReturnValueFfi(__lib.LibraryContext.isolateId);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -81,7 +81,6 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
       stringReleaseFfiHandle(__resultHandle);
     }
   }
-  @override
   String staticFunction() {
     final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticFunction'));
     final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);


### PR DESCRIPTION
Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>