### PR TITLE
Fixed invalid_use_of_type_outside_library error related to dart Iterator class

### DIFF
--- a/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
@@ -23,7 +23,7 @@
 import 'dart:ffi';
 import 'dart:math';
 
-class _LazyIterator<E> extends Iterator<E> {
+class _LazyIterator<E> implements Iterator<E> {
   final List<E> list;
   final int step;
   final int length;

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/_lazy_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/_lazy_list.dart
@@ -1,6 +1,6 @@
 import 'dart:ffi';
 import 'dart:math';
-class _LazyIterator<E> extends Iterator<E> {
+class _LazyIterator<E> implements Iterator<E> {
   final List<E> list;
   final int step;
   final int length;


### PR DESCRIPTION
Fixed invalid_use_of_type_outside_library error related to dart Iterator class.
