### PR TITLE
Fixed return value documentation comments for getter of property element

### DIFF
--- a/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
@@ -36,8 +36,8 @@
 }}{{#parameters}}
 {{!!}}@param {{resolveName}} {{#resolveName comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
 }}{{/parameters}}{{!!
-}}{{!! document the return value if it's neither a constructor nor returning void nor a getter}}{{!!
-}}{{#unless isConstructor returnType.isVoid isGetter logic="and"}}
+}}{{!! document the return value if it's neither a constructor nor returning void }}{{!!
+}}{{#unless isConstructor returnType.isVoid logic="and"}}
 {{!!}}@return {{#resolveName returnType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
 }}{{/unless}}{{!!
 }}{{#if thrownType}}

--- a/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
@@ -21,17 +21,26 @@
 {{#ifPredicate "hasAnyComment"}}
 /**
 {{prefixPartial "combinedComment" " * "}}
- */{{#if attributes.deprecated}}
-@Deprecated{{/if}}{{/ifPredicate}}{{!!
+ */
+{{#if attributes.deprecated}}@Deprecated{{/if}}
+{{/ifPredicate}}
 
-}}{{+combinedComment}}{{resolveName comment}}{{#if comment.isExcluded}}
-@hidden{{/if}}{{#if attributes.deprecated}}
-@deprecated {{resolveName attributes.deprecated.message}}{{/if}}{{!!
+{{+combinedComment}}{{!!
+}}{{resolveName comment}}{{!!
+}}{{#if comment.isExcluded}}
+{{!!}}@hidden{{!!
+}}{{/if}}{{!!
+}}{{#if attributes.deprecated}}
+{{!!}}@deprecated {{resolveName attributes.deprecated.message}}{{!!
+}}{{/if}}{{!!
 }}{{#parameters}}
-@param {{resolveName}} {{#resolveName comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{/parameters}}{{!!
-}}{{#unless isConstructor returnType.isVoid isGetter logic="and"}}{{!! document the return value if
-it's neither a constructor nor returning void nor a getter}}
-@return {{#resolveName returnType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{/unless}}{{!!
+{{!!}}@param {{resolveName}} {{#resolveName comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/parameters}}{{!!
+}}{{!! document the return value if it's neither a constructor nor returning void nor a getter}}{{!!
+}}{{#unless isConstructor returnType.isVoid isGetter logic="and"}}
+{{!!}}@return {{#resolveName returnType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/unless}}{{!!
 }}{{#if thrownType}}
-@throws {{resolveName exception "" "ref"}} {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{/if}}{{!!
+{{!!}}@throws {{resolveName exception "" "ref"}} {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/if}}{{!!
 }}{{/combinedComment}}

--- a/gluecodium/src/test/resources/smoke/attributes/output/android/com/example/smoke/AttributesWithComments.java
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android/com/example/smoke/AttributesWithComments.java
@@ -47,6 +47,7 @@ public final class AttributesWithComments extends NativeBase {
     public native void veryFun();
     /**
      * <p>Getter comment
+     * @return <p>Property comment
      */
     @OnPropertyInClass
     @NonNull

--- a/gluecodium/src/test/resources/smoke/attributes/output/android/com/example/smoke/AttributesWithDeprecated.java
+++ b/gluecodium/src/test/resources/smoke/attributes/output/android/com/example/smoke/AttributesWithDeprecated.java
@@ -53,6 +53,7 @@ public final class AttributesWithDeprecated extends NativeBase {
     /**
      *
      * @deprecated
+     * @return
      */
     @Deprecated
     @OnPropertyInClass

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -188,6 +188,7 @@ public final class Comments extends NativeBase {
     public native String returnCommentOnly(@NonNull final String undocumented);
     /**
      * <p>Gets some very useful property.
+     * @return <p>Some very useful property.
      */
     public native boolean isSomeProperty();
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsInterface.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/CommentsInterface.java
@@ -92,6 +92,7 @@ public interface CommentsInterface {
     void someMethodWithoutReturnTypeOrInputParameters();
     /**
      * <p>Gets some very useful property.
+     * @return <p>Some very useful property.
      */
     boolean isSomeProperty();
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationComments.java
@@ -74,6 +74,7 @@ public interface DeprecationComments {
      * <p>Gets some very useful property.
      * @deprecated <p>Unfortunately, this property's getter is deprecated.
      * Use {@link com.example.smoke.Comments#isSomeProperty} instead.
+     * @return <p>Some very useful property.
      */
     @Deprecated
     boolean isSomeProperty();
@@ -88,6 +89,7 @@ public interface DeprecationComments {
     /**
      * <p>Gets the property but not accessors.
      * @deprecated <p>Will be removed in v3.2.1.
+     * @return <p>Describes the property but not accessors.
      */
     @Deprecated
     @NonNull

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationCommentsOnly.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/DeprecationCommentsOnly.java
@@ -53,6 +53,7 @@ public interface DeprecationCommentsOnly {
     /**
      *
      * @deprecated <p>Unfortunately, this property's getter is deprecated.
+     * @return
      */
     @Deprecated
     boolean isSomeProperty();

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedComments.java
@@ -128,6 +128,7 @@ public final class ExcludedComments extends NativeBase {
     /**
      * <p>Gets some very useful property.
      * @hidden
+     * @return <p>Some very useful property.
      */
     public native boolean isSomeProperty();
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedCommentsOnly.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/ExcludedCommentsOnly.java
@@ -114,6 +114,7 @@ public final class ExcludedCommentsOnly extends NativeBase {
     /**
      *
      * @hidden
+     * @return
      */
     public native boolean isSomeProperty();
     /**


### PR DESCRIPTION
For `property` element, generated getter documentation did not had `@return` for Java.

This is fixed by doing required changes in `JavaMethodComment.mustache` 
