### PR TITLE
Revert ANTLR version back to 4.9

### DIFF
--- a/docs/internal/development_tools.md
+++ b/docs/internal/development_tools.md
@@ -9,7 +9,7 @@ Required tools for Gluecodium itself
 * [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git) - for downloading Gluecodium repository source
   code and for committing the changes to the repository.
 * [Java JDK](https://openjdk.java.net/install/index.html) - for running Gluecodium itself, as well as its unit and
-  integration tests. Java 11 is guaranteed to work, regardless of the JDK vendor. Any version above that may or may not
+  integration tests. Java 8 is guaranteed to work, regardless of the JDK vendor. Any version above that may or may not
   have issues.
 
 Required tools for Gluecodium functional tests

--- a/lime-loader/build.gradle
+++ b/lime-loader/build.gradle
@@ -3,10 +3,10 @@ plugins {
 }
 
 dependencies {
-    antlr "org.antlr:antlr4:4.10.1"
+    antlr "org.antlr:antlr4:4.9.1"
     api project(":lime-runtime")
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'
-    implementation "org.antlr:antlr4-runtime:4.10.1"
+    implementation "org.antlr:antlr4-runtime:4.9.1"
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
     testImplementation 'io.mockk:mockk-dsl-jvm:1.12.5'


### PR DESCRIPTION
Reverted ANTLR version back to 4.9, for Java 8 compatibility on
jitpack.io.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>