### PR TITLE
Fixes RTTI for generated class

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -308,11 +308,11 @@ jobs:
             git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
             mkdir dart-sdk
             pushd dart-sdk
-            fetch dart
-            pushd sdk
-            git fetch --tags
-            git checkout tags/${DART_VERSION}
+            gclient root
+            gclient config --spec 'solutions = [{"name": "sdk", "url": "https://dart.googlesource.com/sdk.git", "deps_file": "DEPS", "managed": False, "custom_deps": {},},]'
+            git clone --depth 1 --branch ${DART_VERSION} https://dart.googlesource.com/sdk.git
             gclient sync
+            pushd sdk
             ./tools/build.py --no-goma --mode release --arch x64 create_sdk --gn-args dart_use_tcmalloc=false
             mkdir -p ${DART_BIN}
             pushd out/ReleaseX64/dart-sdk

--- a/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppClass.mustache
@@ -24,7 +24,7 @@ class {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}}{{!!
 }}{{#if this.parents}}: {{#this.parents}}public {{resolveName this.type "FQN"}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}} {
 public:
     {{resolveName}}();
-    virtual ~{{resolveName}}() = 0;
+    virtual ~{{resolveName}}();
 
 {{#ifPredicate "needsInnerForwardDeclarations"}}
 public:

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncClass.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncClass.h
@@ -1,19 +1,25 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include "smoke/AsyncErrorCode.h"
 #include <cstdint>
 #include <functional>
 #include <system_error>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT AsyncClass {
 public:
     AsyncClass();
-    virtual ~AsyncClass() = 0;
+    virtual ~AsyncClass();
+
+
 public:
     virtual void async_void( std::function<void()> _result_callback, const bool input ) = 0;
     virtual void async_void( const bool input ) = 0;
@@ -26,4 +32,6 @@ public:
     static void async_static( std::function<void()> _result_callback, const bool input );
     static void async_static( const bool input );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncRenamed.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncRenamed.h
@@ -1,17 +1,25 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <functional>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT AsyncRenamed {
 public:
     AsyncRenamed();
-    virtual ~AsyncRenamed() = 0;
+    virtual ~AsyncRenamed();
+
+
 public:
     virtual void callDispose( std::function<void()> _result_callback ) = 0;
     virtual void callDispose(  ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncWithSkips.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncWithSkips.h
@@ -1,19 +1,27 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <functional>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT AsyncWithSkips {
 public:
     AsyncWithSkips();
-    virtual ~AsyncWithSkips() = 0;
+    virtual ~AsyncWithSkips();
+
+
 public:
     static void make_shared_instance( const ::std::string& android_context );
     static void make_shared_instance( std::function<void()> _result_callback );
     static void make_shared_instance(  );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesClass.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesClass.h
@@ -1,18 +1,25 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT [[OnClass]] AttributesClass {
 public:
     AttributesClass();
-    virtual ~AttributesClass() = 0;
+    virtual ~AttributesClass();
+
+
 public:
     [[OnConstInClass]]
     static const bool PI;
+
 public:
     [[OnFunctionInClass]]
     virtual void very_fun( [[OnParameterInClass]] const ::std::string& param ) = 0;
@@ -20,5 +27,8 @@ public:
     virtual ::std::string get_prop(  ) const = 0;
     [[OnPropertyInClass]]
     virtual void set_prop( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesInterface.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesInterface.h
@@ -1,19 +1,26 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT [[OnInterface]] AttributesInterface {
 public:
     AttributesInterface();
-    virtual ~AttributesInterface() = 0;
+    virtual ~AttributesInterface();
+
+
 public:
     [[OnConstInInterface]]
     static const bool PI;
+
 public:
     [[OnFunctionInInterface]]
     virtual void very_fun( [[OnParameterInInterface]] const ::std::string& param ) = 0;
@@ -21,5 +28,8 @@ public:
     virtual ::std::string get_prop(  ) const = 0;
     [[OnPropertyInInterface]]
     virtual void set_prop( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithComments.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithComments.h
@@ -1,33 +1,46 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke {
 /**
  * Class comment
+
  */
 class _GLUECODIUM_CPP_EXPORT [[OnClass]] AttributesWithComments {
 public:
     AttributesWithComments();
-    virtual ~AttributesWithComments() = 0;
+    virtual ~AttributesWithComments();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         /**
          * Field comment
+
          */
         [[OnField]]
         ::std::string field = "";
+
         SomeStruct( );
         explicit SomeStruct( ::std::string field );
+
     };
+
     /**
      * Const comment
+
      */
     [[OnConstInClass]]
     static const bool PI;
+
 public:
     /**
      * Function comment
@@ -46,5 +59,8 @@ public:
      */
     [[OnPropertyInClass]]
     virtual void set_prop( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesWithDeprecated.h
@@ -1,18 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke {
 /**
- * \deprecated
+ * \deprecated 
  */
 class _GLUECODIUM_CPP_EXPORT [[OnClass]] AttributesWithDeprecated {
 public:
     AttributesWithDeprecated();
-    virtual ~AttributesWithDeprecated() = 0;
+    virtual ~AttributesWithDeprecated();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         /**
@@ -20,14 +26,18 @@ public:
          */
         [[OnField]]
         ::std::string field = "";
+
         SomeStruct( );
         explicit SomeStruct( ::std::string field );
+
     };
+
     /**
      * \deprecated
      */
     [[OnConstInClass]]
     static const bool PI;
+
 public:
     /**
      *
@@ -49,5 +59,8 @@ public:
      */
     [[OnPropertyInClass]]
     virtual void set_prop( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/MultipleAttributesCpp.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/MultipleAttributesCpp.h
@@ -1,14 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT MultipleAttributesCpp {
 public:
     MultipleAttributesCpp();
-    virtual ~MultipleAttributesCpp() = 0;
+    virtual ~MultipleAttributesCpp();
+
+
 public:
     [[Foo, Bar]]
     virtual void no_lists2(  ) = 0;
@@ -21,4 +27,6 @@ public:
     [[Foo, Bar, Baz, Fizz]]
     virtual void two_lists(  ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/SpecialAttributes.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/SpecialAttributes.h
@@ -1,18 +1,26 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SpecialAttributes {
 public:
     SpecialAttributes();
-    virtual ~SpecialAttributes() = 0;
+    virtual ~SpecialAttributes();
+
+
 public:
     [[Deprecated("foo\nbar")]]
     virtual void with_escaping(  ) = 0;
     [[HackMerm -rf *]]
     virtual void with_line_break(  ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/BasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/BasicTypes.h
@@ -1,16 +1,22 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT BasicTypes {
 public:
     BasicTypes();
-    virtual ~BasicTypes() = 0;
+    virtual ~BasicTypes();
+
+
 public:
     static ::std::string string_function( const ::std::string& input );
     static bool bool_function( const bool input );
@@ -25,4 +31,6 @@ public:
     static uint32_t uint_function( const uint32_t input );
     static uint64_t ulong_function( const uint64_t input );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include <cstdint>
@@ -10,21 +13,29 @@
 #include <optional>
 #include <string>
 #include <system_error>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT CppRefReturnType {
 public:
     CppRefReturnType();
-    virtual ~CppRefReturnType() = 0;
+    virtual ~CppRefReturnType();
+
+
 public:
     enum class InternalError {
         FOO,
         BAR
     };
+
+
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string field;
+
         SomeStruct( );
         explicit SomeStruct( ::std::string field );
+
     };
+
 public:
     static void void_ref(  );
     static const bool& bool_ref(  );
@@ -41,9 +52,13 @@ public:
     static ::gluecodium::Return< void, ::smoke::CppRefReturnType::SomeStruct > throwing_struct_with_void(  );
     static ::gluecodium::Return< const ::std::string&, ::smoke::CppRefReturnType::SomeStruct > throwing_struct_with_string(  );
     static const ::std::string& get_string_property(  );
+
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::CppRefReturnType::InternalError value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/StringsWithCstring.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/StringsWithCstring.h
@@ -1,15 +1,21 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT StringsWithCstring {
 public:
     StringsWithCstring();
-    virtual ~StringsWithCstring() = 0;
+    virtual ~StringsWithCstring();
+
+
 public:
     /**
      * Method that takes a C string as input and returns an std::string it as output.
@@ -24,4 +30,6 @@ public:
      */
     static ::std::string return_input_string( const ::std::string& input_string );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include <cstdint>
@@ -10,28 +13,37 @@
 #include <optional>
 #include <string>
 #include <system_error>
+
 namespace smoke {
 /**
  * This is some very useful interface.
+
  */
 class _GLUECODIUM_CPP_EXPORT Comments {
 public:
     Comments();
-    virtual ~Comments() = 0;
+    virtual ~Comments();
+
+
 public:
     /**
      * This is some very useful enum.
+
      */
     enum class SomeEnum {
         /**
          * Not quite useful
+
          */
         USELESS,
         /**
          * Somewhat useful
+
          */
         USEFUL
     };
+
+
     /**
      * This is some very useful lambda that does it.
      * \param[in] p0 Very useful input parameter
@@ -39,40 +51,54 @@ public:
      * \return Usefulness of the input
      */
     using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
+
     /**
      * This is some very useful typedef.
+
      */
     using Usefulness = bool;
+
     /**
      * This is some very useful struct.
+
      */
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         /**
          * How useful this struct is
          * remains to be seen
+
          */
         ::smoke::Comments::Usefulness some_field;
         /**
          * Can be `null`
+
          */
         std::optional< ::std::string > nullable_field = std::optional< ::std::string >();
+
         /**
          * This is how easy it is to construct.
          */
         SomeStruct( );
         /**
          * This is how easy it is to construct.
+
          * \param some_field How useful this struct is
          * remains to be seen
+
          */
         explicit SomeStruct( ::smoke::Comments::Usefulness some_field );
         /**
          * This is how easy it is to construct.
+
          * \param some_field How useful this struct is
          * remains to be seen
+
+
          * \param nullable_field Can be `null`
+
          */
         SomeStruct( ::smoke::Comments::Usefulness some_field, std::optional< ::std::string > nullable_field );
+
         /**
          * This is some struct method that does nothing.
          */
@@ -81,11 +107,15 @@ public:
          * This is some static struct method that does nothing.
          */
         static void some_static_struct_method(  );
+
     };
+
     /**
      * This is some very useful constant.
+
      */
     static const ::smoke::Comments::Usefulness VERY_USEFUL;
+
 public:
     /**
      * This is some very useful method that measures the usefulness of its input.
@@ -160,9 +190,13 @@ public:
      * \param[in] value Some very useful property.
      */
     virtual void set_some_property( const ::smoke::Comments::Usefulness value ) = 0;
+
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::Comments::SomeEnum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsLinks.h
@@ -1,13 +1,17 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include "smoke/Comments.h"
 #include <string>
 #include <system_error>
+
 namespace smoke {
 /**
  * The nested types like ::smoke::CommentsLinks::random_method(const ::std::string&, const bool) don't need full name prefix, but it's
@@ -17,30 +21,40 @@ namespace smoke {
  * Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
  *
  * [example1]: http://example.com/1
+
  */
 class _GLUECODIUM_CPP_EXPORT CommentsLinks {
 public:
     CommentsLinks();
-    virtual ~CommentsLinks() = 0;
+    virtual ~CommentsLinks();
+
+
 public:
     /**
      * Links also work in:
+
      */
     struct _GLUECODIUM_CPP_EXPORT RandomStruct {
         /**
          * Some random field ::smoke::Comments::SomeStruct
+
          */
         ::smoke::Comments::SomeStruct random_field;
+
         /**
          * constructor comments ::smoke::Comments::SomeStruct
          */
         RandomStruct( );
         /**
          * constructor comments ::smoke::Comments::SomeStruct
+
          * \param random_field Some random field ::smoke::Comments::SomeStruct
+
          */
         explicit RandomStruct( ::smoke::Comments::SomeStruct random_field );
+
     };
+
 public:
     /**
      * Link types:
@@ -89,4 +103,6 @@ public:
      */
     virtual void random_method( const ::std::string& text, const bool flag ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsMarkdown.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsMarkdown.h
@@ -1,9 +1,13 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
-#include "gluecodium\ExportGluecodiumCpp.h"
+
+#include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 /**
  * First line.
@@ -30,10 +34,15 @@ namespace smoke {
  * ---
  *
  * [title](https://www.markdownguide.org/cheat-sheet/)
+
  */
 class _GLUECODIUM_CPP_EXPORT CommentsMarkdown {
 public:
     CommentsMarkdown();
-    virtual ~CommentsMarkdown() = 0;
+    virtual ~CommentsMarkdown();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsTable.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsTable.h
@@ -1,9 +1,13 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 /**
  * Something lorem something ipsum.
@@ -13,10 +17,15 @@ namespace smoke {
  * | col 1 is |  left-aligned | $1600 |
  * | col 2 is |    centered   |   $12 |
  * | col 3 is | right-aligned |    $1 |
+
  */
 class _GLUECODIUM_CPP_EXPORT CommentsTable {
 public:
     CommentsTable();
-    virtual ~CommentsTable() = 0;
+    virtual ~CommentsTable();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsTableLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CommentsTableLinks.h
@@ -1,9 +1,13 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 /**
  * Something lorem something ipsum.
@@ -13,10 +17,15 @@ namespace smoke {
  * | col 1 is |  ::smoke::CommentsTable | $1600 |
  * | col 2 is |::smoke::Comments::SomeEnum|   $12 |
  * | col 3 is |::smoke::Comments::SomeEnum::USEFUL|    $1 |
+
  */
 class _GLUECODIUM_CPP_EXPORT CommentsTableLinks {
 public:
     CommentsTableLinks();
-    virtual ~CommentsTableLinks() = 0;
+    virtual ~CommentsTableLinks();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CtorLinks.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/CtorLinks.h
@@ -1,25 +1,34 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <memory>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT CtorLinks {
 public:
     CtorLinks();
-    virtual ~CtorLinks() = 0;
+    virtual ~CtorLinks();
+
+
 public:
     /**
      * This class has just one constructor ::smoke::CtorLinks::SingleCtor::create.
+
      */
     class _GLUECODIUM_CPP_EXPORT SingleCtor {
     public:
         SingleCtor();
-        virtual ~SingleCtor() = 0;
+        virtual ~SingleCtor();
+
+
     public:
         /**
          *
@@ -30,11 +39,13 @@ public:
 
     /**
      * This class has just one constructor with one argument ::smoke::CtorLinks::SingleCtorWithOneArgument::create.
+
      */
     class _GLUECODIUM_CPP_EXPORT SingleCtorWithOneArgument {
     public:
         SingleCtorWithOneArgument();
-        virtual ~SingleCtorWithOneArgument() = 0;
+        virtual ~SingleCtorWithOneArgument();
+
 
     public:
         /**
@@ -47,11 +58,13 @@ public:
 
     /**
      * This class has just one constructor with two argument ::smoke::CtorLinks::SingleCtorWithTwoArgument::create.
+
      */
     class _GLUECODIUM_CPP_EXPORT SingleCtorWithTwoArgument {
     public:
         SingleCtorWithTwoArgument();
-        virtual ~SingleCtorWithTwoArgument() = 0;
+        virtual ~SingleCtorWithTwoArgument();
+
 
     public:
         /**
@@ -66,7 +79,9 @@ public:
     class _GLUECODIUM_CPP_EXPORT OverloadedCtors {
     public:
         OverloadedCtors();
-        virtual ~OverloadedCtors() = 0;
+        virtual ~OverloadedCtors();
+
+
     public:
         /**
          *
@@ -83,5 +98,8 @@ public:
          */
         static ::std::shared_ptr< ::smoke::CtorLinks::OverloadedCtors > create( const ::std::string& input, const bool flag );
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
@@ -1,13 +1,17 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <cstdint>
 #include <string>
 #include <system_error>
+
 namespace smoke {
 /**
  * This is some very useful interface.
@@ -16,7 +20,9 @@ namespace smoke {
 class _GLUECODIUM_CPP_EXPORT DeprecationComments {
 public:
     DeprecationComments();
-    virtual ~DeprecationComments() = 0;
+    virtual ~DeprecationComments();
+
+
 public:
     /**
      * This is some very useful enum.
@@ -30,11 +36,14 @@ public:
          */
         USELESS
     };
+
+
     /**
      * This is some very useful typedef.
      * \deprecated Unfortunately, this typedef is deprecated. Use ::smoke::Comments::Usefulness instead.
      */
     using Usefulness = bool;
+
     /**
      * This is some very useful struct.
      * \deprecated Unfortunately, this struct is deprecated. Use ::smoke::Comments::SomeStruct instead.
@@ -46,14 +55,18 @@ public:
          * Use ::smoke::Comments::SomeStruct::some_field instead.
          */
         ::smoke::DeprecationComments::Usefulness some_field = false;
+
         SomeStruct( );
         explicit SomeStruct( ::smoke::DeprecationComments::Usefulness some_field );
+
     };
+
     /**
      * This is some very useful constant.
      * \deprecated Unfortunately, this constant is deprecated. Use ::smoke::Comments::VERY_USEFUL instead.
      */
     static const ::smoke::DeprecationComments::Usefulness VERY_USEFUL;
+
 public:
     /**
      * This is some very useful method that measures the usefulness of its input.
@@ -77,6 +90,7 @@ public:
      * \param[in] value Some very useful property.
      */
     virtual void set_some_property( const ::smoke::DeprecationComments::Usefulness value ) = 0;
+
     /**
      * Gets the property but not accessors.
      * \deprecated Will be removed in v3.2.1.
@@ -89,9 +103,13 @@ public:
      * \param[in] value Describes the property but not accessors.
      */
     virtual void set_property_but_not_accessors( const ::std::string& value ) = 0;
+
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::DeprecationComments::SomeEnum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
@@ -1,12 +1,16 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <cstdint>
 #include <string>
+
 namespace smoke {
 /**
  * \deprecated Unfortunately, this interface is deprecated.
@@ -14,7 +18,9 @@ namespace smoke {
 class _GLUECODIUM_CPP_EXPORT DeprecationCommentsOnly {
 public:
     DeprecationCommentsOnly();
-    virtual ~DeprecationCommentsOnly() = 0;
+    virtual ~DeprecationCommentsOnly();
+
+
 public:
     /**
      * \deprecated Unfortunately, this enum is deprecated.
@@ -25,10 +31,13 @@ public:
          */
         USELESS
     };
+
+
     /**
      * \deprecated Unfortunately, this typedef is deprecated.
      */
     using Usefulness = bool;
+
     /**
      * \deprecated Unfortunately, this struct is deprecated.
      */
@@ -37,13 +46,17 @@ public:
          * \deprecated Unfortunately, this field is deprecated.
          */
         ::smoke::DeprecationCommentsOnly::Usefulness some_field = false;
+
         SomeStruct( );
         explicit SomeStruct( ::smoke::DeprecationCommentsOnly::Usefulness some_field );
+
     };
+
     /**
      * \deprecated Unfortunately, this constant is deprecated.
      */
     static const ::smoke::DeprecationCommentsOnly::Usefulness VERY_USEFUL;
+
 public:
     /**
      *
@@ -64,5 +77,8 @@ public:
      * \param[in] value
      */
     virtual void set_some_property( const ::smoke::DeprecationCommentsOnly::Usefulness value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
@@ -1,75 +1,99 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include <cstdint>
 #include <functional>
 #include <string>
 #include <system_error>
+
 namespace smoke {
 /**
  * This is some very useful class.
  * \private
+
  */
 class _GLUECODIUM_CPP_EXPORT ExcludedComments {
 public:
     ExcludedComments();
-    virtual ~ExcludedComments() = 0;
+    virtual ~ExcludedComments();
+
+
 public:
     /**
      * This is some very useful enum.
      * \private
+
      */
     enum class SomeEnum {
         /**
          * Not quite useful
          * \private
+
          */
         USELESS
     };
+
+
     /**
      * This is some very useful lambda that does it.
      * \param[in] p0 Very useful input parameter
      * \param[in] p1 Slightly less useful input parameter
      * \return Usefulness of the input
      * \private
+
      */
     using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
+
     /**
      * This is some very useful typealias.
      * \private
+
      */
     using Usefulness = bool;
+
     /**
      * This is some very useful struct.
      * \private
+
      */
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         /**
          * How useful this struct is
          * remains to be seen
          * \private
+
          */
         ::smoke::ExcludedComments::Usefulness some_field;
+
         /**
          * This is how easy it is to construct.
          */
         SomeStruct( );
         /**
          * This is how easy it is to construct.
+
          * \param some_field How useful this struct is
          * remains to be seen
+
          */
         explicit SomeStruct( ::smoke::ExcludedComments::Usefulness some_field );
+
     };
+
     /**
      * This is some very useful constant.
      * \private
+
      */
     static const ::smoke::ExcludedComments::Usefulness VERY_USEFUL;
+
 public:
     /**
      * This is some very useful method that measures the usefulness of its input.
@@ -96,9 +120,13 @@ public:
      * \param[in] value Some very useful property.
      */
     virtual void set_some_property( const ::smoke::ExcludedComments::Usefulness value ) = 0;
+
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::ExcludedComments::SomeEnum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsInterface.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsInterface.h
@@ -1,18 +1,27 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
+
 namespace smoke {
 /**
  * This is some very useful interface.
  * \private
+
  */
 class _GLUECODIUM_CPP_EXPORT ExcludedCommentsInterface {
 public:
     ExcludedCommentsInterface();
-    virtual ~ExcludedCommentsInterface() = 0;
+    virtual ~ExcludedCommentsInterface();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
@@ -1,55 +1,78 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include <cstdint>
 #include <functional>
 #include <string>
 #include <system_error>
+
 namespace smoke {
 /**
  * \private
+
  */
 class _GLUECODIUM_CPP_EXPORT ExcludedCommentsOnly {
 public:
     ExcludedCommentsOnly();
-    virtual ~ExcludedCommentsOnly() = 0;
+    virtual ~ExcludedCommentsOnly();
+
+
 public:
     /**
      * \private
+
      */
     enum class SomeEnum {
         /**
          * \private
+
          */
         USELESS
     };
+
+
     /**
+
      * \private
+
      */
     using SomeLambda = ::std::function<double(const ::std::string&, const int32_t)>;
+
     /**
      * \private
+
      */
     using Usefulness = bool;
+
     /**
      * \private
+
      */
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         /**
          * \private
+
          */
         ::smoke::ExcludedCommentsOnly::Usefulness some_field;
+
         SomeStruct( );
         explicit SomeStruct( ::smoke::ExcludedCommentsOnly::Usefulness some_field );
+
     };
+
     /**
      * \private
+
      */
     static const ::smoke::ExcludedCommentsOnly::Usefulness VERY_USEFUL;
+
 public:
     /**
      *
@@ -76,9 +99,13 @@ public:
      * \param[in] value
      */
     virtual void set_some_property( const ::smoke::ExcludedCommentsOnly::Usefulness value ) = 0;
+
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::ExcludedCommentsOnly::SomeEnum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/LambdaComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/LambdaComments.h
@@ -1,39 +1,54 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
 
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <functional>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT LambdaComments {
 public:
     LambdaComments();
-    virtual ~LambdaComments() = 0;
+    virtual ~LambdaComments();
+
+
 public:
     /**
      * The first line of the doc.
      * \param[in] p0 The first input parameter
+
      */
     using WithNoNamedParameters = ::std::function<::std::string(const ::std::string&)>;
+
     /**
      * The first line of the doc.
+
      */
     using WithNoDocsForParameters = ::std::function<::std::string(const ::std::string&)>;
+
     /**
      * The first line of the doc.
      * \param[in] inputParameter The first input parameter. The second sentence of the first input parameter.
      * \return The string.
      */
     using WithNamedParameters = ::std::function<::std::string(const ::std::string& inputParameter)>;
+
     /**
      * The first line of the doc.
      * \return The string.
      */
     using MixedDocNameParameters = ::std::function<::std::string(const ::std::string& inputParameter, const ::std::string& secondInputParameter)>;
+
     using NoCommentsNoNamedParams = ::std::function<::std::string(const ::std::string&, const ::std::string&)>;
+
     using NoCommentsWithNamedParams = ::std::function<::std::string(const ::std::string& first, const ::std::string& second)>;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/LongComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/LongComments.h
@@ -1,18 +1,25 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke {
 /**
  * This is some very useful interface. There is a lot to say about this interface. at least it has a long comment.
+
  */
 class _GLUECODIUM_CPP_EXPORT LongComments {
 public:
     LongComments();
-    virtual ~LongComments() = 0;
+    virtual ~LongComments();
+
+
 public:
     /**
      * This is very important method. It has very important parameters. It has side effects.
@@ -22,4 +29,6 @@ public:
      */
     virtual float some_method_with_long_comment( const ::std::string& input, const double ratio ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/MapScene.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/MapScene.h
@@ -1,26 +1,35 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
-#pragma once
-#include "gluecodium/ExportGluecodiumCpp.h"
 
+#pragma once
+
+#include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <functional>
 #include <optional>
 #include <string>
+
 namespace smoke {
 /**
  * Referencing some type ::smoke::MapScene::load_scene(const int32_t, const std::optional< ::smoke::MapScene::LoadSceneCallback >&).
+
  */
 class _GLUECODIUM_CPP_EXPORT MapScene {
 public:
     MapScene();
-    virtual ~MapScene() = 0;
+    virtual ~MapScene();
+
+
 public:
     using LoadSceneCallback = ::std::function<void(const std::optional< ::std::string >&)>;
+
 public:
     virtual void load_scene( const int32_t map_scheme, const std::optional< ::smoke::MapScene::LoadSceneCallback >& callback ) = 0;
     virtual void load_scene( const ::std::string& configuration_file, const std::optional< ::smoke::MapScene::LoadSceneCallback >& callback ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/MultiLineComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/MultiLineComments.h
@@ -1,10 +1,14 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke {
 /**
  * This is some very useful interface.
@@ -20,11 +24,14 @@ namespace smoke {
  * * escaping
  *
  * ```Some example code;```
+
  */
 class _GLUECODIUM_CPP_EXPORT MultiLineComments {
 public:
     MultiLineComments();
-    virtual ~MultiLineComments() = 0;
+    virtual ~MultiLineComments();
+
+
 public:
     /**
      * This is very important method.
@@ -43,4 +50,6 @@ public:
      */
     virtual float some_method_with_long_comment( const ::std::string& input, const double ratio ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
@@ -1,34 +1,47 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include <cstdint>
 #include <string>
 #include <system_error>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT PlatformComments {
 public:
     PlatformComments();
-    virtual ~PlatformComments() = 0;
+    virtual ~PlatformComments();
+
+
 public:
     /**
      * An error code when something goes wrong.
+
      */
     enum class SomeEnum {
         USELESS,
         USEFUL
     };
+
+
     /**
      * This is a very useful struct.
+
      */
     struct _GLUECODIUM_CPP_EXPORT Something {
         ::std::string nothing;
+
         Something( );
         explicit Something( ::std::string nothing );
+
     };
+
 public:
     /**
      * This is some very useless method that does nothing.
@@ -51,8 +64,11 @@ public:
      */
     virtual void some_deprecated_method(  ) = 0;
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::PlatformComments::SomeEnum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/UnicodeComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/UnicodeComments.h
@@ -1,18 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include "smoke/Comments.h"
 #include <string>
 #include <system_error>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT UnicodeComments {
 public:
     UnicodeComments();
-    virtual ~UnicodeComments() = 0;
+    virtual ~UnicodeComments();
+
+
 public:
     /**
      * Süßölgefäß
@@ -22,4 +28,6 @@ public:
      */
     virtual ::gluecodium::Return< ::smoke::Comments::Usefulness, ::std::error_code > some_method_with_all_comments( const ::std::string& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/constants/output/cpp/include/smoke/CollectionConstants.h
+++ b/gluecodium/src/test/resources/smoke/constants/output/cpp/include/smoke/CollectionConstants.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/UnorderedSetHash.h"
@@ -11,15 +14,24 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT CollectionConstants {
 public:
     CollectionConstants();
-    virtual ~CollectionConstants() = 0;
+    virtual ~CollectionConstants();
+
+
 public:
     static const ::std::vector< ::std::string > LIST_CONSTANT;
+
     static const ::std::unordered_set< ::std::string > SET_CONSTANT;
+
     static const ::std::unordered_map< ::std::string, ::std::string > MAP_CONSTANT;
+
     static const ::std::unordered_map< ::std::vector< ::std::string >, ::std::unordered_set< ::std::string >, ::gluecodium::hash< ::std::vector< ::std::string > > > MIXED_CONSTANT;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/cpp/include/smoke/Constructors.h
+++ b/gluecodium/src/test/resources/smoke/constructors/output/cpp/include/smoke/Constructors.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include "gluecodium/TypeRepository.h"
@@ -12,16 +15,21 @@
 #include <string>
 #include <system_error>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Constructors {
 public:
     Constructors();
-    virtual ~Constructors() = 0;
+    virtual ~Constructors();
+
+
 public:
     enum class ErrorEnum {
         NONE,
         CRASHED
     };
+
+
 public:
     /**
      *
@@ -61,8 +69,11 @@ public:
      */
     static ::std::shared_ptr< ::smoke::Constructors > create( const uint64_t input );
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::Constructors::ErrorEnum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/Dates.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/Dates.h
@@ -1,10 +1,12 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
-#pragma once
-#include "gluecodium/ExportGluecodiumCpp.h"
 
+#pragma once
+
+#include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TimePointHash.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/UnorderedSetHash.h"
@@ -15,28 +17,41 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Dates {
 public:
     Dates();
-    virtual ~Dates() = 0;
+    virtual ~Dates();
+
+
 public:
     using DateTypeDef = ::std::chrono::system_clock::time_point;
+
     using DateArray = ::std::vector< ::std::chrono::system_clock::time_point >;
+
     using DateMap = ::std::unordered_map< ::std::string, ::std::chrono::system_clock::time_point >;
+
     struct _GLUECODIUM_CPP_EXPORT DateStruct {
         ::std::chrono::system_clock::time_point date_field;
         std::optional< ::std::chrono::system_clock::time_point > nullable_date_field = std::optional< ::std::chrono::system_clock::time_point >();
+
         DateStruct( );
         explicit DateStruct( ::std::chrono::system_clock::time_point date_field );
         DateStruct( ::std::chrono::system_clock::time_point date_field, std::optional< ::std::chrono::system_clock::time_point > nullable_date_field );
+
     };
+
 public:
     virtual ::std::chrono::system_clock::time_point date_method( const ::std::chrono::system_clock::time_point& input ) = 0;
     virtual std::optional< ::std::chrono::system_clock::time_point > nullable_date_method( const std::optional< ::std::chrono::system_clock::time_point >& input ) = 0;
     virtual ::std::chrono::system_clock::time_point get_date_property(  ) const = 0;
     virtual void set_date_property( const ::std::chrono::system_clock::time_point& value ) = 0;
+
     virtual ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > > get_date_set(  ) const = 0;
     virtual void set_date_set( const ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DatesSteady.h
+++ b/gluecodium/src/test/resources/smoke/dates/output/cpp/include/smoke/DatesSteady.h
@@ -1,10 +1,12 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
-#pragma once
-#include "gluecodium/ExportGluecodiumCpp.h"
 
+#pragma once
+
+#include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TimePointHash.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/VectorHash.h"
@@ -13,25 +15,36 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT DatesSteady {
 public:
     DatesSteady();
-    virtual ~DatesSteady() = 0;
+    virtual ~DatesSteady();
+
+
 public:
     using MonotonicDate = std::chrono::steady_clock::time_point;
+
     using DateList = ::std::vector< ::smoke::DatesSteady::MonotonicDate >;
+
     using DateMap = ::std::unordered_map< ::smoke::DatesSteady::MonotonicDate, ::std::string, ::gluecodium::hash< ::smoke::DatesSteady::MonotonicDate > >;
+
     struct _GLUECODIUM_CPP_EXPORT DateStruct {
         ::smoke::DatesSteady::MonotonicDate date_field;
         std::optional< ::smoke::DatesSteady::MonotonicDate > nullable_date_field = std::optional< ::smoke::DatesSteady::MonotonicDate >();
+
         DateStruct( );
         explicit DateStruct( ::smoke::DatesSteady::MonotonicDate date_field );
         DateStruct( ::smoke::DatesSteady::MonotonicDate date_field, std::optional< ::smoke::DatesSteady::MonotonicDate > nullable_date_field );
+
     };
+
 public:
     virtual ::smoke::DatesSteady::MonotonicDate date_method( const ::smoke::DatesSteady::MonotonicDate& input ) = 0;
     virtual std::optional< ::smoke::DatesSteady::MonotonicDate > nullable_date_method( const std::optional< ::smoke::DatesSteady::MonotonicDate >& input ) = 0;
     virtual ::smoke::DatesSteady::DateList date_list_method( const ::smoke::DatesSteady::DateList& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/ClassInStruct.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/ClassInStruct.h
@@ -1,18 +1,28 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <functional>
 #include <memory>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT ClassInStruct {
     class _GLUECODIUM_CPP_EXPORT FooChecker {
     public:
         FooChecker();
-        virtual ~FooChecker() = 0;
+        virtual ~FooChecker();
+
+
     };
+
     using SomeLambda = ::std::function<void(const ::std::shared_ptr< ::smoke::ClassInStruct::FooChecker >&)>;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/InterfaceInInterface.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/InterfaceInInterface.h
@@ -1,23 +1,35 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <functional>
 #include <memory>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT InterfaceInInterface {
 public:
     InterfaceInInterface();
-    virtual ~InterfaceInInterface() = 0;
+    virtual ~InterfaceInInterface();
+
+
 public:
     class _GLUECODIUM_CPP_EXPORT FooChecker {
     public:
         FooChecker();
-        virtual ~FooChecker() = 0;
+        virtual ~FooChecker();
+
+
     };
+
     using SomeLambda = ::std::function<void(const ::std::shared_ptr< ::smoke::InterfaceInInterface::FooChecker >&)>;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInClass.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInClass.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/VectorHash.h"
@@ -10,32 +13,48 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT OrderInClass {
 public:
     OrderInClass();
-    virtual ~OrderInClass() = 0;
+    virtual ~OrderInClass();
+
+
 public:
     enum class SomeEnum {
         FOO,
         BAR = 7
     };
+
+
     using SomeTypeDef = int32_t;
+
     struct _GLUECODIUM_CPP_EXPORT NestedStruct {
         ::std::string some_field;
+
         NestedStruct( );
         explicit NestedStruct( ::std::string some_field );
+
     };
+
     using NestedStructArray = ::std::vector< ::smoke::OrderInClass::NestedStruct >;
+
     using ErrorCodeToMessageMap = ::std::unordered_map< int32_t, ::smoke::OrderInClass::NestedStructArray >;
+
     struct _GLUECODIUM_CPP_EXPORT MainStruct {
         ::smoke::OrderInClass::NestedStruct struct_field;
         ::smoke::OrderInClass::SomeTypeDef type_def_field;
         ::smoke::OrderInClass::NestedStructArray struct_array_field;
         ::smoke::OrderInClass::ErrorCodeToMessageMap map_field;
         ::smoke::OrderInClass::SomeEnum enum_field;
+
         MainStruct( );
         MainStruct( ::smoke::OrderInClass::NestedStruct struct_field, ::smoke::OrderInClass::SomeTypeDef type_def_field, ::smoke::OrderInClass::NestedStructArray struct_array_field, ::smoke::OrderInClass::ErrorCodeToMessageMap map_field, ::smoke::OrderInClass::SomeEnum enum_field );
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/DefaultValues.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/DefaultValues.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/UnorderedSetHash.h"
@@ -14,18 +17,27 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT DefaultValues {
 public:
     DefaultValues();
-    virtual ~DefaultValues() = 0;
+    virtual ~DefaultValues();
+
+
 public:
     using LongTypedef = int64_t;
+
     using BooleanTypedef = bool;
+
     using StringTypedef = ::std::string;
+
     using FloatArray = ::std::vector< float >;
+
     using IdToStringMap = ::std::unordered_map< uint32_t, ::std::string >;
+
     using StringSet = ::std::unordered_set< ::std::string >;
+
     struct _GLUECODIUM_CPP_EXPORT StructWithDefaults {
         int32_t int_field = 42;
         uint32_t uint_field = 4294967295;
@@ -33,18 +45,24 @@ public:
         double double_field = -1.4142;
         bool bool_field = true;
         ::std::string string_field = "\\Jonny \"Magic\" Smith\n";
+
         StructWithDefaults( );
         StructWithDefaults( int32_t int_field, uint32_t uint_field, float float_field, double double_field, bool bool_field, ::std::string string_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT NullableStructWithDefaults {
         std::optional< int32_t > int_field = std::optional< int32_t >();
         std::optional< uint32_t > uint_field = std::optional< uint32_t >();
         std::optional< float > float_field = std::optional< float >();
         std::optional< bool > bool_field = std::optional< bool >();
         std::optional< ::std::string > string_field = std::optional< ::std::string >();
+
         NullableStructWithDefaults( );
         NullableStructWithDefaults( std::optional< int32_t > int_field, std::optional< uint32_t > uint_field, std::optional< float > float_field, std::optional< bool > bool_field, std::optional< ::std::string > string_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT StructWithSpecialDefaults {
         float float_nan_field = std::numeric_limits<float>::quiet_NaN();
         float float_infinity_field = std::numeric_limits<float>::infinity();
@@ -52,26 +70,37 @@ public:
         double double_nan_field = std::numeric_limits<double>::quiet_NaN();
         double double_infinity_field = std::numeric_limits<double>::infinity();
         double double_negative_infinity_field = -std::numeric_limits<double>::infinity();
+
         StructWithSpecialDefaults( );
         StructWithSpecialDefaults( float float_nan_field, float float_infinity_field, float float_negative_infinity_field, double double_nan_field, double double_infinity_field, double double_negative_infinity_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT StructWithEmptyDefaults {
         ::std::vector< int32_t > ints_field = {};
         ::smoke::DefaultValues::FloatArray floats_field = {};
         ::smoke::DefaultValues::IdToStringMap map_field = {};
         ::smoke::DefaultValues::StructWithDefaults struct_field = ::smoke::DefaultValues::StructWithDefaults{};
         ::smoke::DefaultValues::StringSet set_type_field = {};
+
         StructWithEmptyDefaults( );
         StructWithEmptyDefaults( ::std::vector< int32_t > ints_field, ::smoke::DefaultValues::FloatArray floats_field, ::smoke::DefaultValues::IdToStringMap map_field, ::smoke::DefaultValues::StructWithDefaults struct_field, ::smoke::DefaultValues::StringSet set_type_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT StructWithTypedefDefaults {
         ::smoke::DefaultValues::LongTypedef long_field = 42;
         ::smoke::DefaultValues::BooleanTypedef bool_field = true;
         ::smoke::DefaultValues::StringTypedef string_field = "\\Jonny \"Magic\" Smith\n";
+
         StructWithTypedefDefaults( );
         StructWithTypedefDefaults( ::smoke::DefaultValues::LongTypedef long_field, ::smoke::DefaultValues::BooleanTypedef bool_field, ::smoke::DefaultValues::StringTypedef string_field );
+
     };
+
 public:
     static ::smoke::DefaultValues::StructWithDefaults process_struct_with_defaults( const ::smoke::DefaultValues::StructWithDefaults& input );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/EnumDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/EnumDefaults.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "fire/Enum1.h"
 #include "fire/Enum2.h"
 #include "fire/Enum3.h"
@@ -10,33 +13,51 @@
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/EnumWrapper.h"
 #include <optional>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT EnumDefaults {
 public:
     EnumDefaults();
-    virtual ~EnumDefaults() = 0;
+    virtual ~EnumDefaults();
+
+
 public:
     using EnumAlias = ::fire::Enum3;
+
     struct _GLUECODIUM_CPP_EXPORT SimpleEnum {
         ::fire::Enum1 enum_field = ::fire::Enum1::DISABLED;
+
         SimpleEnum( );
         explicit SimpleEnum( ::fire::Enum1 enum_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT NullableEnum {
         std::optional< ::fire::Enum2 > enum_field1 = std::optional< ::fire::Enum2 >();
         std::optional< ::fire::Enum2 > enum_field1 = ::fire::Enum2::DISABLED;
+
         NullableEnum( );
         NullableEnum( std::optional< ::fire::Enum2 > enum_field1, std::optional< ::fire::Enum2 > enum_field1 );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT AliasEnum {
         ::smoke::EnumDefaults::EnumAlias enum_field = ::fire::Enum3::DISABLED;
+
         AliasEnum( );
         explicit AliasEnum( ::smoke::EnumDefaults::EnumAlias enum_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT WrappedEnum {
         ::smoke::EnumWrapper struct_field = ::smoke::EnumWrapper{::fire::Enum4::DISABLED};
+
         WrappedEnum( );
         explicit WrappedEnum( ::smoke::EnumWrapper struct_field );
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/EnumDefaultsExternal.h
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/cpp/include/smoke/EnumDefaultsExternal.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "foo/AlienEnum1.h"
 #include "foo/AlienEnum2.h"
 #include "foo/AlienEnum3.h"
@@ -10,33 +13,51 @@
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/EnumWrapper.h"
 #include <optional>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT EnumDefaultsExternal {
 public:
     EnumDefaultsExternal();
-    virtual ~EnumDefaultsExternal() = 0;
+    virtual ~EnumDefaultsExternal();
+
+
 public:
     using EnumAlias = foo::AlienEnum3;
+
     struct _GLUECODIUM_CPP_EXPORT SimpleEnum {
         foo::AlienEnum1 enum_field = foo::AlienEnum1::DISABLED;
+
         SimpleEnum( );
         explicit SimpleEnum( foo::AlienEnum1 enum_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT NullableEnum {
         std::optional< foo::AlienEnum2 > enum_field1 = std::optional< foo::AlienEnum2 >();
         std::optional< foo::AlienEnum2 > enum_field1 = foo::AlienEnum2::DISABLED;
+
         NullableEnum( );
         NullableEnum( std::optional< foo::AlienEnum2 > enum_field1, std::optional< foo::AlienEnum2 > enum_field1 );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT AliasEnum {
         ::smoke::EnumDefaultsExternal::EnumAlias enum_field = foo::AlienEnum3::DISABLED;
+
         AliasEnum( );
         explicit AliasEnum( ::smoke::EnumDefaultsExternal::EnumAlias enum_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT WrappedEnum {
         ::smoke::EnumWrapper struct_field = ::smoke::EnumWrapper{foo::AlienEnum4::DISABLED};
+
         WrappedEnum( );
         explicit WrappedEnum( ::smoke::EnumWrapper struct_field );
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationMilliseconds.h
+++ b/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationMilliseconds.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/DurationHash.h"
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
@@ -14,26 +17,40 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT DurationMilliseconds {
 public:
     DurationMilliseconds();
-    virtual ~DurationMilliseconds() = 0;
+    virtual ~DurationMilliseconds();
+
+
 public:
     using DurationTypeAlias = std::chrono::milliseconds;
+
     using DurationList = ::std::vector< std::chrono::milliseconds >;
+
     using DurationSet = ::std::unordered_set< std::chrono::milliseconds, ::gluecodium::hash< std::chrono::milliseconds > >;
+
     using DurationMap = ::std::unordered_map< ::std::string, std::chrono::milliseconds >;
+
     using DurationKeyMap = ::std::unordered_map< std::chrono::milliseconds, ::std::string, ::gluecodium::hash< std::chrono::milliseconds > >;
+
     struct _GLUECODIUM_CPP_EXPORT DurationStruct {
         std::chrono::milliseconds duration_field;
+
         DurationStruct( );
         explicit DurationStruct( std::chrono::milliseconds duration_field );
+
     };
+
 public:
     virtual std::chrono::milliseconds duration_function( const std::chrono::milliseconds input ) = 0;
     virtual std::optional< std::chrono::milliseconds > nullable_duration_function( const std::optional< std::chrono::milliseconds >& input ) = 0;
     virtual std::chrono::milliseconds get_duration_property(  ) const = 0;
     virtual void set_duration_property( const std::chrono::milliseconds value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationSeconds.h
+++ b/gluecodium/src/test/resources/smoke/durations/output/cpp/include/smoke/DurationSeconds.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/DurationHash.h"
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
@@ -14,26 +17,40 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT DurationSeconds {
 public:
     DurationSeconds();
-    virtual ~DurationSeconds() = 0;
+    virtual ~DurationSeconds();
+
+
 public:
     using DurationTypeAlias = ::std::chrono::seconds;
+
     using DurationList = ::std::vector< ::std::chrono::seconds >;
+
     using DurationSet = ::std::unordered_set< ::std::chrono::seconds, ::gluecodium::hash< ::std::chrono::seconds > >;
+
     using DurationMap = ::std::unordered_map< ::std::string, ::std::chrono::seconds >;
+
     using DurationKeyMap = ::std::unordered_map< ::std::chrono::seconds, ::std::string, ::gluecodium::hash< ::std::chrono::seconds > >;
+
     struct _GLUECODIUM_CPP_EXPORT DurationStruct {
         ::std::chrono::seconds duration_field;
+
         DurationStruct( );
         explicit DurationStruct( ::std::chrono::seconds duration_field );
+
     };
+
 public:
     virtual ::std::chrono::seconds duration_function( const ::std::chrono::seconds input ) = 0;
     virtual std::optional< ::std::chrono::seconds > nullable_duration_function( const std::optional< ::std::chrono::seconds >& input ) = 0;
     virtual ::std::chrono::seconds get_duration_property(  ) const = 0;
     virtual void set_duration_property( const ::std::chrono::seconds value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/Enums.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/Enums.h
@@ -1,39 +1,55 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Hash.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include <cstdint>
 #include <string>
 #include <unordered_map>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Enums {
 public:
     Enums();
-    virtual ~Enums() = 0;
+    virtual ~Enums();
+
+
 public:
     enum class SimpleEnum {
         FIRST,
         SECOND
     };
+
+
     enum class InternalErrorCode {
         ERROR_NONE,
         ERROR_FATAL = 999
     };
+
+
     using ExampleMap = ::std::unordered_map< ::smoke::Enums::SimpleEnum, uint64_t, ::gluecodium::hash< ::smoke::Enums::SimpleEnum > >;
+
     struct _GLUECODIUM_CPP_EXPORT ErrorStruct {
         ::smoke::Enums::InternalErrorCode type;
         ::std::string message;
+
         ErrorStruct( );
         ErrorStruct( ::smoke::Enums::InternalErrorCode type, ::std::string message );
+
     };
+
 public:
     static ::smoke::Enums::SimpleEnum method_with_enumeration( const ::smoke::Enums::SimpleEnum input );
     static ::smoke::Enums::InternalErrorCode flip_enum_value( const ::smoke::Enums::InternalErrorCode input );
     static ::smoke::Enums::InternalErrorCode extract_enum_from_struct( const ::smoke::Enums::ErrorStruct& input );
     static ::smoke::Enums::ErrorStruct create_struct_with_enum_inside( const ::smoke::Enums::InternalErrorCode type, const ::std::string& message );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumsInTypeCollectionInterface.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumsInTypeCollectionInterface.h
@@ -1,16 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/EnumsInTypeCollection.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT EnumsInTypeCollectionInterface {
 public:
     EnumsInTypeCollectionInterface();
-    virtual ~EnumsInTypeCollectionInterface() = 0;
+    virtual ~EnumsInTypeCollectionInterface();
+
+
 public:
     static ::smoke::EnumsInTypeCollection::TCEnum flip_enum_value( const ::smoke::EnumsInTypeCollection::TCEnum input );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableClass.h
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableClass.h
@@ -1,21 +1,32 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Hash.h"
 #include <cstdint>
 #include <memory>
 #include <string>
+
+
 namespace smoke {
+
     class PointerEquatableClass;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT EquatableClass {
 public:
     EquatableClass();
-    virtual ~EquatableClass() = 0;
+    virtual ~EquatableClass();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT EquatableStruct {
         int32_t int_field;
@@ -24,16 +35,23 @@ public:
         ::std::shared_ptr< ::smoke::EquatableClass > nested_equatable_instance;
         /// \warning @NotNull
         ::std::shared_ptr< ::smoke::PointerEquatableClass > nested_pointer_equatable_instance;
+
         EquatableStruct( );
         EquatableStruct( int32_t int_field, ::std::string string_field, ::std::shared_ptr< ::smoke::EquatableClass > nested_equatable_instance, ::std::shared_ptr< ::smoke::PointerEquatableClass > nested_pointer_equatable_instance );
+
         bool operator==( const EquatableStruct& rhs ) const;
         bool operator!=( const EquatableStruct& rhs ) const;
+
     };
+
 public:
     bool operator==( const EquatableClass& rhs );
     bool operator!=( const EquatableClass& rhs );
 };
+
+
 }
+
 namespace gluecodium {
 template<>
 struct hash< ::smoke::EquatableClass > {

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableInterface.h
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/EquatableInterface.h
@@ -1,21 +1,30 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Hash.h"
 #include "gluecodium/TypeRepository.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT EquatableInterface {
 public:
     EquatableInterface();
-    virtual ~EquatableInterface() = 0;
+    virtual ~EquatableInterface();
+
+
 public:
     bool operator==( const EquatableInterface& rhs );
     bool operator!=( const EquatableInterface& rhs );
 };
+
+
 }
+
 namespace gluecodium {
 template<>
 struct hash< ::smoke::EquatableInterface > {

--- a/gluecodium/src/test/resources/smoke/errors/output/cpp/include/smoke/Errors.h
+++ b/gluecodium/src/test/resources/smoke/errors/output/cpp/include/smoke/Errors.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "foo/Bar.h"
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
@@ -10,16 +13,22 @@
 #include <cstdint>
 #include <string>
 #include <system_error>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Errors {
 public:
     Errors();
-    virtual ~Errors() = 0;
+    virtual ~Errors();
+
+
 public:
     enum class InternalErrorCode {
         ERROR_NONE,
         ERROR_FATAL
     };
+
+
+
 public:
     static ::std::error_code method_with_errors(  );
     static ::std::error_code method_with_external_errors(  );
@@ -27,8 +36,11 @@ public:
     static ::gluecodium::Return< void, ::smoke::Payload > method_with_payload_error(  );
     static ::gluecodium::Return< ::std::string, ::smoke::Payload > method_with_payload_error_and_return_value(  );
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::Errors::InternalErrorCode value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Class.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Class.h
@@ -1,19 +1,25 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include "package/Interface.h"
 #include "package/Types.h"
 #include <memory>
 #include <system_error>
+
 namespace package {
 class _GLUECODIUM_CPP_EXPORT Class: public ::package::Interface {
 public:
     Class();
-    virtual ~Class() = 0;
+    virtual ~Class();
+
+
 public:
     /**
      *
@@ -23,5 +29,8 @@ public:
     virtual ::gluecodium::Return< ::package::Types::Struct, ::std::error_code > fun( const ::package::Types::ULong& double ) = 0;
     virtual ::package::Types::Enum get_property(  ) const = 0;
     virtual void set_property( const ::package::Types::Enum value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Interface.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Interface.h
@@ -1,14 +1,22 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
+
 namespace package {
 class _GLUECODIUM_CPP_EXPORT Interface {
 public:
     Interface();
-    virtual ~Interface() = 0;
+    virtual ~Interface();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cpp/include/smoke/Enums.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cpp/include/smoke/Enums.h
@@ -1,18 +1,28 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "foo/Bar.h"
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Enums {
 public:
     Enums();
-    virtual ~Enums() = 0;
+    virtual ~Enums();
+
+
 public:
+
+
 public:
     static void method_with_external_enum( const ::smoke::Enums::External_Enum input );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/cpp/include/smoke/Structs.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/cpp/include/smoke/Structs.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "foo/Bar.h"
 #include "foo/Bazz.h"
 #include "gluecodium/ExportGluecodiumCpp.h"
@@ -11,14 +14,21 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Structs {
 public:
     Structs();
-    virtual ~Structs() = 0;
+    virtual ~Structs();
+
+
 public:
+
+
 public:
     static ::smoke::Structs::ExternalStruct get_external_struct(  );
     static ::fire::SomeVeryExternalStruct get_another_external_struct(  );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithBasicTypes.h
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithBasicTypes.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/UnorderedSetHash.h"
@@ -12,22 +15,31 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT GenericTypesWithBasicTypes {
 public:
     GenericTypesWithBasicTypes();
-    virtual ~GenericTypesWithBasicTypes() = 0;
+    virtual ~GenericTypesWithBasicTypes();
+
+
 public:
     using BasicList = ::std::vector< ::std::string >;
+
     using BasicMap = ::std::unordered_map< ::std::string, ::std::string >;
+
     using BasicSet = ::std::unordered_set< ::std::string >;
+
     struct _GLUECODIUM_CPP_EXPORT StructWithGenerics {
         ::std::vector< uint8_t > numbers_list;
         ::std::unordered_map< uint8_t, ::std::string > numbers_map;
         ::std::unordered_set< uint8_t > numbers_set;
+
         StructWithGenerics( );
         StructWithGenerics( ::std::vector< uint8_t > numbers_list, ::std::unordered_map< uint8_t, ::std::string > numbers_map, ::std::unordered_set< uint8_t > numbers_set );
+
     };
+
 public:
     virtual ::std::vector< int32_t > method_with_list( const ::std::vector< int32_t >& input ) = 0;
     virtual ::std::unordered_map< int32_t, bool > method_with_map( const ::std::unordered_map< int32_t, bool >& input ) = 0;
@@ -37,9 +49,14 @@ public:
     virtual ::smoke::GenericTypesWithBasicTypes::BasicSet method_with_set_type_alias( const ::smoke::GenericTypesWithBasicTypes::BasicSet& input ) = 0;
     virtual ::std::vector< float > get_list_property(  ) const = 0;
     virtual void set_list_property( const ::std::vector< float >& value ) = 0;
+
     virtual ::std::unordered_map< float, double > get_map_property(  ) const = 0;
     virtual void set_map_property( const ::std::unordered_map< float, double >& value ) = 0;
+
     virtual ::std::unordered_set< float > get_set_property(  ) const = 0;
     virtual void set_set_property( const ::std::unordered_set< float >& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithCompoundTypes.h
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithCompoundTypes.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "alien/FooEnum.h"
 #include "alien/FooStruct.h"
 #include "gluecodium/ExportGluecodiumCpp.h"
@@ -16,25 +19,41 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+
 namespace smoke {
+
     class DummyClass;
+
     class DummyInterface;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT GenericTypesWithCompoundTypes {
 public:
     GenericTypesWithCompoundTypes();
-    virtual ~GenericTypesWithCompoundTypes() = 0;
+    virtual ~GenericTypesWithCompoundTypes();
+
+
 public:
     enum class SomeEnum {
         FOO,
         BAR
     };
+
+
+
     struct _GLUECODIUM_CPP_EXPORT BasicStruct {
         double value;
+
         BasicStruct( );
         explicit BasicStruct( double value );
+
     };
+
+
 public:
     virtual ::std::vector< ::alien::FooStruct > method_with_struct_list( const ::std::vector< ::smoke::GenericTypesWithCompoundTypes::BasicStruct >& input ) = 0;
     virtual ::std::unordered_map< ::std::string, ::alien::FooStruct > method_with_struct_map( const ::std::unordered_map< ::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct >& input ) = 0;
@@ -45,4 +64,6 @@ public:
     virtual ::std::vector< ::std::shared_ptr< ::smoke::DummyInterface > > method_with_instances_list( const ::std::vector< ::std::shared_ptr< ::smoke::DummyClass > >& input ) = 0;
     virtual ::std::unordered_map< int32_t, ::std::shared_ptr< ::smoke::DummyInterface > > method_with_instances_map( const ::std::unordered_map< int32_t, ::std::shared_ptr< ::smoke::DummyClass > >& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithGenericTypes.h
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithGenericTypes.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/UnorderedSetHash.h"
@@ -11,11 +14,14 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT GenericTypesWithGenericTypes {
 public:
     GenericTypesWithGenericTypes();
-    virtual ~GenericTypesWithGenericTypes() = 0;
+    virtual ~GenericTypesWithGenericTypes();
+
+
 public:
     virtual ::std::vector< ::std::vector< int32_t > > method_with_list_of_lists( const ::std::vector< ::std::vector< int32_t > >& input ) = 0;
     virtual ::std::unordered_map< ::std::unordered_map< int32_t, bool >, bool, ::gluecodium::hash< ::std::unordered_map< int32_t, bool > > > method_with_map_of_maps( const ::std::unordered_map< int32_t, ::std::unordered_map< int32_t, bool > >& input ) = 0;
@@ -25,4 +31,6 @@ public:
     virtual ::std::unordered_set< ::std::unordered_map< int32_t, bool >, ::gluecodium::hash< ::std::unordered_map< int32_t, bool > > > method_with_map_and_set( const ::std::unordered_map< int32_t, ::std::unordered_set< int32_t > >& input ) = 0;
     virtual ::std::unordered_map< ::std::vector< int32_t >, bool, ::gluecodium::hash< ::std::vector< int32_t > > > method_with_map_generic_keys( const ::std::unordered_map< ::std::unordered_set< int32_t >, bool, ::gluecodium::hash< ::std::unordered_set< int32_t > > >& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/UseOptimizedList.h
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/UseOptimizedList.h
@@ -1,23 +1,37 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/VectorHash.h"
 #include "smoke/VeryBigStruct.h"
 #include <memory>
 #include <vector>
+
+
 namespace smoke {
+
     class UnreasonablyLazyClass;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT UseOptimizedList {
 public:
     UseOptimizedList();
-    virtual ~UseOptimizedList() = 0;
+    virtual ~UseOptimizedList();
+
+
 public:
     static ::std::vector< ::std::shared_ptr< ::smoke::VeryBigStruct > > fetch_the_big_ones(  );
     static ::std::vector< ::std::shared_ptr< ::smoke::UnreasonablyLazyClass > > get_lazy_ones(  );
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ChildClassFromClass.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ChildClassFromClass.h
@@ -1,16 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentClass.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ChildClassFromClass: public ::smoke::ParentClass {
 public:
     ChildClassFromClass();
-    virtual ~ChildClassFromClass() = 0;
+    virtual ~ChildClassFromClass();
+
+
 public:
     virtual void child_class_method(  ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ChildClassFromInterface.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ChildClassFromInterface.h
@@ -1,16 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentInterface.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ChildClassFromInterface: public ::smoke::ParentInterface {
 public:
     ChildClassFromInterface();
-    virtual ~ChildClassFromInterface() = 0;
+    virtual ~ChildClassFromInterface();
+
+
 public:
     virtual void child_class_method(  ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ChildInterface.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ChildInterface.h
@@ -1,16 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentInterface.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ChildInterface: public ::smoke::ParentInterface {
 public:
     ChildInterface();
-    virtual ~ChildInterface() = 0;
+    virtual ~ChildInterface();
+
+
 public:
     virtual void child_method(  ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ForwardDeclarationBug.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ForwardDeclarationBug.h
@@ -1,16 +1,22 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentClass.h"
 #include <memory>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ForwardDeclarationBug: public ::smoke::ParentClass {
 public:
     ForwardDeclarationBug();
-    virtual ~ForwardDeclarationBug() = 0;
+    virtual ~ForwardDeclarationBug();
+
+
 public:
     /**
      *
@@ -18,4 +24,6 @@ public:
      */
     virtual void foo( const ::std::shared_ptr< ::smoke::ParentClass >& bar ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ParentClass.h
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/cpp/include/smoke/ParentClass.h
@@ -1,19 +1,28 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ParentClass {
 public:
     ParentClass();
-    virtual ~ParentClass() = 0;
+    virtual ~ParentClass();
+
+
 public:
     virtual void root_method(  ) = 0;
     virtual ::std::string get_root_property(  ) const = 0;
     virtual void set_root_property( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleClass.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleClass.h
@@ -1,16 +1,22 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <memory>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SimpleClass {
 public:
     SimpleClass();
-    virtual ~SimpleClass() = 0;
+    virtual ~SimpleClass();
+
+
 public:
     virtual ::std::string get_string_value(  ) = 0;
     /**
@@ -20,4 +26,6 @@ public:
      */
     virtual ::std::shared_ptr< ::smoke::SimpleClass > use_simple_class( const ::std::shared_ptr< ::smoke::SimpleClass >& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleInterface.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/SimpleInterface.h
@@ -1,17 +1,23 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <memory>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SimpleInterface {
 public:
     SimpleInterface();
-    virtual ~SimpleInterface() = 0;
+    virtual ~SimpleInterface();
+
+
 public:
     virtual ::std::string get_string_value(  ) = 0;
     /**
@@ -21,4 +27,6 @@ public:
      */
     virtual ::std::shared_ptr< ::smoke::SimpleInterface > use_simple_interface( const ::std::shared_ptr< ::smoke::SimpleInterface >& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/forward/InnerClassForwardDeclarations.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/forward/InnerClassForwardDeclarations.h
@@ -15,7 +15,7 @@ namespace forward {
 class _GLUECODIUM_CPP_EXPORT InnerClassForwardDeclarations {
 public:
     InnerClassForwardDeclarations();
-    virtual ~InnerClassForwardDeclarations() = 0;
+    virtual ~InnerClassForwardDeclarations();
 
 public:
     class InnerInterface1;
@@ -25,7 +25,8 @@ public:
     class _GLUECODIUM_CPP_EXPORT InnerClass1 {
     public:
         InnerClass1();
-        virtual ~InnerClass1() = 0;
+        virtual ~InnerClass1();
+
 
     public:
         /**
@@ -38,7 +39,7 @@ public:
     class _GLUECODIUM_CPP_EXPORT InnerClass2 {
     public:
         InnerClass2();
-        virtual ~InnerClass2() = 0;
+        virtual ~InnerClass2();
 
     public:
         class InnerInnerClass2;
@@ -47,7 +48,8 @@ public:
         class _GLUECODIUM_CPP_EXPORT InnerInnerClass1 {
         public:
             InnerInnerClass1();
-            virtual ~InnerInnerClass1() = 0;
+            virtual ~InnerInnerClass1();
+
 
         public:
             /**
@@ -60,7 +62,8 @@ public:
         class _GLUECODIUM_CPP_EXPORT InnerInnerClass2 {
         public:
             InnerInnerClass2();
-            virtual ~InnerInnerClass2() = 0;
+            virtual ~InnerInnerClass2();
+
 
         public:
             /**
@@ -75,22 +78,29 @@ public:
     class _GLUECODIUM_CPP_EXPORT InnerInterface1 {
     public:
         InnerInterface1();
-        virtual ~InnerInterface1() = 0;
+        virtual ~InnerInterface1();
+
+
     };
 
     class _GLUECODIUM_CPP_EXPORT InnerInterface2 {
     public:
         InnerInterface2();
-        virtual ~InnerInterface2() = 0;
+        virtual ~InnerInterface2();
+
+
     };
 
     class _GLUECODIUM_CPP_EXPORT InnerInterface3 {
     public:
         InnerInterface3();
-        virtual ~InnerInterface3() = 0;
+        virtual ~InnerInterface3();
+
+
     };
 
 };
+
 
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/forward/UseForward.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/cpp/include/smoke/forward/UseForward.h
@@ -1,25 +1,44 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <memory>
+
+
 namespace smoke {
+
     class SimpleClass;
+
     class SimpleInterface;
+
+
+
 namespace forward {
+
     class Class1;
+
     class Class2;
+
+
 }
+
+
 }
+
 namespace smoke {
 namespace forward {
 class _GLUECODIUM_CPP_EXPORT UseForward {
 public:
     UseForward();
-    virtual ~UseForward() = 0;
+    virtual ~UseForward();
+
+
 public:
     /**
      *
@@ -30,5 +49,7 @@ public:
      */
     virtual void use_it( const ::std::shared_ptr< ::smoke::forward::Class1 >& param1, const ::std::shared_ptr< ::smoke::forward::Class2 >& param2, const ::std::shared_ptr< ::smoke::SimpleClass >& simple_class, const ::std::shared_ptr< ::smoke::SimpleInterface >& simple_interface ) = 0;
 };
+
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/Lambdas.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/Lambdas.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/VectorHash.h"
@@ -12,22 +15,33 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Lambdas {
 public:
     Lambdas();
-    virtual ~Lambdas() = 0;
+    virtual ~Lambdas();
+
+
 public:
     using Producer = ::std::function<::std::string()>;
+
     /**
      * Should confuse everyone thoroughly
+
      */
     using Confuser = ::std::function<::smoke::Lambdas::Producer(const ::std::string&)>;
+
     using Consumer = ::std::function<void(const ::std::string&)>;
+
     using Indexer = ::std::function<int32_t(const ::std::string&, const float)>;
+
     using NullableConfuser = ::std::function<std::optional< ::smoke::Lambdas::Producer >(const std::optional< ::std::string >&)>;
+
 public:
     virtual ::smoke::Lambdas::Producer deconfuse( const ::std::string& value, const ::smoke::Lambdas::Confuser& confuser ) = 0;
     static ::std::unordered_map< int32_t, ::std::string > fuse( const ::std::vector< ::std::string >& items, const ::smoke::Lambdas::Indexer& callback );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/LambdasDeclarationOrder.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/cpp/include/smoke/LambdasDeclarationOrder.h
@@ -1,22 +1,34 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <functional>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT LambdasDeclarationOrder {
 public:
     LambdasDeclarationOrder();
-    virtual ~LambdasDeclarationOrder() = 0;
+    virtual ~LambdasDeclarationOrder();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string some_field;
+
         SomeStruct( );
         explicit SomeStruct( ::std::string some_field );
+
     };
+
     using SomeCallback = ::std::function<void(const ::smoke::LambdasDeclarationOrder::SomeStruct&)>;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Calculator.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Calculator.h
@@ -1,18 +1,29 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <memory>
+
+
 namespace smoke {
+
     class CalculatorListener;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Calculator {
 public:
     Calculator();
-    virtual ~Calculator() = 0;
+    virtual ~Calculator();
+
+
 public:
     /**
      *
@@ -25,4 +36,6 @@ public:
      */
     static void unregister_listener( const ::std::shared_ptr< ::smoke::CalculatorListener >& listener );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/CalculatorListener.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/CalculatorListener.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include "gluecodium/UnorderedMapHash.h"
@@ -11,21 +14,33 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+
 namespace smoke {
+
     class CalculationResult;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT CalculatorListener {
 public:
     CalculatorListener();
-    virtual ~CalculatorListener() = 0;
+    virtual ~CalculatorListener();
+
+
 public:
     using NamedCalculationResults = ::std::unordered_map< ::std::string, double >;
+
     struct _GLUECODIUM_CPP_EXPORT ResultStruct {
         double result;
+
         ResultStruct( );
         explicit ResultStruct( double result );
+
     };
+
 public:
     virtual void on_calculation_result( const double calculation_result ) = 0;
     virtual void on_calculation_result_const( const double calculation_result ) const = 0;
@@ -38,4 +53,6 @@ public:
      */
     virtual void on_calculation_result_instance( const ::std::shared_ptr< ::smoke::CalculationResult >& calculation_result ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/InterfaceWithStatic.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/InterfaceWithStatic.h
@@ -1,22 +1,32 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT InterfaceWithStatic {
 public:
     InterfaceWithStatic();
-    virtual ~InterfaceWithStatic() = 0;
+    virtual ~InterfaceWithStatic();
+
+
 public:
     virtual ::std::string regular_function(  ) = 0;
     static ::std::string static_function(  );
     virtual ::std::string get_regular_property(  ) const = 0;
     virtual void set_regular_property( const ::std::string& value ) = 0;
+
     static ::std::string get_static_property(  );
     static void set_static_property( const ::std::string& value );
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
+++ b/gluecodium/src/test/resources/smoke/locales/output/cpp/include/smoke/Locales.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Locale.h"
 #include "gluecodium/UnorderedMapHash.h"
@@ -12,25 +15,39 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Locales {
 public:
     Locales();
-    virtual ~Locales() = 0;
+    virtual ~Locales();
+
+
 public:
     using LocaleTypeDef = ::gluecodium::Locale;
+
     using LocaleArray = ::std::vector< ::gluecodium::Locale >;
+
     using LocaleMap = ::std::unordered_map< ::std::string, ::gluecodium::Locale >;
+
     using LocaleSet = ::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > >;
+
     using LocaleKeyMap = ::std::unordered_map< ::gluecodium::Locale, ::std::string, ::gluecodium::hash< ::gluecodium::Locale > >;
+
     struct _GLUECODIUM_CPP_EXPORT LocaleStruct {
         ::gluecodium::Locale locale_field;
+
         LocaleStruct( );
         explicit LocaleStruct( ::gluecodium::Locale locale_field );
+
     };
+
 public:
     virtual ::gluecodium::Locale locale_method( const ::gluecodium::Locale& input ) = 0;
     virtual ::gluecodium::Locale get_locale_property(  ) const = 0;
     virtual void set_locale_property( const ::gluecodium::Locale& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromClassOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromClassOverloads.h
@@ -1,20 +1,29 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentClass.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ChildClassFromClassOverloads: public ::smoke::ParentClass {
 public:
     ChildClassFromClassOverloads();
-    virtual ~ChildClassFromClassOverloads() = 0;
+    virtual ~ChildClassFromClassOverloads();
+
+
 public:
     virtual void foo( const ::std::string& input ) = 0;
     virtual void bar( const ::std::string& input ) = 0;
+
     using ::smoke::ParentClass::foo;
     using ::smoke::ParentClass::bar;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromInterfaceOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildClassFromInterfaceOverloads.h
@@ -1,20 +1,29 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentInterface.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ChildClassFromInterfaceOverloads: public ::smoke::ParentInterface {
 public:
     ChildClassFromInterfaceOverloads();
-    virtual ~ChildClassFromInterfaceOverloads() = 0;
+    virtual ~ChildClassFromInterfaceOverloads();
+
+
 public:
     virtual void foo( const ::std::string& input ) = 0;
     virtual void bar( const ::std::string& input ) = 0;
+
     using ::smoke::ParentInterface::foo;
     using ::smoke::ParentInterface::bar;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildInterfaceOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/ChildInterfaceOverloads.h
@@ -1,20 +1,29 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentInterface.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ChildInterfaceOverloads: public ::smoke::ParentInterface {
 public:
     ChildInterfaceOverloads();
-    virtual ~ChildInterfaceOverloads() = 0;
+    virtual ~ChildInterfaceOverloads();
+
+
 public:
     virtual void foo( const ::std::string& input ) = 0;
     virtual void bar( const ::std::string& input ) = 0;
+
     using ::smoke::ParentInterface::foo;
     using ::smoke::ParentInterface::bar;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/MethodOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/MethodOverloads.h
@@ -1,27 +1,38 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/VectorHash.h"
 #include <cstdint>
 #include <string>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT MethodOverloads {
 public:
     MethodOverloads();
-    virtual ~MethodOverloads() = 0;
+    virtual ~MethodOverloads();
+
+
 public:
     using StringArray = ::std::vector< ::std::string >;
+
     using IntArray = ::std::vector< int8_t >;
+
     struct _GLUECODIUM_CPP_EXPORT Point {
         double x;
         double y;
+
         Point( );
         Point( double x, double y );
+
     };
+
 public:
     virtual bool is_boolean( const bool input ) = 0;
     virtual bool is_boolean( const int8_t input ) = 0;
@@ -34,4 +45,6 @@ public:
     virtual bool is_float( const ::std::string& input ) = 0;
     virtual bool is_float( const ::smoke::MethodOverloads::IntArray& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/SpecialNames.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/cpp/include/smoke/SpecialNames.h
@@ -1,16 +1,22 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <memory>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SpecialNames {
 public:
     SpecialNames();
-    virtual ~SpecialNames() = 0;
+    virtual ~SpecialNames();
+
+
 public:
     virtual void create(  ) = 0;
     virtual void release(  ) = 0;
@@ -23,4 +29,6 @@ public:
      */
     static ::std::shared_ptr< ::smoke::SpecialNames > make( const ::std::string& result );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsClassClass.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsClassClass.h
@@ -1,20 +1,29 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentClass.h"
 #include "smoke/ParentNarrowOne.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT FirstParentIsClassClass: public ::smoke::ParentClass, public ::smoke::ParentNarrowOne {
 public:
     FirstParentIsClassClass();
-    virtual ~FirstParentIsClassClass() = 0;
+    virtual ~FirstParentIsClassClass();
+
+
 public:
     virtual void child_function(  ) = 0;
     virtual ::std::string get_child_property(  ) const = 0;
     virtual void set_child_property( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsInterfaceInterface.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/FirstParentIsInterfaceInterface.h
@@ -1,20 +1,29 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/ParentInterface.h"
 #include "smoke/ParentNarrowOne.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT FirstParentIsInterfaceInterface: public ::smoke::ParentInterface, public ::smoke::ParentNarrowOne {
 public:
     FirstParentIsInterfaceInterface();
-    virtual ~FirstParentIsInterfaceInterface() = 0;
+    virtual ~FirstParentIsInterfaceInterface();
+
+
 public:
     virtual void child_function(  ) = 0;
     virtual ::std::string get_child_property(  ) const = 0;
     virtual void set_child_property( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ParentNarrowOne.h
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/cpp/include/smoke/ParentNarrowOne.h
@@ -1,19 +1,28 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ParentNarrowOne {
 public:
     ParentNarrowOne();
-    virtual ~ParentNarrowOne() = 0;
+    virtual ~ParentNarrowOne();
+
+
 public:
     virtual void parent_function_one(  ) = 0;
     virtual ::std::string get_parent_property_one(  ) const = 0;
     virtual void set_parent_property_one( const ::std::string& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/name_clash_overloads/output/cpp/include/smoke/AssetsManager.h
+++ b/gluecodium/src/test/resources/smoke/name_clash_overloads/output/cpp/include/smoke/AssetsManager.h
@@ -1,21 +1,32 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
+
+
 namespace smoke {
+
     class Image;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT AssetsManager {
 public:
     AssetsManager();
-    virtual ~AssetsManager() = 0;
+    virtual ~AssetsManager();
+
+
 public:
     virtual void add_asset( const ::std::string& identifier, const ::std::shared_ptr< ::std::vector< uint8_t > >& asset_data ) = 0;
     /**
@@ -25,4 +36,6 @@ public:
      */
     virtual void add_asset( const ::std::string& identifier, const ::std::shared_ptr< ::smoke::Image >& image_data ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cpp/include/namerules/NameRules.h
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cpp/include/namerules/NameRules.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "ExportGluecodiumCpp.h"
 #include "Return.h"
 #include "VectorHash.h"
@@ -11,23 +14,32 @@
 #include <string>
 #include <system_error>
 #include <vector>
+
 namespace namerules {
 class _GLUECODIUM_CPP_EXPORT NameRules {
 public:
     NameRules();
-    virtual ~NameRules() = 0;
+    virtual ~NameRules();
+
+
 public:
     enum class ExampleErrorCode {
         NONE,
         FATAL
     };
+
+
     using StringArray = ::std::vector< ::std::string >;
+
     struct _GLUECODIUM_CPP_EXPORT ExampleStruct {
         double m_value;
         ::std::vector< int64_t > m_int_value;
+
         ExampleStruct( );
         ExampleStruct( double m_value, ::std::vector< int64_t > m_int_value );
+
     };
+
 public:
     /**
      *
@@ -37,13 +49,19 @@ public:
     virtual ::Return< double, ::std::error_code > someMethod( const ::namerules::NameRules::ExampleStruct& some_argument ) = 0;
     virtual uint32_t retrieve_int_property(  ) const = 0;
     virtual void STORE_INT_PROPERTY_NOW( const uint32_t value ) = 0;
+
     virtual bool really_boolean_property(  ) const = 0;
     virtual void STORE_BOOLEAN_PROPERTY_NOW( const bool value ) = 0;
+
     virtual ::namerules::NameRules::ExampleStruct retrieve_struct_property(  ) const = 0;
     virtual void STORE_STRUCT_PROPERTY_NOW( const ::namerules::NameRules::ExampleStruct& value ) = 0;
+
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::namerules::NameRules::ExampleErrorCode value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/cpp/include/root/space/smoke/Basic.h
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/cpp/include/root/space/smoke/Basic.h
@@ -1,20 +1,28 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace root {
 namespace space {
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Basic {
 public:
     Basic();
-    virtual ~Basic() = 0;
+    virtual ~Basic();
+
+
 public:
     static ::std::string basic_method( const ::std::string& input_string );
 };
+
+
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/cpp/include/root/space/smoke/BasicForwardDeclarations.h
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/cpp/include/root/space/smoke/BasicForwardDeclarations.h
@@ -1,24 +1,35 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <memory>
+
 namespace root {
 namespace space {
+
 namespace smoke {
+
     class Basic;
+
+
 }
 }
 }
+
 namespace root {
 namespace space {
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT BasicForwardDeclarations {
 public:
     BasicForwardDeclarations();
-    virtual ~BasicForwardDeclarations() = 0;
+    virtual ~BasicForwardDeclarations();
+
+
 public:
     /**
      *
@@ -26,6 +37,8 @@ public:
      */
     virtual ::std::shared_ptr< ::root::space::smoke::Basic > use_basic(  ) = 0;
 };
+
+
 }
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
@@ -1,40 +1,57 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/OuterClass.h"
 #include "smoke/OuterInterface.h"
 #include <cstdint>
 #include <memory>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT LevelOne {
 public:
     LevelOne();
-    virtual ~LevelOne() = 0;
+    virtual ~LevelOne();
+
+
 public:
     class _GLUECODIUM_CPP_EXPORT LevelTwo {
     public:
         LevelTwo();
-        virtual ~LevelTwo() = 0;
+        virtual ~LevelTwo();
+
+
     public:
         class _GLUECODIUM_CPP_EXPORT LevelThree {
         public:
             LevelThree();
-            virtual ~LevelThree() = 0;
+            virtual ~LevelThree();
+
+
         public:
             enum class LevelFourEnum {
                 NONE
             };
+
+
             struct _GLUECODIUM_CPP_EXPORT LevelFour {
                 static const bool FOO;
+
                 ::std::string string_field;
+
                 LevelFour( );
                 explicit LevelFour( ::std::string string_field );
+
                 static ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour foo_factory(  );
+
             };
+
         public:
             /**
              *
@@ -43,6 +60,10 @@ public:
              */
             virtual ::std::shared_ptr< ::smoke::OuterInterface::InnerClass > foo( const ::std::shared_ptr< ::smoke::OuterClass::InnerInterface >& input ) = 0;
         };
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/MyOuterClass.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/MyOuterClass.h
@@ -1,20 +1,31 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/MyParentInterface.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT MyOuterClass {
 public:
     MyOuterClass();
-    virtual ~MyOuterClass() = 0;
+    virtual ~MyOuterClass();
+
+
 public:
     class _GLUECODIUM_CPP_EXPORT MyNestedImplementation: public ::smoke::MyParentInterface {
     public:
         MyNestedImplementation();
-        virtual ~MyNestedImplementation() = 0;
+        virtual ~MyNestedImplementation();
+
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/NestedReferences.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/NestedReferences.h
@@ -1,22 +1,31 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <memory>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT NestedReferences {
 public:
     NestedReferences();
-    virtual ~NestedReferences() = 0;
+    virtual ~NestedReferences();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT NestedReferences {
         ::std::string string_field;
+
         NestedReferences( );
         explicit NestedReferences( ::std::string string_field );
+
     };
+
 public:
     /**
      *
@@ -26,4 +35,6 @@ public:
      */
     virtual ::std::shared_ptr< ::smoke::NestedReferences > inside_out( const ::smoke::NestedReferences::NestedReferences& struct1, const ::smoke::NestedReferences::NestedReferences& struct2 ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterClass.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterClass.h
@@ -1,32 +1,46 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT OuterClass {
 public:
     OuterClass();
-    virtual ~OuterClass() = 0;
+    virtual ~OuterClass();
+
+
 public:
     class _GLUECODIUM_CPP_EXPORT InnerClass {
     public:
         InnerClass();
-        virtual ~InnerClass() = 0;
+        virtual ~InnerClass();
+
+
     public:
         virtual ::std::string foo( const ::std::string& input ) = 0;
     };
+
     class _GLUECODIUM_CPP_EXPORT InnerInterface {
     public:
         InnerInterface();
-        virtual ~InnerInterface() = 0;
+        virtual ~InnerInterface();
+
+
     public:
         virtual ::std::string foo( const ::std::string& input ) = 0;
     };
+
 public:
     virtual ::std::string foo( const ::std::string& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterClassWithInheritance.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterClassWithInheritance.h
@@ -1,33 +1,47 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
-#include "gluecodium\ExportGluecodiumCpp.h"
-#include "gluecodium\TypeRepository.h"
-#include "smoke\ParentClass.h"
+
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/TypeRepository.h"
+#include "smoke/ParentClass.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT OuterClassWithInheritance: public ::smoke::ParentClass {
 public:
     OuterClassWithInheritance();
-    virtual ~OuterClassWithInheritance() = 0;
+    virtual ~OuterClassWithInheritance();
+
+
 public:
     class _GLUECODIUM_CPP_EXPORT InnerClass {
     public:
         InnerClass();
-        virtual ~InnerClass() = 0;
+        virtual ~InnerClass();
+
+
     public:
         virtual ::std::string bar( const ::std::string& input ) = 0;
     };
+
     class _GLUECODIUM_CPP_EXPORT InnerInterface {
     public:
         InnerInterface();
-        virtual ~InnerInterface() = 0;
+        virtual ~InnerInterface();
+
+
     public:
         virtual ::std::string baz( const ::std::string& input ) = 0;
     };
+
 public:
     virtual ::std::string foo( const ::std::string& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterInterface.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterInterface.h
@@ -1,32 +1,46 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/TypeRepository.h"
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT OuterInterface {
 public:
     OuterInterface();
-    virtual ~OuterInterface() = 0;
+    virtual ~OuterInterface();
+
+
 public:
     class _GLUECODIUM_CPP_EXPORT InnerClass {
     public:
         InnerClass();
-        virtual ~InnerClass() = 0;
+        virtual ~InnerClass();
+
+
     public:
         virtual ::std::string foo( const ::std::string& input ) = 0;
     };
+
     class _GLUECODIUM_CPP_EXPORT InnerInterface {
     public:
         InnerInterface();
-        virtual ~InnerInterface() = 0;
+        virtual ~InnerInterface();
+
+
     public:
         virtual ::std::string foo( const ::std::string& input ) = 0;
     };
+
 public:
     virtual ::std::string foo( const ::std::string& input ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Locale.h"
 #include "gluecodium/TimePointHash.h"
@@ -19,31 +22,45 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT OuterStruct {
     struct _GLUECODIUM_CPP_EXPORT InnerStruct {
         ::std::vector< ::std::chrono::system_clock::time_point > other_field;
+
         InnerStruct( );
         explicit InnerStruct( ::std::vector< ::std::chrono::system_clock::time_point > other_field );
+
         void do_something(  ) const;
+
     };
+
     enum class InnerEnum {
         FOO,
         BAR
     };
+
+
     using InnerLambda = ::std::function<void()>;
+
     using TypeAlias = ::smoke::OuterStruct::InnerEnum;
+
     class _GLUECODIUM_CPP_EXPORT InnerClass {
     public:
         InnerClass();
-        virtual ~InnerClass() = 0;
+        virtual ~InnerClass();
+
+
     public:
         virtual ::std::unordered_set< ::gluecodium::Locale, ::gluecodium::hash< ::gluecodium::Locale > > foo_bar(  ) = 0;
     };
+
     class _GLUECODIUM_CPP_EXPORT Builder {
     public:
         Builder();
-        virtual ~Builder() = 0;
+        virtual ~Builder();
+
+
     public:
         /**
          *
@@ -58,16 +75,25 @@ struct _GLUECODIUM_CPP_EXPORT OuterStruct {
         virtual ::std::shared_ptr< ::smoke::OuterStruct::Builder > field( const ::std::string& value ) = 0;
         virtual ::smoke::OuterStruct build(  ) = 0;
     };
+
     class _GLUECODIUM_CPP_EXPORT InnerInterface {
     public:
         InnerInterface();
-        virtual ~InnerInterface() = 0;
+        virtual ~InnerInterface();
+
+
     public:
         virtual ::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > > bar_baz(  ) = 0;
     };
+
     ::std::string field;
+
     OuterStruct( );
     explicit OuterStruct( ::std::string field );
+
     ::std::error_code do_nothing(  ) const;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/UseFreeTypes.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/UseFreeTypes.h
@@ -1,20 +1,28 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include "smoke/FreeEnum.h"
 #include "smoke/FreePoint.h"
 #include "smoke/FreeTypeDef.h"
 #include <system_error>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT UseFreeTypes {
 public:
     UseFreeTypes();
-    virtual ~UseFreeTypes() = 0;
+    virtual ~UseFreeTypes();
+
+
 public:
     virtual ::gluecodium::Return< ::smoke::FreeTypeDef, ::std::error_code > do_stuff( const ::smoke::FreePoint& point, const ::smoke::FreeEnum mode ) = 0;
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/cpp/include/smoke/Nullable.h
+++ b/gluecodium/src/test/resources/smoke/nullable/output/cpp/include/smoke/Nullable.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/VectorHash.h"
@@ -12,26 +15,41 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
+
 namespace smoke {
+
     class SomeInterface;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Nullable {
 public:
     Nullable();
-    virtual ~Nullable() = 0;
+    virtual ~Nullable();
+
+
 public:
     enum class SomeEnum {
         ON,
         OFF
     };
+
+
     using SomeArray = ::std::vector< ::std::string >;
+
     using SomeMap = ::std::unordered_map< int64_t, ::std::string >;
+
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string string_field;
+
         SomeStruct( );
         explicit SomeStruct( ::std::string string_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT NullableStruct {
         std::optional< ::std::string > string_field = std::optional< ::std::string >();
         std::optional< bool > bool_field = std::optional< bool >();
@@ -42,9 +60,12 @@ public:
         std::optional< ::std::vector< ::std::string > > inline_array_field = std::optional< ::std::vector< ::std::string > >();
         std::optional< ::smoke::Nullable::SomeMap > map_field = std::optional< ::smoke::Nullable::SomeMap >();
         ::std::shared_ptr< ::smoke::SomeInterface > instance_field = ::std::shared_ptr< ::smoke::SomeInterface >();
+
         NullableStruct( );
         NullableStruct( std::optional< ::std::string > string_field, std::optional< bool > bool_field, std::optional< double > double_field, std::optional< ::smoke::Nullable::SomeStruct > struct_field, std::optional< ::smoke::Nullable::SomeEnum > enum_field, std::optional< ::smoke::Nullable::SomeArray > array_field, std::optional< ::std::vector< ::std::string > > inline_array_field, std::optional< ::smoke::Nullable::SomeMap > map_field, ::std::shared_ptr< ::smoke::SomeInterface > instance_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT NullableIntsStruct {
         std::optional< int8_t > int8_field = std::optional< int8_t >();
         std::optional< int16_t > int16_field = std::optional< int16_t >();
@@ -54,9 +75,12 @@ public:
         std::optional< uint16_t > uint16_field = std::optional< uint16_t >();
         std::optional< uint32_t > uint32_field = std::optional< uint32_t >();
         std::optional< uint64_t > uint64_field = std::optional< uint64_t >();
+
         NullableIntsStruct( );
         NullableIntsStruct( std::optional< int8_t > int8_field, std::optional< int16_t > int16_field, std::optional< int32_t > int32_field, std::optional< int64_t > int64_field, std::optional< uint8_t > uint8_field, std::optional< uint16_t > uint16_field, std::optional< uint32_t > uint32_field, std::optional< uint64_t > uint64_field );
+
     };
+
 public:
     virtual std::optional< ::std::string > method_with_string( const std::optional< ::std::string >& input ) = 0;
     virtual std::optional< bool > method_with_boolean( const std::optional< bool >& input ) = 0;
@@ -70,23 +94,35 @@ public:
     virtual ::std::shared_ptr< ::smoke::SomeInterface > method_with_instance( const ::std::shared_ptr< ::smoke::SomeInterface >& input ) = 0;
     virtual std::optional< ::std::string > get_string_property(  ) const = 0;
     virtual void set_string_property( const std::optional< ::std::string >& value ) = 0;
+
     virtual std::optional< bool > is_bool_property(  ) const = 0;
     virtual void set_bool_property( const std::optional< bool >& value ) = 0;
+
     virtual std::optional< double > get_double_property(  ) const = 0;
     virtual void set_double_property( const std::optional< double >& value ) = 0;
+
     virtual std::optional< int64_t > get_int_property(  ) const = 0;
     virtual void set_int_property( const std::optional< int64_t >& value ) = 0;
+
     virtual std::optional< ::smoke::Nullable::SomeStruct > get_struct_property(  ) const = 0;
     virtual void set_struct_property( const std::optional< ::smoke::Nullable::SomeStruct >& value ) = 0;
+
     virtual std::optional< ::smoke::Nullable::SomeEnum > get_enum_property(  ) const = 0;
     virtual void set_enum_property( const std::optional< ::smoke::Nullable::SomeEnum >& value ) = 0;
+
     virtual std::optional< ::smoke::Nullable::SomeArray > get_array_property(  ) const = 0;
     virtual void set_array_property( const std::optional< ::smoke::Nullable::SomeArray >& value ) = 0;
+
     virtual std::optional< ::std::vector< ::std::string > > get_inline_array_property(  ) const = 0;
     virtual void set_inline_array_property( const std::optional< ::std::vector< ::std::string > >& value ) = 0;
+
     virtual std::optional< ::smoke::Nullable::SomeMap > get_map_property(  ) const = 0;
     virtual void set_map_property( const std::optional< ::smoke::Nullable::SomeMap >& value ) = 0;
+
     virtual ::std::shared_ptr< ::smoke::SomeInterface > get_instance_property(  ) const = 0;
     virtual void set_instance_property( const ::std::shared_ptr< ::smoke::SomeInterface >& value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/packages/output/cpp/include/smoke/off/NestedPackages.h
+++ b/gluecodium/src/test/resources/smoke/packages/output/cpp/include/smoke/off/NestedPackages.h
@@ -1,24 +1,35 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke {
 namespace off {
 class _GLUECODIUM_CPP_EXPORT NestedPackages {
 public:
     NestedPackages();
-    virtual ~NestedPackages() = 0;
+    virtual ~NestedPackages();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT SomeStruct {
         ::std::string some_field;
+
         SomeStruct( );
         explicit SomeStruct( ::std::string some_field );
+
     };
+
 public:
     static ::smoke::off::NestedPackages::SomeStruct basic_method( const ::smoke::off::NestedPackages::SomeStruct& input );
 };
+
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/packages/output/cpp/include/smoke_off/UnderscorePackage.h
+++ b/gluecodium/src/test/resources/smoke/packages/output/cpp/include/smoke_off/UnderscorePackage.h
@@ -1,16 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <string>
+
 namespace smoke_off {
 class _GLUECODIUM_CPP_EXPORT UnderscorePackage {
 public:
     UnderscorePackage();
-    virtual ~UnderscorePackage() = 0;
+    virtual ~UnderscorePackage();
+
+
 public:
     static ::std::string basic_method( const ::std::string& input_string );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooInterface.h
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooInterface.h
@@ -1,18 +1,24 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "smoke/fooTypes.h"
 #include <cstdint>
 #include <memory>
 #include <string>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT fooInterface {
 public:
     fooInterface();
-    virtual ~fooInterface() = 0;
+    virtual ~fooInterface();
+
+
 public:
     virtual ::smoke::fooTypes::fooStruct FooMethod( const ::std::string& FooParameter ) = 0;
     /**
@@ -23,5 +29,8 @@ public:
     static ::std::shared_ptr< ::smoke::fooInterface > make( const ::std::string& makeParameter );
     virtual uint32_t GET_FOO_PROPERTY(  ) const = 0;
     virtual void SET_FOO_PROPERTY( const uint32_t value ) = 0;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/cpp/include/smoke/Properties.h
+++ b/gluecodium/src/test/resources/smoke/properties/output/cpp/include/smoke/Properties.h
@@ -1,44 +1,66 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/VectorHash.h"
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
+
+
 namespace smoke {
+
     class PropertiesInterface;
+
+
 }
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Properties {
 public:
     Properties();
-    virtual ~Properties() = 0;
+    virtual ~Properties();
+
+
 public:
     enum class InternalErrorCode {
         ERROR_NONE,
         ERROR_FATAL = 999
     };
+
+
     struct _GLUECODIUM_CPP_EXPORT ExampleStruct {
         double value;
+
         ExampleStruct( );
         explicit ExampleStruct( double value );
+
     };
+
 public:
     virtual uint32_t get_built_in_type_property(  ) const = 0;
     virtual void set_built_in_type_property( const uint32_t value ) = 0;
+
     virtual float get_readonly_property(  ) const = 0;
+
     virtual ::smoke::Properties::ExampleStruct get_struct_property(  ) const = 0;
     virtual void set_struct_property( const ::smoke::Properties::ExampleStruct& value ) = 0;
+
     virtual ::std::vector< ::std::string > get_array_property(  ) const = 0;
     virtual void set_array_property( const ::std::vector< ::std::string >& value ) = 0;
+
     virtual ::smoke::Properties::InternalErrorCode get_complex_type_property(  ) const = 0;
     virtual void set_complex_type_property( const ::smoke::Properties::InternalErrorCode value ) = 0;
+
     virtual ::std::shared_ptr< ::std::vector< uint8_t > > get_byte_buffer_property(  ) const = 0;
     virtual void set_byte_buffer_property( const ::std::shared_ptr< ::std::vector< uint8_t > >& value ) = 0;
+
     /**
      *
      * \return @NotNull
@@ -49,10 +71,16 @@ public:
      * \param[in] value @NotNull
      */
     virtual void set_instance_property( const ::std::shared_ptr< ::smoke::PropertiesInterface >& value ) = 0;
+
     virtual bool is_boolean_property(  ) const = 0;
     virtual void set_boolean_property( const bool value ) = 0;
+
     static ::std::string get_static_property(  );
     static void set_static_property( const ::std::string& value );
+
     static ::smoke::Properties::ExampleStruct get_static_readonly_property(  );
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/ClassWithDocRef.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/ClassWithDocRef.h
@@ -1,16 +1,25 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 /**
  * ::smoke::SkipEnableConstants::SOME_CONSTANT
+
  */
 class _GLUECODIUM_CPP_EXPORT ClassWithDocRef {
 public:
     ClassWithDocRef();
-    virtual ~ClassWithDocRef() = 0;
+    virtual ~ClassWithDocRef();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/ClassWithStructWithSkipLambdaInPlatform.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/ClassWithStructWithSkipLambdaInPlatform.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include "gluecodium\ExportGluecodiumCpp.h"
+#include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <functional>
 
@@ -14,7 +14,8 @@ namespace smoke {
 class _GLUECODIUM_CPP_EXPORT ClassWithStructWithSkipLambdaInPlatform {
 public:
     ClassWithStructWithSkipLambdaInPlatform();
-    virtual ~ClassWithStructWithSkipLambdaInPlatform() = 0;
+    virtual ~ClassWithStructWithSkipLambdaInPlatform();
+
 
 public:
     struct _GLUECODIUM_CPP_EXPORT SkipLambdaInPlatform {

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfEnabled.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfEnabled.h
@@ -1,14 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT EnableIfEnabled {
 public:
     EnableIfEnabled();
-    virtual ~EnableIfEnabled() = 0;
+    virtual ~EnableIfEnabled();
+
+
 public:
     static void enable_if_unquoted(  );
     static void enable_if_unquoted_list(  );
@@ -18,4 +24,6 @@ public:
     static void enable_if_tagged_list(  );
     static void enable_if_mixed_list(  );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfSkipped.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfSkipped.h
@@ -1,13 +1,21 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT EnableIfSkipped {
 public:
     EnableIfSkipped();
-    virtual ~EnableIfSkipped() = 0;
+    virtual ~EnableIfSkipped();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipTagsOnly.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipTagsOnly.h
@@ -1,13 +1,21 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT SkipTagsOnly {
 public:
     SkipTagsOnly();
-    virtual ~SkipTagsOnly() = 0;
+    virtual ~SkipTagsOnly();
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
@@ -1,37 +1,51 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
-#include "gluecodium\ExportGluecodiumCpp.h"
-#include "gluecodium\VectorHash.h"
-#include "smoke\TypeCollection.h"
+
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/VectorHash.h"
+#include "smoke/TypeCollection.h"
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT Structs {
 public:
     Structs();
-    virtual ~Structs() = 0;
+    virtual ~Structs();
+
+
 public:
     enum class FooBar {
         FOO,
         BAR
     };
+
+
     struct _GLUECODIUM_CPP_EXPORT Point {
         double x;
         double y;
+
         Point( );
         Point( double x, double y );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT Line {
         ::smoke::Structs::Point a;
         ::smoke::Structs::Point b;
+
         Line( );
         Line( ::smoke::Structs::Point a, ::smoke::Structs::Point b );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT AllTypesStruct {
         const int8_t int8_field;
         const uint8_t uint8_field;
@@ -47,42 +61,72 @@ public:
         const bool boolean_field;
         const ::std::shared_ptr< ::std::vector< uint8_t > > bytes_field;
         const ::smoke::Structs::Point point_field;
+
+
         AllTypesStruct( int8_t int8_field, uint8_t uint8_field, int16_t int16_field, uint16_t uint16_field, int32_t int32_field, uint32_t uint32_field, int64_t int64_field, uint64_t uint64_field, float float_field, double double_field, ::std::string string_field, bool boolean_field, ::std::shared_ptr< ::std::vector< uint8_t > > bytes_field, ::smoke::Structs::Point point_field );
+
     };
+
     using ArrayOfImmutable = ::std::vector< ::smoke::Structs::AllTypesStruct >;
+
     struct _GLUECODIUM_CPP_EXPORT NestingImmutableStruct {
         ::smoke::Structs::AllTypesStruct struct_field;
+
+
         explicit NestingImmutableStruct( ::smoke::Structs::AllTypesStruct struct_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT DoubleNestingImmutableStruct {
         ::smoke::Structs::NestingImmutableStruct nesting_struct_field;
+
+
         explicit DoubleNestingImmutableStruct( ::smoke::Structs::NestingImmutableStruct nesting_struct_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT StructWithArrayOfImmutable {
         ::smoke::Structs::ArrayOfImmutable array_field;
+
         StructWithArrayOfImmutable( );
         explicit StructWithArrayOfImmutable( ::smoke::Structs::ArrayOfImmutable array_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithCppAccessors {
     private:
         ::std::string string_field;
     public:
+
+
         explicit ImmutableStructWithCppAccessors( ::std::string string_field );
+
+
         ::std::string get_string_field( ) const { return string_field; }
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT MutableStructWithCppAccessors {
     private:
         ::std::string string_field;
     public:
+
         MutableStructWithCppAccessors( );
         explicit MutableStructWithCppAccessors( ::std::string string_field );
+
+
         ::std::string get_string_field( ) const { return string_field; }
+
         void set_string_field( ::std::string value_ ) { string_field = value_; }
+
     };
+
 public:
     static ::smoke::Structs::Point swap_point_coordinates( const ::smoke::Structs::Point& input );
     static ::smoke::Structs::AllTypesStruct return_all_types_struct( const ::smoke::Structs::AllTypesStruct& input );
     static ::smoke::TypeCollection::Point create_point( const double x, const double y );
     static ::smoke::TypeCollection::AllTypesStruct modify_all_types_struct( const ::smoke::TypeCollection::AllTypesStruct& input );
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithConstantsInterface.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithConstantsInterface.h
@@ -1,29 +1,44 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/VectorHash.h"
 #include "smoke/RouteUtils.h"
 #include <string>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT StructsWithConstantsInterface {
 public:
     StructsWithConstantsInterface();
-    virtual ~StructsWithConstantsInterface() = 0;
+    virtual ~StructsWithConstantsInterface();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT MultiRoute {
         static const ::std::string DEFAULT_DESCRIPTION;
+
         static const ::smoke::RouteUtils::RouteType DEFAULT_TYPE;
+
         ::std::vector< ::std::string > descriptions;
         ::smoke::RouteUtils::RouteType type;
+
         MultiRoute( );
         MultiRoute( ::std::vector< ::std::string > descriptions, ::smoke::RouteUtils::RouteType type );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT StructWithConstantsOnly {
         static const ::std::string DEFAULT_DESCRIPTION;
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithMethodsInterface.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/StructsWithMethodsInterface.h
@@ -1,32 +1,46 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include <string>
 #include <system_error>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT StructsWithMethodsInterface {
 public:
     StructsWithMethodsInterface();
-    virtual ~StructsWithMethodsInterface() = 0;
+    virtual ~StructsWithMethodsInterface();
+
+
 public:
     struct _GLUECODIUM_CPP_EXPORT Vector3 {
         double x;
         double y;
         double z;
+
         Vector3( );
         Vector3( double x, double y, double z );
+
         double distance_to( const ::smoke::StructsWithMethodsInterface::Vector3& other ) const;
         ::smoke::StructsWithMethodsInterface::Vector3 add( const ::smoke::StructsWithMethodsInterface::Vector3& other ) const;
         static bool validate( const double x, const double y, const double z );
         static ::smoke::StructsWithMethodsInterface::Vector3 create( const ::std::string& input );
         static ::gluecodium::Return< ::smoke::StructsWithMethodsInterface::Vector3, ::std::error_code > create( const ::smoke::StructsWithMethodsInterface::Vector3& other );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT StructWithStaticMethodsOnly {
         static void do_stuff(  );
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/TypeDefs.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/TypeDefs.h
@@ -1,35 +1,53 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/VectorHash.h"
 #include "smoke/TypeCollection.h"
 #include <string>
 #include <vector>
+
 namespace smoke {
 class _GLUECODIUM_CPP_EXPORT TypeDefs {
 public:
     TypeDefs();
-    virtual ~TypeDefs() = 0;
+    virtual ~TypeDefs();
+
+
 public:
     using PrimitiveTypeDef = double;
+
     using NestedIntTypeDef = ::smoke::TypeDefs::PrimitiveTypeDef;
+
     struct _GLUECODIUM_CPP_EXPORT StructHavingAliasFieldDefinedBelow {
         ::smoke::TypeDefs::PrimitiveTypeDef field;
+
         StructHavingAliasFieldDefinedBelow( );
         explicit StructHavingAliasFieldDefinedBelow( ::smoke::TypeDefs::PrimitiveTypeDef field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT TestStruct {
         ::std::string something;
+
         TestStruct( );
         explicit TestStruct( ::std::string something );
+
     };
+
     using StructArray = ::std::vector< ::smoke::TypeDefs::TestStruct >;
+
     using ComplexTypeDef = ::smoke::TypeDefs::StructArray;
+
     using TestStructTypeDef = ::smoke::TypeDefs::TestStruct;
+
     using NestedStructTypeDef = ::smoke::TypeDefs::TestStructTypeDef;
+
 public:
     static ::smoke::TypeDefs::PrimitiveTypeDef method_with_primitive_type_def( const ::smoke::TypeDefs::PrimitiveTypeDef input );
     static ::smoke::TypeDefs::ComplexTypeDef method_with_complex_type_def( const ::smoke::TypeDefs::ComplexTypeDef& input );
@@ -39,5 +57,8 @@ public:
     static ::smoke::TypeCollection::PointTypeDef return_type_def_point_from_type_collection( const ::smoke::TypeCollection::PointTypeDef& input );
     virtual ::std::vector< ::smoke::TypeDefs::PrimitiveTypeDef > get_primitive_type_property(  ) const = 0;
     virtual void set_primitive_type_property( const ::std::vector< ::smoke::TypeDefs::PrimitiveTypeDef >& value ) = 0;
+
 };
+
+
 }


### PR DESCRIPTION
Pure virtual constructor makes a class header-only. This breaks RTTI when class is sued from several
libraries.
