### PR TITLE
Add doc support of lambda parameters and return value for cpp,swift,dart

### DIFF
--- a/functional-tests/functional/input/lime/CommentsLambda.lime
+++ b/functional-tests/functional/input/lime/CommentsLambda.lime
@@ -1,0 +1,9 @@
+package test
+
+class CommentsLambda {
+    // This is a comment for lambda 
+    // @param[p0] This is the comment for the first parameter of the lambda.
+    // @param[p1] This is the comment for the second parameter of the lambda.
+    lambda MyCallback = (@Java("param1_name") Int?, @Java("param2_name") String) 
+        ->  /*Comment for return value*/ Int
+} 

--- a/functional-tests/functional/input/lime/CommentsLambda.lime
+++ b/functional-tests/functional/input/lime/CommentsLambda.lime
@@ -1,9 +1,0 @@
-package test
-
-class CommentsLambda {
-    // This is a comment for lambda 
-    // @param[p0] This is the comment for the first parameter of the lambda.
-    // @param[p1] This is the comment for the second parameter of the lambda.
-    lambda MyCallback = (@Java("param1_name") Int?, @Java("param2_name") String) 
-        ->  /*Comment for return value*/ Int
-} 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -85,8 +85,8 @@ internal class CppNameResolver(
             is LimeType -> resolveTypeName(element, isFullName = false)
             is LimeTypeRef -> resolveTypeRef(element)
             is LimeReturnType -> resolveTypeRef(element.typeRef)
-            is LimeLambdaParameter -> resolveTypeRef(element.typeRef)
             is LimeNamedElement -> nameCache.getName(element)
+            is LimeLambdaParameter -> resolveTypeRef(element.typeRef)
             else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
         }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -41,6 +41,7 @@ import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.SETTER_NA
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
+import com.here.gluecodium.model.lime.LimeLambdaParameter
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
@@ -84,6 +85,7 @@ internal class CppNameResolver(
             is LimeType -> resolveTypeName(element, isFullName = false)
             is LimeTypeRef -> resolveTypeRef(element)
             is LimeReturnType -> resolveTypeRef(element.typeRef)
+            is LimeLambdaParameter -> resolveTypeRef(element.typeRef)
             is LimeNamedElement -> nameCache.getName(element)
             else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartNameResolver.kt
@@ -39,6 +39,7 @@ import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.IMPORT_PATH_NAME
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
+import com.here.gluecodium.model.lime.LimeLambdaParameter
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
@@ -86,6 +87,7 @@ internal class DartNameResolver(
             is LimeTypeAlias -> resolveName(element.typeRef)
             is LimeType -> resolveTypeName(element)
             is LimeNamedElement -> getPlatformName(element)
+            is LimeLambdaParameter -> resolveTypeRefName(element.typeRef)
             else ->
                 throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
         }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftNameResolver.kt
@@ -40,6 +40,7 @@ import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeGenericType
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeLambdaParameter
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
@@ -75,6 +76,7 @@ internal class SwiftNameResolver(
             is LimeTypeRef -> resolveTypeRefName(element)
             is LimeReturnType -> resolveTypeRefName(element.typeRef)
             is LimeNamedElement -> nameRules.getName(element)
+            is LimeLambdaParameter -> resolveTypeRefName(element.typeRef)
             else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
         }
 

--- a/gluecodium/src/main/resources/templates/cpp/CppLambda.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppLambda.mustache
@@ -18,5 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>cpp/CppDocComment}}{{>cpp/CppAttributes}}
+{{>cpp/CppFunctionDoc}}{{>cpp/CppAttributes}}
 using {{resolveName}} = {{>cpp/CppLambdaType}};

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -18,23 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
-///{{/unless}}{{/resolveName}}{{!!
-}}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}
-/// [{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}
-///{{/unless}}{{/resolveName}}{{/set}}{{/parameters}}{{!!
-}}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}
-/// Returns [{{resolveName returnType.typeRef}}]. {{prefix this "/// " skipFirstLine=true}}
-///{{/unless}}{{/resolveName}}{{!!
-}}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}
-/// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}
-///{{/unless}}{{/resolveName}}{{/if}}{{!!
-}}{{#ifPredicate "needsNoDoc"}}
-/// @nodoc{{/ifPredicate}}{{!!
-}}{{#if attributes.deprecated}}
-@Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
-{{/if}}{{!!
-}}{{#if attributes.dart.attribute}}
+{{>dart/DartLambdaDocs}}
+{{#if attributes.dart.attribute}}
 
 {{#attributes.dart.attribute}}
 @{{this}}{{#if iter.hasNext}}

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -18,7 +18,9 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartFunctionDocs}}{{>dart/DartAttributes}}
+{{>dart/DartLambdaDocs}}
+
+{{>dart/DartAttributes}}
 typedef {{resolveName}} = {{>dart/DartLambdaType}};
 
 // {{resolveName}} "private" section, not exported.

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>dart/DartDocumentation}}{{>dart/DartAttributes}}
+{{>dart/DartFunctionDocs}}{{>dart/DartAttributes}}
 typedef {{resolveName}} = {{>dart/DartLambdaType}};
 
 // {{resolveName}} "private" section, not exported.

--- a/gluecodium/src/main/resources/templates/dart/DartLambdaDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambdaDocs.mustache
@@ -1,0 +1,37 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#resolveName comment}}{{#unless this.isEmpty}}{{prefix this "/// "}}
+///{{/unless}}{{/resolveName}}{{!!
+}}{{#parameters}}{{#set self=this}}{{#resolveName comment}}{{#unless this.isEmpty}}
+/// [{{resolveName self}}] {{prefix this "/// " skipFirstLine=true}}
+///{{/unless}}{{/resolveName}}{{/set}}{{/parameters}}{{!!
+}}{{#resolveName returnType.comment}}{{#unless this.isEmpty}}
+/// Returns [{{resolveName returnType.typeRef}}]. {{prefix this "/// " skipFirstLine=true}}
+///{{/unless}}{{/resolveName}}{{!!
+}}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}
+/// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}
+///{{/unless}}{{/resolveName}}{{/if}}{{!!
+}}{{#ifPredicate "needsNoDoc"}}
+/// @nodoc{{/ifPredicate}}{{!!
+}}{{#if attributes.deprecated}}
+@Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
+{{/if}}{{!!
+}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftLambdaDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftLambdaDefinition.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}
+{{>swift/SwiftFunctionComment}}{{>swift/SwiftAttributes}}
 {{#unless isInterface}}{{resolveName "visibility"}} {{/unless}}typealias {{resolveName}} = {{!!
 }}({{#parameters}}{{#unless typeRef.isNullable}}{{#instanceOf typeRef.type.actualType "LimeLambda"}}@escaping {{/instanceOf}}{{/unless}}{{!!
 }}{{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}) -> {{resolveName returnType}}

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -34,6 +34,9 @@ public:
     };
     /**
      * This is some very useful lambda that does it.
+     * \param[in] ::std::string Very useful input parameter
+     * \param[in] int32_t Slightly less useful input parameter
+     * \return Usefulness of the input
      */
     using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
@@ -33,6 +33,9 @@ public:
     /**
      * This is some very useful lambda that does it.
      * \private
+     * \param[in] ::std::string Very useful input parameter
+     * \param[in] int32_t Slightly less useful input parameter
+     * \return Usefulness of the input
      */
     using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
@@ -28,7 +28,11 @@ public:
         USELESS
     };
     /**
+     *
      * \private
+     * \param[in] ::std::string
+     * \param[in] int32_t
+     * \return
      */
     using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -232,6 +232,13 @@ void smokeCommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsSomestructReleaseHandleNullable(handle);
 // End of Comments_SomeStruct "private" section.
 /// This is some very useful lambda that does it.
+///
+/// [String] Very useful input parameter
+///
+/// [int] Slightly less useful input parameter
+///
+/// Returns [double]. Usefulness of the input
+///
 typedef Comments_SomeLambda = double Function(String, int);
 // Comments_SomeLambda "private" section, not exported.
 final _smokeCommentsSomelambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -164,6 +164,13 @@ void smokeExcludedcommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handl
   _smokeExcludedcommentsSomestructReleaseHandleNullable(handle);
 // End of ExcludedComments_SomeStruct "private" section.
 /// This is some very useful lambda that does it.
+///
+/// [String] Very useful input parameter
+///
+/// [int] Slightly less useful input parameter
+///
+/// Returns [double]. Usefulness of the input
+///
 /// @nodoc
 typedef ExcludedComments_SomeLambda = double Function(String, int);
 // ExcludedComments_SomeLambda "private" section, not exported.

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -8,6 +8,10 @@ public class Comments {
     /// This is some very useful exception.
     public typealias SomethingWrongError = Comments.SomeEnum
     /// This is some very useful lambda that does it.
+    /// - Parameters:
+    ///   - String: Very useful input parameter
+    ///   - Int32: Slightly less useful input parameter
+    /// - Returns: Usefulness of the input
     public typealias SomeLambda = (String, Int32) -> Double
     /// This is some very useful constant.
     public static let veryUseful: Comments.Usefulness = true

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedComments.swift
@@ -11,6 +11,10 @@ public class ExcludedComments {
     /// :nodoc:
     public typealias SomethingWrongError = ExcludedComments.SomeEnum
     /// This is some very useful lambda that does it.
+    /// - Parameters:
+    ///   - String: Very useful input parameter
+    ///   - Int32: Slightly less useful input parameter
+    /// - Returns: Usefulness of the input
     /// :nodoc:
     public typealias SomeLambda = (String, Int32) -> Double
     /// This is some very useful constant.

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/ExcludedCommentsOnly.swift
@@ -7,6 +7,11 @@ public class ExcludedCommentsOnly {
     public typealias Usefulness = Bool
     /// :nodoc:
     public typealias SomethingWrongError = ExcludedCommentsOnly.SomeEnum
+    ///
+    /// - Parameters:
+    ///   - String:
+    ///   - Int32:
+    /// - Returns:
     /// :nodoc:
     public typealias SomeLambda = (String, Int32) -> Double
     /// :nodoc:

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/Lambdas.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/Lambdas.h
@@ -21,6 +21,8 @@ public:
     using Producer = ::std::function<::std::string()>;
     /**
      * Should confuse everyone thoroughly
+     * \param[in] ::std::string
+     * \return
      */
     using Confuser = ::std::function<::smoke::Lambdas::Producer(const ::std::string&)>;
     using Consumer = ::std::function<void(const ::std::string&)>;

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -101,6 +101,7 @@ void smokeLambdasProducerReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdasProducerReleaseHandleNullable(handle);
 // End of Lambdas_Producer "private" section.
 /// Should confuse everyone thoroughly
+///
 typedef Lambdas_Confuser = Lambdas_Producer Function(String);
 // Lambdas_Confuser "private" section, not exported.
 final _smokeLambdasConfuserRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<

--- a/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/swift/smoke/Lambdas.swift
@@ -4,6 +4,8 @@ import Foundation
 public class Lambdas {
     public typealias Producer = () -> String
     /// Should confuse everyone thoroughly
+    /// - Parameter String:
+    /// - Returns:
     public typealias Convoluter = (String) -> Lambdas.Producer
     public typealias Consumer = (String) -> Void
     public typealias Indexer = (String, Float) -> Int32

--- a/lime-loader/src/main/antlr/LimeParser.g4
+++ b/lime-loader/src/main/antlr/LimeParser.g4
@@ -52,7 +52,7 @@ parentTypes
 function
     : docComment* annotation* ('static' NewLine*)? 'fun' NewLine* simpleId NewLine*
       '(' NewLine* (parameter (',' NewLine* parameter)*)?  ')' NewLine*
-      returnType? throwsClause? NewLine*
+      (':' returnType)? throwsClause? NewLine*
     ;
 
 constructor
@@ -74,7 +74,7 @@ parameter
     ;
 
 returnType
-    : ':' NewLine* docComment* typeRef NewLine*
+    : NewLine* docComment* typeRef NewLine*
     ;
 
 throwsClause
@@ -133,7 +133,7 @@ exception
 lambda
     : docComment* annotation* 'lambda' NewLine* simpleId NewLine* '=' NewLine*
       '(' NewLine* (lambdaParameter (',' NewLine* lambdaParameter)*)? ')' NewLine*
-      '->' NewLine* typeRef NewLine+
+      '->' returnType
     ;
 
 lambdaParameter

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -512,15 +512,19 @@ internal class AntlrLimeModelBuilder(
                 )
             )
         }
+        val returnType = ctx.returnType()
+            ?.let {
+                LimeReturnType(
+                    typeMapper.mapTypeRef(currentPath, it.typeRef()),
+                    getComment("return", it.docComment(), it)
+                )
+            } ?: LimeReturnType.VOID
         val limeElement = LimeLambda(
             path = currentPath,
             comment = parseStructuredComment(ctx.docComment(), ctx).description,
             attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
             parameters = parameters,
-            returnType = LimeReturnType(
-                typeMapper.mapTypeRef(currentPath, ctx.typeRef()),
-                getComment("return", null, ctx)
-            )
+            returnType = returnType
         )
 
         storeResultAndPopStacks(limeElement)


### PR DESCRIPTION
see: https://github.com/heremaps/gluecodium/issues/1544

Currently, the documentation of parameters and return values for lambdas only works for java. All the other generators don't work. This is because that Java's lambda declaration is called [functional interface](https://www.geeksforgeeks.org/functional-interfaces-java/) and is similar like a function declaration. However, for the other generators, the mustache template file only uses normal documentation instead of function documentation. 

For the return type, the issue is that the LimeParser doesn't have doc support for the return type of a lambda.

This change addresses the two issues.

The fix still has some limitation, though. In java, one can use specify a name for the lambda parameter and use that in the parameter documentation. With the current change, only the types will appear in the lambda declaration and docs. To limit the scope of this change. This is left for future improvement.

