### PR TITLE
Clean up the generated code for java.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
  * Dart: disabled generation of `invalid_use_of_visible_for_testing_member` warning from the generated code for a hierarchy of classes.
  * Dart: removed generation of redundant import for constants declared with external types. The redundant import caused linter warnings.
  * Dart: removed generation of redundant `default` clause in exhaustive switch-cases for enumerations. The redundant `default` caused linter warnings.
+ * Java: cleaned up the generated code: removed blank lines. 
 
 ## 13.10.1
 Release date 2024-12-12

--- a/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
@@ -21,11 +21,11 @@
 {{#ifPredicate "hasAnyComment"}}
 /**
 {{prefixPartial "combinedComment" " * "}}
- */
-{{#if attributes.deprecated}}@Deprecated{{/if}}
-{{/ifPredicate}}
+ */{{#if attributes.deprecated}}
+@Deprecated {{/if}}{{!!
+}}{{/ifPredicate}}{{!!
 
-{{+combinedComment}}{{!!
+}}{{+combinedComment}}{{!!
 }}{{resolveName comment}}{{!!
 }}{{#resolveName property.additionalDescriptionComment}}{{#unless this.isEmpty}}
 {{this}}{{/unless}}{{/resolveName}}{{!!

--- a/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaStructConstructors.mustache
@@ -24,8 +24,8 @@
 
 {{#unless constructorComment.isEmpty}}
     /**
-{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
-{{#uninitializedFields}}
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}{{!!
+}}{{#uninitializedFields}}
      * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
 {{/uninitializedFields}}
      */
@@ -58,7 +58,6 @@
 }}{{#set struct=this}}{{#fieldConstructors}}
 {{#ifPredicate "hasAnyComment"}}
     /**
-
 {{#unless comment.isEmpty}}{{#resolveName comment}}{{prefix this "     * "}}
 {{/resolveName}}{{/unless}}{{!!
 }}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{prefix this "     * "}}


### PR DESCRIPTION
Clean up the generated code for Java: remove blank lines between javadoc and method signature.