### PR TITLE
duplicate_definition for internal classes with throwing constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   * Added new lambda syntax that allows to specify parameter name.
 ### Bug fixes:
   * Fixed documentation generation for lambdas.
+  * Fixed name clash and compilation errors for internally generated dart functions in case lime file contains
+   internal classes/structs with throwing functions/constructors that have the same name and classes/structs are contained
+   in the same external class.
 
 ## 13.6.4
 ### Features:

--- a/functional-tests/functional/input/lime/StructsWithMethods.lime
+++ b/functional-tests/functional/input/lime/StructsWithMethods.lime
@@ -81,6 +81,20 @@ class StructsWithMethodsInterface {
         ) throws ValidationUtils.Validation
     }
 
+    struct Vector4 {
+        x: Double = 2.0
+        @Dart(Default)
+        constructor create(
+        ) throws ValidationUtils.Validation
+    }
+
+    struct Vector5 {
+        y: Double = 7.0
+        @Dart(Default)
+        constructor create(
+        ) throws ValidationUtils.Validation
+    }
+
     struct StructWithStaticMethodsOnly {
         static fun doStuff()
     }

--- a/functional-tests/functional/input/src/cpp/StructsWithMethods.cpp
+++ b/functional-tests/functional/input/src/cpp/StructsWithMethods.cpp
@@ -102,6 +102,20 @@ StructsWithMethodsInterface::Vector3::create( const StructsWithMethodsInterface:
          );
 }
 
+lorem_ipsum::test::Return< StructsWithMethodsInterface::Vector4, std::error_code >
+StructsWithMethodsInterface::Vector4::create( )
+{
+    return lorem_ipsum::test::Return< StructsWithMethodsInterface::Vector4, std::error_code >(
+        StructsWithMethodsInterface::Vector4( ) );
+}
+
+lorem_ipsum::test::Return< StructsWithMethodsInterface::Vector5, std::error_code >
+StructsWithMethodsInterface::Vector5::create( )
+{
+    return lorem_ipsum::test::Return< StructsWithMethodsInterface::Vector5, std::error_code >(
+        StructsWithMethodsInterface::Vector5( ) );
+}
+
 void
 StructsWithMethodsInterface::StructWithStaticMethodsOnly::do_stuff( )
 {

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionBody.mustache
@@ -36,9 +36,9 @@
   {{#resolveName}}{{#setJoin "varName" "_" this "Handle" delimiter=""}}{{>dart/DartFfiReleaseHandle}}{{/setJoin}}{{/resolveName}}
 {{/parameters}}
 {{#if this.thrownType}}
-  if (_{{resolveName}}ReturnHasError(__callResultHandle) != 0) {
-      final __errorHandle = _{{resolveName}}ReturnGetError(__callResultHandle);
-      _{{resolveName}}ReturnReleaseHandle(__callResultHandle);
+  if (_{{resolveName}}{{resolveName "Ffi"}}ReturnHasError(__callResultHandle) != 0) {
+      final __errorHandle = _{{resolveName}}{{resolveName "Ffi"}}ReturnGetError(__callResultHandle);
+      _{{resolveName}}{{resolveName "Ffi"}}ReturnReleaseHandle(__callResultHandle);
       try {
         throw {{resolveName exception}}({{#set call="FromFfi" typeRef=exception.errorType}}{{>dart/DartFfiConversionCall}}{{/set}}(__errorHandle));
       } finally {
@@ -46,9 +46,9 @@
       }
   }
 {{#unless returnType.isVoid}}
-  final __resultHandle = _{{resolveName}}ReturnGetResult(__callResultHandle);
+  final __resultHandle = _{{resolveName}}{{resolveName "Ffi"}}ReturnGetResult(__callResultHandle);
 {{/unless}}
-  _{{resolveName}}ReturnReleaseHandle(__callResultHandle);
+  _{{resolveName}}{{resolveName "Ffi"}}ReturnReleaseHandle(__callResultHandle);
 {{/if}}
 {{#if isConstructor}}{{#if isStruct}}{{>ffiReturnConversion}}{{/if}}{{!!
 }}{{#unless isStruct}}  return __resultHandle;{{/unless}}{{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionException.mustache
@@ -19,21 +19,21 @@
   !
   !}}
 {{#if thrownType}}{{#unless attributes.async}}
-final _{{resolveName}}ReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}{{resolveName "Ffi"}}ReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('{{>dart/DartFunctionFfiName}}_return_release_handle'));
 {{#unless returnType.isVoid}}
-final _{{resolveName}}ReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}{{resolveName "Ffi"}}ReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName returnType.typeRef "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName returnType.typeRef "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{>dart/DartFunctionFfiName}}_return_get_result'));
 {{/unless}}
-final _{{resolveName}}ReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}{{resolveName "Ffi"}}ReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     {{resolveName exception.errorType "FfiApiTypes"}} Function(Pointer<Void>),
     {{resolveName exception.errorType "FfiDartTypes"}} Function(Pointer<Void>)
   >('{{>dart/DartFunctionFfiName}}_return_get_error'));
-final _{{resolveName}}ReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _{{resolveName}}{{resolveName "Ffi"}}ReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('{{>dart/DartFunctionFfiName}}_return_has_error'));

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -341,19 +341,19 @@ final _smokeCommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_release_handle'));
-final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error'));
@@ -366,17 +366,17 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     final _handle = this.handle;
     final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
     stringReleaseFfiHandle(_inputParameterHandle);
-    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
-        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    if (_someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
         try {
           throw Comments_SomethingWrongException(smokeCommentsSomeenumFromFfi(__errorHandle));
         } finally {
           smokeCommentsSomeenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
-    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -139,19 +139,19 @@ final _smokeCommentslinksReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_release_handle'));
-final _randomMethodReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodsmokeCommentslinksRandommethodSomeenumReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_release_handle'));
-final _randomMethodReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodsmokeCommentslinksRandommethodSomeenumReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_result'));
-final _randomMethodReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodsmokeCommentslinksRandommethodSomeenumReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_get_error'));
-final _randomMethodReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _randomMethodsmokeCommentslinksRandommethodSomeenumReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error'));
@@ -164,17 +164,17 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
     final _handle = this.handle;
     final __callResultHandle = _randomMethodFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
     smokeCommentsSomeenumReleaseFfiHandle(_inputParameterHandle);
-    if (_randomMethodReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _randomMethodReturnGetError(__callResultHandle);
-        _randomMethodReturnReleaseHandle(__callResultHandle);
+    if (_randomMethodsmokeCommentslinksRandommethodSomeenumReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _randomMethodsmokeCommentslinksRandommethodSomeenumReturnGetError(__callResultHandle);
+        _randomMethodsmokeCommentslinksRandommethodSomeenumReturnReleaseHandle(__callResultHandle);
         try {
           throw Comments_SomethingWrongException(smokeCommentsSomeenumFromFfi(__errorHandle));
         } finally {
           smokeCommentsSomeenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _randomMethodReturnGetResult(__callResultHandle);
-    _randomMethodReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _randomMethodsmokeCommentslinksRandommethodSomeenumReturnGetResult(__callResultHandle);
+    _randomMethodsmokeCommentslinksRandommethodSomeenumReturnReleaseHandle(__callResultHandle);
     try {
       return smokeCommentsSomeenumFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -6,7 +6,6 @@ import 'package:library/src/builtin_types__conversion.dart';
 /// This is some very useful class.
 /// @nodoc
 abstract class ExcludedComments {
-
   /// This is some very useful constant.
   /// @nodoc
   static final bool veryUseful = true;
@@ -274,25 +273,24 @@ final _smokeExcludedcommentsReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_release_handle'));
-final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_has_error'));
 class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments {
   ExcludedComments$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedComments_someMethodWithAllComments__String'));
@@ -300,17 +298,17 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     final _handle = this.handle;
     final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
     stringReleaseFfiHandle(_inputParameterHandle);
-    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
-        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    if (_someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
         try {
           throw ExcludedComments_SomethingWrongException(smokeExcludedcommentsSomeenumFromFfi(__errorHandle));
         } finally {
           smokeExcludedcommentsSomeenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
-    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -5,7 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 /// @nodoc
 abstract class ExcludedCommentsOnly {
-
   /// @nodoc
   static final bool veryUseful = true;
   /// @nodoc
@@ -244,25 +243,24 @@ final _smokeExcludedcommentsonlyReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_release_handle'));
-final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_has_error'));
 class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedCommentsOnly {
   ExcludedCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String'));
@@ -270,17 +268,17 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     final _handle = this.handle;
     final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputParameterHandle);
     stringReleaseFfiHandle(_inputParameterHandle);
-    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
-        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    if (_someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
         try {
           throw ExcludedCommentsOnly_SomethingWrongException(smokeExcludedcommentsonlySomeenumFromFfi(__errorHandle));
         } finally {
           smokeExcludedcommentsonlySomeenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
-    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -4,7 +4,6 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 abstract class PlatformComments {
-
   /// This is some very useless method that cannot have overloads.
   ///
   void doNothing();
@@ -161,25 +160,24 @@ final _smokePlatformcommentsReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_release_handle'));
-final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error'));
 class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments {
   PlatformComments$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));
@@ -199,17 +197,17 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
     final _handle = this.handle;
     final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
-    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
-        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    if (_someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
         try {
           throw PlatformComments_SomethingWrongException(smokePlatformcommentsSomeenumFromFfi(__errorHandle));
         } finally {
           smokePlatformcommentsSomeenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
-    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -5,7 +5,6 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
 abstract class UnicodeComments {
-
   /// Süßölgefäß
   ///
   /// [input] שלום
@@ -29,25 +28,24 @@ final _smokeUnicodecommentsReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_release_handle'));
-final _someMethodWithAllCommentsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_release_handle'));
-final _someMethodWithAllCommentsReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_result'));
-final _someMethodWithAllCommentsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_get_error'));
-final _someMethodWithAllCommentsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error'));
 class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
   UnicodeComments$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));
@@ -55,17 +53,17 @@ class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
     final _handle = this.handle;
     final __callResultHandle = _someMethodWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
-    if (_someMethodWithAllCommentsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _someMethodWithAllCommentsReturnGetError(__callResultHandle);
-        _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    if (_someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnGetError(__callResultHandle);
+        _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
         try {
           throw Comments_SomethingWrongException(smokeCommentsSomeenumFromFfi(__errorHandle));
         } finally {
           smokeCommentsSomeenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _someMethodWithAllCommentsReturnGetResult(__callResultHandle);
-    _someMethodWithAllCommentsReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnGetResult(__callResultHandle);
+    _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnReleaseHandle(__callResultHandle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -13,7 +13,6 @@ abstract class Constructors {
   factory Constructors.fromString(String input) => $prototype.fromString(input);
   factory Constructors.fromList(List<double> input) => $prototype.fromList(input);
   factory Constructors.create(int input) => $prototype.create(input);
-
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Constructors$Impl(Pointer<Void>.fromAddress(0));
@@ -94,19 +93,19 @@ final _smokeConstructorsGetTypeId = __lib.catchArgumentError(() => __lib.nativeL
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_get_type_id'));
-final _fromStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringsmokeConstructorsCreateStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_release_handle'));
-final _fromStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringsmokeConstructorsCreateStringReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_get_result'));
-final _fromStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringsmokeConstructorsCreateStringReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_get_error'));
-final _fromStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _fromStringsmokeConstructorsCreateStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_has_error'));
@@ -114,7 +113,6 @@ final _fromStringReturnHasError = __lib.catchArgumentError(() => __lib.nativeLib
 @visibleForTesting
 class Constructors$Impl extends __lib.NativeBase implements Constructors {
   Constructors$Impl(Pointer<Void> handle) : super(handle);
-
   Constructors $init() {
     final _result_handle = _$init();
     final _result = Constructors$Impl(_result_handle);
@@ -182,17 +180,17 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
     final _inputHandle = stringToFfi(input);
     final __callResultHandle = _fromStringFfi(__lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
-    if (_fromStringReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _fromStringReturnGetError(__callResultHandle);
-        _fromStringReturnReleaseHandle(__callResultHandle);
+    if (_fromStringsmokeConstructorsCreateStringReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _fromStringsmokeConstructorsCreateStringReturnGetError(__callResultHandle);
+        _fromStringsmokeConstructorsCreateStringReturnReleaseHandle(__callResultHandle);
         try {
           throw Constructors_ConstructorExplodedException(smokeConstructorsErrorenumFromFfi(__errorHandle));
         } finally {
           smokeConstructorsErrorenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _fromStringReturnGetResult(__callResultHandle);
-    _fromStringReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _fromStringsmokeConstructorsCreateStringReturnGetResult(__callResultHandle);
+    _fromStringsmokeConstructorsCreateStringReturnReleaseHandle(__callResultHandle);
     return __resultHandle;
   }
   static Pointer<Void> _fromList(List<double> input) {

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -7,7 +7,6 @@ import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'package:meta/meta.dart';
 abstract class Errors {
-
   static void methodWithErrors() => $prototype.methodWithErrors();
   static void methodWithExternalErrors() => $prototype.methodWithExternalErrors();
   static String methodWithErrorsAndReturnValue() => $prototype.methodWithErrorsAndReturnValue();
@@ -153,71 +152,71 @@ final _smokeErrorsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_release_handle'));
-final _methodWithErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorssmokeErrorsMethodwitherrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_release_handle'));
-final _methodWithErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorssmokeErrorsMethodwitherrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_get_error'));
-final _methodWithErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorssmokeErrorsMethodwitherrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_has_error'));
-final _methodWithExternalErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_release_handle'));
-final _methodWithExternalErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_get_error'));
-final _methodWithExternalErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_has_error'));
-final _methodWithErrorsAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_release_handle'));
-final _methodWithErrorsAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_result'));
-final _methodWithErrorsAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_get_error'));
-final _methodWithErrorsAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_has_error'));
-final _methodWithPayloadErrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_release_handle'));
-final _methodWithPayloadErrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_get_error'));
-final _methodWithPayloadErrorReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_has_error'));
-final _methodWithPayloadErrorAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_release_handle'));
-final _methodWithPayloadErrorAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_result'));
-final _methodWithPayloadErrorAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_get_error'));
-final _methodWithPayloadErrorAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error'));
@@ -225,49 +224,48 @@ final _methodWithPayloadErrorAndReturnValueReturnHasError = __lib.catchArgumentE
 @visibleForTesting
 class Errors$Impl extends __lib.NativeBase implements Errors {
   Errors$Impl(Pointer<Void> handle) : super(handle);
-
   void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
     final __callResultHandle = _methodWithErrorsFfi(__lib.LibraryContext.isolateId);
-    if (_methodWithErrorsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithErrorsReturnGetError(__callResultHandle);
-        _methodWithErrorsReturnReleaseHandle(__callResultHandle);
+    if (_methodWithErrorssmokeErrorsMethodwitherrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorssmokeErrorsMethodwitherrorsReturnGetError(__callResultHandle);
+        _methodWithErrorssmokeErrorsMethodwitherrorsReturnReleaseHandle(__callResultHandle);
         try {
           throw Errors_InternalException(smokeErrorsInternalerrorcodeFromFfi(__errorHandle));
         } finally {
           smokeErrorsInternalerrorcodeReleaseFfiHandle(__errorHandle);
         }
     }
-    _methodWithErrorsReturnReleaseHandle(__callResultHandle);
+    _methodWithErrorssmokeErrorsMethodwitherrorsReturnReleaseHandle(__callResultHandle);
   }
   void methodWithExternalErrors() {
     final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors'));
     final __callResultHandle = _methodWithExternalErrorsFfi(__lib.LibraryContext.isolateId);
-    if (_methodWithExternalErrorsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithExternalErrorsReturnGetError(__callResultHandle);
-        _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
+    if (_methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnGetError(__callResultHandle);
+        _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnReleaseHandle(__callResultHandle);
         try {
           throw Errors_ExternalException(smokeErrorsExternalerrorsFromFfi(__errorHandle));
         } finally {
           smokeErrorsExternalerrorsReleaseFfiHandle(__errorHandle);
         }
     }
-    _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
+    _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnReleaseHandle(__callResultHandle);
   }
   String methodWithErrorsAndReturnValue() {
     final _methodWithErrorsAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue'));
     final __callResultHandle = _methodWithErrorsAndReturnValueFfi(__lib.LibraryContext.isolateId);
-    if (_methodWithErrorsAndReturnValueReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithErrorsAndReturnValueReturnGetError(__callResultHandle);
-        _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
+    if (_methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnGetError(__callResultHandle);
+        _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnReleaseHandle(__callResultHandle);
         try {
           throw Errors_InternalException(smokeErrorsInternalerrorcodeFromFfi(__errorHandle));
         } finally {
           smokeErrorsInternalerrorcodeReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithErrorsAndReturnValueReturnGetResult(__callResultHandle);
-    _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnGetResult(__callResultHandle);
+    _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnReleaseHandle(__callResultHandle);
     try {
       return stringFromFfi(__resultHandle);
     } finally {
@@ -277,31 +275,31 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
   void methodWithPayloadError() {
     final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError'));
     final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadErrorReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithPayloadErrorReturnGetError(__callResultHandle);
-        _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
+    if (_methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnReleaseHandle(__callResultHandle);
         try {
           throw WithPayloadException(smokePayloadFromFfi(__errorHandle));
         } finally {
           smokePayloadReleaseFfiHandle(__errorHandle);
         }
     }
-    _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
+    _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnReleaseHandle(__callResultHandle);
   }
   String methodWithPayloadErrorAndReturnValue() {
     final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue'));
     final __callResultHandle = _methodWithPayloadErrorAndReturnValueFfi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadErrorAndReturnValueReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithPayloadErrorAndReturnValueReturnGetError(__callResultHandle);
-        _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
+    if (_methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnReleaseHandle(__callResultHandle);
         try {
           throw WithPayloadException(smokePayloadFromFfi(__errorHandle));
         } finally {
           smokePayloadReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithPayloadErrorAndReturnValueReturnGetResult(__callResultHandle);
-    _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnGetResult(__callResultHandle);
+    _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnReleaseHandle(__callResultHandle);
     try {
       return stringFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -17,7 +17,6 @@ abstract class ErrorsInterface {
     methodWithExternalErrorsLambda,
     methodWithErrorsAndReturnValueLambda,
   );
-
   void methodWithErrors();
   void methodWithExternalErrors();
   String methodWithErrorsAndReturnValue();
@@ -171,71 +170,71 @@ final _smokeErrorsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_get_type_id'));
-final _methodWithErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_release_handle'));
-final _methodWithErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_get_error'));
-final _methodWithErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_has_error'));
-final _methodWithExternalErrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_release_handle'));
-final _methodWithExternalErrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_get_error'));
-final _methodWithExternalErrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_has_error'));
-final _methodWithErrorsAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_release_handle'));
-final _methodWithErrorsAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_result'));
-final _methodWithErrorsAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_get_error'));
-final _methodWithErrorsAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_has_error'));
-final _methodWithPayloadErrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_release_handle'));
-final _methodWithPayloadErrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_get_error'));
-final _methodWithPayloadErrorReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_has_error'));
-final _methodWithPayloadErrorAndReturnValueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_release_handle'));
-final _methodWithPayloadErrorAndReturnValueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_result'));
-final _methodWithPayloadErrorAndReturnValueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_get_error'));
-final _methodWithPayloadErrorAndReturnValueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error'));
@@ -248,7 +247,6 @@ class ErrorsInterface$Lambdas implements ErrorsInterface {
     this.methodWithExternalErrorsLambda,
     this.methodWithErrorsAndReturnValueLambda,
   );
-
   @override
   void methodWithErrors() =>
     methodWithErrorsLambda();
@@ -263,55 +261,54 @@ class ErrorsInterface$Lambdas implements ErrorsInterface {
 @visibleForTesting
 class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
   ErrorsInterface$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors'));
     final _handle = this.handle;
     final __callResultHandle = _methodWithErrorsFfi(_handle, __lib.LibraryContext.isolateId);
-    if (_methodWithErrorsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithErrorsReturnGetError(__callResultHandle);
-        _methodWithErrorsReturnReleaseHandle(__callResultHandle);
+    if (_methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnGetError(__callResultHandle);
+        _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnReleaseHandle(__callResultHandle);
         try {
           throw ErrorsInterface_InternalException(smokeErrorsinterfaceInternalerrorFromFfi(__errorHandle));
         } finally {
           smokeErrorsinterfaceInternalerrorReleaseFfiHandle(__errorHandle);
         }
     }
-    _methodWithErrorsReturnReleaseHandle(__callResultHandle);
+    _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnReleaseHandle(__callResultHandle);
   }
   @override
   void methodWithExternalErrors() {
     final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithExternalErrors'));
     final _handle = this.handle;
     final __callResultHandle = _methodWithExternalErrorsFfi(_handle, __lib.LibraryContext.isolateId);
-    if (_methodWithExternalErrorsReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithExternalErrorsReturnGetError(__callResultHandle);
-        _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
+    if (_methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnGetError(__callResultHandle);
+        _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnReleaseHandle(__callResultHandle);
         try {
           throw ErrorsInterface_ExternalException(smokeErrorsinterfaceExternalerrorsFromFfi(__errorHandle));
         } finally {
           smokeErrorsinterfaceExternalerrorsReleaseFfiHandle(__errorHandle);
         }
     }
-    _methodWithExternalErrorsReturnReleaseHandle(__callResultHandle);
+    _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnReleaseHandle(__callResultHandle);
   }
   @override
   String methodWithErrorsAndReturnValue() {
     final _methodWithErrorsAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue'));
     final _handle = this.handle;
     final __callResultHandle = _methodWithErrorsAndReturnValueFfi(_handle, __lib.LibraryContext.isolateId);
-    if (_methodWithErrorsAndReturnValueReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithErrorsAndReturnValueReturnGetError(__callResultHandle);
-        _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
+    if (_methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnGetError(__callResultHandle);
+        _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnReleaseHandle(__callResultHandle);
         try {
           throw ErrorsInterface_InternalException(smokeErrorsinterfaceInternalerrorFromFfi(__errorHandle));
         } finally {
           smokeErrorsinterfaceInternalerrorReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithErrorsAndReturnValueReturnGetResult(__callResultHandle);
-    _methodWithErrorsAndReturnValueReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnGetResult(__callResultHandle);
+    _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnReleaseHandle(__callResultHandle);
     try {
       return stringFromFfi(__resultHandle);
     } finally {
@@ -321,31 +318,31 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
   void methodWithPayloadError() {
     final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError'));
     final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadErrorReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithPayloadErrorReturnGetError(__callResultHandle);
-        _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
+    if (_methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnReleaseHandle(__callResultHandle);
         try {
           throw WithPayloadException(smokePayloadFromFfi(__errorHandle));
         } finally {
           smokePayloadReleaseFfiHandle(__errorHandle);
         }
     }
-    _methodWithPayloadErrorReturnReleaseHandle(__callResultHandle);
+    _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnReleaseHandle(__callResultHandle);
   }
   String methodWithPayloadErrorAndReturnValue() {
     final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue'));
     final __callResultHandle = _methodWithPayloadErrorAndReturnValueFfi(__lib.LibraryContext.isolateId);
-    if (_methodWithPayloadErrorAndReturnValueReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _methodWithPayloadErrorAndReturnValueReturnGetError(__callResultHandle);
-        _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
+    if (_methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnGetError(__callResultHandle);
+        _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnReleaseHandle(__callResultHandle);
         try {
           throw WithPayloadException(smokePayloadFromFfi(__errorHandle));
         } finally {
           smokePayloadReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _methodWithPayloadErrorAndReturnValueReturnGetResult(__callResultHandle);
-    _methodWithPayloadErrorAndReturnValueReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnGetResult(__callResultHandle);
+    _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnReleaseHandle(__callResultHandle);
     try {
       return stringFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -34,19 +34,19 @@ final _packageClassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrar
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Class_get_type_id'));
-final _funReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funpackageClassFunListofPackageTypesStructReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_package_Types_Struct_return_release_handle'));
-final _funReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funpackageClassFunListofPackageTypesStructReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_package_Types_Struct_return_get_result'));
-final _funReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funpackageClassFunListofPackageTypesStructReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_package_Types_Struct_return_get_error'));
-final _funReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _funpackageClassFunListofPackageTypesStructReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_package_Types_Struct_return_has_error'));
@@ -73,17 +73,17 @@ class Class$Impl extends __lib.NativeBase implements Class {
     final _handle = this.handle;
     final __callResultHandle = _funFfi(_handle, __lib.LibraryContext.isolateId, _doubleHandle);
     foobarListofPackageTypesStructReleaseFfiHandle(_doubleHandle);
-    if (_funReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _funReturnGetError(__callResultHandle);
-        _funReturnReleaseHandle(__callResultHandle);
+    if (_funpackageClassFunListofPackageTypesStructReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _funpackageClassFunListofPackageTypesStructReturnGetError(__callResultHandle);
+        _funpackageClassFunListofPackageTypesStructReturnReleaseHandle(__callResultHandle);
         try {
           throw Types_ExceptionException(packageTypesEnumFromFfi(__errorHandle));
         } finally {
           packageTypesEnumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _funReturnGetResult(__callResultHandle);
-    _funReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _funpackageClassFunListofPackageTypesStructReturnGetResult(__callResultHandle);
+    _funpackageClassFunListofPackageTypesStructReturnReleaseHandle(__callResultHandle);
     try {
       return packageTypesStructFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -8,15 +8,15 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
-final _doNothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doNothingsmokeOuterstructDonothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_release_handle'));
-final _doNothingReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doNothingsmokeOuterstructDonothingReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_get_error'));
-final _doNothingReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doNothingsmokeOuterstructDonothingReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_has_error'));
@@ -412,16 +412,16 @@ class OuterStruct$Impl {
     final _handle = smokeOuterstructToFfi($that);
     final __callResultHandle = _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
     smokeOuterstructReleaseFfiHandle(_handle);
-    if (_doNothingReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _doNothingReturnGetError(__callResultHandle);
-        _doNothingReturnReleaseHandle(__callResultHandle);
+    if (_doNothingsmokeOuterstructDonothingReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _doNothingsmokeOuterstructDonothingReturnGetError(__callResultHandle);
+        _doNothingsmokeOuterstructDonothingReturnReleaseHandle(__callResultHandle);
         try {
           throw OuterStruct_InstantiationException(smokeOuterstructInnerenumFromFfi(__errorHandle));
         } finally {
           smokeOuterstructInnerenumReleaseFfiHandle(__errorHandle);
         }
     }
-    _doNothingReturnReleaseHandle(__callResultHandle);
+    _doNothingsmokeOuterstructDonothingReturnReleaseHandle(__callResultHandle);
   }
 }
 Pointer<Void> smokeOuterstructToFfi(OuterStruct value) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -7,7 +7,6 @@ import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
 abstract class UseFreeTypes {
-
   DateTime doStuff(FreePoint point, FreeEnum mode);
 }
 // UseFreeTypes "private" section, not exported.
@@ -23,25 +22,24 @@ final _smokeUsefreetypesReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_release_handle'));
-final _doStuffReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_release_handle'));
-final _doStuffReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_result'));
-final _doStuffReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_get_error'));
-final _doStuffReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
 class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
   UseFreeTypes$Impl(Pointer<Void> handle) : super(handle);
-
   @override
   DateTime doStuff(FreePoint point, FreeEnum mode) {
     final _doStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));
@@ -51,17 +49,17 @@ class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
     final __callResultHandle = _doStuffFfi(_handle, __lib.LibraryContext.isolateId, _pointHandle, _modeHandle);
     smokeFreepointReleaseFfiHandle(_pointHandle);
     smokeFreeenumReleaseFfiHandle(_modeHandle);
-    if (_doStuffReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _doStuffReturnGetError(__callResultHandle);
-        _doStuffReturnReleaseHandle(__callResultHandle);
+    if (_doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnGetError(__callResultHandle);
+        _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnReleaseHandle(__callResultHandle);
         try {
           throw FreeException(smokeFreeenumFromFfi(__errorHandle));
         } finally {
           smokeFreeenumReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _doStuffReturnGetResult(__callResultHandle);
-    _doStuffReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnGetResult(__callResultHandle);
+    _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnReleaseHandle(__callResultHandle);
     try {
       return dateFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs_with_methods.dart
@@ -5,19 +5,19 @@ import 'package:library/src/smoke/validation_utils.dart';
 import 'package:meta/meta.dart';
 class StructsWithMethods {
 }
-final _copyReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copysmokeStructswithmethodsVectorCreateVectorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_release_handle'));
-final _copyReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copysmokeStructswithmethodsVectorCreateVectorReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_result'));
-final _copyReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copysmokeStructswithmethodsVectorCreateVectorReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_get_error'));
-final _copyReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+final _copysmokeStructswithmethodsVectorCreateVectorReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_StructsWithMethods_Vector_create__Vector_return_has_error'));
@@ -107,17 +107,17 @@ class StructsWithMethods_Vector$Impl {
     final _otherHandle = smokeStructswithmethodsVectorToFfi(other);
     final __callResultHandle = _copyFfi(__lib.LibraryContext.isolateId, _otherHandle);
     smokeStructswithmethodsVectorReleaseFfiHandle(_otherHandle);
-    if (_copyReturnHasError(__callResultHandle) != 0) {
-        final __errorHandle = _copyReturnGetError(__callResultHandle);
-        _copyReturnReleaseHandle(__callResultHandle);
+    if (_copysmokeStructswithmethodsVectorCreateVectorReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _copysmokeStructswithmethodsVectorCreateVectorReturnGetError(__callResultHandle);
+        _copysmokeStructswithmethodsVectorCreateVectorReturnReleaseHandle(__callResultHandle);
         try {
           throw ValidationUtils_ValidationException(smokeValidationutilsValidationerrorcodeFromFfi(__errorHandle));
         } finally {
           smokeValidationutilsValidationerrorcodeReleaseFfiHandle(__errorHandle);
         }
     }
-    final __resultHandle = _copyReturnGetResult(__callResultHandle);
-    _copyReturnReleaseHandle(__callResultHandle);
+    final __resultHandle = _copysmokeStructswithmethodsVectorCreateVectorReturnGetResult(__callResultHandle);
+    _copysmokeStructswithmethodsVectorCreateVectorReturnReleaseHandle(__callResultHandle);
     try {
       return smokeStructswithmethodsVectorFromFfi(__resultHandle);
     } finally {

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/input/ThrowingConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/input/ThrowingConstructors.lime
@@ -1,0 +1,45 @@
+# Copyright (C) 2023 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+open class ExternalClass {
+    enum ErrorEnum {
+        NONE,
+        CRASHED
+    }
+
+    @Dart(Default)
+    constructor create() throws ConstructorExploded
+
+    class InternalOne {
+        @Dart(Default)
+        constructor create() throws ConstructorExploded   
+
+        @Dart("WithParameter")
+        constructor create(
+            value: ULong
+        ) throws ConstructorExploded   
+    }
+
+    class InternalTwo {
+        @Dart(Default)
+        constructor create() throws ConstructorExploded   
+    }
+
+    exception ConstructorExploded(ErrorEnum)
+}

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/ffi/ffi_smoke_ExternalClass.cpp
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/ffi/ffi_smoke_ExternalClass.cpp
@@ -1,0 +1,253 @@
+#include "ffi_smoke_ExternalClass.h"
+#include "ConversionBase.h"
+#include "InstanceCache.h"
+#include "FinalizerData.h"
+#include "IsolateContext.h"
+#include "gluecodium\TypeRepository.h"
+#include "smoke\ExternalClass.h"
+#include <cstdint>
+#include <memory>
+#include <memory>
+#include <new>
+#ifdef __cplusplus
+extern "C" {
+#endif
+void
+library_smoke_ExternalClass_create_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass>, smoke::ExternalClass::ErrorEnum>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_create_return_get_result(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::ExternalClass>>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass>, smoke::ExternalClass::ErrorEnum>*>(handle)->unsafe_value()
+    );
+}
+uint32_t
+library_smoke_ExternalClass_create_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<smoke::ExternalClass::ErrorEnum>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass>, smoke::ExternalClass::ErrorEnum>*>(handle)->error()
+    );
+}
+bool
+library_smoke_ExternalClass_create_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass>, smoke::ExternalClass::ErrorEnum>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_create(int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    auto&& _cpp_call_result = smoke::ExternalClass::create();
+    if (_cpp_call_result.has_value()) {
+        return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass>, smoke::ExternalClass::ErrorEnum>(
+            std::forward<std::shared_ptr<smoke::ExternalClass>>(_cpp_call_result.unsafe_value())
+        ));
+    }
+    auto _error_code = _cpp_call_result.error();
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass>, smoke::ExternalClass::ErrorEnum>(
+        static_cast<smoke::ExternalClass::ErrorEnum>(_error_code.value())
+    ));
+}
+void
+library_smoke_ExternalClass_InternalOne_create_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalOne_create_return_get_result(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::ExternalClass::InternalOne>>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle)->unsafe_value()
+    );
+}
+uint32_t
+library_smoke_ExternalClass_InternalOne_create_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<smoke::ExternalClass::ErrorEnum>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle)->error()
+    );
+}
+bool
+library_smoke_ExternalClass_InternalOne_create_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalOne_create(int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    auto&& _cpp_call_result = smoke::ExternalClass::InternalOne::create();
+    if (_cpp_call_result.has_value()) {
+        return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>(
+            std::forward<std::shared_ptr<smoke::ExternalClass::InternalOne>>(_cpp_call_result.unsafe_value())
+        ));
+    }
+    auto _error_code = _cpp_call_result.error();
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>(
+        static_cast<smoke::ExternalClass::ErrorEnum>(_error_code.value())
+    ));
+}
+void
+library_smoke_ExternalClass_InternalOne_create__ULong_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalOne_create__ULong_return_get_result(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::ExternalClass::InternalOne>>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle)->unsafe_value()
+    );
+}
+uint32_t
+library_smoke_ExternalClass_InternalOne_create__ULong_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<smoke::ExternalClass::ErrorEnum>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle)->error()
+    );
+}
+bool
+library_smoke_ExternalClass_InternalOne_create__ULong_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalOne_create__ULong(int32_t _isolate_id, uint64_t value) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    auto&& _cpp_call_result = smoke::ExternalClass::InternalOne::create(
+        gluecodium::ffi::Conversion<uint64_t>::toCpp(value)
+    );
+    if (_cpp_call_result.has_value()) {
+        return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>(
+            std::forward<std::shared_ptr<smoke::ExternalClass::InternalOne>>(_cpp_call_result.unsafe_value())
+        ));
+    }
+    auto _error_code = _cpp_call_result.error();
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalOne>, smoke::ExternalClass::ErrorEnum>(
+        static_cast<smoke::ExternalClass::ErrorEnum>(_error_code.value())
+    ));
+}
+void
+library_smoke_ExternalClass_InternalTwo_create_return_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalTwo>, smoke::ExternalClass::ErrorEnum>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalTwo_create_return_get_result(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<std::shared_ptr<smoke::ExternalClass::InternalTwo>>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalTwo>, smoke::ExternalClass::ErrorEnum>*>(handle)->unsafe_value()
+    );
+}
+uint32_t
+library_smoke_ExternalClass_InternalTwo_create_return_get_error(FfiOpaqueHandle handle) {
+    return gluecodium::ffi::Conversion<smoke::ExternalClass::ErrorEnum>::toFfi(
+        reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalTwo>, smoke::ExternalClass::ErrorEnum>*>(handle)->error()
+    );
+}
+bool
+library_smoke_ExternalClass_InternalTwo_create_return_has_error(FfiOpaqueHandle handle) {
+    return !reinterpret_cast<gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalTwo>, smoke::ExternalClass::ErrorEnum>*>(handle)->has_value();
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalTwo_create(int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    auto&& _cpp_call_result = smoke::ExternalClass::InternalTwo::create();
+    if (_cpp_call_result.has_value()) {
+        return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalTwo>, smoke::ExternalClass::ErrorEnum>(
+            std::forward<std::shared_ptr<smoke::ExternalClass::InternalTwo>>(_cpp_call_result.unsafe_value())
+        ));
+    }
+    auto _error_code = _cpp_call_result.error();
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) gluecodium::Return<std::shared_ptr<smoke::ExternalClass::InternalTwo>, smoke::ExternalClass::ErrorEnum>(
+        static_cast<smoke::ExternalClass::ErrorEnum>(_error_code.value())
+    ));
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_ExternalClass_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::ExternalClass>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_ExternalClass_release_handle(handle);
+}
+void
+library_smoke_ExternalClass_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_ExternalClass_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::ExternalClass>(
+            *reinterpret_cast<std::shared_ptr<smoke::ExternalClass>*>(handle)
+        )
+    );
+}
+void
+library_smoke_ExternalClass_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::ExternalClass>*>(handle);
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_ExternalClass_InternalOne_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::ExternalClass::InternalOne>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_ExternalClass_InternalOne_release_handle(handle);
+}
+void
+library_smoke_ExternalClass_InternalOne_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_ExternalClass_InternalOne_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalOne_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::ExternalClass::InternalOne>(
+            *reinterpret_cast<std::shared_ptr<smoke::ExternalClass::InternalOne>*>(handle)
+        )
+    );
+}
+void
+library_smoke_ExternalClass_InternalOne_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::ExternalClass::InternalOne>*>(handle);
+}
+// "Private" finalizer, not exposed to be callable from Dart.
+void
+library_smoke_ExternalClass_InternalTwo_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
+    auto ptr_ptr = reinterpret_cast<std::shared_ptr<smoke::ExternalClass::InternalTwo>*>(handle);
+    library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
+    library_smoke_ExternalClass_InternalTwo_release_handle(handle);
+}
+void
+library_smoke_ExternalClass_InternalTwo_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
+    FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_ExternalClass_InternalTwo_finalizer};
+    Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_InternalTwo_copy_handle(FfiOpaqueHandle handle) {
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::shared_ptr<smoke::ExternalClass::InternalTwo>(
+            *reinterpret_cast<std::shared_ptr<smoke::ExternalClass::InternalTwo>*>(handle)
+        )
+    );
+}
+void
+library_smoke_ExternalClass_InternalTwo_release_handle(FfiOpaqueHandle handle) {
+    delete reinterpret_cast<std::shared_ptr<smoke::ExternalClass::InternalTwo>*>(handle);
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_ErrorEnum_create_handle_nullable(uint32_t value)
+{
+    return reinterpret_cast<FfiOpaqueHandle>(
+        new (std::nothrow) std::optional<smoke::ExternalClass::ErrorEnum>(
+            gluecodium::ffi::Conversion<smoke::ExternalClass::ErrorEnum>::toCpp(value)
+        )
+    );
+}
+void
+library_smoke_ExternalClass_ErrorEnum_release_handle_nullable(FfiOpaqueHandle handle)
+{
+    delete reinterpret_cast<std::optional<smoke::ExternalClass::ErrorEnum>*>(handle);
+}
+uint32_t
+library_smoke_ExternalClass_ErrorEnum_get_value_nullable(FfiOpaqueHandle handle)
+{
+    return gluecodium::ffi::Conversion<smoke::ExternalClass::ErrorEnum>::toFfi(
+        **reinterpret_cast<std::optional<smoke::ExternalClass::ErrorEnum>*>(handle)
+    );
+}
+FfiOpaqueHandle
+library_smoke_ExternalClass_get_type_id(FfiOpaqueHandle handle) {
+    const auto& type_id = ::gluecodium::get_type_repository().get_id(reinterpret_cast<std::shared_ptr<smoke::ExternalClass>*>(handle)->get());
+    return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::string(type_id));
+}
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/ffi/ffi_smoke_ExternalClass.h
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/ffi/ffi_smoke_ExternalClass.h
@@ -1,0 +1,110 @@
+
+#pragma once
+
+#include "Export.h"
+#include "OpaqueHandle.h"
+#include "dart_api_dl.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+
+
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_create_return_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_create_return_get_result(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT uint32_t library_smoke_ExternalClass_create_return_get_error(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT bool library_smoke_ExternalClass_create_return_has_error(FfiOpaqueHandle handle);
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_create(int32_t _isolate_id);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_InternalOne_create_return_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalOne_create_return_get_result(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT uint32_t library_smoke_ExternalClass_InternalOne_create_return_get_error(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT bool library_smoke_ExternalClass_InternalOne_create_return_has_error(FfiOpaqueHandle handle);
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalOne_create(int32_t _isolate_id);
+
+
+
+
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_InternalOne_create__ULong_return_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalOne_create__ULong_return_get_result(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT uint32_t library_smoke_ExternalClass_InternalOne_create__ULong_return_get_error(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT bool library_smoke_ExternalClass_InternalOne_create__ULong_return_has_error(FfiOpaqueHandle handle);
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalOne_create__ULong(int32_t _isolate_id, uint64_t value);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_InternalTwo_create_return_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalTwo_create_return_get_result(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT uint32_t library_smoke_ExternalClass_InternalTwo_create_return_get_error(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT bool library_smoke_ExternalClass_InternalTwo_create_return_has_error(FfiOpaqueHandle handle);
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalTwo_create(int32_t _isolate_id);
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_copy_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_InternalOne_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalOne_copy_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_InternalOne_release_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_InternalTwo_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_InternalTwo_copy_handle(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_InternalTwo_release_handle(FfiOpaqueHandle handle);
+
+
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_ErrorEnum_create_handle_nullable(uint32_t value);
+_GLUECODIUM_FFI_EXPORT void library_smoke_ExternalClass_ErrorEnum_release_handle_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT uint32_t library_smoke_ExternalClass_ErrorEnum_get_value_nullable(FfiOpaqueHandle handle);
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_ExternalClass_get_type_id(FfiOpaqueHandle handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/smoke.dart
@@ -1,0 +1,3 @@
+
+
+export 'src/smoke/external_class.dart' show ExternalClass, ExternalClass$Impl, ExternalClass_ConstructorExplodedException, ExternalClass_ErrorEnum, ExternalClass_InternalOne, ExternalClass_InternalOne$Impl, ExternalClass_InternalTwo, ExternalClass_InternalTwo$Impl;

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
@@ -1,0 +1,368 @@
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+abstract class ExternalClass {
+  factory ExternalClass() => $prototype.$init();
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = ExternalClass$Impl(Pointer<Void>.fromAddress(0));
+}
+enum ExternalClass_ErrorEnum {
+    none,
+    crashed
+}
+// ExternalClass_ErrorEnum "private" section, not exported.
+int smokeExternalclassErrorenumToFfi(ExternalClass_ErrorEnum value) {
+  switch (value) {
+  case ExternalClass_ErrorEnum.none:
+    return 0;
+  case ExternalClass_ErrorEnum.crashed:
+    return 1;
+  default:
+    throw StateError("Invalid enum value $value for ExternalClass_ErrorEnum enum.");
+  }
+}
+ExternalClass_ErrorEnum smokeExternalclassErrorenumFromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return ExternalClass_ErrorEnum.none;
+  case 1:
+    return ExternalClass_ErrorEnum.crashed;
+  default:
+    throw StateError("Invalid numeric value $handle for ExternalClass_ErrorEnum enum.");
+  }
+}
+void smokeExternalclassErrorenumReleaseFfiHandle(int handle) {}
+final _smokeExternalclassErrorenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_ExternalClass_ErrorEnum_create_handle_nullable'));
+final _smokeExternalclassErrorenumReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_ErrorEnum_release_handle_nullable'));
+final _smokeExternalclassErrorenumGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_ErrorEnum_get_value_nullable'));
+Pointer<Void> smokeExternalclassErrorenumToFfiNullable(ExternalClass_ErrorEnum? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeExternalclassErrorenumToFfi(value);
+  final result = _smokeExternalclassErrorenumCreateHandleNullable(_handle);
+  smokeExternalclassErrorenumReleaseFfiHandle(_handle);
+  return result;
+}
+ExternalClass_ErrorEnum? smokeExternalclassErrorenumFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeExternalclassErrorenumGetValueNullable(handle);
+  final result = smokeExternalclassErrorenumFromFfi(_handle);
+  smokeExternalclassErrorenumReleaseFfiHandle(_handle);
+  return result;
+}
+void smokeExternalclassErrorenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeExternalclassErrorenumReleaseHandleNullable(handle);
+// End of ExternalClass_ErrorEnum "private" section.
+class ExternalClass_ConstructorExplodedException implements Exception {
+  final ExternalClass_ErrorEnum error;
+  ExternalClass_ConstructorExplodedException(this.error);
+}
+abstract class ExternalClass_InternalOne {
+  factory ExternalClass_InternalOne() => $prototype.$init();
+  factory ExternalClass_InternalOne.WithParameter(int value) => $prototype.WithParameter(value);
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = ExternalClass_InternalOne$Impl(Pointer<Void>.fromAddress(0));
+}
+// ExternalClass_InternalOne "private" section, not exported.
+final _smokeExternalclassInternaloneRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_ExternalClass_InternalOne_register_finalizer'));
+final _smokeExternalclassInternaloneCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_copy_handle'));
+final _smokeExternalclassInternaloneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_release_handle'));
+final _$initsmokeExternalclassInternaloneCreateReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create_return_release_handle'));
+final _$initsmokeExternalclassInternaloneCreateReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create_return_get_result'));
+final _$initsmokeExternalclassInternaloneCreateReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create_return_get_error'));
+final _$initsmokeExternalclassInternaloneCreateReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create_return_has_error'));
+final _WithParametersmokeExternalclassInternaloneCreateUlongReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create__ULong_return_release_handle'));
+final _WithParametersmokeExternalclassInternaloneCreateUlongReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create__ULong_return_get_result'));
+final _WithParametersmokeExternalclassInternaloneCreateUlongReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create__ULong_return_get_error'));
+final _WithParametersmokeExternalclassInternaloneCreateUlongReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalOne_create__ULong_return_has_error'));
+/// @nodoc
+@visibleForTesting
+class ExternalClass_InternalOne$Impl extends __lib.NativeBase implements ExternalClass_InternalOne {
+  ExternalClass_InternalOne$Impl(Pointer<Void> handle) : super(handle);
+  ExternalClass_InternalOne $init() {
+    final _result_handle = _$init();
+    final _result = ExternalClass_InternalOne$Impl(_result_handle);
+    __lib.cacheInstance(_result_handle, _result);
+    _smokeExternalclassInternaloneRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+  ExternalClass_InternalOne WithParameter(int value) {
+    final _result_handle = _WithParameter(value);
+    final _result = ExternalClass_InternalOne$Impl(_result_handle);
+    __lib.cacheInstance(_result_handle, _result);
+    _smokeExternalclassInternaloneRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+  static Pointer<Void> _$init() {
+    final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ExternalClass_InternalOne_create'));
+    final __callResultHandle = _$initFfi(__lib.LibraryContext.isolateId);
+    if (_$initsmokeExternalclassInternaloneCreateReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _$initsmokeExternalclassInternaloneCreateReturnGetError(__callResultHandle);
+        _$initsmokeExternalclassInternaloneCreateReturnReleaseHandle(__callResultHandle);
+        try {
+          throw ExternalClass_ConstructorExplodedException(smokeExternalclassErrorenumFromFfi(__errorHandle));
+        } finally {
+          smokeExternalclassErrorenumReleaseFfiHandle(__errorHandle);
+        }
+    }
+    final __resultHandle = _$initsmokeExternalclassInternaloneCreateReturnGetResult(__callResultHandle);
+    _$initsmokeExternalclassInternaloneCreateReturnReleaseHandle(__callResultHandle);
+    return __resultHandle;
+  }
+  static Pointer<Void> _WithParameter(int value) {
+    final _WithParameterFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_ExternalClass_InternalOne_create__ULong'));
+    final _valueHandle = (value);
+    final __callResultHandle = _WithParameterFfi(__lib.LibraryContext.isolateId, _valueHandle);
+    if (_WithParametersmokeExternalclassInternaloneCreateUlongReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _WithParametersmokeExternalclassInternaloneCreateUlongReturnGetError(__callResultHandle);
+        _WithParametersmokeExternalclassInternaloneCreateUlongReturnReleaseHandle(__callResultHandle);
+        try {
+          throw ExternalClass_ConstructorExplodedException(smokeExternalclassErrorenumFromFfi(__errorHandle));
+        } finally {
+          smokeExternalclassErrorenumReleaseFfiHandle(__errorHandle);
+        }
+    }
+    final __resultHandle = _WithParametersmokeExternalclassInternaloneCreateUlongReturnGetResult(__callResultHandle);
+    _WithParametersmokeExternalclassInternaloneCreateUlongReturnReleaseHandle(__callResultHandle);
+    return __resultHandle;
+  }
+}
+Pointer<Void> smokeExternalclassInternaloneToFfi(ExternalClass_InternalOne value) =>
+  _smokeExternalclassInternaloneCopyHandle((value as __lib.NativeBase).handle);
+ExternalClass_InternalOne smokeExternalclassInternaloneFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is ExternalClass_InternalOne) return instance;
+  final _copiedHandle = _smokeExternalclassInternaloneCopyHandle(handle);
+  final result = ExternalClass_InternalOne$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeExternalclassInternaloneRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeExternalclassInternaloneReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeExternalclassInternaloneReleaseHandle(handle);
+Pointer<Void> smokeExternalclassInternaloneToFfiNullable(ExternalClass_InternalOne? value) =>
+  value != null ? smokeExternalclassInternaloneToFfi(value) : Pointer<Void>.fromAddress(0);
+ExternalClass_InternalOne? smokeExternalclassInternaloneFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeExternalclassInternaloneFromFfi(handle) : null;
+void smokeExternalclassInternaloneReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeExternalclassInternaloneReleaseHandle(handle);
+// End of ExternalClass_InternalOne "private" section.
+abstract class ExternalClass_InternalTwo {
+  factory ExternalClass_InternalTwo() => $prototype.$init();
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = ExternalClass_InternalTwo$Impl(Pointer<Void>.fromAddress(0));
+}
+// ExternalClass_InternalTwo "private" section, not exported.
+final _smokeExternalclassInternaltwoRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_ExternalClass_InternalTwo_register_finalizer'));
+final _smokeExternalclassInternaltwoCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalTwo_copy_handle'));
+final _smokeExternalclassInternaltwoReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalTwo_release_handle'));
+final _$initsmokeExternalclassInternaltwoCreateReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalTwo_create_return_release_handle'));
+final _$initsmokeExternalclassInternaltwoCreateReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalTwo_create_return_get_result'));
+final _$initsmokeExternalclassInternaltwoCreateReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalTwo_create_return_get_error'));
+final _$initsmokeExternalclassInternaltwoCreateReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_InternalTwo_create_return_has_error'));
+/// @nodoc
+@visibleForTesting
+class ExternalClass_InternalTwo$Impl extends __lib.NativeBase implements ExternalClass_InternalTwo {
+  ExternalClass_InternalTwo$Impl(Pointer<Void> handle) : super(handle);
+  ExternalClass_InternalTwo $init() {
+    final _result_handle = _$init();
+    final _result = ExternalClass_InternalTwo$Impl(_result_handle);
+    __lib.cacheInstance(_result_handle, _result);
+    _smokeExternalclassInternaltwoRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+  static Pointer<Void> _$init() {
+    final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ExternalClass_InternalTwo_create'));
+    final __callResultHandle = _$initFfi(__lib.LibraryContext.isolateId);
+    if (_$initsmokeExternalclassInternaltwoCreateReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _$initsmokeExternalclassInternaltwoCreateReturnGetError(__callResultHandle);
+        _$initsmokeExternalclassInternaltwoCreateReturnReleaseHandle(__callResultHandle);
+        try {
+          throw ExternalClass_ConstructorExplodedException(smokeExternalclassErrorenumFromFfi(__errorHandle));
+        } finally {
+          smokeExternalclassErrorenumReleaseFfiHandle(__errorHandle);
+        }
+    }
+    final __resultHandle = _$initsmokeExternalclassInternaltwoCreateReturnGetResult(__callResultHandle);
+    _$initsmokeExternalclassInternaltwoCreateReturnReleaseHandle(__callResultHandle);
+    return __resultHandle;
+  }
+}
+Pointer<Void> smokeExternalclassInternaltwoToFfi(ExternalClass_InternalTwo value) =>
+  _smokeExternalclassInternaltwoCopyHandle((value as __lib.NativeBase).handle);
+ExternalClass_InternalTwo smokeExternalclassInternaltwoFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is ExternalClass_InternalTwo) return instance;
+  final _copiedHandle = _smokeExternalclassInternaltwoCopyHandle(handle);
+  final result = ExternalClass_InternalTwo$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeExternalclassInternaltwoRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeExternalclassInternaltwoReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeExternalclassInternaltwoReleaseHandle(handle);
+Pointer<Void> smokeExternalclassInternaltwoToFfiNullable(ExternalClass_InternalTwo? value) =>
+  value != null ? smokeExternalclassInternaltwoToFfi(value) : Pointer<Void>.fromAddress(0);
+ExternalClass_InternalTwo? smokeExternalclassInternaltwoFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeExternalclassInternaltwoFromFfi(handle) : null;
+void smokeExternalclassInternaltwoReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeExternalclassInternaltwoReleaseHandle(handle);
+// End of ExternalClass_InternalTwo "private" section.
+// ExternalClass "private" section, not exported.
+final _smokeExternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_ExternalClass_register_finalizer'));
+final _smokeExternalclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_copy_handle'));
+final _smokeExternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_release_handle'));
+final _smokeExternalclassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_get_type_id'));
+final _$initsmokeExternalclassCreateReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_create_return_release_handle'));
+final _$initsmokeExternalclassCreateReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_create_return_get_result'));
+final _$initsmokeExternalclassCreateReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_create_return_get_error'));
+final _$initsmokeExternalclassCreateReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_ExternalClass_create_return_has_error'));
+/// @nodoc
+@visibleForTesting
+class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
+  ExternalClass$Impl(Pointer<Void> handle) : super(handle);
+  ExternalClass $init() {
+    final _result_handle = _$init();
+    final _result = ExternalClass$Impl(_result_handle);
+    __lib.cacheInstance(_result_handle, _result);
+    _smokeExternalclassRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+  static Pointer<Void> _$init() {
+    final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ExternalClass_create'));
+    final __callResultHandle = _$initFfi(__lib.LibraryContext.isolateId);
+    if (_$initsmokeExternalclassCreateReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _$initsmokeExternalclassCreateReturnGetError(__callResultHandle);
+        _$initsmokeExternalclassCreateReturnReleaseHandle(__callResultHandle);
+        try {
+          throw ExternalClass_ConstructorExplodedException(smokeExternalclassErrorenumFromFfi(__errorHandle));
+        } finally {
+          smokeExternalclassErrorenumReleaseFfiHandle(__errorHandle);
+        }
+    }
+    final __resultHandle = _$initsmokeExternalclassCreateReturnGetResult(__callResultHandle);
+    _$initsmokeExternalclassCreateReturnReleaseHandle(__callResultHandle);
+    return __resultHandle;
+  }
+}
+Pointer<Void> smokeExternalclassToFfi(ExternalClass value) =>
+  _smokeExternalclassCopyHandle((value as __lib.NativeBase).handle);
+ExternalClass smokeExternalclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is ExternalClass) return instance;
+  final _typeIdHandle = _smokeExternalclassGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+  final _copiedHandle = _smokeExternalclassCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : ExternalClass$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeExternalclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+void smokeExternalclassReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeExternalclassReleaseHandle(handle);
+Pointer<Void> smokeExternalclassToFfiNullable(ExternalClass? value) =>
+  value != null ? smokeExternalclassToFfi(value) : Pointer<Void>.fromAddress(0);
+ExternalClass? smokeExternalclassFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeExternalclassFromFfi(handle) : null;
+void smokeExternalclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeExternalclassReleaseHandle(handle);
+// End of ExternalClass "private" section.


### PR DESCRIPTION
Added ffi prefix to name of functions handling error and return type retrival from throwing functions. This prevent duplicate_definition error if more than one class has those function inside one file, for example in case of multiple internal classes.

Relates-To:  #1547
