### PR TITLE
Use `std::declval` instead of a null pointer for `decltype()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+  * Fixed C++ warnings for external types and structs with `@Cpp(Accessors)`.
+
 ## 13.4.1
 Release date: 2022-00-05
 ### Bug fixes:

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImplIncludesCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppImplIncludesCollector.kt
@@ -42,7 +42,7 @@ internal class CppImplIncludesCollector(
 
         val externalContainers = allTypes.filter { it is LimeContainer && it.external?.cpp != null }
         if (externalContainers.isNotEmpty()) {
-            result += CppLibraryIncludes.TYPE_TRAITS
+            result += listOf(CppLibraryIncludes.TYPE_TRAITS, CppLibraryIncludes.UTILITY)
             result += externalContainers.flatMap { includesResolver.resolveElementImports(it) }
         }
         if (allTypes.any { it is LimeStruct }) {

--- a/gluecodium/src/main/resources/templates/cpp/CppFunctionStaticCheck.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFunctionStaticCheck.mustache
@@ -23,7 +23,7 @@ static_assert(
         {{resolveName returnType.typeRef}},
         std::remove_cv<std::remove_reference<decltype({{!!
 }}{{#if isStatic}}{{className}}::{{resolveName}}({{/if}}{{!!
-}}{{#unless isStatic}}(({{className}}*)nullptr)->{{resolveName}}({{/unless}}{{!!
+}}{{#unless isStatic}}std::declval<{{className}}>().{{resolveName}}({{/unless}}{{!!
 }}{{#parameters}}
             *(({{resolveName typeRef}}*)nullptr){{#if iter.hasNext}}, {{/if}}{{/parameters}}))>::type>::type
     >::value,

--- a/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppStructImpl.mustache
@@ -54,7 +54,7 @@ bool {{parentName}}::operator!=( const {{resolveName}}& rhs ) const
 static_assert(
     std::is_same<
         {{resolveName typeRef}},
-        std::remove_cv<std::remove_reference<decltype(((const {{structName}}*)nullptr)->{{this}}())>::type>::type
+        std::remove_cv<std::remove_reference<decltype(std::declval<{{structName}}>().{{this}}())>::type>::type
     >::value,
     "Expected '{{resolveName typeRef}}' return type for '{{structName}}::{{this}}'."
 );
@@ -63,7 +63,7 @@ static_assert(
 static_assert(
     std::is_same<
         void,
-        decltype((({{structName}}*)nullptr)->{{this}}(*(({{resolveName typeRef}}*)nullptr)))
+        decltype(std::declval<{{structName}}>().{{this}}(*(({{resolveName typeRef}}*)nullptr)))
     >::value,
     "Expected 'void' return type for '{{structName}}::{{this}}'."
 );

--- a/gluecodium/src/main/resources/templates/cpp/StructHashImpl.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/StructHashImpl.mustache
@@ -23,8 +23,8 @@ hash< {{resolveName "FQN"}} >::operator( )( const {{resolveName "FQN"}}& t ) con
 {
     size_t hash_value = 43;
 {{#if attributes.cpp.accessors}}
-    {{#resolveName "FQN"}}{{#set structName=this}}{{#fields}}hash_value = ( hash_value ^ {{>common/InternalNamespace}}hash< decltype{{!!
-    }}( ( ( const {{structName}}* )nullptr )->{{resolveName this "" "getter"}}( ) ) >( )( t.{{resolveName this "" "getter"}}( ) ) ) << 1;
+    {{#resolveName "FQN"}}{{#set structName=this}}{{#fields}}hash_value = (hash_value ^ {{>common/InternalNamespace}}hash< decltype({{!!
+    }}std::declval<{{structName}}>().{{resolveName this "" "getter"}}()) >()(t.{{resolveName this "" "getter"}}())) << 1;
     {{/fields}}{{/set}}{{/resolveName}}
 {{/if}}{{#unless attributes.cpp.accessors}}
 {{#fields}}

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/src/smoke/EquatableStructWithAccessors.cpp
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/src/smoke/EquatableStructWithAccessors.cpp
@@ -27,7 +27,7 @@ std::size_t
 hash< ::smoke::EquatableStructWithAccessors >::operator( )( const ::smoke::EquatableStructWithAccessors& t ) const
 {
     size_t hash_value = 43;
-    hash_value = ( hash_value ^ ::gluecodium::hash< decltype( ( ( const ::smoke::EquatableStructWithAccessors* )nullptr )->get_foo_field( ) ) >( )( t.get_foo_field( ) ) ) << 1;
+    hash_value = (hash_value ^ ::gluecodium::hash< decltype(std::declval<::smoke::EquatableStructWithAccessors>().get_foo_field()) >()(t.get_foo_field())) << 1;
     return hash_value;
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cpp/src/smoke/ClassWithOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cpp/src/smoke/ClassWithOverloads.cpp
@@ -4,18 +4,19 @@
 // -------------------------------------------------------------------------------------------------
 #include "include/ExternalTypes.h"
 #include <type_traits>
+#include <utility>
 namespace smoke {
 static_assert(
     std::is_same<
         ::std::string,
-        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->oneOverloadNotExposed())>::type>::type
+        std::remove_cv<std::remove_reference<decltype(std::declval<::smoke::ClassWithOverloads>().oneOverloadNotExposed())>::type>::type
     >::value,
     "Expected '::std::string' return type for '::smoke::ClassWithOverloads::oneOverloadNotExposed'."
 );
 static_assert(
     std::is_same<
         ::std::string,
-        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->allOverloadsExposed(
+        std::remove_cv<std::remove_reference<decltype(std::declval<::smoke::ClassWithOverloads>().allOverloadsExposed(
             *((::std::string*)nullptr)))>::type>::type
     >::value,
     "Expected '::std::string' return type for '::smoke::ClassWithOverloads::allOverloadsExposed'."
@@ -23,7 +24,7 @@ static_assert(
 static_assert(
     std::is_same<
         ::std::string,
-        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->allOverloadsExposed(
+        std::remove_cv<std::remove_reference<decltype(std::declval<::smoke::ClassWithOverloads>().allOverloadsExposed(
             *((::std::vector< ::std::string >*)nullptr)))>::type>::type
     >::value,
     "Expected '::std::string' return type for '::smoke::ClassWithOverloads::allOverloadsExposed'."
@@ -31,7 +32,7 @@ static_assert(
 static_assert(
     std::is_same<
         ::std::string,
-        std::remove_cv<std::remove_reference<decltype(((::smoke::ClassWithOverloads*)nullptr)->allOverloadsExposed(
+        std::remove_cv<std::remove_reference<decltype(std::declval<::smoke::ClassWithOverloads>().allOverloadsExposed(
             *((::std::string*)nullptr),
             *((bool*)nullptr)))>::type>::type
     >::value,

--- a/gluecodium/src/test/resources/smoke/external_types/output/cpp/src/smoke/StructWithOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cpp/src/smoke/StructWithOverloads.cpp
@@ -9,28 +9,28 @@ namespace smoke {
 static_assert(
     std::is_same<
         int32_t,
-        std::remove_cv<std::remove_reference<decltype(((const external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedAccessors())>::type>::type
+        std::remove_cv<std::remove_reference<decltype(std::declval<external::ClassWithOverloads::StructWithOverloads>().overloadedAccessors())>::type>::type
     >::value,
     "Expected 'int32_t' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedAccessors'."
 );
 static_assert(
     std::is_same<
         void,
-        decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedAccessors(*((int32_t*)nullptr)))
+        decltype(std::declval<external::ClassWithOverloads::StructWithOverloads>().overloadedAccessors(*((int32_t*)nullptr)))
     >::value,
     "Expected 'void' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedAccessors'."
 );
 static_assert(
     std::is_same<
         ::std::string,
-        std::remove_cv<std::remove_reference<decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedMethod())>::type>::type
+        std::remove_cv<std::remove_reference<decltype(std::declval<external::ClassWithOverloads::StructWithOverloads>().overloadedMethod())>::type>::type
     >::value,
     "Expected '::std::string' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedMethod'."
 );
 static_assert(
     std::is_same<
         ::std::string,
-        std::remove_cv<std::remove_reference<decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedMethod(
+        std::remove_cv<std::remove_reference<decltype(std::declval<external::ClassWithOverloads::StructWithOverloads>().overloadedMethod(
             *((::std::string*)nullptr)))>::type>::type
     >::value,
     "Expected '::std::string' return type for 'external::ClassWithOverloads::StructWithOverloads::overloadedMethod'."
@@ -38,7 +38,7 @@ static_assert(
 static_assert(
     std::is_same<
         ::std::string,
-        std::remove_cv<std::remove_reference<decltype(((external::ClassWithOverloads::StructWithOverloads*)nullptr)->overloadedMethod(
+        std::remove_cv<std::remove_reference<decltype(std::declval<external::ClassWithOverloads::StructWithOverloads>().overloadedMethod(
             *((::std::string*)nullptr),
             *((bool*)nullptr)))>::type>::type
     >::value,


### PR DESCRIPTION
Updated C++ templates for "external" types and structs with `@Cpp(Accessors)`. New code uses `decltype(std::declval<>()...)` instead of `decltype(nullptr...)`. This fixes warnings when compiling this code.

Signed-off-by: Daniel Kamkha <daniel.kamkha@here.com>