### PR TITLE
Avoids passing of useless parameter

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -277,7 +277,7 @@ internal class JavaGenerator : Generator {
                 "JniThrowNewException",
             )
         private val UTILS_FILES_HEADER_ONLY =
-            listOf("ArrayConversionUtils", "JniCallJavaMethod", "JniTemplateMetainfo")
+            listOf("ArrayConversionUtils", "JniCallJavaMethod", "JniTemplateMetainfo", "JniTypeId")
 
         private fun annotationFromOption(option: Pair<String, List<String>>?) = option?.let { JavaImport(option.second, option.first) }
     }

--- a/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/CppProxyImplementation.mustache
@@ -92,7 +92,7 @@ namespace jni
         auto nErrorValue = {{#set typeRef=exception.errorType}}{{>jni/JniConversionPrefix}}{{/set}}convert_from_jni(
             jniEnv,
             jErrorValue,
-            ({{resolveName exception.errorType "C++ FQN"}}*)nullptr );
+            TypeId<{{resolveName exception.errorType "C++ FQN"}}>{});
 
 {{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}
         return ::std::error_code{nErrorValue};
@@ -108,7 +108,7 @@ namespace jni
 }}{{#unless returnType.isVoid}}
     return {{#unlessPredicate returnType.typeRef "isJniPrimitive"}}{{!!
     }}{{#returnType}}{{>jni/JniConversionPrefix}}{{/returnType}}convert_from_jni( jniEnv, _result, {{!!
-    }}({{resolveName returnType "C++"}}*)nullptr ){{/unlessPredicate}}{{!!
+    }}TypeId<{{resolveName returnType "C++"}}>{}){{/unlessPredicate}}{{!!
     }}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}_result{{/ifPredicate}};
 {{/unless}}
 {{#if thrownType}}{{#if returnType.isVoid}}{{#instanceOf exception.errorType.type.actualType "LimeEnumeration"}}

--- a/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
@@ -39,7 +39,7 @@ namespace jni
 {{/if}}
 
 {{resolveName "C++ FQN"}}
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{#if external.java.converter}}_ext{{/if}}, {{resolveName "C++ FQN"}}*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{#if external.java.converter}}_ext{{/if}}, TypeId<{{resolveName "C++ FQN"}}>)
 {
 {{#if external.java.converter}}
 {{prefixPartial "jni/ExternalConversionFromJni" "    "}}
@@ -57,15 +57,15 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{#if extern
 {{/ifPredicate}}{{!!
 }}{{#unlessPredicate "needsOrdinalConversion"}}
     return {{resolveName "C++ FQN"}}(
-        {{>common/InternalNamespace}}jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        {{>common/InternalNamespace}}jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 {{/unlessPredicate}}
 }
 
 std::optional<{{resolveName "C++ FQN"}}>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<{{resolveName "C++ FQN"}}>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<{{resolveName "C++ FQN"}}>>)
 {
     return _jinput
-        ? std::optional<{{resolveName "C++ FQN"}}>(convert_from_jni(_jenv, _jinput, ({{resolveName "C++ FQN"}}*)nullptr))
+        ? std::optional<{{resolveName "C++ FQN"}}>(convert_from_jni(_jenv, _jinput, TypeId<{{resolveName "C++ FQN"}}>{}))
         : std::optional<{{resolveName "C++ FQN"}}>{};
 }
 

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -136,7 +136,7 @@ jint
 {{#unlessPredicate typeRef "isJniPrimitive"}}
     {{resolveName typeRef "C++"}} {{resolveName}} = {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(_jenv,
             {{>common/InternalNamespace}}jni::make_non_releasing_ref(j{{resolveName}}),
-            ({{resolveName typeRef "C++"}}*)nullptr);
+            {{>common/InternalNamespace}}jni::TypeId<{{resolveName typeRef "C++"}}>{});
 {{/unlessPredicate}}{{#ifPredicate typeRef "isJniPrimitive"}}
     {{resolveName typeRef "C++"}} {{resolveName}} = j{{resolveName}};
 {{/ifPredicate}}
@@ -150,7 +150,7 @@ jint
 }}{{#instanceOf container "LimeStruct"}}
     auto _ninstance = {{>common/InternalNamespace}}jni::convert_from_jni(_jenv,
         {{>common/InternalNamespace}}jni::make_non_releasing_ref(_jinstance),
-        ({{resolveName container "C++ FQN"}}*)nullptr);
+        {{>common/InternalNamespace}}jni::TypeId<{{resolveName container "C++ FQN"}}>{});
 {{/instanceOf}}{{/unless}}
 
 {{#if thrownType}}

--- a/gluecodium/src/main/resources/templates/jni/InstanceConversionHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/InstanceConversionHeader.mustache
@@ -29,6 +29,7 @@
 #include "JniCallJavaMethod.h"
 {{/ifPredicate}}
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
 {{#ifPredicate model "hasOverloadedLambda"}}
@@ -44,7 +45,7 @@ namespace jni
 {
 
 {{#model}}
-JNIEXPORT {{>cppTypeName}} {{>conversionPrefix}}convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, {{>cppTypeName}}*);
+JNIEXPORT {{>cppTypeName}} {{>conversionPrefix}}convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<{{>cppTypeName}}>);
 JNIEXPORT JniReference<jobject> {{>conversionPrefix}}convert_to_jni(JNIEnv* _jenv, const {{>cppTypeName}}& _ninput);
 {{#ifPredicate "hasOverloadedLambda"}}{{>jni/LambdaOverloadedConversionHeader}}{{/ifPredicate}}
 {{/model}}

--- a/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/InstanceConversionImplementation.mustache
@@ -71,7 +71,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 {{#interface}}{{>cppTypeName}}{{/interface}} try_descendant_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, {{#interface}}{{>cppTypeName}}{{/interface}}*) {
 {{#this}}{{!! pre-sorted, most distant descendants are prioritized }}
     if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<{{resolveName "C++ FQN"}}>::java_class.get())) {
-        return {{>conversionPrefix}}convert_from_jni(_env, _jobj, ({{>cppTypeName}}*)nullptr);
+        return {{>conversionPrefix}}convert_from_jni(_env, _jobj, TypeId<{{>cppTypeName}}>{});
     }
 {{/this}}
     return {};
@@ -79,7 +79,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 
 {{/eval}}{{/set}}{{/instanceOf}}{{/unless}}
 
-{{>cppTypeName}} {{>conversionPrefix}}convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, {{>cppTypeName}}*)
+{{>cppTypeName}} {{>conversionPrefix}}convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<{{>cppTypeName}}>)
 {
     {{>cppTypeName}} _nresult{};
 {{#if isNarrow}}

--- a/gluecodium/src/main/resources/templates/jni/LambdaOverloadedConversionHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/LambdaOverloadedConversionHeader.mustache
@@ -18,15 +18,15 @@
   ! License-Filename: LICENSE
   !
   !}}
-JNIEXPORT std::optional<{{resolveName "C++ FQN"}}> {{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::optional<{{resolveName "C++ FQN"}}>*);
+JNIEXPORT std::optional<{{resolveName "C++ FQN"}}> {{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<{{resolveName "C++ FQN"}}>>);
 JNIEXPORT JniReference<jobject> {{resolveName "mangled"}}_convert_to_jni(JNIEnv* _env, const std::optional<{{resolveName "C++ FQN"}}>& _ninput);
 
 // Functions to create ArrayLists from C++ vectors and vice versa, for overloaded lambdas.
 
 JNIEXPORT JniReference<jobject> {{resolveName "mangled"}}_convert_to_jni(JNIEnv* _env, const std::vector<{{resolveName "C++ FQN"}}>& _ninput);
 JNIEXPORT JniReference<jobject> {{resolveName "mangled"}}_convert_to_jni(JNIEnv* _env, const std::optional<std::vector<{{resolveName "C++ FQN"}}>>& _ninput);
-JNIEXPORT std::vector<{{resolveName "C++ FQN"}}> {{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::vector<{{resolveName "C++ FQN"}}>*);
-JNIEXPORT std::optional<std::vector<{{resolveName "C++ FQN"}}>> {{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::optional<std::vector<{{resolveName "C++ FQN"}}>>*);
+JNIEXPORT std::vector<{{resolveName "C++ FQN"}}> {{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<{{resolveName "C++ FQN"}}>>);
+JNIEXPORT std::optional<std::vector<{{resolveName "C++ FQN"}}>> {{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<{{resolveName "C++ FQN"}}>>>);
 
 // Templated functions to create HashMaps from C++ unordered_maps and vice versa, for overloaded lambdas as values.
 
@@ -55,7 +55,7 @@ JniReference<jobject>
 template <typename K, typename Hash>
 std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>
 {{resolveName "mangled"}}_convert_from_jni(
-    JNIEnv* _env, const JniReference<jobject>& _jMap, std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>*
+    JNIEnv* _env, const JniReference<jobject>& _jMap, TypeId<std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>>
 ) {
     std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash> _nresult{};
 
@@ -82,10 +82,10 @@ std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>
     while (call_java_method<jboolean>(_env, jIterator, hasNextMethodId)) {
         auto jEntry = call_java_method<jobject>(_env, jIterator, nextMethodId);
         auto jKey = call_java_method<jobject>(_env, jEntry, getKeyMethodId);
-        K nKey = convert_from_jni(_env, jKey, (K*)nullptr);
+        K nKey = convert_from_jni(_env, jKey, TypeId<K>{});
 
         auto jValue = call_java_method<jobject>(_env, jEntry, getValueMethodId);
-        auto nValue = {{resolveName "mangled"}}_convert_from_jni(_env, jValue, ({{resolveName "C++ FQN"}}*)nullptr);
+        auto nValue = {{resolveName "mangled"}}_convert_from_jni(_env, jValue, TypeId<{{resolveName "C++ FQN"}}>{});
 
         _nresult.emplace(std::move(nKey), std::move(nValue));
     }
@@ -97,10 +97,10 @@ template<typename K, typename Hash>
 std::optional<std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>>
 {{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& _jMap,
-                 std::optional<std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>>*)
+                 TypeId<std::optional<std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>>>)
 {
     return _jMap
         ? std::optional<std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>>(
-            {{resolveName "mangled"}}_convert_from_jni(_env, _jMap, (std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>*)nullptr)
+            {{resolveName "mangled"}}_convert_from_jni(_env, _jMap, TypeId<std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>>{})
         ) : std::optional<std::unordered_map<K, {{resolveName "C++ FQN"}}, Hash>>{};
 }

--- a/gluecodium/src/main/resources/templates/jni/LambdaOverloadedConversionImpl.mustache
+++ b/gluecodium/src/main/resources/templates/jni/LambdaOverloadedConversionImpl.mustache
@@ -19,9 +19,9 @@
   !
   !}}
 std::optional<{{resolveName "C++ FQN"}}>
-{{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::optional<{{resolveName "C++ FQN"}}>*) {
+{{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<{{resolveName "C++ FQN"}}>>) {
     return _jobj
-        ? std::optional<{{resolveName "C++ FQN"}}>({{resolveName "mangled"}}_convert_from_jni(_env, _jobj, ({{resolveName "C++ FQN"}}*)nullptr))
+        ? std::optional<{{resolveName "C++ FQN"}}>({{resolveName "mangled"}}_convert_from_jni(_env, _jobj, TypeId<{{resolveName "C++ FQN"}}>{}))
         : std::optional<{{resolveName "C++ FQN"}}>{};
 }
 
@@ -50,7 +50,7 @@ JniReference<jobject>
 }
 
 std::vector<{{resolveName "C++ FQN"}}>
-{{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::vector<{{resolveName "C++ FQN"}}>*) {
+{{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<{{resolveName "C++ FQN"}}>>) {
     std::vector<{{resolveName "C++ FQN"}}> _nresult{};
     if (_env->IsSameObject(_arrayList.get(), nullptr)) {
         return _nresult;
@@ -64,15 +64,15 @@ std::vector<{{resolveName "C++ FQN"}}>
     auto getMethodId = _env->GetMethodID(javaArrayListClass.get(), "get", "(I)Ljava/lang/Object;");
     for (jint i = 0; i < length; i++) {
         auto javaListItem = call_java_method<jobject>(_env, _arrayList, getMethodId, i);
-        _nresult.push_back({{resolveName "mangled"}}_convert_from_jni(_env, javaListItem, ({{resolveName "C++ FQN"}}*)nullptr));
+        _nresult.push_back({{resolveName "mangled"}}_convert_from_jni(_env, javaListItem, TypeId<{{resolveName "C++ FQN"}}>{}));
     }
 
     return _nresult;
 }
 
 std::optional<std::vector<{{resolveName "C++ FQN"}}>>
-{{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::optional<std::vector<{{resolveName "C++ FQN"}}>>*) {
+{{resolveName "mangled"}}_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<{{resolveName "C++ FQN"}}>>>) {
     return _arrayList
-        ? std::optional<std::vector<{{resolveName "C++ FQN"}}>>({{resolveName "mangled"}}_convert_from_jni(_env, _arrayList, (std::vector<{{resolveName "C++ FQN"}}>*)nullptr))
+        ? std::optional<std::vector<{{resolveName "C++ FQN"}}>>({{resolveName "mangled"}}_convert_from_jni(_env, _arrayList, TypeId<std::vector<{{resolveName "C++ FQN"}}>>{}))
         : std::optional<std::vector<{{resolveName "C++ FQN"}}>>{};
 }

--- a/gluecodium/src/main/resources/templates/jni/StructConversionHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionHeader.mustache
@@ -26,6 +26,7 @@
 {{>common/Include}}
 {{/includes}}
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
 
 {{#internalNamespace}}
@@ -35,9 +36,9 @@ namespace {{.}}
 namespace jni
 {
 {{#struct}}
-JNIEXPORT {{resolveName "C++ FQN"}} convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, {{resolveName "C++ FQN"}}*);
+JNIEXPORT {{resolveName "C++ FQN"}} convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<{{resolveName "C++ FQN"}}>);
 JNIEXPORT std::optional<{{resolveName "C++ FQN"}}> convert_from_jni({{!!
-}}JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<{{resolveName "C++ FQN"}}>*);
+}}JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<{{resolveName "C++ FQN"}}>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput);
 {{#if external.java.converter constructors}}
 JNIEXPORT JniReference<jobject> convert_to_jni_internal(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput);

--- a/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
@@ -41,7 +41,7 @@ namespace jni
 
 {{resolveName "C++ FQN"}}
 convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
-}}{{#if external.java.converter}}_ext{{/if}}, {{resolveName "C++ FQN"}}*)
+}}{{#if external.java.converter}}_ext{{/if}}, TypeId<{{resolveName "C++ FQN"}}>)
 {
 {{#if external.java.converter}}
 {{prefixPartial "jni/ExternalConversionFromJni" "    "}}
@@ -50,7 +50,7 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
 {{#fields}}{{#ifPredicate "shouldRetain"}}{{#if external.java.getterName}}{{#unlessPredicate typeRef "isJniPrimitive"}}
     auto j_{{resolveName "C++"}} = call_java_method<{{resolveName typeRef}}>(_jenv, _jinput, {{!!
     }}"{{external.java.getterName}}", "(){{resolveName typeRef "signature"}}");
-    auto n_{{resolveName "C++"}} = {{>jni/JniConversionPrefix}}convert_from_jni(_jenv, j_{{resolveName "C++"}}, ({{resolveName typeRef "C++"}}*)nullptr);
+    auto n_{{resolveName "C++"}} = {{>jni/JniConversionPrefix}}convert_from_jni(_jenv, j_{{resolveName "C++"}}, TypeId<{{resolveName typeRef "C++"}}>{});
 {{/unlessPredicate}}{{#ifPredicate typeRef "isJniPrimitive"}}
     auto n_{{resolveName "C++"}} = call_java_method<{{resolveName typeRef}}>(_jenv, _jinput, {{!!
     }}"{{external.java.getterName}}", "(){{resolveName typeRef "signature"}}");
@@ -65,14 +65,14 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
         _jenv,
         {{>common/InternalNamespace}}jni::get_object_field_value({{!!
         }}_jenv, _jinput, "{{resolveName}}", "L{{resolveName typeRef.type.actualType}};"),
-        ({{resolveName typeRef "C++"}}*)nullptr );
+        TypeId<{{resolveName typeRef "C++"}}>{} );
 {{/unless}}
 {{/notInstanceOf}}{{#instanceOf typeRef.type.actualType "LimeBasicType"}}
     {{resolveName typeRef "C++"}} n_{{resolveName "C++"}} = {{>common/InternalNamespace}}jni::get_field_value(
         _jenv,
         _jinput,
         "{{resolveName}}",
-        ({{resolveName typeRef "C++"}}*)nullptr );
+        TypeId<{{resolveName typeRef "C++"}}>{} );
 {{/instanceOf}}{{/unless}}
     {{#unlessPredicate struct "hasImmutableFields"}}_nout.{{!!
     }}{{#ifPredicate "hasCppSetter"}}{{resolveName this "C++" "setter"}}(n_{{resolveName this "C++"}}){{/ifPredicate}}{{!!
@@ -87,10 +87,10 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
 }
 
 std::optional<{{resolveName "C++ FQN"}}>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<{{resolveName "C++ FQN"}}>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<{{resolveName "C++ FQN"}}>>)
 {
     return _jinput
-        ? std::optional<{{resolveName "C++ FQN"}}>(convert_from_jni(_jenv, _jinput, ({{resolveName "C++ FQN"}}*)nullptr))
+        ? std::optional<{{resolveName "C++ FQN"}}>(convert_from_jni(_jenv, _jinput, TypeId<{{resolveName "C++ FQN"}}>{}))
         : std::optional<{{resolveName "C++ FQN"}}>{};
 }
 

--- a/gluecodium/src/main/resources/templates/jni/utils/ArrayConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/ArrayConversionUtilsHeader.mustache
@@ -28,6 +28,7 @@
 #include "JniClassCache.h"
 #include "JniCppConversionUtils.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 
 #include <memory>
 #include <optional>
@@ -46,13 +47,13 @@ namespace jni
 
 template < typename K, typename V, typename Hash >
 std::unordered_map< K, V, Hash >
-convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _jMap, std::unordered_map< K, V, Hash >* );
+convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _jMap, TypeId<std::unordered_map< K, V, Hash>> );
 
 template<typename K, typename V, typename Hash>
 std::optional<std::unordered_map<K, V, Hash>>
 convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& _jMap,
-                 std::optional<std::unordered_map<K, V, Hash>>*);
+                 TypeId<std::optional<std::unordered_map<K, V, Hash>>>);
 
 template < typename K, typename V, typename Hash >
 JniReference<jobject>
@@ -78,13 +79,13 @@ convert_to_jni(JNIEnv* _env, const std::optional<std::unordered_set<T, Hash>>& _
 
 template <typename T, typename Hash>
 std::unordered_set<T, Hash>
-convert_from_jni( JNIEnv* _env, const JniReference<jobject>& jSet, std::unordered_set<T, Hash>* );
+convert_from_jni( JNIEnv* _env, const JniReference<jobject>& jSet, TypeId<std::unordered_set<T, Hash>> );
 
 template<typename T, typename Hash>
 std::optional<std::unordered_set<T, Hash>>
 convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& jSet,
-                 std::optional<std::unordered_set<T, Hash>>*);
+                 TypeId<std::optional<std::unordered_set<T, Hash>>>);
 
 // Templated functions to create ArrayLists from C++ vectors and vice versa
 
@@ -114,7 +115,7 @@ convert_to_jni(JNIEnv* _env, const std::optional<std::vector<T>>& _ninput)
 
 template < typename T >
 std::vector< T >
-convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _arrayList, std::vector< T >* )
+convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector< T >> )
 {
     std::vector< T > _nresult{};
 
@@ -132,7 +133,7 @@ convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _arrayList, std::ve
     for ( jint i = 0; i < length; i++ )
     {
         auto javaListItem = call_java_method<jobject>( _env, _arrayList, getMethodId, i );
-        _nresult.push_back( convert_from_jni( _env, javaListItem, (T*)nullptr ) );
+        _nresult.push_back( convert_from_jni( _env, javaListItem, TypeId<T>{} ) );
     }
 
     return _nresult;
@@ -142,10 +143,10 @@ template<typename T>
 std::optional<std::vector<T>>
 convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& _arrayList,
-                 std::optional<std::vector<T>>*)
+                 TypeId<std::optional<std::vector<T>>>)
 {
     return _arrayList
-        ? std::optional<std::vector<T>>(convert_from_jni(_env, _arrayList, (std::vector<T>*)nullptr))
+        ? std::optional<std::vector<T>>(convert_from_jni(_env, _arrayList, TypeId<std::vector<T>>{}))
         : std::optional<std::vector<T>>{};
 }
 
@@ -188,7 +189,7 @@ convert_to_jni(JNIEnv* _env, const std::optional<std::unordered_map<K, V, Hash>>
 
 template < typename K, typename V, typename Hash >
 ::std::unordered_map< K, V, Hash >
-convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _jMap, ::std::unordered_map< K, V, Hash >* )
+convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _jMap, TypeId<::std::unordered_map< K, V, Hash >> )
 {
     ::std::unordered_map< K, V, Hash > _nresult{};
 
@@ -218,10 +219,10 @@ convert_from_jni( JNIEnv* _env, const JniReference<jobject>& _jMap, ::std::unord
     {
         auto jEntry = call_java_method<jobject>( _env, jIterator, nextMethodId );
         auto jKey = call_java_method<jobject>( _env, jEntry, getKeyMethodId );
-        K nKey = convert_from_jni( _env, jKey, (K*)nullptr );
+        K nKey = convert_from_jni( _env, jKey, TypeId<K>{} );
 
         auto jValue = call_java_method<jobject>( _env, jEntry, getValueMethodId );
-        V nValue = convert_from_jni( _env, jValue, (V*)nullptr );
+        V nValue = convert_from_jni( _env, jValue, TypeId<V>{} );
 
         _nresult.emplace( std::move( nKey ), std::move( nValue ) );
     }
@@ -233,10 +234,10 @@ template<typename K, typename V, typename Hash>
 std::optional<std::unordered_map<K, V, Hash>>
 convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& _jMap,
-                 std::optional<std::unordered_map<K, V, Hash>>*)
+                 TypeId<std::optional<std::unordered_map<K, V, Hash>>>)
 {
     return _jMap
-        ? std::optional<std::unordered_map<K, V, Hash>>(convert_from_jni(_env, _jMap, (std::unordered_map<K, V, Hash>*)nullptr))
+        ? std::optional<std::unordered_map<K, V, Hash>>(convert_from_jni(_env, _jMap, TypeId<std::unordered_map<K, V, Hash>>{}))
         : std::optional<std::unordered_map<K, V, Hash>>{};
 }
 
@@ -289,7 +290,7 @@ convert_to_jni(JNIEnv* _env, const std::optional<std::unordered_set<T, Hash>>& _
 
 template <typename T, typename Hash >
 std::unordered_set<T, Hash>
-convert_from_jni( JNIEnv* _env, const JniReference<jobject>& jSet, std::unordered_set<T, Hash>* )
+convert_from_jni( JNIEnv* _env, const JniReference<jobject>& jSet, TypeId<std::unordered_set<T, Hash>> )
 {
     std::unordered_set<T, Hash> _nresult{};
 
@@ -309,7 +310,7 @@ convert_from_jni( JNIEnv* _env, const JniReference<jobject>& jSet, std::unordere
     while (call_java_method<jboolean>(_env, jIterator, hasNextMethodId))
     {
         auto jElement = call_java_method<jobject>(_env, jIterator, nextMethodId);
-        T nElement = convert_from_jni(_env, jElement, (T*)nullptr);
+        T nElement = convert_from_jni(_env, jElement, TypeId<T>{});
         _nresult.insert(std::move(nElement));
     }
 
@@ -320,10 +321,10 @@ template<typename T, typename Hash>
 std::optional<std::unordered_set<T, Hash>>
 convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& jSet,
-                 std::optional<std::unordered_set<T, Hash>>*)
+                 TypeId<std::optional<std::unordered_set<T, Hash>>>)
 {
     return jSet
-        ? std::optional<std::unordered_set<T, Hash>>(convert_from_jni(_env, jSet, (std::unordered_set<T, Hash>*)nullptr))
+        ? std::optional<std::unordered_set<T, Hash>>(convert_from_jni(_env, jSet, TypeId<std::unordered_set<T, Hash>>{}))
         : std::optional<std::unordered_set<T, Hash>>{};
 }
 

--- a/gluecodium/src/main/resources/templates/jni/utils/BoxingConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/BoxingConversionUtilsHeader.mustache
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "JniReference.h"
+#include "JniTypeId.h"
 
 #include <jni.h>
 #include <optional>
@@ -49,17 +50,17 @@ JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint64_t nval
 
 // The following functions are unboxing and converting primitive values from Java boxed types.
 
-JNIEXPORT bool convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* );
-JNIEXPORT double convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* );
-JNIEXPORT float convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* );
-JNIEXPORT int8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* );
-JNIEXPORT int16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* );
-JNIEXPORT int32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int32_t* );
-JNIEXPORT int64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int64_t* );
-JNIEXPORT uint8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint8_t* );
-JNIEXPORT uint16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint16_t* );
-JNIEXPORT uint32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint32_t* );
-JNIEXPORT uint64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint64_t* );
+JNIEXPORT bool convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<bool> );
+JNIEXPORT double convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<double> );
+JNIEXPORT float convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<float> );
+JNIEXPORT int8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int8_t> );
+JNIEXPORT int16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int16_t> );
+JNIEXPORT int32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int32_t> );
+JNIEXPORT int64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int64_t> );
+JNIEXPORT uint8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint8_t> );
+JNIEXPORT uint16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint16_t> );
+JNIEXPORT uint32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint32_t> );
+JNIEXPORT uint64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint64_t> );
 
 // Boxing/unboxing conversion functions for nullable types
 
@@ -76,27 +77,27 @@ JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<uint3
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<uint64_t> nvalue );
 
 JNIEXPORT std::optional<bool> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<bool>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<bool>> );
 JNIEXPORT std::optional<float> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<float>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<float>> );
 JNIEXPORT std::optional<double> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<double>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<double>> );
 JNIEXPORT std::optional<int8_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int8_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int8_t>> );
 JNIEXPORT std::optional<int16_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int16_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int16_t>> );
 JNIEXPORT std::optional<int32_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int32_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int32_t>> );
 JNIEXPORT std::optional<int64_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int64_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int64_t>> );
 JNIEXPORT std::optional<uint8_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint8_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint8_t>> );
 JNIEXPORT std::optional<uint16_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint16_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint16_t>> );
 JNIEXPORT std::optional<uint32_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint32_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint32_t>> );
 JNIEXPORT std::optional<uint64_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint64_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint64_t>> );
 
 }
 {{#internalNamespace}}

--- a/gluecodium/src/main/resources/templates/jni/utils/BoxingConversionUtilsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/BoxingConversionUtilsImplementation.mustache
@@ -161,7 +161,7 @@ convert_to_jni( JNIEnv* env, const uint64_t nvalue )
 }
 
 bool
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<bool> )
 {
     auto javaBooleanClass = find_class( env, "java/lang/Boolean" );
     auto booleanValueMethodId = env->GetMethodID( javaBooleanClass.get(), "booleanValue", "()Z" );
@@ -169,7 +169,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* )
 }
 
 double
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<double> )
 {
     auto javaDoubleClass = find_class( env, "java/lang/Double" );
     auto doubleValueMethodId = env->GetMethodID( javaDoubleClass.get(), "doubleValue", "()D" );
@@ -177,7 +177,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* )
 }
 
 float
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<float> )
 {
     auto javaFloatClass = find_class( env, "java/lang/Float" );
     auto floatValueMethodId = env->GetMethodID( javaFloatClass.get(), "floatValue", "()F" );
@@ -185,7 +185,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* )
 }
 
 int8_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int8_t> )
 {
     auto javaByteClass = find_class( env, "java/lang/Byte" );
     auto byteValueMethodId = env->GetMethodID( javaByteClass.get(), "byteValue", "()B" );
@@ -193,7 +193,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* )
 }
 
 int16_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int16_t> )
 {
     auto javaShortClass = find_class(env, "java/lang/Short" );
     auto shortValueMethodId = env->GetMethodID( javaShortClass.get(), "shortValue", "()S" );
@@ -201,37 +201,37 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* )
 }
 
 int32_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int32_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int32_t> )
 {
     return unbox_int_value( env, jvalue );
 }
 
 int64_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int64_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int64_t> )
 {
     return unbox_long_value( env, jvalue );
 }
 
 uint8_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint8_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint8_t> )
 {
     return unbox_short_value( env, jvalue );
 }
 
 uint16_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint16_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint16_t> )
 {
     return unbox_int_value( env, jvalue );
 }
 
 uint32_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint32_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint32_t> )
 {
     return unbox_long_value( env, jvalue );
 }
 
 uint64_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint64_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint64_t> )
 {
     return unbox_long_value( env, jvalue );
 }
@@ -304,7 +304,7 @@ convert_to_jni( JNIEnv* env, std::optional<uint64_t> nvalue )
 
 std::optional<bool>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<bool>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<bool>> )
 {
     if ( !jvalue )
     {
@@ -316,7 +316,7 @@ convert_from_jni(
 
 std::optional<float>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<float>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<float>> )
 {
     if ( !jvalue )
     {
@@ -328,7 +328,7 @@ convert_from_jni(
 
 std::optional<double>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<double>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<double>> )
 {
     if ( !jvalue )
     {
@@ -340,7 +340,7 @@ convert_from_jni(
 
 std::optional<int8_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int8_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int8_t>> )
 {
     if ( !jvalue )
     {
@@ -352,7 +352,7 @@ convert_from_jni(
 
 std::optional<int16_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int16_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int16_t>> )
 {
     if ( !jvalue )
     {
@@ -364,7 +364,7 @@ convert_from_jni(
 
 std::optional<int32_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int32_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int32_t>> )
 {
     if ( !jvalue )
     {
@@ -376,7 +376,7 @@ convert_from_jni(
 
 std::optional<int64_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int64_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int64_t>> )
 {
     if ( !jvalue )
     {
@@ -388,7 +388,7 @@ convert_from_jni(
 
 std::optional<uint8_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint8_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint8_t>> )
 {
     if ( !jvalue )
     {
@@ -400,7 +400,7 @@ convert_from_jni(
 
 std::optional<uint16_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint16_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint16_t>> )
 {
     if ( !jvalue )
     {
@@ -412,7 +412,7 @@ convert_from_jni(
 
 std::optional<uint32_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint32_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint32_t>> )
 {
     if ( !jvalue )
     {
@@ -424,7 +424,7 @@ convert_from_jni(
 
 std::optional<uint64_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint64_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint64_t>> )
 {
     if ( !jvalue )
     {

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsHeader.mustache
@@ -26,6 +26,7 @@
 
 #include "JniCppConversionUtils.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include "{{>common/InternalInclude}}Locale.h"
 
 #include <chrono>
@@ -49,110 +50,110 @@ JNIEXPORT JniReference< jobject > get_object_field_value( JNIEnv* env,
                                        const char* fieldSignature );
 
 JNIEXPORT bool get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, bool* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<bool> );
 JNIEXPORT int8_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, int8_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<int8_t> );
 JNIEXPORT int16_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, int16_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<int16_t> );
 JNIEXPORT int32_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, int32_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<int32_t> );
 JNIEXPORT int64_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, int64_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<int64_t> );
 JNIEXPORT uint8_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, uint8_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<uint8_t> );
 JNIEXPORT uint16_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, uint16_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<uint16_t> );
 JNIEXPORT uint32_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, uint32_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<uint32_t> );
 JNIEXPORT uint64_t get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, uint64_t* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<uint64_t> );
 JNIEXPORT float get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, float* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<float> );
 JNIEXPORT double get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, double* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<double> );
 JNIEXPORT ::std::string get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, ::std::string* );
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<::std::string> );
 
 JNIEXPORT std::optional< bool > get_field_value( JNIEnv* env,
                                            const JniReference< jobject >& object,
                                            const char* fieldName,
-                                           std::optional< bool >* );
+                                           TypeId<std::optional< bool >> );
 JNIEXPORT std::optional< int8_t > get_field_value( JNIEnv* env,
                                              const JniReference< jobject >& object,
                                              const char* fieldName,
-                                             std::optional< int8_t >* );
+                                             TypeId<std::optional< int8_t >> );
 JNIEXPORT std::optional< int16_t > get_field_value( JNIEnv* env,
                                               const JniReference< jobject >& object,
                                               const char* fieldName,
-                                              std::optional< int16_t >* );
+                                              TypeId<std::optional< int16_t >> );
 JNIEXPORT std::optional< int32_t > get_field_value( JNIEnv* env,
                                               const JniReference< jobject >& object,
                                               const char* fieldName,
-                                              std::optional< int32_t >* );
+                                              TypeId<std::optional< int32_t >> );
 JNIEXPORT std::optional< int64_t > get_field_value( JNIEnv* env,
                                               const JniReference< jobject >& object,
                                               const char* fieldName,
-                                              std::optional< int64_t >* );
+                                              TypeId<std::optional< int64_t >> );
 JNIEXPORT std::optional< uint8_t > get_field_value( JNIEnv* env,
                                               const JniReference< jobject >& object,
                                               const char* fieldName,
-                                              std::optional< uint8_t >* );
+                                              TypeId<std::optional< uint8_t >> );
 JNIEXPORT std::optional< uint16_t > get_field_value( JNIEnv* env,
                                                const JniReference< jobject >& object,
                                                const char* fieldName,
-                                               std::optional< uint16_t >* );
+                                               TypeId<std::optional< uint16_t >> );
 JNIEXPORT std::optional< uint32_t > get_field_value( JNIEnv* env,
                                                const JniReference< jobject >& object,
                                                const char* fieldName,
-                                               std::optional< uint32_t >* );
+                                               TypeId<std::optional< uint32_t >> );
 JNIEXPORT std::optional< uint64_t > get_field_value( JNIEnv* env,
                                                const JniReference< jobject >& object,
                                                const char* fieldName,
-                                               std::optional< uint64_t >* );
+                                               TypeId<std::optional< uint64_t >> );
 JNIEXPORT std::optional< float > get_field_value( JNIEnv* env,
                                             const JniReference< jobject >& object,
                                             const char* fieldName,
-                                            std::optional< float >* );
+                                            TypeId<std::optional< float >> );
 JNIEXPORT std::optional< double > get_field_value( JNIEnv* env,
                                              const JniReference< jobject >& object,
                                              const char* fieldName,
-                                             std::optional< double >* );
+                                             TypeId<std::optional< double >> );
 JNIEXPORT std::optional< ::std::string > get_field_value( JNIEnv* env,
                                                     const JniReference< jobject >& object,
                                                     const char* fieldName,
-                                                    std::optional< ::std::string >* );
+                                                    TypeId<std::optional< ::std::string >> );
 
 JNIEXPORT ::std::shared_ptr< ::std::vector< uint8_t > > get_field_value(
     JNIEnv* env,
     const JniReference< jobject >& object,
     const char* fieldName,
-    ::std::shared_ptr< ::std::vector< uint8_t > >* );
+    TypeId<::std::shared_ptr< ::std::vector< uint8_t > >> );
 JNIEXPORT std::optional< ::std::shared_ptr< ::std::vector< uint8_t > > > get_field_value(
     JNIEnv* env,
     const JniReference< jobject >& object,
     const char* fieldName,
-    std::optional< ::std::shared_ptr< ::std::vector< uint8_t > > >* );
+    TypeId<std::optional< ::std::shared_ptr< ::std::vector< uint8_t > > >> );
 
 template<class Clock, class Duration>
 std::chrono::time_point<Clock, Duration>
 get_field_value(
-    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, std::chrono::time_point<Clock, Duration>*
+    JNIEnv* env, const JniReference<jobject>& object, const char* fieldName, TypeId<std::chrono::time_point<Clock, Duration>>
 ) {
     auto fieldValue = get_object_field_value(env, object, fieldName, "Ljava/util/Date;");
 
-    return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(env, fieldValue, (std::chrono::time_point<Clock, Duration>*)nullptr);
+    return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(env, fieldValue, TypeId<std::chrono::time_point<Clock, Duration>>{});
 }
 
 template<class Clock, class Duration>
 std::optional<std::chrono::time_point<Clock, Duration>>
 get_field_value(
     JNIEnv* env, const JniReference<jobject >& object, const char* fieldName,
-    std::optional<std::chrono::time_point<Clock, Duration>>*
+    TypeId<std::optional<std::chrono::time_point<Clock, Duration>>>
 ) {
     auto fieldValue = get_object_field_value(env, object, fieldName, "Ljava/util/Date;");
 
     return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(
-        env, fieldValue, (std::optional<std::chrono::time_point<Clock, Duration>>*)nullptr
+        env, fieldValue, TypeId<std::optional<std::chrono::time_point<Clock, Duration>>>{}
     );
 }
 
@@ -160,12 +161,12 @@ JNIEXPORT {{>common/InternalNamespace}}Locale get_field_value(
     JNIEnv* env,
     const JniReference< jobject >& object,
     const char* fieldName,
-    {{>common/InternalNamespace}}Locale* );
+    TypeId<{{>common/InternalNamespace}}Locale> );
 JNIEXPORT std::optional< {{>common/InternalNamespace}}Locale > get_field_value(
     JNIEnv* env,
     const JniReference< jobject >& object,
     const char* fieldName,
-    std::optional< {{>common/InternalNamespace}}Locale >* );
+    TypeId<std::optional< {{>common/InternalNamespace}}Locale >> );
 
 // -------------------- JNI object field setters --------------------------------------------------
 
@@ -303,11 +304,11 @@ JNIEXPORT ::std::chrono::duration<Rep, Period> get_field_value(
     JNIEnv* env,
     const JniReference<jobject>& object,
     const char* fieldName,
-    ::std::chrono::duration<Rep, Period>* ) {
+    TypeId<::std::chrono::duration<Rep, Period>> ) {
 
     auto fieldValue = get_object_field_value(env, object, fieldName, "L{{durationPackage}}/Duration;");
 
-    return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(env, fieldValue, (::std::chrono::duration<Rep, Period>*)nullptr);
+    return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(env, fieldValue, TypeId<::std::chrono::duration<Rep, Period>>{});
 }
 
 template<class Rep, class Period>
@@ -315,12 +316,12 @@ JNIEXPORT std::optional<::std::chrono::duration<Rep, Period>> get_field_value(
     JNIEnv* env,
     const JniReference<jobject>& object,
     const char* fieldName,
-    std::optional<::std::chrono::duration<Rep, Period>>* ) {
+    TypeId<std::optional<::std::chrono::duration<Rep, Period>>> ) {
 
     auto fieldValue = get_object_field_value(env, object, fieldName, "L{{durationPackage}}/Duration;");
 
     return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(
-        env, fieldValue, (std::optional<::std::chrono::duration<Rep, Period>>*)nullptr);
+        env, fieldValue, TypeId<::std::chrono::duration<Rep, Period>>{});
 }
 
 template<class Rep, class Period>

--- a/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/FieldAccessMethodsImplementation.mustache
@@ -37,7 +37,7 @@ bool
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 bool* )
+                 TypeId<bool> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "Z" );
 
@@ -48,7 +48,7 @@ int8_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 int8_t* )
+                 TypeId<int8_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "B" );
 
@@ -59,7 +59,7 @@ int16_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 int16_t* )
+                 TypeId<int16_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "S" );
 
@@ -70,7 +70,7 @@ int32_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 int32_t* )
+                 TypeId<int32_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "I" );
 
@@ -81,7 +81,7 @@ int64_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 int64_t* )
+                 TypeId<int64_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "J" );
 
@@ -92,7 +92,7 @@ uint8_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 uint8_t* )
+                 TypeId<uint8_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "S" );
 
@@ -103,7 +103,7 @@ uint16_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 uint16_t* )
+                 TypeId<uint16_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "I" );
 
@@ -114,7 +114,7 @@ uint32_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 uint32_t* )
+                 TypeId<uint32_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "J" );
 
@@ -125,7 +125,7 @@ uint64_t
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 uint64_t* )
+                 TypeId<uint64_t> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "J" );
 
@@ -136,7 +136,7 @@ float
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 float* )
+                 TypeId<float> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "F" );
 
@@ -147,7 +147,7 @@ double
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 double* )
+                 TypeId<double> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "D" );
 
@@ -158,191 +158,191 @@ std::string
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::string* )
+                 TypeId<std::string> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/String;" );
 
-    return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni( env, fieldValue, (std::string*)nullptr );
+    return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(env, fieldValue, TypeId<std::string>{});
 }
 
 std::optional<bool>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<bool>* )
+                 TypeId<std::optional<bool>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Boolean;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<bool>*)nullptr );
+    return convert_from_jni(env, fieldValue, TypeId<std::optional<bool>>{});
 }
 
 std::optional<int8_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<int8_t>* )
+                 TypeId<std::optional<int8_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Byte;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<int8_t>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<int8_t>>{} );
 }
 
 std::optional<int16_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<int16_t>* )
+                 TypeId<std::optional<int16_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Short;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<int16_t>*)nullptr );
+    return convert_from_jni(env, fieldValue, TypeId<std::optional<int16_t>>{});
 }
 
 std::optional<int32_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<int32_t>* )
+                 TypeId<std::optional<int32_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Integer;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<int32_t>*)nullptr );
+    return convert_from_jni(env, fieldValue, TypeId<std::optional<int32_t>>{});
 }
 
 std::optional<int64_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<int64_t>* )
+                 TypeId<std::optional<int64_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Long;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<int64_t>*)nullptr );
+    return convert_from_jni(env, fieldValue, TypeId<std::optional<int64_t>>{});
 }
 
 std::optional<uint8_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<uint8_t>* )
+                 TypeId<std::optional<uint8_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Short;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<uint8_t>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<uint8_t>>{});
 }
 
 std::optional<uint16_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<uint16_t>* )
+                 TypeId<std::optional<uint16_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Integer;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<uint16_t>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<uint16_t>>{});
 }
 
 std::optional<uint32_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<uint32_t>* )
+                 TypeId<std::optional<uint32_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Long;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<uint32_t>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<uint32_t>>{});
 }
 
 std::optional<uint64_t>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<uint64_t>* )
+                 TypeId<std::optional<uint64_t>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Long;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<uint64_t>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<uint64_t>>{} );
 }
 
 std::optional<float>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<float>* )
+                 TypeId<std::optional<float>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Float;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<float>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<float>>{} );
 }
 
 std::optional<double>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<double>* )
+                 TypeId<std::optional<double>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/Double;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<double>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<double>>{} );
 }
 
 std::optional<std::string>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<std::string>* )
+                 TypeId<std::optional<std::string>> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/lang/String;" );
 
-    return convert_from_jni( env, fieldValue, (std::optional<std::string>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<std::string>>{} );
 }
 
 std::shared_ptr<std::vector<uint8_t>>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::shared_ptr<std::vector<uint8_t>>* )
+                 TypeId<std::shared_ptr<std::vector<uint8_t>>> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "[B" );
     auto fieldValue = make_local_ref( env, static_cast<jbyteArray>( env->GetObjectField( object.get(), fieldId ) ) );
 
-    return convert_from_jni( env, fieldValue, (std::shared_ptr<std::vector<uint8_t>>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::shared_ptr<std::vector<uint8_t>>>{} );
 }
 
 std::optional<std::shared_ptr<std::vector<uint8_t>>>
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional<std::shared_ptr<std::vector<uint8_t>>>* )
+                 TypeId<std::optional<std::shared_ptr<std::vector<uint8_t>>>> )
 {
     auto fieldId = env->GetFieldID( get_object_class(env, object).get(), fieldName, "[B" );
     auto fieldValue = make_local_ref( env, static_cast<jbyteArray>( env->GetObjectField( object.get(), fieldId ) ) );
 
-    return convert_from_jni( env, fieldValue, (std::optional<std::shared_ptr<std::vector<uint8_t>>>*)nullptr );
+    return convert_from_jni( env, fieldValue, TypeId<std::optional<std::shared_ptr<std::vector<uint8_t>>>>{} );
 }
 
 {{>common/InternalNamespace}}Locale
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 {{>common/InternalNamespace}}Locale* )
+                 TypeId<{{>common/InternalNamespace}}Locale> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/util/Locale;" );
 
     return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(
-        env, fieldValue, ({{>common/InternalNamespace}}Locale*)nullptr );
+        env, fieldValue, TypeId<{{>common/InternalNamespace}}Locale>{});
 }
 
 std::optional< {{>common/InternalNamespace}}Locale >
 get_field_value( JNIEnv* env,
                  const JniReference<jobject>& object,
                  const char* fieldName,
-                 std::optional< {{>common/InternalNamespace}}Locale >* )
+                 TypeId<std::optional< {{>common/InternalNamespace}}Locale >> )
 {
     auto fieldValue = get_object_field_value( env, object, fieldName, "Ljava/util/Locale;" );
 
     return {{>common/InternalNamespace}}jni::{{>jni/JniConversionPrefix}}convert_from_jni(
-        env, fieldValue, (std::optional< {{>common/InternalNamespace}}Locale >*)nullptr );
+        env, fieldValue, TypeId<std::optional<{{>common/InternalNamespace}}Locale>>{});
 }
 
 JniReference<jobject>

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCallbackErrorCheckingImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCallbackErrorCheckingImplementation.mustache
@@ -47,7 +47,7 @@ void checkExceptionAndReportIfAny(JNIEnv* env)
     std::string errorMessage = "REASON: ";
 
     auto exceptionToString = call_java_method<jstring>(env, exception, "toString", "()Ljava/lang/String;");
-    errorMessage += convert_from_jni(env, exceptionToString, (std::string*) nullptr);
+    errorMessage += convert_from_jni(env, exceptionToString, TypeId<std::string>{});
 
     auto frames = call_java_method<jobjectArray>(env, exception, "getStackTrace", "()[Ljava/lang/StackTraceElement;");
     auto framesLength = static_cast<size_t>(env->GetArrayLength(frames.get()));
@@ -59,7 +59,7 @@ void checkExceptionAndReportIfAny(JNIEnv* env)
     for (auto i = 0; i < framesLength; ++i) {
         auto stackFrame = make_local_ref(env, env->GetObjectArrayElement(frames.get(), i));
         auto stackFrameToString = call_java_method<jstring>(env, stackFrame.get(), "toString", "()Ljava/lang/String;");
-        const auto functionCallStackLine = convert_from_jni(env, stackFrameToString, (std::string*) nullptr);
+        const auto functionCallStackLine = convert_from_jni(env, stackFrameToString, TypeId<std::string>{});
 
         // This is done so that all stack frame messages will be on same line with actual exception message.
         if (i == 0) {

--- a/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheHeader.mustache
@@ -32,8 +32,6 @@ namespace {{.}}
 namespace jni
 {
 
-using TypeId = std::string_view;
-
 class JNIEXPORT CachedJavaClassBase
 {
 public:
@@ -44,7 +42,7 @@ public:
     static void init(JNIEnv* env);
 
 protected:
-    static jni::JniReference<jclass>* get_java_class_for_instance(const TypeId& id);
+    static jni::JniReference<jclass>* get_java_class_for_instance(const std::string_view& id);
 
 private:
     void do_init(JNIEnv* env);
@@ -59,7 +57,7 @@ class CachedJavaClass : public CachedJavaClassBase
 {
 public:
     using CachedJavaClassBase::CachedJavaClassBase;
-    static const jni::JniReference<jclass>& get_java_class(const TypeId& id)
+    static const jni::JniReference<jclass>& get_java_class(const std::string_view& id)
     {
         auto instance_java_class = get_java_class_for_instance(id);
         return instance_java_class != nullptr ? *instance_java_class : java_class;

--- a/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheImplementation.mustache
@@ -41,9 +41,9 @@ std::list<{{>common/InternalNamespace}}jni::CachedJavaClassBase*>& get_registere
     return list;
 }
 
-std::unordered_map<TypeId, jni::JniReference<jclass>*>& get_instance_class_map()
+std::unordered_map<std::string_view, jni::JniReference<jclass>*>& get_instance_class_map()
 {
-    static std::unordered_map<TypeId, jni::JniReference<jclass>*> classes;
+    static std::unordered_map<std::string_view, jni::JniReference<jclass>*> classes;
     return classes;
 }
 
@@ -72,7 +72,7 @@ CachedJavaClassBase::CachedJavaClassBase(const char* name, const char* cpp_name)
 }
 
 jni::JniReference<jclass>*
-CachedJavaClassBase::get_java_class_for_instance(const TypeId& id) {
+CachedJavaClassBase::get_java_class_for_instance(const std::string_view& id) {
     const auto& classes = get_instance_class_map();
     const auto& found = classes.find(id);
     return found != classes.end() ? found->second : nullptr;

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
@@ -28,6 +28,7 @@
 #include "JniClassCache.h"
 #include "JniReference.h"
 #include "JniThrowNewException.h"
+#include "JniTypeId.h"
 #include "{{>common/InternalInclude}}Locale.h"
 
 #include <chrono>
@@ -51,28 +52,28 @@ namespace jni
 /**
  * Converts a JNI jstring to an std::string.
  */
-JNIEXPORT std::string convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, std::string* );
-JNIEXPORT std::string convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, std::string* );
+JNIEXPORT std::string convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::string> );
+JNIEXPORT std::string convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, TypeId<std::string> );
 JNIEXPORT std::optional<std::string> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<std::string>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<std::string>> );
 JNIEXPORT std::optional<std::string> convert_from_jni(
-    JNIEnv* env, const JniReference<jstring>& jvalue, std::optional<std::string>* );
+    JNIEnv* env, const JniReference<jstring>& jvalue, TypeId<std::optional<std::string>> );
 
 /**
  * Converts a jbyteArray to a byte buffer
  */
 JNIEXPORT std::shared_ptr< ::std::vector< uint8_t > > convert_from_jni(
-    JNIEnv* env, const JniReference<jbyteArray>& jvalue, std::shared_ptr< ::std::vector< uint8_t > >* );
-JNIEXPORT std::optional<std::shared_ptr< ::std::vector< uint8_t > > > convert_from_jni(
+    JNIEnv* env, const JniReference<jbyteArray>& jvalue, TypeId<std::shared_ptr<::std::vector<uint8_t>>> );
+JNIEXPORT std::optional<std::shared_ptr<::std::vector<uint8_t>>> convert_from_jni(
     JNIEnv* env, const JniReference<jbyteArray>& jvalue,
-    std::optional< std::shared_ptr< ::std::vector< uint8_t > > >* );
+    TypeId<std::optional<std::shared_ptr<::std::vector<uint8_t>>>> );
 
 /**
  * Converts a Java Date object to an std::chrono::time_point.
  */
 template<class Clock, class Duration>
 std::chrono::time_point<Clock, Duration>
-convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, std::chrono::time_point<Clock, Duration>*) {
+convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::chrono::time_point<Clock, Duration>>) {
     if (!jvalue)
     {
         {{>common/InternalNamespace}}jni::throw_new_null_pointer_exception(env);
@@ -92,11 +93,11 @@ std::optional<std::chrono::time_point<Clock, Duration>>
 convert_from_jni(
     JNIEnv* env,
     const JniReference<jobject>& jvalue,
-    std::optional<std::chrono::time_point<Clock, Duration>>*
+    TypeId<std::optional<std::chrono::time_point<Clock, Duration>>>
 ) {
     return jvalue
         ? std::optional<std::chrono::time_point<Clock, Duration>>(
-            convert_from_jni(env, jvalue, (std::chrono::time_point<Clock, Duration>*)nullptr)
+            convert_from_jni(env, jvalue, TypeId<std::chrono::time_point<Clock, Duration>>{})
         )
         : std::optional<std::chrono::time_point<Clock, Duration>>{};
 }
@@ -106,7 +107,7 @@ convert_from_jni(
  */
 template<class Rep, class Period>
 std::chrono::duration<Rep, Period>
-convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, std::chrono::duration<Rep, Period>*) {
+convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::chrono::duration<Rep, Period>>) {
     if (!jvalue) {
         {{>common/InternalNamespace}}jni::throw_new_null_pointer_exception(env);
         return {};
@@ -140,12 +141,12 @@ template<class Rep, class Period>
 std::optional<std::chrono::duration<Rep, Period>>
 convert_from_jni(
     JNIEnv* env, const JniReference<jobject>& jvalue,
-    std::optional<std::chrono::duration<Rep, Period>>*
+    TypeId<std::optional<std::chrono::duration<Rep, Period>>>
 ) {
 
     return jvalue
         ? std::optional<std::chrono::duration<Rep, Period>>(
-            convert_from_jni( env, jvalue, (std::chrono::duration<Rep, Period>*)nullptr))
+            convert_from_jni( env, jvalue, TypeId<std::chrono::duration<Rep, Period>>{}))
         : std::optional<std::chrono::duration<Rep, Period>>{};
 }
 
@@ -153,10 +154,10 @@ convert_from_jni(
  * Converts a Java Locale object to {{>common/InternalNamespace}}Locale.
  */
 JNIEXPORT {{>common/InternalNamespace}}Locale convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}Locale*);
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<{{>common/InternalNamespace}}Locale>);
 JNIEXPORT std::optional<{{>common/InternalNamespace}}Locale> convert_from_jni(
     JNIEnv* env, const JniReference<jobject>& jvalue,
-    std::optional<{{>common/InternalNamespace}}Locale>*);
+    TypeId<std::optional<{{>common/InternalNamespace}}Locale>>);
 
 // -------------------- C++ to JNI conversion functions --------------------------------------------
 
@@ -227,10 +228,10 @@ JNIEXPORT JniReference<jobject> convert_to_jni(
 
 template<class R, class... Args>
 std::optional<std::function<R(Args...)>>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<std::function<R(Args...)>>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<std::function<R(Args...)>>>)
 {
     return _jinput
-        ? convert_from_jni(_jenv, _jinput, (std::function<R(Args...)>*)nullptr)
+        ? convert_from_jni(_jenv, _jinput, TypeId<std::function<R(Args...)>>{})
         : std::optional<std::function<R(Args...)>>{};
 }
 

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsImplementation.mustache
@@ -42,7 +42,7 @@ convert_string_from_jni( JNIEnv* env, jstring java_string )
 }
 
 std::string
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, std::string* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::string> )
 {
     if ( !jvalue )
     {
@@ -54,7 +54,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, std::string*
 }
 
 std::string
-convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, std::string* )
+convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, TypeId<std::string> )
 {
     if ( !jvalue )
     {
@@ -66,7 +66,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, std::string*
 }
 
 std::optional<std::string>
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<std::string>* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<std::string>> )
 {
     return jvalue
         ? std::optional<std::string>( convert_string_from_jni( env, static_cast<jstring>( jvalue.get( ) ) ) )
@@ -74,7 +74,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, std::optiona
 }
 
 std::optional<std::string>
-convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, std::optional<std::string>* )
+convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, TypeId<std::optional<std::string>> )
 {
     return jvalue
         ? std::optional<std::string>( convert_string_from_jni( env, jvalue.get( ) ) )
@@ -83,7 +83,7 @@ convert_from_jni( JNIEnv* env, const JniReference<jstring>& jvalue, std::optiona
 
 std::shared_ptr< std::vector< uint8_t > >
 convert_from_jni( JNIEnv* env, const JniReference<jbyteArray>& jvalue,
-                  std::shared_ptr< std::vector< uint8_t > >* )
+                  TypeId<std::shared_ptr<std::vector<uint8_t>>> )
 {
     if ( !jvalue )
     {
@@ -101,16 +101,16 @@ convert_from_jni( JNIEnv* env, const JniReference<jbyteArray>& jvalue,
 std::optional< std::shared_ptr< std::vector< uint8_t > > >
 convert_from_jni( JNIEnv* env,
                   const JniReference<jbyteArray>& jvalue,
-                  std::optional< std::shared_ptr< std::vector< uint8_t > > >* )
+                  TypeId<std::optional<std::shared_ptr<std::vector<uint8_t>>>> )
 {
     return jvalue
         ? std::optional< std::shared_ptr< std::vector< uint8_t > > >(
-            convert_from_jni( env, jvalue, (std::shared_ptr< std::vector< uint8_t > >*)nullptr ) )
+            convert_from_jni( env, jvalue, TypeId<std::shared_ptr<std::vector<uint8_t>>>{} ) )
         : std::optional< std::shared_ptr< std::vector< uint8_t > > >{};
 }
 
 {{>common/InternalNamespace}}Locale
-convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/InternalNamespace}}Locale*) {
+convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<{{>common/InternalNamespace}}Locale>) {
     if (!jvalue) {
         {{>common/InternalNamespace}}jni::throw_new_null_pointer_exception(env);
         return {{>common/InternalNamespace}}Locale();
@@ -122,20 +122,20 @@ convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue, {{>common/Int
     auto languageTag = call_java_method<jstring>(env, jvalue, "toLanguageTag", "()Ljava/lang/String;");
 
     return {{>common/InternalNamespace}}Locale(
-        convert_from_jni(env, languageCode, (std::string*)nullptr),
-        convert_from_jni(env, countryCode, (std::string*)nullptr),
-        convert_from_jni(env, scriptCode, (std::string*)nullptr),
-        convert_from_jni(env, languageTag, (std::string*)nullptr)
+        convert_from_jni(env, languageCode, TypeId<std::string>{}),
+        convert_from_jni(env, countryCode, TypeId<std::string>{}),
+        convert_from_jni(env, scriptCode, TypeId<std::string>{}),
+        convert_from_jni(env, languageTag, TypeId<std::string>{})
     );
 }
 
 std::optional<{{>common/InternalNamespace}}Locale>
 convert_from_jni(JNIEnv* env, const JniReference<jobject>& jvalue,
-                 std::optional<{{>common/InternalNamespace}}Locale>*)
+                 TypeId<std::optional<{{>common/InternalNamespace}}Locale>>)
 {
     return jvalue
         ? std::optional<{{>common/InternalNamespace}}Locale>(
-            convert_from_jni(env, jvalue, ({{>common/InternalNamespace}}Locale*)nullptr))
+            convert_from_jni(env, jvalue, TypeId<{{>common/InternalNamespace}}Locale>{}))
         : std::optional<{{>common/InternalNamespace}}Locale>{};
 }
 

--- a/gluecodium/src/main/resources/templates/jni/utils/JniNativeHandleImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniNativeHandleImplementation.mustache
@@ -32,7 +32,7 @@ namespace jni
 
 std::int64_t get_class_native_handle(JNIEnv * const env, const JniReference<jobject>& jobj) noexcept
 {
-    return get_field_value(env, jobj, "nativeHandle", (int64_t*)nullptr);
+    return get_field_value(env, jobj, "nativeHandle", TypeId<int64_t>{});
 }
 
 std::int64_t get_class_native_handle(JNIEnv * const env, const jobject jobj) noexcept

--- a/gluecodium/src/main/resources/templates/jni/utils/JniTypeIdHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniTypeIdHeader.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -22,26 +22,17 @@
 
 #pragma once
 
-{{#includes}}
-{{>common/Include}}
-{{/includes}}
-#include "JniReference.h"
-#include "JniTypeId.h"
-#include <optional>
-
 {{#internalNamespace}}
 namespace {{.}}
 {
 {{/internalNamespace}}
 namespace jni
 {
-{{#enum}}
-JNIEXPORT {{resolveName "C++ FQN"}} convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<{{resolveName "C++ FQN"}}>);
-JNIEXPORT std::optional<{{resolveName "C++ FQN"}}> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<{{resolveName "C++ FQN"}}>>);
-JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}} _ninput);
-JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<{{resolveName "C++ FQN"}}> _ninput);
-{{/enum}}
-}
+
+template<typename T>
+struct TypeId final {};
+
+} // namespace jni
 {{#internalNamespace}}
-}
+} // namespace {{.}}
 {{/internalNamespace}}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.cpp
@@ -1,9 +1,13 @@
 /*
+
  *
  */
+
 #include "BoxingConversionUtils.h"
+
 #include "JniCallJavaMethod.h"
 #include "JniCppConversionUtils.h"
+
 namespace
 {
 template<typename T>
@@ -14,6 +18,7 @@ box_value_in_object( JNIEnv* env, const char* className, const char* signature, 
     auto theConstructor = env->GetMethodID( javaClass.get(), "<init>", signature );
     return ::gluecodium::jni::new_object(env, javaClass, theConstructor, param );
 }
+
 jint
 unbox_short_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& jvalue )
 {
@@ -21,6 +26,7 @@ unbox_short_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& 
     auto intValueMethodId = env->GetMethodID( javaIntegerClass.get(), "shortValue", "()S" );
     return ::gluecodium::jni::call_java_method<jshort>( env, jvalue, intValueMethodId );
 }
+
 jint
 unbox_int_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& jvalue )
 {
@@ -28,6 +34,7 @@ unbox_int_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& jv
     auto intValueMethodId = env->GetMethodID( javaIntegerClass.get(), "intValue", "()I" );
     return ::gluecodium::jni::call_java_method<jint>( env, jvalue, intValueMethodId );
 }
+
 jlong
 unbox_long_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& jvalue )
 {
@@ -35,6 +42,7 @@ unbox_long_value( JNIEnv* env, const ::gluecodium::jni::JniReference<jobject>& j
     auto longValueMethodId = env->GetMethodID( javaLongClass.get(), "longValue", "()J" );
     return ::gluecodium::jni::call_java_method<jlong>( env, jvalue, longValueMethodId );
 }
+
 template<typename T>
 ::gluecodium::jni::JniReference<jobject>
 box_uint_in_object( JNIEnv* env, T param )
@@ -43,6 +51,7 @@ box_uint_in_object( JNIEnv* env, T param )
     auto theConstructor = env->GetMethodID( javaClass.get(), "<init>", "(J)V" );
     return new_object(env, javaClass, theConstructor, static_cast< int64_t >( param ) );
 }
+
 template<>
 ::gluecodium::jni::JniReference<jobject>
 box_uint_in_object( JNIEnv* env, uint8_t param )
@@ -51,6 +60,7 @@ box_uint_in_object( JNIEnv* env, uint8_t param )
     auto theConstructor = env->GetMethodID( javaClass.get(), "<init>", "(S)V" );
     return new_object(env, javaClass, theConstructor, static_cast< int16_t >( param ) );
 }
+
 template<>
 ::gluecodium::jni::JniReference<jobject>
 box_uint_in_object( JNIEnv* env, uint16_t param )
@@ -60,6 +70,7 @@ box_uint_in_object( JNIEnv* env, uint16_t param )
     return new_object(env, javaClass, theConstructor, static_cast< int32_t >( param ) );
 }
 }
+
 namespace gluecodium
 {
 namespace jni
@@ -69,179 +80,212 @@ convert_to_jni( JNIEnv* env, const bool nvalue )
 {
     return box_value_in_object<jboolean>( env, "java/lang/Boolean", "(Z)V", nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const double nvalue )
 {
     return box_value_in_object<jdouble>( env, "java/lang/Double", "(D)V", nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const float nvalue )
 {
     return box_value_in_object<jfloat>( env, "java/lang/Float", "(F)V", nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int8_t nvalue )
 {
     return box_value_in_object<jbyte>( env, "java/lang/Byte", "(B)V", nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int16_t nvalue )
 {
     return box_value_in_object<jshort>( env, "java/lang/Short", "(S)V", nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int32_t nvalue )
 {
     return box_value_in_object<jint>( env, "java/lang/Integer", "(I)V", nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const int64_t nvalue )
 {
     return box_value_in_object<jlong>( env, "java/lang/Long", "(J)V", nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint8_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint16_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint32_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, const uint64_t nvalue )
 {
     return box_uint_in_object( env, nvalue );
 }
+
 bool
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<bool> )
 {
     auto javaBooleanClass = find_class( env, "java/lang/Boolean" );
     auto booleanValueMethodId = env->GetMethodID( javaBooleanClass.get(), "booleanValue", "()Z" );
     return call_java_method<jboolean>( env, jvalue, booleanValueMethodId );
 }
+
 double
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<double> )
 {
     auto javaDoubleClass = find_class( env, "java/lang/Double" );
     auto doubleValueMethodId = env->GetMethodID( javaDoubleClass.get(), "doubleValue", "()D" );
     return call_java_method<jdouble>( env, jvalue, doubleValueMethodId );
 }
+
 float
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<float> )
 {
     auto javaFloatClass = find_class( env, "java/lang/Float" );
     auto floatValueMethodId = env->GetMethodID( javaFloatClass.get(), "floatValue", "()F" );
     return call_java_method<jfloat>( env, jvalue, floatValueMethodId );
 }
+
 int8_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int8_t> )
 {
     auto javaByteClass = find_class( env, "java/lang/Byte" );
     auto byteValueMethodId = env->GetMethodID( javaByteClass.get(), "byteValue", "()B" );
     return call_java_method<jbyte>( env, jvalue, byteValueMethodId );
 }
+
 int16_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int16_t> )
 {
     auto javaShortClass = find_class(env, "java/lang/Short" );
     auto shortValueMethodId = env->GetMethodID( javaShortClass.get(), "shortValue", "()S" );
     return call_java_method<jshort>( env, jvalue, shortValueMethodId );
 }
+
 int32_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int32_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int32_t> )
 {
     return unbox_int_value( env, jvalue );
 }
+
 int64_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int64_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int64_t> )
 {
     return unbox_long_value( env, jvalue );
 }
+
 uint8_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint8_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint8_t> )
 {
     return unbox_short_value( env, jvalue );
 }
+
 uint16_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint16_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint16_t> )
 {
     return unbox_int_value( env, jvalue );
 }
+
 uint32_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint32_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint32_t> )
 {
     return unbox_long_value( env, jvalue );
 }
+
 uint64_t
-convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint64_t* )
+convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint64_t> )
 {
     return unbox_long_value( env, jvalue );
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<bool> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<float> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<double> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<int8_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<int16_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<int32_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<int64_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<uint8_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<uint16_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<uint32_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 JniReference<jobject>
 convert_to_jni( JNIEnv* env, std::optional<uint64_t> nvalue )
 {
     return nvalue ? convert_to_jni( env, *nvalue ) : JniReference<jobject>{};
 }
+
 std::optional<bool>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<bool>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<bool>> )
 {
     if ( !jvalue )
     {
@@ -250,9 +294,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<jboolean>( env, jvalue, "booleanValue", "()Z" );
     return std::optional<bool>( unboxedValue );
 }
+
 std::optional<float>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<float>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<float>> )
 {
     if ( !jvalue )
     {
@@ -261,9 +306,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<jfloat>( env, jvalue, "floatValue", "()F" );
     return std::optional<float>( unboxedValue );
 }
+
 std::optional<double>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<double>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<double>> )
 {
     if ( !jvalue )
     {
@@ -272,9 +318,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<jdouble>( env, jvalue, "doubleValue", "()D" );
     return std::optional<double>( unboxedValue );
 }
+
 std::optional<int8_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int8_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int8_t>> )
 {
     if ( !jvalue )
     {
@@ -283,9 +330,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int8_t>( env, jvalue, "byteValue", "()B" );
     return std::optional<int8_t>( unboxedValue );
 }
+
 std::optional<int16_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int16_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int16_t>> )
 {
     if ( !jvalue )
     {
@@ -294,9 +342,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int16_t>( env, jvalue, "shortValue", "()S" );
     return std::optional<int16_t>( unboxedValue );
 }
+
 std::optional<int32_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int32_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int32_t>> )
 {
     if ( !jvalue )
     {
@@ -305,9 +354,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int32_t>( env, jvalue, "intValue", "()I" );
     return std::optional<int32_t>( unboxedValue );
 }
+
 std::optional<int64_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int64_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int64_t>> )
 {
     if ( !jvalue )
     {
@@ -316,9 +366,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int64_t>( env, jvalue, "longValue", "()J" );
     return std::optional<int64_t>( unboxedValue );
 }
+
 std::optional<uint8_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint8_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint8_t>> )
 {
     if ( !jvalue )
     {
@@ -327,9 +378,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int16_t>( env, jvalue, "shortValue", "()S" );
     return std::optional<uint8_t>( static_cast<uint8_t>( unboxedValue ) );
 }
+
 std::optional<uint16_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint16_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint16_t>> )
 {
     if ( !jvalue )
     {
@@ -338,9 +390,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int32_t>( env, jvalue, "intValue", "()I" );
     return std::optional<uint16_t>( static_cast<uint16_t>( unboxedValue ) );
 }
+
 std::optional<uint32_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint32_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint32_t>> )
 {
     if ( !jvalue )
     {
@@ -349,9 +402,10 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int64_t>( env, jvalue, "longValue", "()J" );
     return std::optional<uint32_t>( static_cast<uint32_t>( unboxedValue ) );
 }
+
 std::optional<uint64_t>
 convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint64_t>* )
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint64_t>> )
 {
     if ( !jvalue )
     {
@@ -360,5 +414,6 @@ convert_from_jni(
     auto unboxedValue = call_java_method<int64_t>( env, jvalue, "longValue", "()J" );
     return std::optional<uint64_t>( static_cast<uint64_t>( unboxedValue ) );
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/BoxingConversionUtils.h
@@ -1,15 +1,22 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "JniReference.h"
+#include "JniTypeId.h"
+
 #include <jni.h>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
 // The following functions are converting and boxing primitive values into Java boxed types.
+
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const bool nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const double nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const float nvalue );
@@ -21,19 +28,23 @@ JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint8_t nvalu
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint16_t nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint32_t nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, const uint64_t nvalue );
+
 // The following functions are unboxing and converting primitive values from Java boxed types.
-JNIEXPORT bool convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, bool* );
-JNIEXPORT double convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, double* );
-JNIEXPORT float convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, float* );
-JNIEXPORT int8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int8_t* );
-JNIEXPORT int16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int16_t* );
-JNIEXPORT int32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int32_t* );
-JNIEXPORT int64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, int64_t* );
-JNIEXPORT uint8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint8_t* );
-JNIEXPORT uint16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint16_t* );
-JNIEXPORT uint32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint32_t* );
-JNIEXPORT uint64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, uint64_t* );
+
+JNIEXPORT bool convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<bool> );
+JNIEXPORT double convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<double> );
+JNIEXPORT float convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<float> );
+JNIEXPORT int8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int8_t> );
+JNIEXPORT int16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int16_t> );
+JNIEXPORT int32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int32_t> );
+JNIEXPORT int64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<int64_t> );
+JNIEXPORT uint8_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint8_t> );
+JNIEXPORT uint16_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint16_t> );
+JNIEXPORT uint32_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint32_t> );
+JNIEXPORT uint64_t convert_from_jni( JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<uint64_t> );
+
 // Boxing/unboxing conversion functions for nullable types
+
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<bool> nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<float> nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<double> nvalue );
@@ -45,27 +56,29 @@ JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<uint8
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<uint16_t> nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<uint32_t> nvalue );
 JNIEXPORT JniReference<jobject> convert_to_jni( JNIEnv* env, std::optional<uint64_t> nvalue );
+
 JNIEXPORT std::optional<bool> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<bool>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<bool>> );
 JNIEXPORT std::optional<float> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<float>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<float>> );
 JNIEXPORT std::optional<double> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<double>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<double>> );
 JNIEXPORT std::optional<int8_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int8_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int8_t>> );
 JNIEXPORT std::optional<int16_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int16_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int16_t>> );
 JNIEXPORT std::optional<int32_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int32_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int32_t>> );
 JNIEXPORT std::optional<int64_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<int64_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<int64_t>> );
 JNIEXPORT std::optional<uint8_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint8_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint8_t>> );
 JNIEXPORT std::optional<uint16_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint16_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint16_t>> );
 JNIEXPORT std::optional<uint32_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint32_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint32_t>> );
 JNIEXPORT std::optional<uint64_t> convert_from_jni(
-    JNIEnv* env, const JniReference<jobject>& jvalue, std::optional<uint64_t>* );
+    JNIEnv* env, const JniReference<jobject>& jvalue, TypeId<std::optional<uint64_t>> );
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android/jni/com_example_smoke_BasicTypes.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_BasicTypes_stringFunction(JNIEnv* _jenv, jobject _jinstan
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android/jni/com_example_smoke_Constructors.cpp
@@ -45,7 +45,7 @@ Java_com_example_smoke_Constructors_create__Lcom_example_smoke_Constructors_2(JN
 
     ::std::shared_ptr< ::smoke::Constructors > other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
-            (::std::shared_ptr< ::smoke::Constructors >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Constructors >>{});
 
 
 
@@ -71,7 +71,7 @@ Java_com_example_smoke_Constructors_create__Ljava_lang_String_2J(JNIEnv* _jenv, 
 
     ::std::string foo = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jfoo),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
@@ -103,7 +103,7 @@ Java_com_example_smoke_Constructors_create__Ljava_lang_String_2(JNIEnv* _jenv, j
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
@@ -145,7 +145,7 @@ Java_com_example_smoke_Constructors_create__Ljava_util_List_2(JNIEnv* _jenv, job
 
     ::std::vector< double > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< double >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< double >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_Dates.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_Dates_dateMethod(JNIEnv* _jenv, jobject _jinstance, jobje
 
     ::std::chrono::system_clock::time_point input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::chrono::system_clock::time_point*)nullptr);
+            ::gluecodium::jni::TypeId<::std::chrono::system_clock::time_point>{});
 
 
 
@@ -48,7 +48,7 @@ Java_com_example_smoke_Dates_nullableDateMethod(JNIEnv* _jenv, jobject _jinstanc
 
     std::optional< ::std::chrono::system_clock::time_point > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::std::chrono::system_clock::time_point >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::std::chrono::system_clock::time_point >>{});
 
 
 
@@ -95,7 +95,7 @@ Java_com_example_smoke_Dates_setDateProperty(JNIEnv* _jenv, jobject _jinstance, 
 
     ::std::chrono::system_clock::time_point value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::chrono::system_clock::time_point*)nullptr);
+            ::gluecodium::jni::TypeId<::std::chrono::system_clock::time_point>{});
 
 
 
@@ -142,7 +142,7 @@ Java_com_example_smoke_Dates_setDateSet(JNIEnv* _jenv, jobject _jinstance, jobje
 
     ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android/jni/com_example_smoke_DatesSteady.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_DatesSteady_dateMethod(JNIEnv* _jenv, jobject _jinstance,
 
     ::smoke::DatesSteady::MonotonicDate input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::DatesSteady::MonotonicDate*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::DatesSteady::MonotonicDate>{});
 
 
 
@@ -48,7 +48,7 @@ Java_com_example_smoke_DatesSteady_nullableDateMethod(JNIEnv* _jenv, jobject _ji
 
     std::optional< ::smoke::DatesSteady::MonotonicDate > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::smoke::DatesSteady::MonotonicDate >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::DatesSteady::MonotonicDate >>{});
 
 
 
@@ -73,7 +73,7 @@ Java_com_example_smoke_DatesSteady_dateListMethod(JNIEnv* _jenv, jobject _jinsta
 
     ::smoke::DatesSteady::DateList input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::DatesSteady::DateList*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::DatesSteady::DateList>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationMilliseconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationMilliseconds.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_DurationMilliseconds_durationFunction(JNIEnv* _jenv, jobj
 
     std::chrono::milliseconds input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::chrono::milliseconds*)nullptr);
+            ::gluecodium::jni::TypeId<std::chrono::milliseconds>{});
 
 
 
@@ -48,7 +48,7 @@ Java_com_example_smoke_DurationMilliseconds_nullableDurationFunction(JNIEnv* _je
 
     std::optional< std::chrono::milliseconds > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< std::chrono::milliseconds >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< std::chrono::milliseconds >>{});
 
 
 
@@ -95,7 +95,7 @@ Java_com_example_smoke_DurationMilliseconds_setDurationProperty(JNIEnv* _jenv, j
 
     std::chrono::milliseconds value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::chrono::milliseconds*)nullptr);
+            ::gluecodium::jni::TypeId<std::chrono::milliseconds>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationOverloads.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_DurationOverloads_durationFunction__Lcom_example_time_Dur
 
     ::std::chrono::seconds input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::chrono::seconds*)nullptr);
+            ::gluecodium::jni::TypeId<::std::chrono::seconds>{});
 
 
 
@@ -48,7 +48,7 @@ Java_com_example_smoke_DurationOverloads_durationFunction__Ljava_lang_String_2(J
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationSeconds.cpp
+++ b/gluecodium/src/test/resources/smoke/durations/output/android/jni/com_example_smoke_DurationSeconds.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_DurationSeconds_durationFunction(JNIEnv* _jenv, jobject _
 
     ::std::chrono::seconds input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::chrono::seconds*)nullptr);
+            ::gluecodium::jni::TypeId<::std::chrono::seconds>{});
 
 
 
@@ -48,7 +48,7 @@ Java_com_example_smoke_DurationSeconds_nullableDurationFunction(JNIEnv* _jenv, j
 
     std::optional< ::std::chrono::seconds > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::std::chrono::seconds >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::std::chrono::seconds >>{});
 
 
 
@@ -95,7 +95,7 @@ Java_com_example_smoke_DurationSeconds_setDurationProperty(JNIEnv* _jenv, jobjec
 
     ::std::chrono::seconds value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::chrono::seconds*)nullptr);
+            ::gluecodium::jni::TypeId<::std::chrono::seconds>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_EnumWithAlias__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_EnumWithAlias__Conversion.cpp
@@ -1,28 +1,35 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_EnumWithAlias__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::EnumWithAlias
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::EnumWithAlias*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::EnumWithAlias>)
 {
     return ::smoke::EnumWithAlias(
-        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
+
 std::optional<::smoke::EnumWithAlias>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::EnumWithAlias>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::EnumWithAlias>>)
 {
     return _jinput
-        ? std::optional<::smoke::EnumWithAlias>(convert_from_jni(_jenv, _jinput, (::smoke::EnumWithAlias*)nullptr))
+        ? std::optional<::smoke::EnumWithAlias>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::EnumWithAlias>{}))
         : std::optional<::smoke::EnumWithAlias>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/EnumWithAlias", com_example_smoke_EnumWithAlias, ::smoke::EnumWithAlias)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::EnumWithAlias _ninput)
 {
@@ -42,10 +49,12 @@ convert_to_jni(JNIEnv* _jenv, const ::smoke::EnumWithAlias _ninput)
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/EnumWithAlias;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::EnumWithAlias> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_EnumsInTypeCollection_TCEnum__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_EnumsInTypeCollection_TCEnum__Conversion.h
@@ -1,17 +1,21 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/EnumsInTypeCollection.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
 
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::EnumsInTypeCollection::TCEnum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::EnumsInTypeCollection::TCEnum*);
-JNIEXPORT std::optional<::smoke::EnumsInTypeCollection::TCEnum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::EnumsInTypeCollection::TCEnum>*);
+JNIEXPORT ::smoke::EnumsInTypeCollection::TCEnum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::EnumsInTypeCollection::TCEnum>);
+JNIEXPORT std::optional<::smoke::EnumsInTypeCollection::TCEnum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::EnumsInTypeCollection::TCEnum>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::EnumsInTypeCollection::TCEnum _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::EnumsInTypeCollection::TCEnum> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_Enums_SimpleEnum__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_Enums_SimpleEnum__Conversion.cpp
@@ -1,28 +1,35 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Enums_SimpleEnum__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Enums::SimpleEnum
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Enums::SimpleEnum*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Enums::SimpleEnum>)
 {
     return ::smoke::Enums::SimpleEnum(
-        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
+
 std::optional<::smoke::Enums::SimpleEnum>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Enums::SimpleEnum>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Enums::SimpleEnum>>)
 {
     return _jinput
-        ? std::optional<::smoke::Enums::SimpleEnum>(convert_from_jni(_jenv, _jinput, (::smoke::Enums::SimpleEnum*)nullptr))
+        ? std::optional<::smoke::Enums::SimpleEnum>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Enums::SimpleEnum>{}))
         : std::optional<::smoke::Enums::SimpleEnum>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Enums$SimpleEnum", com_example_smoke_Enums_00024SimpleEnum, ::smoke::Enums::SimpleEnum)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Enums::SimpleEnum _ninput)
 {
@@ -39,10 +46,12 @@ convert_to_jni(JNIEnv* _jenv, const ::smoke::Enums::SimpleEnum _ninput)
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/Enums$SimpleEnum;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Enums::SimpleEnum> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_Enums_SimpleEnum__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/android/jni/com_example_smoke_Enums_SimpleEnum__Conversion.h
@@ -1,17 +1,21 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/Enums.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
 
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::Enums::SimpleEnum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Enums::SimpleEnum*);
-JNIEXPORT std::optional<::smoke::Enums::SimpleEnum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Enums::SimpleEnum>*);
+JNIEXPORT ::smoke::Enums::SimpleEnum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Enums::SimpleEnum>);
+JNIEXPORT std::optional<::smoke::Enums::SimpleEnum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Enums::SimpleEnum>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Enums::SimpleEnum _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Enums::SimpleEnum> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_ErrorsInterfaceImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/jni/com_example_smoke_ErrorsInterfaceImplCppProxy.cpp
@@ -38,7 +38,7 @@ com_example_smoke_ErrorsInterface_CppProxy::method_with_errors(  ) {
         auto nErrorValue = convert_from_jni(
             jniEnv,
             jErrorValue,
-            (::smoke::ErrorsInterface::InternalError*)nullptr );
+            TypeId<::smoke::ErrorsInterface::InternalError>{});
 
 
         return ::std::error_code{nErrorValue};
@@ -73,7 +73,7 @@ com_example_smoke_ErrorsInterface_CppProxy::method_with_external_errors(  ) {
         auto nErrorValue = convert_from_jni(
             jniEnv,
             jErrorValue,
-            (::smoke::ErrorsInterface::ExternalErrors*)nullptr );
+            TypeId<::smoke::ErrorsInterface::ExternalErrors>{});
 
 
         return ::std::error_code{nErrorValue};
@@ -108,7 +108,7 @@ com_example_smoke_ErrorsInterface_CppProxy::method_with_errors_and_return_value(
         auto nErrorValue = convert_from_jni(
             jniEnv,
             jErrorValue,
-            (::smoke::ErrorsInterface::InternalError*)nullptr );
+            TypeId<::smoke::ErrorsInterface::InternalError>{});
 
 
         return ::std::error_code{nErrorValue};
@@ -117,7 +117,7 @@ com_example_smoke_ErrorsInterface_CppProxy::method_with_errors_and_return_value(
     else
     {
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
     }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Class__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Class__Conversion.h
@@ -1,19 +1,25 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "package/Class.h"
 #include "com_example_package_Types_Enum__Conversion.h"
 #include "com_example_package_Types_Struct__Conversion.h"
 #include "JniReference.h"
-
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT std::shared_ptr<::package::Class> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::package::Class>*);
+
+JNIEXPORT std::shared_ptr<::package::Class> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::package::Class>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::package::Class>& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Types_Enum__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Types_Enum__Conversion.h
@@ -1,16 +1,21 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "package/Types.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::package::Types::Enum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::package::Types::Enum*);
-JNIEXPORT std::optional<::package::Types::Enum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::package::Types::Enum>*);
+JNIEXPORT ::package::Types::Enum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::package::Types::Enum>);
+JNIEXPORT std::optional<::package::Types::Enum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::package::Types::Enum>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::package::Types::Enum _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::package::Types::Enum> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Types_Struct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android/jni/com_example_package_Types_Struct__Conversion.h
@@ -1,17 +1,22 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "package/Types.h"
 #include "com_example_package_Types_Enum__Conversion.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::package::Types::Struct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::package::Types::Struct*);
-JNIEXPORT std::optional<::package::Types::Struct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::package::Types::Struct>*);
+JNIEXPORT ::package::Types::Struct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::package::Types::Struct>);
+JNIEXPORT std::optional<::package::Types::Struct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::package::Types::Struct>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::package::Types::Struct& _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::package::Types::Struct> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_JavaExternalCtor_make(JNIEnv* _jenv, jobject _jinstance, 
 
     ::std::string field = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jfield),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo__Conversion.cpp
@@ -21,7 +21,7 @@ struct Dummycom_example_FooConverterType {};
 REGISTER_JNI_CLASS_CACHE("com/example/FooConverter", com_example_FooConverter, Dummycom_example_FooConverterType)
 
 ::smoke::JavaExternalCtor
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smoke::JavaExternalCtor*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, TypeId<::smoke::JavaExternalCtor>)
 {
     auto& converterClass = CachedJavaClass<Dummycom_example_FooConverterType>::java_class;
 
@@ -39,16 +39,16 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smok
         _jenv,
         _jinput,
         "field",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
     _nout.field = n_field;
     return _nout;
 }
 
 std::optional<::smoke::JavaExternalCtor>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::JavaExternalCtor>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::JavaExternalCtor>>)
 {
     return _jinput
-        ? std::optional<::smoke::JavaExternalCtor>(convert_from_jni(_jenv, _jinput, (::smoke::JavaExternalCtor*)nullptr))
+        ? std::optional<::smoke::JavaExternalCtor>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::JavaExternalCtor>{}))
         : std::optional<::smoke::JavaExternalCtor>{};
 }
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_DurationExternal__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_DurationExternal__Conversion.cpp
@@ -1,45 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_DurationExternal__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 std::chrono::duration<uint64_t, std::ratio<1,1000>>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::chrono::duration<uint64_t, std::ratio<1,1000>>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::chrono::duration<uint64_t, std::ratio<1,1000>>>)
 {
+    
     uint64_t n_value = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "value",
-        (uint64_t*)nullptr );
+        TypeId<uint64_t>{} );
+    
     return std::chrono::duration<uint64_t, std::ratio<1,1000>>(std::move(n_value));
 }
+
 std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>>)
 {
     return _jinput
-        ? std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>(convert_from_jni(_jenv, _jinput, (std::chrono::duration<uint64_t, std::ratio<1,1000>>*)nullptr))
+        ? std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>(convert_from_jni(_jenv, _jinput, TypeId<std::chrono::duration<uint64_t, std::ratio<1,1000>>>{}))
         : std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/DurationExternal", com_example_smoke_DurationExternal, std::chrono::duration<uint64_t, std::ratio<1,1000>>)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::chrono::duration<uint64_t, std::ratio<1,1000>>& _ninput)
 {
     auto& javaClass = CachedJavaClass<std::chrono::duration<uint64_t, std::ratio<1,1000>>>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "value", _ninput.count());
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums.cpp
@@ -24,7 +24,7 @@ Java_com_example_smoke_Enums_methodWithExternalEnum(JNIEnv* _jenv, jobject _jins
 
     ::smoke::Enums::External_Enum input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::Enums::External_Enum*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::Enums::External_Enum>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_ExternalEnum__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_ExternalEnum__Conversion.cpp
@@ -1,28 +1,35 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Enums_ExternalEnum__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Enums::External_Enum
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Enums::External_Enum*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Enums::External_Enum>)
 {
     return ::smoke::Enums::External_Enum(
-        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
+
 std::optional<::smoke::Enums::External_Enum>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Enums::External_Enum>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Enums::External_Enum>>)
 {
     return _jinput
-        ? std::optional<::smoke::Enums::External_Enum>(convert_from_jni(_jenv, _jinput, (::smoke::Enums::External_Enum*)nullptr))
+        ? std::optional<::smoke::Enums::External_Enum>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Enums::External_Enum>{}))
         : std::optional<::smoke::Enums::External_Enum>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Enums$ExternalEnum", com_example_smoke_Enums_00024ExternalEnum, ::smoke::Enums::External_Enum)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Enums::External_Enum _ninput)
 {
@@ -39,10 +46,12 @@ convert_to_jni(JNIEnv* _jenv, const ::smoke::Enums::External_Enum _ninput)
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/Enums$ExternalEnum;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Enums::External_Enum> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_VeryExternalEnum__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_VeryExternalEnum__Conversion.cpp
@@ -1,28 +1,35 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Enums_VeryExternalEnum__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::fire::SomeVeryExternalEnum
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::fire::SomeVeryExternalEnum*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::fire::SomeVeryExternalEnum>)
 {
     return ::fire::SomeVeryExternalEnum(
-        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
+
 std::optional<::fire::SomeVeryExternalEnum>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::fire::SomeVeryExternalEnum>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::fire::SomeVeryExternalEnum>>)
 {
     return _jinput
-        ? std::optional<::fire::SomeVeryExternalEnum>(convert_from_jni(_jenv, _jinput, (::fire::SomeVeryExternalEnum*)nullptr))
+        ? std::optional<::fire::SomeVeryExternalEnum>(convert_from_jni(_jenv, _jinput, TypeId<::fire::SomeVeryExternalEnum>{}))
         : std::optional<::fire::SomeVeryExternalEnum>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Enums$VeryExternalEnum", com_example_smoke_Enums_00024VeryExternalEnum, ::fire::SomeVeryExternalEnum)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::fire::SomeVeryExternalEnum _ninput)
 {
@@ -39,10 +46,12 @@ convert_to_jni(JNIEnv* _jenv, const ::fire::SomeVeryExternalEnum _ninput)
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/Enums$VeryExternalEnum;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::fire::SomeVeryExternalEnum> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/ExternalClass", com_example_smoke_Ex
 
 
 
-std::shared_ptr<::fire::Baz> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::fire::Baz>*)
+std::shared_ptr<::fire::Baz> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::fire::Baz>>)
 {
     std::shared_ptr<::fire::Baz> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass__Conversion.h
@@ -1,16 +1,23 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "foo/Bar.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT std::shared_ptr<::fire::Baz> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::fire::Baz>*);
+
+JNIEXPORT std::shared_ptr<::fire::Baz> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::fire::Baz>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::fire::Baz>& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterface__Conversion.cpp
@@ -27,7 +27,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 }
 
 
-std::shared_ptr<::smoke::ExternalInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ExternalInterface>*)
+std::shared_ptr<::smoke::ExternalInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ExternalInterface>>)
 {
     std::shared_ptr<::smoke::ExternalInterface> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterface__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterface__Conversion.h
@@ -1,16 +1,23 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "foo/Bar.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT std::shared_ptr<::smoke::ExternalInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ExternalInterface>*);
+
+JNIEXPORT std::shared_ptr<::smoke::ExternalInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ExternalInterface>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ExternalInterface>& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_JavaExternalTypesStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_JavaExternalTypesStruct__Conversion.cpp
@@ -1,69 +1,89 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_JavaExternalTypesStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::JavaExternalTypesStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::JavaExternalTypesStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::JavaExternalTypesStruct>)
 {
+    
     ::smoke::Currency n_currency = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "currency", "Ljava/util/Currency;"),
-        (::smoke::Currency*)nullptr );
+        TypeId<::smoke::Currency>{} );
+    
     ::smoke::TimeZone n_time_zone = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "timeZone", "Ljava/util/SimpleTimeZone;"),
-        (::smoke::TimeZone*)nullptr );
+        TypeId<::smoke::TimeZone>{} );
+    
     ::smoke::Month n_month = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "month", "Ljava/time/Month;"),
-        (::smoke::Month*)nullptr );
+        TypeId<::smoke::Month>{} );
+    
     ::smoke::SystemColor n_color = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "color", "Ljava/lang/Integer;"),
-        (::smoke::SystemColor*)nullptr );
+        TypeId<::smoke::SystemColor>{} );
+    
     ::smoke::Season n_season = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "season", "Ljava/lang/String;"),
-        (::smoke::Season*)nullptr );
+        TypeId<::smoke::Season>{} );
+    
     return ::smoke::JavaExternalTypesStruct(std::move(n_currency), std::move(n_time_zone), std::move(n_month), std::move(n_color), std::move(n_season));
 }
+
 std::optional<::smoke::JavaExternalTypesStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::JavaExternalTypesStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::JavaExternalTypesStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::JavaExternalTypesStruct>(convert_from_jni(_jenv, _jinput, (::smoke::JavaExternalTypesStruct*)nullptr))
+        ? std::optional<::smoke::JavaExternalTypesStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::JavaExternalTypesStruct>{}))
         : std::optional<::smoke::JavaExternalTypesStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/JavaExternalTypesStruct", com_example_smoke_JavaExternalTypesStruct, ::smoke::JavaExternalTypesStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::JavaExternalTypesStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::JavaExternalTypesStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     auto jcurrency = convert_to_jni(_jenv, _ninput.currency);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "currency", "Ljava/util/Currency;", jcurrency);
+
     auto jtime_zone = convert_to_jni(_jenv, _ninput.time_zone);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "timeZone", "Ljava/util/SimpleTimeZone;", jtime_zone);
+
     auto jmonth = convert_to_jni(_jenv, _ninput.month);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "month", "Ljava/time/Month;", jmonth);
+
     auto jcolor = convert_to_jni(_jenv, _ninput.color);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "color", "Ljava/lang/Integer;", jcolor);
+
     auto jseason = convert_to_jni(_jenv, _ninput.season);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "season", "Ljava/lang/String;", jseason);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::JavaExternalTypesStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.cpp
@@ -1,68 +1,81 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Structs_ExternalStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Structs::ExternalStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Structs::ExternalStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Structs::ExternalStruct>)
 {
     ::smoke::Structs::ExternalStruct _nout{};
     ::std::string n_stringField = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "stringField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
     _nout.stringField = n_stringField;
     ::std::string n_externalStringField = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "externalStringField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
     _nout.set_some_string(n_externalStringField);
     ::std::vector< int8_t > n_externalArrayField = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "externalArrayField", "Ljava/util/List;"),
-        (::std::vector< int8_t >*)nullptr );
+        TypeId<::std::vector< int8_t >>{} );
     _nout.set_some_array(n_externalArrayField);
     ::fire::SomeVeryExternalStruct n_externalStructField = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "externalStructField", "Lcom/example/smoke/Structs$AnotherExternalStruct;"),
-        (::fire::SomeVeryExternalStruct*)nullptr );
+        TypeId<::fire::SomeVeryExternalStruct>{} );
     _nout.set_some_struct(n_externalStructField);
     return _nout;
 }
+
 std::optional<::smoke::Structs::ExternalStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Structs::ExternalStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Structs::ExternalStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::Structs::ExternalStruct>(convert_from_jni(_jenv, _jinput, (::smoke::Structs::ExternalStruct*)nullptr))
+        ? std::optional<::smoke::Structs::ExternalStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Structs::ExternalStruct>{}))
         : std::optional<::smoke::Structs::ExternalStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Structs$ExternalStruct", com_example_smoke_Structs_00024ExternalStruct, ::smoke::Structs::ExternalStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Structs::ExternalStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Structs::ExternalStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.stringField);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "externalStringField", _ninput.get_some_string());
+
     auto jexternalArrayField = convert_to_jni(_jenv, _ninput.get_some_array());
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "externalArrayField", "Ljava/util/List;", jexternalArrayField);
+
     auto jexternalStructField = convert_to_jni(_jenv, _ninput.get_some_struct());
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "externalStructField", "Lcom/example/smoke/Structs$AnotherExternalStruct;", jexternalStructField);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Structs::ExternalStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_Integer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_Integer__Conversion.cpp
@@ -21,7 +21,7 @@ struct Dummycom_here_android_test_ColorConverterType {};
 REGISTER_JNI_CLASS_CACHE("com/here/android/test/ColorConverter", com_here_android_test_ColorConverter, Dummycom_here_android_test_ColorConverterType)
 
 ::smoke::SystemColor
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smoke::SystemColor*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, TypeId<::smoke::SystemColor>)
 {
     auto& converterClass = CachedJavaClass<Dummycom_here_android_test_ColorConverterType>::java_class;
 
@@ -39,34 +39,34 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smok
         _jenv,
         _jinput,
         "red",
-        (float*)nullptr );
+        TypeId<float>{} );
     _nout.red = n_red;
     float n_green = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "green",
-        (float*)nullptr );
+        TypeId<float>{} );
     _nout.green = n_green;
     float n_blue = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "blue",
-        (float*)nullptr );
+        TypeId<float>{} );
     _nout.blue = n_blue;
     float n_alpha = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "alpha",
-        (float*)nullptr );
+        TypeId<float>{} );
     _nout.alpha = n_alpha;
     return _nout;
 }
 
 std::optional<::smoke::SystemColor>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::SystemColor>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::SystemColor>>)
 {
     return _jinput
-        ? std::optional<::smoke::SystemColor>(convert_from_jni(_jenv, _jinput, (::smoke::SystemColor*)nullptr))
+        ? std::optional<::smoke::SystemColor>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::SystemColor>{}))
         : std::optional<::smoke::SystemColor>{};
 }
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_String__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_String__Conversion.cpp
@@ -20,7 +20,7 @@ struct Dummycom_here_android_test_SeasonConverterType {};
 REGISTER_JNI_CLASS_CACHE("com/here/android/test/SeasonConverter", com_here_android_test_SeasonConverter, Dummycom_here_android_test_SeasonConverterType)
 
 ::smoke::Season
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smoke::Season*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, TypeId<::smoke::Season>)
 {
     auto& converterClass = CachedJavaClass<Dummycom_here_android_test_SeasonConverterType>::java_class;
 
@@ -34,14 +34,14 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput_ext, ::smok
     auto _jinput = make_local_ref(
         _jenv, _jenv->CallStaticObjectMethod(converterClass.get(), convertMethodId, _jinput_ext.get()));
     return ::smoke::Season(
-        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
 
 std::optional<::smoke::Season>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Season>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Season>>)
 {
     return _jinput
-        ? std::optional<::smoke::Season>(convert_from_jni(_jenv, _jinput, (::smoke::Season*)nullptr))
+        ? std::optional<::smoke::Season>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Season>{}))
         : std::optional<::smoke::Season>{};
 }
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_time_Month__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_time_Month__Conversion.cpp
@@ -1,16 +1,20 @@
 /*
+
  *
  */
+
 #include "java_time_Month__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Month
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Month*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Month>)
 {
     auto ordinal = call_java_method<jint>(_jenv, _jinput, "ordinal", "()I");
     switch(ordinal) {
@@ -24,14 +28,17 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::M
             return {};
     }
 }
+
 std::optional<::smoke::Month>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Month>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Month>>)
 {
     return _jinput
-        ? std::optional<::smoke::Month>(convert_from_jni(_jenv, _jinput, (::smoke::Month*)nullptr))
+        ? std::optional<::smoke::Month>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Month>{}))
         : std::optional<::smoke::Month>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("java/time/Month", java_time_Month, ::smoke::Month)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Month _ninput)
 {
@@ -51,10 +58,12 @@ convert_to_jni(JNIEnv* _jenv, const ::smoke::Month _ninput)
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Ljava/time/Month;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Month> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_Currency__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_Currency__Conversion.cpp
@@ -1,44 +1,58 @@
 /*
+
  *
  */
+
 #include "java_util_Currency__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Currency
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Currency*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Currency>)
 {
+    
     auto j_currency_code = call_java_method<jstring>(_jenv, _jinput, "getCurrencyCode", "()Ljava/lang/String;");
-    auto n_currency_code = convert_from_jni(_jenv, j_currency_code, (::std::string*)nullptr);
+    auto n_currency_code = convert_from_jni(_jenv, j_currency_code, TypeId<::std::string>{});
+    
     auto n_numeric_code = call_java_method<jint>(_jenv, _jinput, "getNumericCode", "()I");
+    
     return ::smoke::Currency(std::move(n_currency_code), std::move(n_numeric_code));
 }
+
 std::optional<::smoke::Currency>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Currency>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Currency>>)
 {
     return _jinput
-        ? std::optional<::smoke::Currency>(convert_from_jni(_jenv, _jinput, (::smoke::Currency*)nullptr))
+        ? std::optional<::smoke::Currency>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Currency>{}))
         : std::optional<::smoke::Currency>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("java/util/Currency", java_util_Currency, ::smoke::Currency)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Currency& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Currency>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "currencyCode", _ninput.currency_code);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "numericCode", _ninput.numeric_code);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Currency> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_SimpleTimeZone__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_SimpleTimeZone__Conversion.cpp
@@ -1,43 +1,53 @@
 /*
+
  *
  */
+
 #include "java_util_SimpleTimeZone__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::TimeZone
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::TimeZone*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::TimeZone>)
 {
     ::smoke::TimeZone _nout{};
     auto n_raw_offset = call_java_method<jint>(_jenv, _jinput, "getRawOffset", "()I");
     _nout.raw_offset = n_raw_offset;
     return _nout;
 }
+
 std::optional<::smoke::TimeZone>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::TimeZone>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::TimeZone>>)
 {
     return _jinput
-        ? std::optional<::smoke::TimeZone>(convert_from_jni(_jenv, _jinput, (::smoke::TimeZone*)nullptr))
+        ? std::optional<::smoke::TimeZone>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::TimeZone>{}))
         : std::optional<::smoke::TimeZone>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("java/util/SimpleTimeZone", java_util_SimpleTimeZone, ::smoke::TimeZone)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::TimeZone& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::TimeZone>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     call_java_method<void>(_jenv, _jresult, "setRawOffset", "(I)V", _ninput.raw_offset);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::TimeZone> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/jni/com_example_smoke_ImmutableStructWithClash__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/jni/com_example_smoke_ImmutableStructWithClash__Conversion.cpp
@@ -1,57 +1,73 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_ImmutableStructWithClash__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::ImmutableStructWithClash
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::ImmutableStructWithClash*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::ImmutableStructWithClash>)
 {
+    
     ::std::string n_string_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "stringField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
+    
     int32_t n_int_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "intField",
-        (int32_t*)nullptr );
+        TypeId<int32_t>{} );
+    
     bool n_bool_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "boolField",
-        (bool*)nullptr );
+        TypeId<bool>{} );
+    
     return ::smoke::ImmutableStructWithClash(std::move(n_bool_field), std::move(n_int_field), std::move(n_string_field));
 }
+
 std::optional<::smoke::ImmutableStructWithClash>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::ImmutableStructWithClash>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::ImmutableStructWithClash>>)
 {
     return _jinput
-        ? std::optional<::smoke::ImmutableStructWithClash>(convert_from_jni(_jenv, _jinput, (::smoke::ImmutableStructWithClash*)nullptr))
+        ? std::optional<::smoke::ImmutableStructWithClash>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::ImmutableStructWithClash>{}))
         : std::optional<::smoke::ImmutableStructWithClash>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/ImmutableStructWithClash", com_example_smoke_ImmutableStructWithClash, ::smoke::ImmutableStructWithClash)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::ImmutableStructWithClash& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::ImmutableStructWithClash>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.string_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::ImmutableStructWithClash> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithList(JNIEnv* _jenv, 
 
     ::std::vector< int32_t > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< int32_t >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< int32_t >>{});
 
 
 
@@ -48,7 +48,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMap(JNIEnv* _jenv, j
 
     ::std::unordered_map< int32_t, bool > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< int32_t, bool >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< int32_t, bool >>{});
 
 
 
@@ -73,7 +73,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSet(JNIEnv* _jenv, j
 
     ::std::unordered_set< int32_t > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_set< int32_t >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_set< int32_t >>{});
 
 
 
@@ -98,7 +98,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias(JNIEnv
 
     ::smoke::GenericTypesWithBasicTypes::BasicList input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::GenericTypesWithBasicTypes::BasicList*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::GenericTypesWithBasicTypes::BasicList>{});
 
 
 
@@ -123,7 +123,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias(JNIEnv*
 
     ::smoke::GenericTypesWithBasicTypes::BasicMap input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::GenericTypesWithBasicTypes::BasicMap*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::GenericTypesWithBasicTypes::BasicMap>{});
 
 
 
@@ -148,7 +148,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias(JNIEnv*
 
     ::smoke::GenericTypesWithBasicTypes::BasicSet input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::GenericTypesWithBasicTypes::BasicSet*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::GenericTypesWithBasicTypes::BasicSet>{});
 
 
 
@@ -195,7 +195,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_setListProperty(JNIEnv* _jenv,
 
     ::std::vector< float > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::vector< float >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< float >>{});
 
 
 
@@ -242,7 +242,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_setMapProperty(JNIEnv* _jenv, 
 
     ::std::unordered_map< float, double > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::unordered_map< float, double >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< float, double >>{});
 
 
 
@@ -289,7 +289,7 @@ Java_com_example_smoke_GenericTypesWithBasicTypes_setSetProperty(JNIEnv* _jenv, 
 
     ::std::unordered_set< float > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::unordered_set< float >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_set< float >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes_StructWithGenerics__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithBasicTypes_StructWithGenerics__Conversion.cpp
@@ -1,61 +1,73 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_GenericTypesWithBasicTypes_StructWithGenerics__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::GenericTypesWithBasicTypes::StructWithGenerics
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::GenericTypesWithBasicTypes::StructWithGenerics*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>)
 {
     ::smoke::GenericTypesWithBasicTypes::StructWithGenerics _nout{};
     ::std::vector< uint8_t > n_numbers_list = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "numbersList", "Ljava/util/List;"),
-        (::std::vector< uint8_t >*)nullptr );
+        TypeId<::std::vector< uint8_t >>{} );
     _nout.numbers_list = n_numbers_list;
     ::std::unordered_map< uint8_t, ::std::string > n_numbers_map = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "numbersMap", "Ljava/util/Map;"),
-        (::std::unordered_map< uint8_t, ::std::string >*)nullptr );
+        TypeId<::std::unordered_map< uint8_t, ::std::string >>{} );
     _nout.numbers_map = n_numbers_map;
     ::std::unordered_set< uint8_t > n_numbers_set = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "numbersSet", "Ljava/util/Set;"),
-        (::std::unordered_set< uint8_t >*)nullptr );
+        TypeId<::std::unordered_set< uint8_t >>{} );
     _nout.numbers_set = n_numbers_set;
     return _nout;
 }
+
 std::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>>)
 {
     return _jinput
-        ? std::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(convert_from_jni(_jenv, _jinput, (::smoke::GenericTypesWithBasicTypes::StructWithGenerics*)nullptr))
+        ? std::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>{}))
         : std::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/GenericTypesWithBasicTypes$StructWithGenerics", com_example_smoke_GenericTypesWithBasicTypes_00024StructWithGenerics, ::smoke::GenericTypesWithBasicTypes::StructWithGenerics)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::GenericTypesWithBasicTypes::StructWithGenerics& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::GenericTypesWithBasicTypes::StructWithGenerics>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     auto jnumbers_list = convert_to_jni(_jenv, _ninput.numbers_list);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "numbersList", "Ljava/util/List;", jnumbers_list);
+
     auto jnumbers_map = convert_to_jni(_jenv, _ninput.numbers_map);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "numbersMap", "Ljava/util/Map;", jnumbers_map);
+
     auto jnumbers_set = convert_to_jni(_jenv, _ninput.numbers_set);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "numbersSet", "Ljava/util/Set;", jnumbers_set);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::GenericTypesWithBasicTypes::StructWithGenerics> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithCompoundTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithCompoundTypes.cpp
@@ -29,7 +29,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithStructList(JNIEnv
 
     ::std::vector< ::smoke::GenericTypesWithCompoundTypes::BasicStruct > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< ::smoke::GenericTypesWithCompoundTypes::BasicStruct >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::smoke::GenericTypesWithCompoundTypes::BasicStruct >>{});
 
 
 
@@ -54,7 +54,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithStructMap(JNIEnv*
 
     ::std::unordered_map< ::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< ::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< ::std::string, ::smoke::GenericTypesWithCompoundTypes::BasicStruct >>{});
 
 
 
@@ -79,7 +79,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumList(JNIEnv* 
 
     ::std::vector< ::smoke::GenericTypesWithCompoundTypes::SomeEnum > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< ::smoke::GenericTypesWithCompoundTypes::SomeEnum >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::smoke::GenericTypesWithCompoundTypes::SomeEnum >>{});
 
 
 
@@ -104,7 +104,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey(JNIEnv
 
     ::std::unordered_map< ::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash< ::smoke::GenericTypesWithCompoundTypes::SomeEnum > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< ::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash< ::smoke::GenericTypesWithCompoundTypes::SomeEnum > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< ::smoke::GenericTypesWithCompoundTypes::SomeEnum, bool, ::gluecodium::hash< ::smoke::GenericTypesWithCompoundTypes::SomeEnum > >>{});
 
 
 
@@ -129,7 +129,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue(JNIE
 
     ::std::unordered_map< int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< int32_t, ::smoke::GenericTypesWithCompoundTypes::SomeEnum >>{});
 
 
 
@@ -154,7 +154,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet(JNIEnv* _
 
     ::std::unordered_set< ::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash< ::smoke::GenericTypesWithCompoundTypes::SomeEnum > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_set< ::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash< ::smoke::GenericTypesWithCompoundTypes::SomeEnum > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_set< ::smoke::GenericTypesWithCompoundTypes::SomeEnum, ::gluecodium::hash< ::smoke::GenericTypesWithCompoundTypes::SomeEnum > >>{});
 
 
 
@@ -179,7 +179,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList(JNI
 
     ::std::vector< ::std::shared_ptr< ::smoke::DummyClass > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< ::std::shared_ptr< ::smoke::DummyClass > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::DummyClass > >>{});
 
 
 
@@ -204,7 +204,7 @@ Java_com_example_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap(JNIE
 
     ::std::unordered_map< int32_t, ::std::shared_ptr< ::smoke::DummyClass > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< int32_t, ::std::shared_ptr< ::smoke::DummyClass > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< int32_t, ::std::shared_ptr< ::smoke::DummyClass > >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithGenericTypes.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_GenericTypesWithGenericTypes.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListOfLists(JNIEnv
 
     ::std::vector< ::std::vector< int32_t > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< ::std::vector< int32_t > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::std::vector< int32_t > >>{});
 
 
 
@@ -48,7 +48,7 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps(JNIEnv* 
 
     ::std::unordered_map< int32_t, ::std::unordered_map< int32_t, bool > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< int32_t, ::std::unordered_map< int32_t, bool > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< int32_t, ::std::unordered_map< int32_t, bool > >>{});
 
 
 
@@ -73,7 +73,7 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets(JNIEnv* 
 
     ::std::unordered_set< ::std::unordered_set< int32_t >, ::gluecodium::hash< ::std::unordered_set< int32_t > > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_set< ::std::unordered_set< int32_t >, ::gluecodium::hash< ::std::unordered_set< int32_t > > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_set< ::std::unordered_set< int32_t >, ::gluecodium::hash< ::std::unordered_set< int32_t > > >>{});
 
 
 
@@ -98,7 +98,7 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListAndMap(JNIEnv*
 
     ::std::vector< ::std::unordered_map< int32_t, bool > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< ::std::unordered_map< int32_t, bool > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::std::unordered_map< int32_t, bool > >>{});
 
 
 
@@ -123,7 +123,7 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithListAndSet(JNIEnv*
 
     ::std::vector< ::std::unordered_set< int32_t > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< ::std::unordered_set< int32_t > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::std::unordered_set< int32_t > >>{});
 
 
 
@@ -148,7 +148,7 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet(JNIEnv* 
 
     ::std::unordered_map< int32_t, ::std::unordered_set< int32_t > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< int32_t, ::std::unordered_set< int32_t > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< int32_t, ::std::unordered_set< int32_t > >>{});
 
 
 
@@ -173,7 +173,7 @@ Java_com_example_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys(JNI
 
     ::std::unordered_map< ::std::unordered_set< int32_t >, bool, ::gluecodium::hash< ::std::unordered_set< int32_t > > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::unordered_map< ::std::unordered_set< int32_t >, bool, ::gluecodium::hash< ::std::unordered_set< int32_t > > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::unordered_map< ::std::unordered_set< int32_t >, bool, ::gluecodium::hash< ::std::unordered_set< int32_t > > >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_UseOptimizedListStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android/jni/com_example_smoke_UseOptimizedListStruct__Conversion.cpp
@@ -15,7 +15,7 @@ namespace jni
 {
 
 ::smoke::UseOptimizedListStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::UseOptimizedListStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::UseOptimizedListStruct>)
 {
     
     auto j_structs = get_object_field_value(_jenv, _jinput, "structs", "Ljava/util/List;");
@@ -30,10 +30,10 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::U
 }
 
 std::optional<::smoke::UseOptimizedListStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::UseOptimizedListStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::UseOptimizedListStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::UseOptimizedListStruct>(convert_from_jni(_jenv, _jinput, (::smoke::UseOptimizedListStruct*)nullptr))
+        ? std::optional<::smoke::UseOptimizedListStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::UseOptimizedListStruct>{}))
         : std::optional<::smoke::UseOptimizedListStruct>{};
 }
 

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_foobar_CrossPackageChildInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_foobar_CrossPackageChildInterfaceImpl.cpp
@@ -64,7 +64,7 @@ Java_com_example_foobar_CrossPackageChildInterfaceImpl_setRootProperty(JNIEnv* _
 
     ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromClass__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ChildClassFromClass", co
 
 
 
-std::shared_ptr<::smoke::ChildClassFromClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ChildClassFromClass>*)
+std::shared_ptr<::smoke::ChildClassFromClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ChildClassFromClass>>)
 {
     std::shared_ptr<::smoke::ChildClassFromClass> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface.cpp
@@ -82,7 +82,7 @@ Java_com_example_smoke_ChildClassFromInterface_setRootProperty(JNIEnv* _jenv, jo
 
     ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassFromInterface__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ChildClassFromInterface"
 
 
 
-std::shared_ptr<::smoke::ChildClassFromInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ChildClassFromInterface>*)
+std::shared_ptr<::smoke::ChildClassFromInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ChildClassFromInterface>>)
 {
     std::shared_ptr<::smoke::ChildClassFromInterface> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildClassWithIncludes.cpp
@@ -28,13 +28,13 @@ Java_com_example_smoke_ChildClassWithIncludes_rootMethod(JNIEnv* _jenv, jobject 
 
     ::smoke::IncludableStruct input1 = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput1),
-            (::smoke::IncludableStruct*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::IncludableStruct>{});
 
 
 
     ::smoke::IncludableEnum input2 = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput2),
-            (::smoke::IncludableEnum*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::IncludableEnum>{});
 
 
 
@@ -81,7 +81,7 @@ Java_com_example_smoke_ChildClassWithIncludes_setRootProperty(JNIEnv* _jenv, job
 
     ::smoke::IncludableLambda value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::smoke::IncludableLambda*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::IncludableLambda>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterfaceImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterfaceImplCppProxy.cpp
@@ -38,7 +38,7 @@ com_example_smoke_ChildInterface_CppProxy::get_root_property(  ) const {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ChildInterface__Conversion.cpp
@@ -30,13 +30,13 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 
 std::shared_ptr<::smoke::ChildInterface> try_descendant_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ChildInterface>*) {
     if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::smoke::GrandChildInterface>::java_class.get())) {
-        return convert_from_jni(_env, _jobj, (std::shared_ptr<::smoke::GrandChildInterface>*)nullptr);
+        return convert_from_jni(_env, _jobj, TypeId<std::shared_ptr<::smoke::GrandChildInterface>>{});
     }
     return {};
 }
 
 
-std::shared_ptr<::smoke::ChildInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ChildInterface>*)
+std::shared_ptr<::smoke::ChildInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ChildInterface>>)
 {
     std::shared_ptr<::smoke::ChildInterface> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ParentInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/android/jni/com_example_smoke_ParentInterface__Conversion.cpp
@@ -31,19 +31,19 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 
 std::shared_ptr<::smoke::ParentInterface> try_descendant_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ParentInterface>*) {
     if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::smoke::GrandChildInterface>::java_class.get())) {
-        return convert_from_jni(_env, _jobj, (std::shared_ptr<::smoke::GrandChildInterface>*)nullptr);
+        return convert_from_jni(_env, _jobj, TypeId<std::shared_ptr<::smoke::GrandChildInterface>>{});
     }
     if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::foobar::CrossPackageChildInterface>::java_class.get())) {
-        return convert_from_jni(_env, _jobj, (std::shared_ptr<::foobar::CrossPackageChildInterface>*)nullptr);
+        return convert_from_jni(_env, _jobj, TypeId<std::shared_ptr<::foobar::CrossPackageChildInterface>>{});
     }
     if (_env->IsInstanceOf(_jobj.get(), CachedJavaInterface<::smoke::ChildInterface>::java_class.get())) {
-        return convert_from_jni(_env, _jobj, (std::shared_ptr<::smoke::ChildInterface>*)nullptr);
+        return convert_from_jni(_env, _jobj, TypeId<std::shared_ptr<::smoke::ChildInterface>>{});
     }
     return {};
 }
 
 
-std::shared_ptr<::smoke::ParentInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ParentInterface>*)
+std::shared_ptr<::smoke::ParentInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ParentInterface>>)
 {
     std::shared_ptr<::smoke::ParentInterface> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass.cpp
@@ -42,7 +42,7 @@ Java_com_example_smoke_SimpleClass_useSimpleClass(JNIEnv* _jenv, jobject _jinsta
 
     ::std::shared_ptr< ::smoke::SimpleClass > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::shared_ptr< ::smoke::SimpleClass >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::SimpleClass >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/SimpleClass", com_example_smoke_Simp
 
 
 
-std::shared_ptr<::smoke::SimpleClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::SimpleClass>*)
+std::shared_ptr<::smoke::SimpleClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleClass>>)
 {
     std::shared_ptr<::smoke::SimpleClass> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleClass__Conversion.h
@@ -1,16 +1,23 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/SimpleClass.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT std::shared_ptr<::smoke::SimpleClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::SimpleClass>*);
+
+JNIEXPORT std::shared_ptr<::smoke::SimpleClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleClass>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleClass>& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterfaceImpl.cpp
@@ -42,7 +42,7 @@ Java_com_example_smoke_SimpleInterfaceImpl_useSimpleInterface(JNIEnv* _jenv, job
 
     ::std::shared_ptr< ::smoke::SimpleInterface > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::shared_ptr< ::smoke::SimpleInterface >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::SimpleInterface >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.cpp
@@ -27,7 +27,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 }
 
 
-std::shared_ptr<::smoke::SimpleInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::SimpleInterface>*)
+std::shared_ptr<::smoke::SimpleInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleInterface>>)
 {
     std::shared_ptr<::smoke::SimpleInterface> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_SimpleInterface__Conversion.h
@@ -1,16 +1,23 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/SimpleInterface.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT std::shared_ptr<::smoke::SimpleInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::SimpleInterface>*);
+
+JNIEXPORT std::shared_ptr<::smoke::SimpleInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleInterface>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleInterface>& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithClass__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_StructWithClass__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::StructWithClass
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::StructWithClass*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::StructWithClass>)
 {
     ::smoke::StructWithClass _nout{};
     ::std::shared_ptr< ::smoke::SimpleClass > n_class_instance = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "classInstance", "Lcom/example/smoke/SimpleClass;"),
-        (::std::shared_ptr< ::smoke::SimpleClass >*)nullptr );
+        TypeId<::std::shared_ptr< ::smoke::SimpleClass >>{} );
     _nout.class_instance = n_class_instance;
     return _nout;
 }
+
 std::optional<::smoke::StructWithClass>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::StructWithClass>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::StructWithClass>>)
 {
     return _jinput
-        ? std::optional<::smoke::StructWithClass>(convert_from_jni(_jenv, _jinput, (::smoke::StructWithClass*)nullptr))
+        ? std::optional<::smoke::StructWithClass>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::StructWithClass>{}))
         : std::optional<::smoke::StructWithClass>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/StructWithClass", com_example_smoke_StructWithClass, ::smoke::StructWithClass)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::StructWithClass& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::StructWithClass>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     auto jclass_instance = convert_to_jni(_jenv, _ninput.class_instance);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "classInstance", "Lcom/example/smoke/SimpleClass;", jclass_instance);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::StructWithClass> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android/jni/com_example_smoke_StructWithInterface__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_StructWithInterface__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::StructWithInterface
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::StructWithInterface*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::StructWithInterface>)
 {
     ::smoke::StructWithInterface _nout{};
     ::std::shared_ptr< ::smoke::SimpleInterface > n_interface_instance = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "interfaceInstance", "Lcom/example/smoke/SimpleInterface;"),
-        (::std::shared_ptr< ::smoke::SimpleInterface >*)nullptr );
+        TypeId<::std::shared_ptr< ::smoke::SimpleInterface >>{} );
     _nout.interface_instance = n_interface_instance;
     return _nout;
 }
+
 std::optional<::smoke::StructWithInterface>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::StructWithInterface>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::StructWithInterface>>)
 {
     return _jinput
-        ? std::optional<::smoke::StructWithInterface>(convert_from_jni(_jenv, _jinput, (::smoke::StructWithInterface*)nullptr))
+        ? std::optional<::smoke::StructWithInterface>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::StructWithInterface>{}))
         : std::optional<::smoke::StructWithInterface>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/StructWithInterface", com_example_smoke_StructWithInterface, ::smoke::StructWithInterface)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::StructWithInterface& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::StructWithInterface>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     auto jinterface_instance = convert_to_jni(_jenv, _ninput.interface_instance);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "interfaceInstance", "Lcom/example/smoke/SimpleInterface;", jinterface_instance);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::StructWithInterface> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas.cpp
@@ -26,13 +26,13 @@ Java_com_example_smoke_Lambdas_deconfuse(JNIEnv* _jenv, jobject _jinstance, jstr
 
     ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
     ::smoke::Lambdas::Confuser confuser = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jconfuser),
-            (::smoke::Lambdas::Confuser*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::Lambdas::Confuser>{});
 
 
 
@@ -57,13 +57,13 @@ Java_com_example_smoke_Lambdas_fuse(JNIEnv* _jenv, jobject _jinstance, jobject j
 
     ::std::vector< ::std::string > items = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jitems),
-            (::std::vector< ::std::string >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::std::string >>{});
 
 
 
     ::smoke::Lambdas::Indexer callback = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jcallback),
-            (::smoke::Lambdas::Indexer*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::Lambdas::Indexer>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
@@ -24,7 +24,7 @@ Java_com_example_smoke_Lambdas_00024ConfounderImpl_confuse(JNIEnv* _jenv, jobjec
 
     ::std::string p0 = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jp0),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ConfounderImplCppProxy.cpp
@@ -27,7 +27,7 @@ com_example_smoke_Lambdas_00024Confounder_CppProxy::operator()( const ::std::str
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return com_example_smoke_Lambdas_00024Producer_convert_from_jni( jniEnv, _result, (::smoke::Lambdas::Producer*)nullptr );
+    return com_example_smoke_Lambdas_00024Producer_convert_from_jni( jniEnv, _result, TypeId<::smoke::Lambdas::Producer>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
@@ -28,7 +28,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::Lamb
 }
 
 
-::smoke::Lambdas::Confuser convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::Lambdas::Confuser*)
+::smoke::Lambdas::Confuser convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::Lambdas::Confuser>)
 {
     ::smoke::Lambdas::Confuser _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Confounder__Conversion.h
@@ -1,18 +1,25 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/Lambdas.h"
 #include <functional>
 #include "com_example_smoke_Lambdas_Producer__Conversion.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::Lambdas::Confuser convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::Lambdas::Confuser*);
+
+JNIEXPORT ::smoke::Lambdas::Confuser convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::Lambdas::Confuser>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Lambdas::Confuser& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
@@ -28,7 +28,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::Lamb
 }
 
 
-::smoke::Lambdas::Indexer convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::Lambdas::Indexer*)
+::smoke::Lambdas::Indexer convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::Lambdas::Indexer>)
 {
     ::smoke::Lambdas::Indexer _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.cpp
@@ -25,7 +25,7 @@ com_example_smoke_Lambdas_00024Producer_CppProxy::operator()(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_OverloadedLambda__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_OverloadedLambda__Conversion.cpp
@@ -28,7 +28,7 @@ void com_example_smoke_OverloadedLambda_createCppProxy(JNIEnv* env, const JniRef
 }
 
 
-::smoke::OverloadedLambda com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::OverloadedLambda*)
+::smoke::OverloadedLambda com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::OverloadedLambda>)
 {
     ::smoke::OverloadedLambda _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();
@@ -70,9 +70,9 @@ com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _jenv, const ::smoke::
 }
 
 std::optional<::smoke::OverloadedLambda>
-com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::optional<::smoke::OverloadedLambda>*) {
+com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::OverloadedLambda>>) {
     return _jobj
-        ? std::optional<::smoke::OverloadedLambda>(com_example_smoke_OverloadedLambda_convert_from_jni(_env, _jobj, (::smoke::OverloadedLambda*)nullptr))
+        ? std::optional<::smoke::OverloadedLambda>(com_example_smoke_OverloadedLambda_convert_from_jni(_env, _jobj, TypeId<::smoke::OverloadedLambda>{}))
         : std::optional<::smoke::OverloadedLambda>{};
 }
 
@@ -101,7 +101,7 @@ com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optio
 }
 
 std::vector<::smoke::OverloadedLambda>
-com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::vector<::smoke::OverloadedLambda>*) {
+com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<::smoke::OverloadedLambda>>) {
     std::vector<::smoke::OverloadedLambda> _nresult{};
     if (_env->IsSameObject(_arrayList.get(), nullptr)) {
         return _nresult;
@@ -115,16 +115,16 @@ com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniRefer
     auto getMethodId = _env->GetMethodID(javaArrayListClass.get(), "get", "(I)Ljava/lang/Object;");
     for (jint i = 0; i < length; i++) {
         auto javaListItem = call_java_method<jobject>(_env, _arrayList, getMethodId, i);
-        _nresult.push_back(com_example_smoke_OverloadedLambda_convert_from_jni(_env, javaListItem, (::smoke::OverloadedLambda*)nullptr));
+        _nresult.push_back(com_example_smoke_OverloadedLambda_convert_from_jni(_env, javaListItem, TypeId<::smoke::OverloadedLambda>{}));
     }
 
     return _nresult;
 }
 
 std::optional<std::vector<::smoke::OverloadedLambda>>
-com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::optional<std::vector<::smoke::OverloadedLambda>>*) {
+com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::OverloadedLambda>>>) {
     return _arrayList
-        ? std::optional<std::vector<::smoke::OverloadedLambda>>(com_example_smoke_OverloadedLambda_convert_from_jni(_env, _arrayList, (std::vector<::smoke::OverloadedLambda>*)nullptr))
+        ? std::optional<std::vector<::smoke::OverloadedLambda>>(com_example_smoke_OverloadedLambda_convert_from_jni(_env, _arrayList, TypeId<std::vector<::smoke::OverloadedLambda>>{}))
         : std::optional<std::vector<::smoke::OverloadedLambda>>{};
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_OverloadedLambda__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_OverloadedLambda__Conversion.h
@@ -1,88 +1,113 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/OverloadedLambda.h"
 #include <functional>
 #include "JniCallJavaMethod.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
 #include <unordered_map>
 #include <vector>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::OverloadedLambda com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::OverloadedLambda*);
+
+JNIEXPORT ::smoke::OverloadedLambda com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::OverloadedLambda>);
 JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _jenv, const ::smoke::OverloadedLambda& _ninput);
-JNIEXPORT std::optional<::smoke::OverloadedLambda> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::optional<::smoke::OverloadedLambda>*);
+JNIEXPORT std::optional<::smoke::OverloadedLambda> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::OverloadedLambda>>);
 JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<::smoke::OverloadedLambda>& _ninput);
+
 // Functions to create ArrayLists from C++ vectors and vice versa, for overloaded lambdas.
+
 JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::vector<::smoke::OverloadedLambda>& _ninput);
 JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<std::vector<::smoke::OverloadedLambda>>& _ninput);
-JNIEXPORT std::vector<::smoke::OverloadedLambda> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::vector<::smoke::OverloadedLambda>*);
-JNIEXPORT std::optional<std::vector<::smoke::OverloadedLambda>> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::optional<std::vector<::smoke::OverloadedLambda>>*);
+JNIEXPORT std::vector<::smoke::OverloadedLambda> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<::smoke::OverloadedLambda>>);
+JNIEXPORT std::optional<std::vector<::smoke::OverloadedLambda>> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::OverloadedLambda>>>);
+
 // Templated functions to create HashMaps from C++ unordered_maps and vice versa, for overloaded lambdas as values.
+
 template <typename K, typename Hash>
 JniReference<jobject>
 com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::unordered_map<K, ::smoke::OverloadedLambda, Hash>& _ninput) {
     auto javaClass = find_class(_env, "java/util/HashMap");
     auto result = create_object(_env, javaClass);
     jmethodID putMethodId = _env->GetMethodID(javaClass.get(), "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
     for (const auto& pair : _ninput) {
         auto jKey = convert_to_jni(_env, pair.first);
         auto jValue = com_example_smoke_OverloadedLambda_convert_to_jni(_env, pair.second);
         call_java_method<jobject>(_env, result, putMethodId, jKey, jValue);
     }
+
     return result;
 }
+
 template <typename K, typename Hash>
 JniReference<jobject>
 com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>& _ninput) {
     return _ninput ? com_example_smoke_OverloadedLambda_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
 }
+
 template <typename K, typename Hash>
 std::unordered_map<K, ::smoke::OverloadedLambda, Hash>
 com_example_smoke_OverloadedLambda_convert_from_jni(
-    JNIEnv* _env, const JniReference<jobject>& _jMap, std::unordered_map<K, ::smoke::OverloadedLambda, Hash>*
+    JNIEnv* _env, const JniReference<jobject>& _jMap, TypeId<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>
 ) {
     std::unordered_map<K, ::smoke::OverloadedLambda, Hash> _nresult{};
+
     if (_env->IsSameObject(_jMap.get(), nullptr)) {
         return _nresult;
     }
+
     auto javaMapClass = find_class(_env, "java/util/Map");
     auto entrySetMethodId = _env->GetMethodID(javaMapClass.get(), "entrySet", "()Ljava/util/Set;");
     auto jEntrySet = call_java_method<jobject>(_env, _jMap, entrySetMethodId);
+
     auto javaSetClass = find_class(_env, "java/util/Set");
     auto iteratorMethodId = _env->GetMethodID(javaSetClass.get(), "iterator", "()Ljava/util/Iterator;");
     auto jIterator = call_java_method<jobject>(_env, jEntrySet, iteratorMethodId);
+
     auto javaIteratorClass = find_class(_env, "java/util/Iterator");
     auto hasNextMethodId = _env->GetMethodID(javaIteratorClass.get(), "hasNext", "()Z");
     auto nextMethodId = _env->GetMethodID(javaIteratorClass.get(), "next", "()Ljava/lang/Object;");
+
     auto javaMapEntryClass = find_class(_env, "java/util/Map$Entry");
     auto getKeyMethodId = _env->GetMethodID(javaMapEntryClass.get(), "getKey", "()Ljava/lang/Object;");
     auto getValueMethodId = _env->GetMethodID(javaMapEntryClass.get(), "getValue", "()Ljava/lang/Object;");
+
     while (call_java_method<jboolean>(_env, jIterator, hasNextMethodId)) {
         auto jEntry = call_java_method<jobject>(_env, jIterator, nextMethodId);
         auto jKey = call_java_method<jobject>(_env, jEntry, getKeyMethodId);
-        K nKey = convert_from_jni(_env, jKey, (K*)nullptr);
+        K nKey = convert_from_jni(_env, jKey, TypeId<K>{});
+
         auto jValue = call_java_method<jobject>(_env, jEntry, getValueMethodId);
-        auto nValue = com_example_smoke_OverloadedLambda_convert_from_jni(_env, jValue, (::smoke::OverloadedLambda*)nullptr);
+        auto nValue = com_example_smoke_OverloadedLambda_convert_from_jni(_env, jValue, TypeId<::smoke::OverloadedLambda>{});
+
         _nresult.emplace(std::move(nKey), std::move(nValue));
     }
+
     return _nresult;
 }
+
 template<typename K, typename Hash>
 std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>
 com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& _jMap,
-                 std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>*)
+                 TypeId<std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>>)
 {
     return _jMap
         ? std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>(
-            com_example_smoke_OverloadedLambda_convert_from_jni(_env, _jMap, (std::unordered_map<K, ::smoke::OverloadedLambda, Hash>*)nullptr)
+            com_example_smoke_OverloadedLambda_convert_from_jni(_env, _jMap, TypeId<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>{})
         ) : std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_StandaloneProducer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_StandaloneProducer__Conversion.cpp
@@ -28,7 +28,7 @@ void com_example_smoke_StandaloneProducer_createCppProxy(JNIEnv* env, const JniR
 }
 
 
-::smoke::StandaloneProducer com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::StandaloneProducer*)
+::smoke::StandaloneProducer com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::StandaloneProducer>)
 {
     ::smoke::StandaloneProducer _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();
@@ -70,9 +70,9 @@ com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _jenv, const ::smoke
 }
 
 std::optional<::smoke::StandaloneProducer>
-com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::optional<::smoke::StandaloneProducer>*) {
+com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::StandaloneProducer>>) {
     return _jobj
-        ? std::optional<::smoke::StandaloneProducer>(com_example_smoke_StandaloneProducer_convert_from_jni(_env, _jobj, (::smoke::StandaloneProducer*)nullptr))
+        ? std::optional<::smoke::StandaloneProducer>(com_example_smoke_StandaloneProducer_convert_from_jni(_env, _jobj, TypeId<::smoke::StandaloneProducer>{}))
         : std::optional<::smoke::StandaloneProducer>{};
 }
 
@@ -101,7 +101,7 @@ com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::opt
 }
 
 std::vector<::smoke::StandaloneProducer>
-com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::vector<::smoke::StandaloneProducer>*) {
+com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<::smoke::StandaloneProducer>>) {
     std::vector<::smoke::StandaloneProducer> _nresult{};
     if (_env->IsSameObject(_arrayList.get(), nullptr)) {
         return _nresult;
@@ -115,16 +115,16 @@ com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniRef
     auto getMethodId = _env->GetMethodID(javaArrayListClass.get(), "get", "(I)Ljava/lang/Object;");
     for (jint i = 0; i < length; i++) {
         auto javaListItem = call_java_method<jobject>(_env, _arrayList, getMethodId, i);
-        _nresult.push_back(com_example_smoke_StandaloneProducer_convert_from_jni(_env, javaListItem, (::smoke::StandaloneProducer*)nullptr));
+        _nresult.push_back(com_example_smoke_StandaloneProducer_convert_from_jni(_env, javaListItem, TypeId<::smoke::StandaloneProducer>{}));
     }
 
     return _nresult;
 }
 
 std::optional<std::vector<::smoke::StandaloneProducer>>
-com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::optional<std::vector<::smoke::StandaloneProducer>>*) {
+com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::StandaloneProducer>>>) {
     return _arrayList
-        ? std::optional<std::vector<::smoke::StandaloneProducer>>(com_example_smoke_StandaloneProducer_convert_from_jni(_env, _arrayList, (std::vector<::smoke::StandaloneProducer>*)nullptr))
+        ? std::optional<std::vector<::smoke::StandaloneProducer>>(com_example_smoke_StandaloneProducer_convert_from_jni(_env, _arrayList, TypeId<std::vector<::smoke::StandaloneProducer>>{}))
         : std::optional<std::vector<::smoke::StandaloneProducer>>{};
 }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_StandaloneProducer__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android/jni/com_example_smoke_StandaloneProducer__Conversion.h
@@ -1,88 +1,113 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/StandaloneProducer.h"
 #include <functional>
 #include "JniCallJavaMethod.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
 #include <unordered_map>
 #include <vector>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::StandaloneProducer com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::StandaloneProducer*);
+
+JNIEXPORT ::smoke::StandaloneProducer com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::StandaloneProducer>);
 JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _jenv, const ::smoke::StandaloneProducer& _ninput);
-JNIEXPORT std::optional<::smoke::StandaloneProducer> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::optional<::smoke::StandaloneProducer>*);
+JNIEXPORT std::optional<::smoke::StandaloneProducer> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::StandaloneProducer>>);
 JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<::smoke::StandaloneProducer>& _ninput);
+
 // Functions to create ArrayLists from C++ vectors and vice versa, for overloaded lambdas.
+
 JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::vector<::smoke::StandaloneProducer>& _ninput);
 JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<std::vector<::smoke::StandaloneProducer>>& _ninput);
-JNIEXPORT std::vector<::smoke::StandaloneProducer> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::vector<::smoke::StandaloneProducer>*);
-JNIEXPORT std::optional<std::vector<::smoke::StandaloneProducer>> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, std::optional<std::vector<::smoke::StandaloneProducer>>*);
+JNIEXPORT std::vector<::smoke::StandaloneProducer> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<::smoke::StandaloneProducer>>);
+JNIEXPORT std::optional<std::vector<::smoke::StandaloneProducer>> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::StandaloneProducer>>>);
+
 // Templated functions to create HashMaps from C++ unordered_maps and vice versa, for overloaded lambdas as values.
+
 template <typename K, typename Hash>
 JniReference<jobject>
 com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::unordered_map<K, ::smoke::StandaloneProducer, Hash>& _ninput) {
     auto javaClass = find_class(_env, "java/util/HashMap");
     auto result = create_object(_env, javaClass);
     jmethodID putMethodId = _env->GetMethodID(javaClass.get(), "put", "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+
     for (const auto& pair : _ninput) {
         auto jKey = convert_to_jni(_env, pair.first);
         auto jValue = com_example_smoke_StandaloneProducer_convert_to_jni(_env, pair.second);
         call_java_method<jobject>(_env, result, putMethodId, jKey, jValue);
     }
+
     return result;
 }
+
 template <typename K, typename Hash>
 JniReference<jobject>
 com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>& _ninput) {
     return _ninput ? com_example_smoke_StandaloneProducer_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
 }
+
 template <typename K, typename Hash>
 std::unordered_map<K, ::smoke::StandaloneProducer, Hash>
 com_example_smoke_StandaloneProducer_convert_from_jni(
-    JNIEnv* _env, const JniReference<jobject>& _jMap, std::unordered_map<K, ::smoke::StandaloneProducer, Hash>*
+    JNIEnv* _env, const JniReference<jobject>& _jMap, TypeId<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>
 ) {
     std::unordered_map<K, ::smoke::StandaloneProducer, Hash> _nresult{};
+
     if (_env->IsSameObject(_jMap.get(), nullptr)) {
         return _nresult;
     }
+
     auto javaMapClass = find_class(_env, "java/util/Map");
     auto entrySetMethodId = _env->GetMethodID(javaMapClass.get(), "entrySet", "()Ljava/util/Set;");
     auto jEntrySet = call_java_method<jobject>(_env, _jMap, entrySetMethodId);
+
     auto javaSetClass = find_class(_env, "java/util/Set");
     auto iteratorMethodId = _env->GetMethodID(javaSetClass.get(), "iterator", "()Ljava/util/Iterator;");
     auto jIterator = call_java_method<jobject>(_env, jEntrySet, iteratorMethodId);
+
     auto javaIteratorClass = find_class(_env, "java/util/Iterator");
     auto hasNextMethodId = _env->GetMethodID(javaIteratorClass.get(), "hasNext", "()Z");
     auto nextMethodId = _env->GetMethodID(javaIteratorClass.get(), "next", "()Ljava/lang/Object;");
+
     auto javaMapEntryClass = find_class(_env, "java/util/Map$Entry");
     auto getKeyMethodId = _env->GetMethodID(javaMapEntryClass.get(), "getKey", "()Ljava/lang/Object;");
     auto getValueMethodId = _env->GetMethodID(javaMapEntryClass.get(), "getValue", "()Ljava/lang/Object;");
+
     while (call_java_method<jboolean>(_env, jIterator, hasNextMethodId)) {
         auto jEntry = call_java_method<jobject>(_env, jIterator, nextMethodId);
         auto jKey = call_java_method<jobject>(_env, jEntry, getKeyMethodId);
-        K nKey = convert_from_jni(_env, jKey, (K*)nullptr);
+        K nKey = convert_from_jni(_env, jKey, TypeId<K>{});
+
         auto jValue = call_java_method<jobject>(_env, jEntry, getValueMethodId);
-        auto nValue = com_example_smoke_StandaloneProducer_convert_from_jni(_env, jValue, (::smoke::StandaloneProducer*)nullptr);
+        auto nValue = com_example_smoke_StandaloneProducer_convert_from_jni(_env, jValue, TypeId<::smoke::StandaloneProducer>{});
+
         _nresult.emplace(std::move(nKey), std::move(nValue));
     }
+
     return _nresult;
 }
+
 template<typename K, typename Hash>
 std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>
 com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env,
                  const JniReference<jobject>& _jMap,
-                 std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>*)
+                 TypeId<std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>>)
 {
     return _jMap
         ? std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>(
-            com_example_smoke_StandaloneProducer_convert_from_jni(_env, _jMap, (std::unordered_map<K, ::smoke::StandaloneProducer, Hash>*)nullptr)
+            com_example_smoke_StandaloneProducer_convert_from_jni(_env, _jMap, TypeId<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>{})
         ) : std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.cpp
@@ -27,7 +27,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 }
 
 
-std::shared_ptr<::smoke::CalculatorListener> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::CalculatorListener>*)
+std::shared_ptr<::smoke::CalculatorListener> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::CalculatorListener>>)
 {
     std::shared_ptr<::smoke::CalculatorListener> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_CalculatorListener__Conversion.h
@@ -1,18 +1,25 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/CalculatorListener.h"
 #include "com_example_smoke_CalculationResult__Conversion.h"
 #include "com_example_smoke_CalculatorListener_ResultStruct__Conversion.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT std::shared_ptr<::smoke::CalculatorListener> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::CalculatorListener>*);
+
+JNIEXPORT std::shared_ptr<::smoke::CalculatorListener> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::CalculatorListener>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::CalculatorListener>& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImpl.cpp
@@ -78,7 +78,7 @@ Java_com_example_smoke_InterfaceWithStaticImpl_setRegularProperty(JNIEnv* _jenv,
 
     ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
@@ -120,7 +120,7 @@ Java_com_example_smoke_InterfaceWithStaticImpl_setStaticProperty(JNIEnv* _jenv, 
 
     ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.cpp
@@ -25,7 +25,7 @@ com_example_smoke_InterfaceWithStatic_CppProxy::regular_function(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
 
@@ -40,7 +40,7 @@ com_example_smoke_InterfaceWithStatic_CppProxy::get_regular_property(  ) const {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithNullableImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithNullableImplCppProxy.cpp
@@ -26,7 +26,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_byte( const std::op
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< int8_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int8_t >>{});
 
 
 
@@ -41,7 +41,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_byte( const std::
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< uint8_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint8_t >>{});
 
 
 
@@ -56,7 +56,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_short( const std::o
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< int16_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int16_t >>{});
 
 
 
@@ -71,7 +71,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_short( const std:
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< uint16_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint16_t >>{});
 
 
 
@@ -86,7 +86,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_int( const std::opt
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< int32_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int32_t >>{});
 
 
 
@@ -101,7 +101,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_int( const std::o
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< uint32_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint32_t >>{});
 
 
 
@@ -116,7 +116,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_long( const std::op
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< int64_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int64_t >>{});
 
 
 
@@ -131,7 +131,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_long( const std::
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< uint64_t >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint64_t >>{});
 
 
 
@@ -146,7 +146,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const std::
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< bool >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< bool >>{});
 
 
 
@@ -161,7 +161,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_float( const std::o
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< float >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< float >>{});
 
 
 
@@ -176,7 +176,7 @@ com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const std::
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (std::optional< double >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< double >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
@@ -29,7 +29,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_message(  ) const {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
 
@@ -60,7 +60,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_packed_message(  ) const 
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::shared_ptr< ::smoke::CalculationResult >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::shared_ptr< ::smoke::CalculationResult >>{});
 
 
 
@@ -91,7 +91,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_structured_message(  ) co
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::smoke::ListenerWithProperties::ResultStruct*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenerWithProperties::ResultStruct>{});
 
 
 
@@ -122,7 +122,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_enumerated_message(  ) co
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::smoke::ListenerWithProperties::ResultEnum*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenerWithProperties::ResultEnum>{});
 
 
 
@@ -153,7 +153,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_arrayed_message(  ) const
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::vector< ::std::string >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::vector< ::std::string >>{});
 
 
 
@@ -184,7 +184,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_mapped_message(  ) const 
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::smoke::ListenerWithProperties::StringToDouble*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenerWithProperties::StringToDouble>{});
 
 
 
@@ -215,7 +215,7 @@ com_example_smoke_ListenerWithProperties_CppProxy::get_buffered_message(  ) cons
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::shared_ptr< ::std::vector< uint8_t > >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::shared_ptr< ::std::vector< uint8_t > >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
@@ -27,7 +27,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 }
 
 
-std::shared_ptr<::smoke::ListenerWithProperties> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ListenerWithProperties>*)
+std::shared_ptr<::smoke::ListenerWithProperties> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenerWithProperties>>)
 {
     std::shared_ptr<::smoke::ListenerWithProperties> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
@@ -42,7 +42,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_string(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
 
@@ -56,7 +56,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_struct(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::smoke::ListenersWithReturnValues::ResultStruct*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenersWithReturnValues::ResultStruct>{});
 
 
 
@@ -70,7 +70,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_enum(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::smoke::ListenersWithReturnValues::ResultEnum*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenersWithReturnValues::ResultEnum>{});
 
 
 
@@ -84,7 +84,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_array(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::vector< double >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::vector< double >>{});
 
 
 
@@ -98,7 +98,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_map(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::smoke::ListenersWithReturnValues::StringToDouble*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenersWithReturnValues::StringToDouble>{});
 
 
 
@@ -112,7 +112,7 @@ com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_instance(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::shared_ptr< ::smoke::CalculationResult >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::shared_ptr< ::smoke::CalculationResult >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
@@ -27,7 +27,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 }
 
 
-std::shared_ptr<::smoke::ListenersWithReturnValues> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ListenersWithReturnValues>*)
+std::shared_ptr<::smoke::ListenersWithReturnValues> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenersWithReturnValues>>)
 {
     std::shared_ptr<::smoke::ListenersWithReturnValues> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/locales/output/android/jni/com_example_smoke_Locales.cpp
+++ b/gluecodium/src/test/resources/smoke/locales/output/android/jni/com_example_smoke_Locales.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_Locales_localeMethod(JNIEnv* _jenv, jobject _jinstance, j
 
     ::gluecodium::Locale input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::gluecodium::Locale*)nullptr);
+            ::gluecodium::jni::TypeId<::gluecodium::Locale>{});
 
 
 
@@ -70,7 +70,7 @@ Java_com_example_smoke_Locales_setLocaleProperty(JNIEnv* _jenv, jobject _jinstan
 
     ::gluecodium::Locale value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::gluecodium::Locale*)nullptr);
+            ::gluecodium::jni::TypeId<::gluecodium::Locale>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_JavaMethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_JavaMethodOverloads.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_JavaMethodOverloads_three__Ljava_lang_String_2(JNIEnv* _j
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
@@ -47,7 +47,7 @@ Java_com_example_smoke_JavaMethodOverloads_three__Ljava_util_List_2(JNIEnv* _jen
 
     ::std::vector< ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::vector< ::std::string >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::std::string >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_MethodOverloads.cpp
@@ -70,7 +70,7 @@ Java_com_example_smoke_MethodOverloads_isBoolean__Ljava_lang_String_2(JNIEnv* _j
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
@@ -95,7 +95,7 @@ Java_com_example_smoke_MethodOverloads_isBoolean__Lcom_example_smoke_MethodOverl
 
     ::smoke::MethodOverloads::Point input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::MethodOverloads::Point*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::Point>{});
 
 
 
@@ -128,13 +128,13 @@ Java_com_example_smoke_MethodOverloads_isBoolean__ZBLjava_lang_String_2Lcom_exam
 
     ::std::string input3 = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput3),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
     ::smoke::MethodOverloads::Point input4 = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput4),
-            (::smoke::MethodOverloads::Point*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::Point>{});
 
 
 
@@ -159,7 +159,7 @@ Java_com_example_smoke_MethodOverloads_isBooleanStringArrayOverload(JNIEnv* _jen
 
     ::smoke::MethodOverloads::StringArray input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::MethodOverloads::StringArray*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::StringArray>{});
 
 
 
@@ -184,7 +184,7 @@ Java_com_example_smoke_MethodOverloads_isBooleanIntArrayOverload(JNIEnv* _jenv, 
 
     ::smoke::MethodOverloads::IntArray input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::MethodOverloads::IntArray*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::IntArray>{});
 
 
 
@@ -228,7 +228,7 @@ Java_com_example_smoke_MethodOverloads_isFloat__Ljava_lang_String_2(JNIEnv* _jen
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
@@ -253,7 +253,7 @@ Java_com_example_smoke_MethodOverloads_isFloat__Ljava_util_List_2(JNIEnv* _jenv,
 
     ::smoke::MethodOverloads::IntArray input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::smoke::MethodOverloads::IntArray*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::IntArray>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_SpecialNames.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android/jni/com_example_smoke_SpecialNames.cpp
@@ -95,7 +95,7 @@ Java_com_example_smoke_SpecialNames_make(JNIEnv* _jenv, jobject _jinstance, jstr
 
     ::std::string result = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jresult),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/jni/com_example_smoke_ParentNarrowOne__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android/jni/com_example_smoke_ParentNarrowOne__Conversion.cpp
@@ -27,7 +27,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 }
 
 
-std::shared_ptr<::smoke::ParentNarrowOne> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ParentNarrowOne>*)
+std::shared_ptr<::smoke::ParentNarrowOne> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ParentNarrowOne>>)
 {
     std::shared_ptr<::smoke::ParentNarrowOne> _nresult{};
     createCppProxy(_env, _jobj, _nresult);

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID.cpp
@@ -48,7 +48,7 @@ Java_com_example_namerules_NAME_1RULES_1DROID_some_1method(JNIEnv* _jenv, jobjec
 
     ::namerules::NameRules::ExampleStruct some_argument = ::jni::convert_from_jni(_jenv,
             ::jni::make_non_releasing_ref(jsome_argument),
-            (::namerules::NameRules::ExampleStruct*)nullptr);
+            ::jni::TypeId<::namerules::NameRules::ExampleStruct>{});
 
 
 
@@ -201,7 +201,7 @@ Java_com_example_namerules_NAME_1RULES_1DROID_STORE_1STRUCT_1PROPERTY(JNIEnv* _j
 
     ::namerules::NameRules::ExampleStruct value = ::jni::convert_from_jni(_jenv,
             ::jni::make_non_releasing_ref(jvalue),
-            (::namerules::NameRules::ExampleStruct*)nullptr);
+            ::jni::TypeId<::namerules::NameRules::ExampleStruct>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID_EXAMPLE_ERROR_CODE_DROID__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID_EXAMPLE_ERROR_CODE_DROID__Conversion.cpp
@@ -1,26 +1,33 @@
 /*
+
  *
  */
+
 #include "com_example_namerules_NAME_RULES_DROID_EXAMPLE_ERROR_CODE_DROID__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace jni
 {
+
 ::namerules::NameRules::ExampleErrorCode
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::namerules::NameRules::ExampleErrorCode*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::namerules::NameRules::ExampleErrorCode>)
 {
     return ::namerules::NameRules::ExampleErrorCode(
-        ::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
+
 std::optional<::namerules::NameRules::ExampleErrorCode>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::namerules::NameRules::ExampleErrorCode>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::namerules::NameRules::ExampleErrorCode>>)
 {
     return _jinput
-        ? std::optional<::namerules::NameRules::ExampleErrorCode>(convert_from_jni(_jenv, _jinput, (::namerules::NameRules::ExampleErrorCode*)nullptr))
+        ? std::optional<::namerules::NameRules::ExampleErrorCode>(convert_from_jni(_jenv, _jinput, TypeId<::namerules::NameRules::ExampleErrorCode>{}))
         : std::optional<::namerules::NameRules::ExampleErrorCode>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/namerules/NAME_RULES_DROID$EXAMPLE_ERROR_CODE_DROID", com_example_namerules_NAME_1RULES_1DROID_00024EXAMPLE_1ERROR_1CODE_1DROID, ::namerules::NameRules::ExampleErrorCode)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::namerules::NameRules::ExampleErrorCode _ninput)
 {
@@ -37,9 +44,11 @@ convert_to_jni(JNIEnv* _jenv, const ::namerules::NameRules::ExampleErrorCode _ni
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/namerules/NAME_RULES_DROID$EXAMPLE_ERROR_CODE_DROID;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::namerules::NameRules::ExampleErrorCode> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID_EXAMPLE_STRUCT_DROID__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android/jni/com_example_namerules_NAME_RULES_DROID_EXAMPLE_STRUCT_DROID__Conversion.cpp
@@ -1,51 +1,62 @@
 /*
+
  *
  */
+
 #include "com_example_namerules_NAME_RULES_DROID_EXAMPLE_STRUCT_DROID__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace jni
 {
+
 ::namerules::NameRules::ExampleStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::namerules::NameRules::ExampleStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::namerules::NameRules::ExampleStruct>)
 {
     ::namerules::NameRules::ExampleStruct _nout{};
     double n_m_value = ::jni::get_field_value(
         _jenv,
         _jinput,
         "j_value",
-        (double*)nullptr );
+        TypeId<double>{} );
     _nout.m_value = n_m_value;
     ::std::vector< int64_t > n_m_int_value = convert_from_jni(
         _jenv,
         ::jni::get_object_field_value(_jenv, _jinput, "j_int_value", "Ljava/util/List;"),
-        (::std::vector< int64_t >*)nullptr );
+        TypeId<::std::vector< int64_t >>{} );
     _nout.m_int_value = n_m_int_value;
     return _nout;
 }
+
 std::optional<::namerules::NameRules::ExampleStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::namerules::NameRules::ExampleStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::namerules::NameRules::ExampleStruct>>)
 {
     return _jinput
-        ? std::optional<::namerules::NameRules::ExampleStruct>(convert_from_jni(_jenv, _jinput, (::namerules::NameRules::ExampleStruct*)nullptr))
+        ? std::optional<::namerules::NameRules::ExampleStruct>(convert_from_jni(_jenv, _jinput, TypeId<::namerules::NameRules::ExampleStruct>{}))
         : std::optional<::namerules::NameRules::ExampleStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/namerules/NAME_RULES_DROID$EXAMPLE_STRUCT_DROID", com_example_namerules_NAME_1RULES_1DROID_00024EXAMPLE_1STRUCT_1DROID, ::namerules::NameRules::ExampleStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::namerules::NameRules::ExampleStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::namerules::NameRules::ExampleStruct>::java_class;
     auto _jresult = ::jni::alloc_object(_jenv, javaClass);
+
     ::jni::set_field_value(_jenv, _jresult, "j_value", _ninput.m_value);
+
     auto jm_int_value = convert_to_jni(_jenv, _ninput.m_int_value);
     ::jni::set_object_field_value(_jenv, _jresult, "j_int_value", "Ljava/util/List;", jm_int_value);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::namerules::NameRules::ExampleStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/android/jni/com_example_smoke_Basic.cpp
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/android/jni/com_example_smoke_Basic.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_Basic_basicMethod(JNIEnv* _jenv, jobject _jinstance, jstr
 
     ::std::string inputString = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinputString),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/android/jni/com_example_smoke_BasicTypes_SomeStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/android/jni/com_example_smoke_BasicTypes_SomeStruct__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_BasicTypes_SomeStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::root::space::smoke::BasicTypes::SomeStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::root::space::smoke::BasicTypes::SomeStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::root::space::smoke::BasicTypes::SomeStruct>)
 {
     ::root::space::smoke::BasicTypes::SomeStruct _nout{};
     ::std::string n_some_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "someField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
     _nout.some_field = n_some_field;
     return _nout;
 }
+
 std::optional<::root::space::smoke::BasicTypes::SomeStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::root::space::smoke::BasicTypes::SomeStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::root::space::smoke::BasicTypes::SomeStruct>>)
 {
     return _jinput
-        ? std::optional<::root::space::smoke::BasicTypes::SomeStruct>(convert_from_jni(_jenv, _jinput, (::root::space::smoke::BasicTypes::SomeStruct*)nullptr))
+        ? std::optional<::root::space::smoke::BasicTypes::SomeStruct>(convert_from_jni(_jenv, _jinput, TypeId<::root::space::smoke::BasicTypes::SomeStruct>{}))
         : std::optional<::root::space::smoke::BasicTypes::SomeStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/BasicTypes$SomeStruct", com_example_smoke_BasicTypes_00024SomeStruct, ::root::space::smoke::BasicTypes::SomeStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::root::space::smoke::BasicTypes::SomeStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::root::space::smoke::BasicTypes::SomeStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "someField", _ninput.some_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::root::space::smoke::BasicTypes::SomeStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree.cpp
@@ -26,7 +26,7 @@ Java_com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_foo(JNIEnv* _jenv,
 
     ::std::shared_ptr< ::smoke::OuterClass::InnerInterface > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::shared_ptr< ::smoke::OuterClass::InnerInterface >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::OuterClass::InnerInterface >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum__Conversion.cpp
@@ -1,28 +1,35 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>)
 {
     return ::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum(
-        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
+
 std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>>)
 {
     return _jinput
-        ? std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>(convert_from_jni(_jenv, _jinput, (::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum*)nullptr))
+        ? std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>{}))
         : std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/LevelOne$LevelTwo$LevelThree$LevelFourEnum", com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_00024LevelFourEnum, ::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum _ninput)
 {
@@ -36,10 +43,12 @@ convert_to_jni(JNIEnv* _jenv, const ::smoke::LevelOne::LevelTwo::LevelThree::Lev
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/LevelOne$LevelTwo$LevelThree$LevelFourEnum;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFourEnum> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_LevelOne_LevelTwo_LevelThree_LevelFour__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>)
 {
     ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour _nout{};
     ::std::string n_string_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "stringField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
     _nout.string_field = n_string_field;
     return _nout;
 }
+
 std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>>)
 {
     return _jinput
-        ? std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>(convert_from_jni(_jenv, _jinput, (::smoke::LevelOne::LevelTwo::LevelThree::LevelFour*)nullptr))
+        ? std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>{}))
         : std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/LevelOne$LevelTwo$LevelThree$LevelFour", com_example_smoke_LevelOne_00024LevelTwo_00024LevelThree_00024LevelFour, ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::LevelOne::LevelTwo::LevelThree::LevelFour& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.string_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::LevelOne::LevelTwo::LevelThree::LevelFour> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_LevelOne_LevelTwo_LevelThree__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/LevelOne$LevelTwo$LevelThree", com_e
 
 
 
-std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>*)
+std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree>>)
 {
     std::shared_ptr<::smoke::LevelOne::LevelTwo::LevelThree> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences.cpp
@@ -24,13 +24,13 @@ Java_com_example_smoke_NestedReferences_insideOut(JNIEnv* _jenv, jobject _jinsta
 
     ::smoke::NestedReferences::NestedReferences struct1 = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jstruct1),
-            (::smoke::NestedReferences::NestedReferences*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::NestedReferences::NestedReferences>{});
 
 
 
     ::smoke::NestedReferences::NestedReferences struct2 = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jstruct2),
-            (::smoke::NestedReferences::NestedReferences*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::NestedReferences::NestedReferences>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_NestedReferences__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/NestedReferences", com_example_smoke
 
 
 
-std::shared_ptr<::smoke::NestedReferences> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::NestedReferences>*)
+std::shared_ptr<::smoke::NestedReferences> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::NestedReferences>>)
 {
     std::shared_ptr<::smoke::NestedReferences> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerClass.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_OuterClass_00024InnerClass_foo(JNIEnv* _jenv, jobject _ji
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterClass_InnerInterfaceImpl.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_OuterClass_00024InnerInterfaceImpl_foo(JNIEnv* _jenv, job
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerClass.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerClass.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_OuterInterface_00024InnerClass_foo(JNIEnv* _jenv, jobject
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterInterface_InnerInterfaceImpl.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_OuterInterface_00024InnerInterfaceImpl_foo(JNIEnv* _jenv,
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct.cpp
@@ -27,7 +27,7 @@ Java_com_example_smoke_OuterStruct_doNothing(JNIEnv* _jenv, jobject _jinstance)
 
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
-        (::smoke::OuterStruct*)nullptr);
+        ::gluecodium::jni::TypeId<::smoke::OuterStruct>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerEnum__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerEnum__Conversion.cpp
@@ -1,28 +1,35 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_OuterStruct_InnerEnum__Conversion.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::OuterStruct::InnerEnum
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::OuterStruct::InnerEnum*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::OuterStruct::InnerEnum>)
 {
     return ::smoke::OuterStruct::InnerEnum(
-        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", (int32_t*)nullptr));
+        ::gluecodium::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
 }
+
 std::optional<::smoke::OuterStruct::InnerEnum>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::OuterStruct::InnerEnum>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::OuterStruct::InnerEnum>>)
 {
     return _jinput
-        ? std::optional<::smoke::OuterStruct::InnerEnum>(convert_from_jni(_jenv, _jinput, (::smoke::OuterStruct::InnerEnum*)nullptr))
+        ? std::optional<::smoke::OuterStruct::InnerEnum>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::OuterStruct::InnerEnum>{}))
         : std::optional<::smoke::OuterStruct::InnerEnum>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/OuterStruct$InnerEnum", com_example_smoke_OuterStruct_00024InnerEnum, ::smoke::OuterStruct::InnerEnum)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::OuterStruct::InnerEnum _ninput)
 {
@@ -39,10 +46,12 @@ convert_to_jni(JNIEnv* _jenv, const ::smoke::OuterStruct::InnerEnum _ninput)
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/smoke/OuterStruct$InnerEnum;");
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::OuterStruct::InnerEnum> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerInterfaceImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerInterfaceImplCppProxy.cpp
@@ -25,7 +25,7 @@ com_example_smoke_OuterStruct_00024InnerInterface_CppProxy::bar_baz(  ) {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > >*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::unordered_map< ::std::string, ::std::shared_ptr< ::std::vector< uint8_t > > >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerLambda__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerLambda__Conversion.cpp
@@ -28,7 +28,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::Oute
 }
 
 
-::smoke::OuterStruct::InnerLambda convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::OuterStruct::InnerLambda*)
+::smoke::OuterStruct::InnerLambda convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::OuterStruct::InnerLambda>)
 {
     ::smoke::OuterStruct::InnerLambda _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerLambda__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerLambda__Conversion.h
@@ -1,17 +1,24 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/OuterStruct.h"
 #include <functional>
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::OuterStruct::InnerLambda convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, ::smoke::OuterStruct::InnerLambda*);
+
+JNIEXPORT ::smoke::OuterStruct::InnerLambda convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::OuterStruct::InnerLambda>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::OuterStruct::InnerLambda& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerStruct.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerStruct.cpp
@@ -23,7 +23,7 @@ Java_com_example_smoke_OuterStruct_00024InnerStruct_doSomething(JNIEnv* _jenv, j
 
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
-        (::smoke::OuterStruct::InnerStruct*)nullptr);
+        ::gluecodium::jni::TypeId<::smoke::OuterStruct::InnerStruct>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android/jni/com_example_smoke_OuterStruct_InnerStruct__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_OuterStruct_InnerStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::OuterStruct::InnerStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::OuterStruct::InnerStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::OuterStruct::InnerStruct>)
 {
     ::smoke::OuterStruct::InnerStruct _nout{};
     ::std::vector< ::std::chrono::system_clock::time_point > n_other_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "otherField", "Ljava/util/List;"),
-        (::std::vector< ::std::chrono::system_clock::time_point >*)nullptr );
+        TypeId<::std::vector< ::std::chrono::system_clock::time_point >>{} );
     _nout.other_field = n_other_field;
     return _nout;
 }
+
 std::optional<::smoke::OuterStruct::InnerStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::OuterStruct::InnerStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::OuterStruct::InnerStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::OuterStruct::InnerStruct>(convert_from_jni(_jenv, _jinput, (::smoke::OuterStruct::InnerStruct*)nullptr))
+        ? std::optional<::smoke::OuterStruct::InnerStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::OuterStruct::InnerStruct>{}))
         : std::optional<::smoke::OuterStruct::InnerStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/OuterStruct$InnerStruct", com_example_smoke_OuterStruct_00024InnerStruct, ::smoke::OuterStruct::InnerStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::OuterStruct::InnerStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::OuterStruct::InnerStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     auto jother_field = convert_to_jni(_jenv, _ninput.other_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "otherField", "Ljava/util/List;", jother_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::OuterStruct::InnerStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/no_cache/output/android/jni/com_example_smoke_NoCacheClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/android/jni/com_example_smoke_NoCacheClass__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/NoCacheClass", com_example_smoke_NoC
 
 
 
-std::shared_ptr<::smoke::NoCacheClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::NoCacheClass>*)
+std::shared_ptr<::smoke::NoCacheClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::NoCacheClass>>)
 {
     std::shared_ptr<::smoke::NoCacheClass> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/no_cache/output/android/jni/com_example_smoke_NoCacheInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/android/jni/com_example_smoke_NoCacheInterface__Conversion.cpp
@@ -27,7 +27,7 @@ void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared
 }
 
 
-std::shared_ptr<::smoke::NoCacheInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::NoCacheInterface>*)
+std::shared_ptr<::smoke::NoCacheInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::NoCacheInterface>>)
 {
     std::shared_ptr<::smoke::NoCacheInterface> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable.cpp
@@ -26,7 +26,7 @@ Java_com_example_smoke_Nullable_methodWithString(JNIEnv* _jenv, jobject _jinstan
 
     std::optional< ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::std::string >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::std::string >>{});
 
 
 
@@ -51,7 +51,7 @@ Java_com_example_smoke_Nullable_methodWithBoolean(JNIEnv* _jenv, jobject _jinsta
 
     std::optional< bool > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< bool >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< bool >>{});
 
 
 
@@ -76,7 +76,7 @@ Java_com_example_smoke_Nullable_methodWithDouble(JNIEnv* _jenv, jobject _jinstan
 
     std::optional< double > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< double >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< double >>{});
 
 
 
@@ -101,7 +101,7 @@ Java_com_example_smoke_Nullable_methodWithInt(JNIEnv* _jenv, jobject _jinstance,
 
     std::optional< int64_t > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< int64_t >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< int64_t >>{});
 
 
 
@@ -126,7 +126,7 @@ Java_com_example_smoke_Nullable_methodWithSomeStruct(JNIEnv* _jenv, jobject _jin
 
     std::optional< ::smoke::Nullable::SomeStruct > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::smoke::Nullable::SomeStruct >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeStruct >>{});
 
 
 
@@ -151,7 +151,7 @@ Java_com_example_smoke_Nullable_methodWithSomeEnum(JNIEnv* _jenv, jobject _jinst
 
     std::optional< ::smoke::Nullable::SomeEnum > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::smoke::Nullable::SomeEnum >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeEnum >>{});
 
 
 
@@ -176,7 +176,7 @@ Java_com_example_smoke_Nullable_methodWithSomeArray(JNIEnv* _jenv, jobject _jins
 
     std::optional< ::smoke::Nullable::SomeArray > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::smoke::Nullable::SomeArray >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeArray >>{});
 
 
 
@@ -201,7 +201,7 @@ Java_com_example_smoke_Nullable_methodWithInlineArray(JNIEnv* _jenv, jobject _ji
 
     std::optional< ::std::vector< ::std::string > > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::std::vector< ::std::string > >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::std::vector< ::std::string > >>{});
 
 
 
@@ -226,7 +226,7 @@ Java_com_example_smoke_Nullable_methodWithSomeMap(JNIEnv* _jenv, jobject _jinsta
 
     std::optional< ::smoke::Nullable::SomeMap > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (std::optional< ::smoke::Nullable::SomeMap >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeMap >>{});
 
 
 
@@ -251,7 +251,7 @@ Java_com_example_smoke_Nullable_methodWithInstance(JNIEnv* _jenv, jobject _jinst
 
     ::std::shared_ptr< ::smoke::SomeInterface > input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::shared_ptr< ::smoke::SomeInterface >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::SomeInterface >>{});
 
 
 
@@ -298,7 +298,7 @@ Java_com_example_smoke_Nullable_setStringProperty(JNIEnv* _jenv, jobject _jinsta
 
     std::optional< ::std::string > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< ::std::string >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::std::string >>{});
 
 
 
@@ -345,7 +345,7 @@ Java_com_example_smoke_Nullable_setBoolProperty(JNIEnv* _jenv, jobject _jinstanc
 
     std::optional< bool > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< bool >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< bool >>{});
 
 
 
@@ -392,7 +392,7 @@ Java_com_example_smoke_Nullable_setDoubleProperty(JNIEnv* _jenv, jobject _jinsta
 
     std::optional< double > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< double >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< double >>{});
 
 
 
@@ -439,7 +439,7 @@ Java_com_example_smoke_Nullable_setIntProperty(JNIEnv* _jenv, jobject _jinstance
 
     std::optional< int64_t > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< int64_t >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< int64_t >>{});
 
 
 
@@ -486,7 +486,7 @@ Java_com_example_smoke_Nullable_setStructProperty(JNIEnv* _jenv, jobject _jinsta
 
     std::optional< ::smoke::Nullable::SomeStruct > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< ::smoke::Nullable::SomeStruct >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeStruct >>{});
 
 
 
@@ -533,7 +533,7 @@ Java_com_example_smoke_Nullable_setEnumProperty(JNIEnv* _jenv, jobject _jinstanc
 
     std::optional< ::smoke::Nullable::SomeEnum > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< ::smoke::Nullable::SomeEnum >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeEnum >>{});
 
 
 
@@ -580,7 +580,7 @@ Java_com_example_smoke_Nullable_setArrayProperty(JNIEnv* _jenv, jobject _jinstan
 
     std::optional< ::smoke::Nullable::SomeArray > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< ::smoke::Nullable::SomeArray >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeArray >>{});
 
 
 
@@ -627,7 +627,7 @@ Java_com_example_smoke_Nullable_setInlineArrayProperty(JNIEnv* _jenv, jobject _j
 
     std::optional< ::std::vector< ::std::string > > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< ::std::vector< ::std::string > >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::std::vector< ::std::string > >>{});
 
 
 
@@ -674,7 +674,7 @@ Java_com_example_smoke_Nullable_setMapProperty(JNIEnv* _jenv, jobject _jinstance
 
     std::optional< ::smoke::Nullable::SomeMap > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (std::optional< ::smoke::Nullable::SomeMap >*)nullptr);
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::Nullable::SomeMap >>{});
 
 
 
@@ -721,7 +721,7 @@ Java_com_example_smoke_Nullable_setInstanceProperty(JNIEnv* _jenv, jobject _jins
 
     ::std::shared_ptr< ::smoke::SomeInterface > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::shared_ptr< ::smoke::SomeInterface >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::SomeInterface >>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_NullableCollectionsStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_NullableCollectionsStruct__Conversion.cpp
@@ -1,54 +1,65 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_NullableCollectionsStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::NullableCollectionsStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::NullableCollectionsStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::NullableCollectionsStruct>)
 {
     ::smoke::NullableCollectionsStruct _nout{};
     ::std::vector< std::optional< ::std::chrono::system_clock::time_point > > n_dates = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "dates", "Ljava/util/List;"),
-        (::std::vector< std::optional< ::std::chrono::system_clock::time_point > >*)nullptr );
+        TypeId<::std::vector< std::optional< ::std::chrono::system_clock::time_point > >>{} );
     _nout.dates = n_dates;
     ::std::unordered_map< int32_t, std::optional< ::smoke::Nullable::SomeStruct > > n_structs = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "structs", "Ljava/util/Map;"),
-        (::std::unordered_map< int32_t, std::optional< ::smoke::Nullable::SomeStruct > >*)nullptr );
+        TypeId<::std::unordered_map< int32_t, std::optional< ::smoke::Nullable::SomeStruct > >>{} );
     _nout.structs = n_structs;
     return _nout;
 }
+
 std::optional<::smoke::NullableCollectionsStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::NullableCollectionsStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::NullableCollectionsStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::NullableCollectionsStruct>(convert_from_jni(_jenv, _jinput, (::smoke::NullableCollectionsStruct*)nullptr))
+        ? std::optional<::smoke::NullableCollectionsStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::NullableCollectionsStruct>{}))
         : std::optional<::smoke::NullableCollectionsStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/NullableCollectionsStruct", com_example_smoke_NullableCollectionsStruct, ::smoke::NullableCollectionsStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::NullableCollectionsStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::NullableCollectionsStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     auto jdates = convert_to_jni(_jenv, _ninput.dates);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "dates", "Ljava/util/List;", jdates);
+
     auto jstructs = convert_to_jni(_jenv, _ninput.structs);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "structs", "Ljava/util/Map;", jstructs);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::NullableCollectionsStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableIntsStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableIntsStruct__Conversion.cpp
@@ -1,96 +1,113 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Nullable_NullableIntsStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Nullable::NullableIntsStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Nullable::NullableIntsStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Nullable::NullableIntsStruct>)
 {
     ::smoke::Nullable::NullableIntsStruct _nout{};
     std::optional< int8_t > n_int8_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int8Field",
-        (std::optional< int8_t >*)nullptr );
+        TypeId<std::optional< int8_t >>{} );
     _nout.int8_field = n_int8_field;
     std::optional< int16_t > n_int16_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int16Field",
-        (std::optional< int16_t >*)nullptr );
+        TypeId<std::optional< int16_t >>{} );
     _nout.int16_field = n_int16_field;
     std::optional< int32_t > n_int32_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int32Field",
-        (std::optional< int32_t >*)nullptr );
+        TypeId<std::optional< int32_t >>{} );
     _nout.int32_field = n_int32_field;
     std::optional< int64_t > n_int64_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int64Field",
-        (std::optional< int64_t >*)nullptr );
+        TypeId<std::optional< int64_t >>{} );
     _nout.int64_field = n_int64_field;
     std::optional< uint8_t > n_uint8_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint8Field",
-        (std::optional< uint8_t >*)nullptr );
+        TypeId<std::optional< uint8_t >>{} );
     _nout.uint8_field = n_uint8_field;
     std::optional< uint16_t > n_uint16_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint16Field",
-        (std::optional< uint16_t >*)nullptr );
+        TypeId<std::optional< uint16_t >>{} );
     _nout.uint16_field = n_uint16_field;
     std::optional< uint32_t > n_uint32_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint32Field",
-        (std::optional< uint32_t >*)nullptr );
+        TypeId<std::optional< uint32_t >>{} );
     _nout.uint32_field = n_uint32_field;
     std::optional< uint64_t > n_uint64_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint64Field",
-        (std::optional< uint64_t >*)nullptr );
+        TypeId<std::optional< uint64_t >>{} );
     _nout.uint64_field = n_uint64_field;
     return _nout;
 }
+
 std::optional<::smoke::Nullable::NullableIntsStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Nullable::NullableIntsStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Nullable::NullableIntsStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::Nullable::NullableIntsStruct>(convert_from_jni(_jenv, _jinput, (::smoke::Nullable::NullableIntsStruct*)nullptr))
+        ? std::optional<::smoke::Nullable::NullableIntsStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Nullable::NullableIntsStruct>{}))
         : std::optional<::smoke::Nullable::NullableIntsStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Nullable$NullableIntsStruct", com_example_smoke_Nullable_00024NullableIntsStruct, ::smoke::Nullable::NullableIntsStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Nullable::NullableIntsStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Nullable::NullableIntsStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int8Field", _ninput.int8_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int16Field", _ninput.int16_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int32Field", _ninput.int32_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int64Field", _ninput.int64_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint8Field", _ninput.uint8_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint16Field", _ninput.uint16_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint32Field", _ninput.uint32_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint64Field", _ninput.uint64_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Nullable::NullableIntsStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android/jni/com_example_smoke_Nullable_NullableStruct__Conversion.cpp
@@ -1,103 +1,121 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Nullable_NullableStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Nullable::NullableStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Nullable::NullableStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Nullable::NullableStruct>)
 {
     ::smoke::Nullable::NullableStruct _nout{};
     std::optional< ::std::string > n_string_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "stringField",
-        (std::optional< ::std::string >*)nullptr );
+        TypeId<std::optional< ::std::string >>{} );
     _nout.string_field = n_string_field;
     std::optional< bool > n_bool_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "boolField",
-        (std::optional< bool >*)nullptr );
+        TypeId<std::optional< bool >>{} );
     _nout.bool_field = n_bool_field;
     std::optional< double > n_double_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "doubleField",
-        (std::optional< double >*)nullptr );
+        TypeId<std::optional< double >>{} );
     _nout.double_field = n_double_field;
     std::optional< ::smoke::Nullable::SomeStruct > n_struct_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "structField", "Lcom/example/smoke/Nullable$SomeStruct;"),
-        (std::optional< ::smoke::Nullable::SomeStruct >*)nullptr );
+        TypeId<std::optional< ::smoke::Nullable::SomeStruct >>{} );
     _nout.struct_field = n_struct_field;
     std::optional< ::smoke::Nullable::SomeEnum > n_enum_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "enumField", "Lcom/example/smoke/Nullable$SomeEnum;"),
-        (std::optional< ::smoke::Nullable::SomeEnum >*)nullptr );
+        TypeId<std::optional< ::smoke::Nullable::SomeEnum >>{} );
     _nout.enum_field = n_enum_field;
     std::optional< ::smoke::Nullable::SomeArray > n_array_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "arrayField", "Ljava/util/List;"),
-        (std::optional< ::smoke::Nullable::SomeArray >*)nullptr );
+        TypeId<std::optional< ::smoke::Nullable::SomeArray >>{} );
     _nout.array_field = n_array_field;
     std::optional< ::std::vector< ::std::string > > n_inline_array_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "inlineArrayField", "Ljava/util/List;"),
-        (std::optional< ::std::vector< ::std::string > >*)nullptr );
+        TypeId<std::optional< ::std::vector< ::std::string > >>{} );
     _nout.inline_array_field = n_inline_array_field;
     std::optional< ::smoke::Nullable::SomeMap > n_map_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "mapField", "Ljava/util/Map;"),
-        (std::optional< ::smoke::Nullable::SomeMap >*)nullptr );
+        TypeId<std::optional< ::smoke::Nullable::SomeMap >>{} );
     _nout.map_field = n_map_field;
     ::std::shared_ptr< ::smoke::SomeInterface > n_instance_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "instanceField", "Lcom/example/smoke/SomeInterface;"),
-        (::std::shared_ptr< ::smoke::SomeInterface >*)nullptr );
+        TypeId<::std::shared_ptr< ::smoke::SomeInterface >>{} );
     _nout.instance_field = n_instance_field;
     return _nout;
 }
+
 std::optional<::smoke::Nullable::NullableStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Nullable::NullableStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Nullable::NullableStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::Nullable::NullableStruct>(convert_from_jni(_jenv, _jinput, (::smoke::Nullable::NullableStruct*)nullptr))
+        ? std::optional<::smoke::Nullable::NullableStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Nullable::NullableStruct>{}))
         : std::optional<::smoke::Nullable::NullableStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Nullable$NullableStruct", com_example_smoke_Nullable_00024NullableStruct, ::smoke::Nullable::NullableStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Nullable::NullableStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Nullable::NullableStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.string_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "doubleField", _ninput.double_field);
+
     auto jstruct_field = convert_to_jni(_jenv, _ninput.struct_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "structField", "Lcom/example/smoke/Nullable$SomeStruct;", jstruct_field);
+
     auto jenum_field = convert_to_jni(_jenv, _ninput.enum_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "enumField", "Lcom/example/smoke/Nullable$SomeEnum;", jenum_field);
+
     auto jarray_field = convert_to_jni(_jenv, _ninput.array_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "arrayField", "Ljava/util/List;", jarray_field);
+
     auto jinline_array_field = convert_to_jni(_jenv, _ninput.inline_array_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "inlineArrayField", "Ljava/util/List;", jinline_array_field);
+
     auto jmap_field = convert_to_jni(_jenv, _ninput.map_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "mapField", "Ljava/util/Map;", jmap_field);
+
     auto jinstance_field = convert_to_jni(_jenv, _ninput.instance_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "instanceField", "Lcom/example/smoke/SomeInterface;", jinstance_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Nullable::NullableStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/packages/output/android/jni/com_example_smokeoff_UnderscorePackage.cpp
+++ b/gluecodium/src/test/resources/smoke/packages/output/android/jni/com_example_smokeoff_UnderscorePackage.cpp
@@ -23,7 +23,7 @@ Java_com_example_smokeoff_UnderscorePackage_basicMethod(JNIEnv* _jenv, jobject _
 
     ::std::string inputString = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinputString),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/packages/output/android/jni/com_example_smokeoff_UnderscorePackage__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/packages/output/android/jni/com_example_smokeoff_UnderscorePackage__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smokeoff/UnderscorePackage", com_example_s
 
 
 
-std::shared_ptr<::smoke_off::UnderscorePackage> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke_off::UnderscorePackage>*)
+std::shared_ptr<::smoke_off::UnderscorePackage> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke_off::UnderscorePackage>>)
 {
     std::shared_ptr<::smoke_off::UnderscorePackage> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android/jni/com_example_smoke_barInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android/jni/com_example_smoke_barInterface__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/barInterface", com_example_smoke_bar
 
 
 
-std::shared_ptr<::smoke::fooInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::fooInterface>*)
+std::shared_ptr<::smoke::fooInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::fooInterface>>)
 {
     std::shared_ptr<::smoke::fooInterface> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android/jni/com_example_smoke_barTypes_barEnum__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android/jni/com_example_smoke_barTypes_barEnum__Conversion.h
@@ -1,17 +1,21 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/fooTypes.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
 
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::fooTypes::fooEnum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::fooTypes::fooEnum*);
-JNIEXPORT std::optional<::smoke::fooTypes::fooEnum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::fooTypes::fooEnum>*);
+JNIEXPORT ::smoke::fooTypes::fooEnum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::fooTypes::fooEnum>);
+JNIEXPORT std::optional<::smoke::fooTypes::fooEnum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::fooTypes::fooEnum>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::fooTypes::fooEnum _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::fooTypes::fooEnum> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/android/jni/com_example_smoke_Properties.cpp
+++ b/gluecodium/src/test/resources/smoke/properties/output/android/jni/com_example_smoke_Properties.cpp
@@ -114,7 +114,7 @@ Java_com_example_smoke_Properties_setStructProperty(JNIEnv* _jenv, jobject _jins
 
     ::smoke::Properties::ExampleStruct value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::smoke::Properties::ExampleStruct*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::Properties::ExampleStruct>{});
 
 
 
@@ -161,7 +161,7 @@ Java_com_example_smoke_Properties_setArrayProperty(JNIEnv* _jenv, jobject _jinst
 
     ::std::vector< ::std::string > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::vector< ::std::string >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::vector< ::std::string >>{});
 
 
 
@@ -208,7 +208,7 @@ Java_com_example_smoke_Properties_setComplexTypeProperty(JNIEnv* _jenv, jobject 
 
     ::smoke::Properties::InternalErrorCode value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::smoke::Properties::InternalErrorCode*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::Properties::InternalErrorCode>{});
 
 
 
@@ -255,7 +255,7 @@ Java_com_example_smoke_Properties_setByteBufferProperty(JNIEnv* _jenv, jobject _
 
     ::std::shared_ptr< ::std::vector< uint8_t > > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::shared_ptr< ::std::vector< uint8_t > >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::std::vector< uint8_t > >>{});
 
 
 
@@ -302,7 +302,7 @@ Java_com_example_smoke_Properties_setInstanceProperty(JNIEnv* _jenv, jobject _ji
 
     ::std::shared_ptr< ::smoke::PropertiesInterface > value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::shared_ptr< ::smoke::PropertiesInterface >*)nullptr);
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::PropertiesInterface >>{});
 
 
 
@@ -389,7 +389,7 @@ Java_com_example_smoke_Properties_setStaticProperty(JNIEnv* _jenv, jobject _jins
 
     ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jvalue),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform_SkipLambdaInPlatform__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform_SkipLambdaInPlatform__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_ClassWithStructWithSkipLambdaInPlatform_SkipLambdaInPlatform__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>)
 {
     ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform _nout{};
     int32_t n_int_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "intField",
-        (int32_t*)nullptr );
+        TypeId<int32_t>{} );
     _nout.int_field = n_int_field;
     return _nout;
 }
+
 std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>>)
 {
     return _jinput
-        ? std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>(convert_from_jni(_jenv, _jinput, (::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform*)nullptr))
+        ? std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>{}))
         : std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/ClassWithStructWithSkipLambdaInPlatform$SkipLambdaInPlatform", com_example_smoke_ClassWithStructWithSkipLambdaInPlatform_00024SkipLambdaInPlatform, ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform_SkipLambdaInPlatform__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform_SkipLambdaInPlatform__Conversion.h
@@ -1,16 +1,21 @@
 /*
+
  *
  */
+
 #pragma once
-#include "smoke\ClassWithStructWithSkipLambdaInPlatform.h"
+
+#include "smoke/ClassWithStructWithSkipLambdaInPlatform.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform*);
-JNIEXPORT std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>*);
+JNIEXPORT ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>);
+JNIEXPORT std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform& _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::ClassWithStructWithSkipLambdaInPlatform::SkipLambdaInPlatform> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform__Conversion.cpp
@@ -21,7 +21,7 @@ REGISTER_JNI_CLASS_CACHE("com/example/smoke/ClassWithStructWithSkipLambdaInPlatf
 
 
 
-std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform>*)
+std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform>>)
 {
     std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform> _nresult{};
     auto& nativeBaseClass = get_cached_native_base_class();

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_ClassWithStructWithSkipLambdaInPlatform__Conversion.h
@@ -1,16 +1,23 @@
 /*
+
  *
  */
+
 #pragma once
-#include "smoke\ClassWithStructWithSkipLambdaInPlatform.h"
+
+#include "smoke/ClassWithStructWithSkipLambdaInPlatform.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <memory>
 #include <optional>
+
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform>*);
+
+JNIEXPORT std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ClassWithStructWithSkipLambdaInPlatform>& _ninput);
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_EnableIfField__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_EnableIfField__Conversion.cpp
@@ -1,54 +1,65 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_EnableIfField__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::EnableIfField
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::EnableIfField*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::EnableIfField>)
 {
     ::smoke::EnableIfField _nout{};
     int32_t n_int_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "intField",
-        (int32_t*)nullptr );
+        TypeId<int32_t>{} );
     _nout.int_field = n_int_field;
     bool n_bool_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "boolField",
-        (bool*)nullptr );
+        TypeId<bool>{} );
     _nout.bool_field = n_bool_field;
     return _nout;
 }
+
 std::optional<::smoke::EnableIfField>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::EnableIfField>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::EnableIfField>>)
 {
     return _jinput
-        ? std::optional<::smoke::EnableIfField>(convert_from_jni(_jenv, _jinput, (::smoke::EnableIfField*)nullptr))
+        ? std::optional<::smoke::EnableIfField>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::EnableIfField>{}))
         : std::optional<::smoke::EnableIfField>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/EnableIfField", com_example_smoke_EnableIfField, ::smoke::EnableIfField)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::EnableIfField& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::EnableIfField>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::EnableIfField> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.cpp
@@ -1,52 +1,66 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_SkipFieldInPlatformImmutable__Conversion.h"
 #include "smoke/DummyStruct.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::SkipFieldInPlatformImmutable
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::SkipFieldInPlatformImmutable*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::SkipFieldInPlatformImmutable>)
 {
+    
     int32_t n_int_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "intField",
-        (int32_t*)nullptr );
+        TypeId<int32_t>{} );
+    
     bool n_bool_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "boolField",
-        (bool*)nullptr );
+        TypeId<bool>{} );
+    
     return ::smoke::SkipFieldInPlatformImmutable(std::move(n_int_field), ::smoke::DummyStruct{}, std::move(n_bool_field));
 }
+
 std::optional<::smoke::SkipFieldInPlatformImmutable>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::SkipFieldInPlatformImmutable>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::SkipFieldInPlatformImmutable>>)
 {
     return _jinput
-        ? std::optional<::smoke::SkipFieldInPlatformImmutable>(convert_from_jni(_jenv, _jinput, (::smoke::SkipFieldInPlatformImmutable*)nullptr))
+        ? std::optional<::smoke::SkipFieldInPlatformImmutable>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::SkipFieldInPlatformImmutable>{}))
         : std::optional<::smoke::SkipFieldInPlatformImmutable>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/SkipFieldInPlatformImmutable", com_example_smoke_SkipFieldInPlatformImmutable, ::smoke::SkipFieldInPlatformImmutable)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::SkipFieldInPlatformImmutable& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::SkipFieldInPlatformImmutable>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::SkipFieldInPlatformImmutable> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatformImmutable__Conversion.h
@@ -1,17 +1,21 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/SkipFieldInPlatformImmutable.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
 
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::SkipFieldInPlatformImmutable convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::SkipFieldInPlatformImmutable*);
-JNIEXPORT std::optional<::smoke::SkipFieldInPlatformImmutable> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::SkipFieldInPlatformImmutable>*);
+JNIEXPORT ::smoke::SkipFieldInPlatformImmutable convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::SkipFieldInPlatformImmutable>);
+JNIEXPORT std::optional<::smoke::SkipFieldInPlatformImmutable> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::SkipFieldInPlatformImmutable>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::SkipFieldInPlatformImmutable& _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::SkipFieldInPlatformImmutable> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatform__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFieldInPlatform__Conversion.cpp
@@ -1,54 +1,65 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_SkipFieldInPlatform__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::SkipFieldInPlatform
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::SkipFieldInPlatform*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::SkipFieldInPlatform>)
 {
     ::smoke::SkipFieldInPlatform _nout{};
     int32_t n_int_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "intField",
-        (int32_t*)nullptr );
+        TypeId<int32_t>{} );
     _nout.int_field = n_int_field;
     bool n_bool_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "boolField",
-        (bool*)nullptr );
+        TypeId<bool>{} );
     _nout.bool_field = n_bool_field;
     return _nout;
 }
+
 std::optional<::smoke::SkipFieldInPlatform>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::SkipFieldInPlatform>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::SkipFieldInPlatform>>)
 {
     return _jinput
-        ? std::optional<::smoke::SkipFieldInPlatform>(convert_from_jni(_jenv, _jinput, (::smoke::SkipFieldInPlatform*)nullptr))
+        ? std::optional<::smoke::SkipFieldInPlatform>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::SkipFieldInPlatform>{}))
         : std::optional<::smoke::SkipFieldInPlatform>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/SkipFieldInPlatform", com_example_smoke_SkipFieldInPlatform, ::smoke::SkipFieldInPlatform)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::SkipFieldInPlatform& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::SkipFieldInPlatform>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "intField", _ninput.int_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "boolField", _ninput.bool_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::SkipFieldInPlatform> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipField__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipField__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_SkipField__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::SkipField
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::SkipField*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::SkipField>)
 {
     ::smoke::SkipField _nout{};
     ::std::string n_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "field",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
     _nout.field = n_field;
     return _nout;
 }
+
 std::optional<::smoke::SkipField>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::SkipField>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::SkipField>>)
 {
     return _jinput
-        ? std::optional<::smoke::SkipField>(convert_from_jni(_jenv, _jinput, (::smoke::SkipField*)nullptr))
+        ? std::optional<::smoke::SkipField>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::SkipField>{}))
         : std::optional<::smoke::SkipField>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/SkipField", com_example_smoke_SkipField, ::smoke::SkipField)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::SkipField& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::SkipField>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "field", _ninput.field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::SkipField> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipSetterImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipSetterImplCppProxy.cpp
@@ -26,7 +26,7 @@ com_example_smoke_SkipSetter_CppProxy::get_foo(  ) const {
 
     checkExceptionAndReportIfAny(jniEnv);
 
-    return convert_from_jni( jniEnv, _result, (::std::string*)nullptr );
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethodsInterface_Vector3.cpp
@@ -25,13 +25,13 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_distanceTo(JNIEn
 
     ::smoke::StructsWithMethodsInterface::Vector3 other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
-            (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::StructsWithMethodsInterface::Vector3>{});
 
 
 
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
-        (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
+        ::gluecodium::jni::TypeId<::smoke::StructsWithMethodsInterface::Vector3>{});
 
 
 
@@ -49,13 +49,13 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_add(JNIEnv* _jen
 
     ::smoke::StructsWithMethodsInterface::Vector3 other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
-            (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::StructsWithMethodsInterface::Vector3>{});
 
 
 
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
-        (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
+        ::gluecodium::jni::TypeId<::smoke::StructsWithMethodsInterface::Vector3>{});
 
 
 
@@ -99,7 +99,7 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Ljava_la
 
     ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jinput),
-            (::std::string*)nullptr);
+            ::gluecodium::jni::TypeId<::std::string>{});
 
 
 
@@ -121,7 +121,7 @@ Java_com_example_smoke_StructsWithMethodsInterface_00024Vector3_create__Lcom_exa
 
     ::smoke::StructsWithMethodsInterface::Vector3 other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
-            (::smoke::StructsWithMethodsInterface::Vector3*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::StructsWithMethodsInterface::Vector3>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethods_Vector.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_StructsWithMethods_Vector.cpp
@@ -25,13 +25,13 @@ Java_com_example_smoke_StructsWithMethods_00024Vector_distanceTo(JNIEnv* _jenv, 
 
     ::smoke::StructsWithMethods::Vector other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
-            (::smoke::StructsWithMethods::Vector*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::StructsWithMethods::Vector>{});
 
 
 
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
-        (::smoke::StructsWithMethods::Vector*)nullptr);
+        ::gluecodium::jni::TypeId<::smoke::StructsWithMethods::Vector>{});
 
 
 
@@ -49,13 +49,13 @@ Java_com_example_smoke_StructsWithMethods_00024Vector_add(JNIEnv* _jenv, jobject
 
     ::smoke::StructsWithMethods::Vector other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
-            (::smoke::StructsWithMethods::Vector*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::StructsWithMethods::Vector>{});
 
 
 
     auto _ninstance = ::gluecodium::jni::convert_from_jni(_jenv,
         ::gluecodium::jni::make_non_releasing_ref(_jinstance),
-        (::smoke::StructsWithMethods::Vector*)nullptr);
+        ::gluecodium::jni::TypeId<::smoke::StructsWithMethods::Vector>{});
 
 
 
@@ -119,7 +119,7 @@ Java_com_example_smoke_StructsWithMethods_00024Vector_create__Lcom_example_smoke
 
     ::smoke::StructsWithMethods::Vector other = ::gluecodium::jni::convert_from_jni(_jenv,
             ::gluecodium::jni::make_non_releasing_ref(jother),
-            (::smoke::StructsWithMethods::Vector*)nullptr);
+            ::gluecodium::jni::TypeId<::smoke::StructsWithMethods::Vector>{});
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.cpp
@@ -1,123 +1,161 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Structs_AllTypesStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Structs::AllTypesStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Structs::AllTypesStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Structs::AllTypesStruct>)
 {
+    
     int8_t n_int8_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int8Field",
-        (int8_t*)nullptr );
+        TypeId<int8_t>{} );
+    
     uint8_t n_uint8_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint8Field",
-        (uint8_t*)nullptr );
+        TypeId<uint8_t>{} );
+    
     int16_t n_int16_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int16Field",
-        (int16_t*)nullptr );
+        TypeId<int16_t>{} );
+    
     uint16_t n_uint16_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint16Field",
-        (uint16_t*)nullptr );
+        TypeId<uint16_t>{} );
+    
     int32_t n_int32_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int32Field",
-        (int32_t*)nullptr );
+        TypeId<int32_t>{} );
+    
     uint32_t n_uint32_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint32Field",
-        (uint32_t*)nullptr );
+        TypeId<uint32_t>{} );
+    
     int64_t n_int64_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "int64Field",
-        (int64_t*)nullptr );
+        TypeId<int64_t>{} );
+    
     uint64_t n_uint64_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "uint64Field",
-        (uint64_t*)nullptr );
+        TypeId<uint64_t>{} );
+    
     float n_float_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "floatField",
-        (float*)nullptr );
+        TypeId<float>{} );
+    
     double n_double_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "doubleField",
-        (double*)nullptr );
+        TypeId<double>{} );
+    
     ::std::string n_string_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "stringField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
+    
     bool n_boolean_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "booleanField",
-        (bool*)nullptr );
+        TypeId<bool>{} );
+    
     ::std::shared_ptr< ::std::vector< uint8_t > > n_bytes_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "bytesField",
-        (::std::shared_ptr< ::std::vector< uint8_t > >*)nullptr );
+        TypeId<::std::shared_ptr< ::std::vector< uint8_t > >>{} );
+    
     ::smoke::Structs::Point n_point_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "pointField", "Lcom/example/smoke/Structs$Point;"),
-        (::smoke::Structs::Point*)nullptr );
+        TypeId<::smoke::Structs::Point>{} );
+    
     return ::smoke::Structs::AllTypesStruct(std::move(n_int8_field), std::move(n_uint8_field), std::move(n_int16_field), std::move(n_uint16_field), std::move(n_int32_field), std::move(n_uint32_field), std::move(n_int64_field), std::move(n_uint64_field), std::move(n_float_field), std::move(n_double_field), std::move(n_string_field), std::move(n_boolean_field), std::move(n_bytes_field), std::move(n_point_field));
 }
+
 std::optional<::smoke::Structs::AllTypesStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Structs::AllTypesStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Structs::AllTypesStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::Structs::AllTypesStruct>(convert_from_jni(_jenv, _jinput, (::smoke::Structs::AllTypesStruct*)nullptr))
+        ? std::optional<::smoke::Structs::AllTypesStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Structs::AllTypesStruct>{}))
         : std::optional<::smoke::Structs::AllTypesStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Structs$AllTypesStruct", com_example_smoke_Structs_00024AllTypesStruct, ::smoke::Structs::AllTypesStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Structs::AllTypesStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Structs::AllTypesStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int8Field", _ninput.int8_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint8Field", _ninput.uint8_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int16Field", _ninput.int16_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint16Field", _ninput.uint16_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int32Field", _ninput.int32_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint32Field", _ninput.uint32_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "int64Field", _ninput.int64_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "uint64Field", _ninput.uint64_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "floatField", _ninput.float_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "doubleField", _ninput.double_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.string_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "booleanField", _ninput.boolean_field);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "bytesField", _ninput.bytes_field);
+
     auto jpoint_field = convert_to_jni(_jenv, _ninput.point_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "pointField", "Lcom/example/smoke/Structs$Point;", jpoint_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Structs::AllTypesStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_AllTypesStruct__Conversion.h
@@ -1,18 +1,22 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include "smoke/Structs.h"
 #include "com_example_smoke_Structs_Point__Conversion.h"
 #include "JniReference.h"
+#include "JniTypeId.h"
 #include <optional>
 
 namespace gluecodium
 {
 namespace jni
 {
-JNIEXPORT ::smoke::Structs::AllTypesStruct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Structs::AllTypesStruct*);
-JNIEXPORT std::optional<::smoke::Structs::AllTypesStruct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Structs::AllTypesStruct>*);
+JNIEXPORT ::smoke::Structs::AllTypesStruct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Structs::AllTypesStruct>);
+JNIEXPORT std::optional<::smoke::Structs::AllTypesStruct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Structs::AllTypesStruct>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Structs::AllTypesStruct& _ninput);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Structs::AllTypesStruct> _ninput);
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_ImmutableStructWithCppAccessors__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_ImmutableStructWithCppAccessors__Conversion.cpp
@@ -1,45 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Structs_ImmutableStructWithCppAccessors__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Structs::ImmutableStructWithCppAccessors
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Structs::ImmutableStructWithCppAccessors*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Structs::ImmutableStructWithCppAccessors>)
 {
+    
     ::std::string n_string_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "stringField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
+    
     return ::smoke::Structs::ImmutableStructWithCppAccessors(std::move(n_string_field));
 }
+
 std::optional<::smoke::Structs::ImmutableStructWithCppAccessors>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Structs::ImmutableStructWithCppAccessors>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Structs::ImmutableStructWithCppAccessors>>)
 {
     return _jinput
-        ? std::optional<::smoke::Structs::ImmutableStructWithCppAccessors>(convert_from_jni(_jenv, _jinput, (::smoke::Structs::ImmutableStructWithCppAccessors*)nullptr))
+        ? std::optional<::smoke::Structs::ImmutableStructWithCppAccessors>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Structs::ImmutableStructWithCppAccessors>{}))
         : std::optional<::smoke::Structs::ImmutableStructWithCppAccessors>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Structs$ImmutableStructWithCppAccessors", com_example_smoke_Structs_00024ImmutableStructWithCppAccessors, ::smoke::Structs::ImmutableStructWithCppAccessors)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Structs::ImmutableStructWithCppAccessors& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Structs::ImmutableStructWithCppAccessors>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.get_string_field());
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Structs::ImmutableStructWithCppAccessors> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_MutableStructWithCppAccessors__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_MutableStructWithCppAccessors__Conversion.cpp
@@ -1,47 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Structs_MutableStructWithCppAccessors__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Structs::MutableStructWithCppAccessors
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Structs::MutableStructWithCppAccessors*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Structs::MutableStructWithCppAccessors>)
 {
     ::smoke::Structs::MutableStructWithCppAccessors _nout{};
     ::std::string n_string_field = ::gluecodium::jni::get_field_value(
         _jenv,
         _jinput,
         "stringField",
-        (::std::string*)nullptr );
+        TypeId<::std::string>{} );
     _nout.set_string_field(n_string_field);
     return _nout;
 }
+
 std::optional<::smoke::Structs::MutableStructWithCppAccessors>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Structs::MutableStructWithCppAccessors>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Structs::MutableStructWithCppAccessors>>)
 {
     return _jinput
-        ? std::optional<::smoke::Structs::MutableStructWithCppAccessors>(convert_from_jni(_jenv, _jinput, (::smoke::Structs::MutableStructWithCppAccessors*)nullptr))
+        ? std::optional<::smoke::Structs::MutableStructWithCppAccessors>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Structs::MutableStructWithCppAccessors>{}))
         : std::optional<::smoke::Structs::MutableStructWithCppAccessors>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Structs$MutableStructWithCppAccessors", com_example_smoke_Structs_00024MutableStructWithCppAccessors, ::smoke::Structs::MutableStructWithCppAccessors)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Structs::MutableStructWithCppAccessors& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Structs::MutableStructWithCppAccessors>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     ::gluecodium::jni::set_field_value(_jenv, _jresult, "stringField", _ninput.get_string_field());
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Structs::MutableStructWithCppAccessors> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_NestingImmutableStruct__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/jni/com_example_smoke_Structs_NestingImmutableStruct__Conversion.cpp
@@ -1,45 +1,57 @@
 /*
+
  *
  */
+
 #include "com_example_smoke_Structs_NestingImmutableStruct__Conversion.h"
 #include "ArrayConversionUtils.h"
 #include "FieldAccessMethods.h"
 #include "JniCallJavaMethod.h"
 #include "JniClassCache.h"
+
 namespace gluecodium
 {
 namespace jni
 {
+
 ::smoke::Structs::NestingImmutableStruct
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, ::smoke::Structs::NestingImmutableStruct*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Structs::NestingImmutableStruct>)
 {
+    
     ::smoke::Structs::AllTypesStruct n_struct_field = convert_from_jni(
         _jenv,
         ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "structField", "Lcom/example/smoke/Structs$AllTypesStruct;"),
-        (::smoke::Structs::AllTypesStruct*)nullptr );
+        TypeId<::smoke::Structs::AllTypesStruct>{} );
+    
     return ::smoke::Structs::NestingImmutableStruct(std::move(n_struct_field));
 }
+
 std::optional<::smoke::Structs::NestingImmutableStruct>
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, std::optional<::smoke::Structs::NestingImmutableStruct>*)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Structs::NestingImmutableStruct>>)
 {
     return _jinput
-        ? std::optional<::smoke::Structs::NestingImmutableStruct>(convert_from_jni(_jenv, _jinput, (::smoke::Structs::NestingImmutableStruct*)nullptr))
+        ? std::optional<::smoke::Structs::NestingImmutableStruct>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::Structs::NestingImmutableStruct>{}))
         : std::optional<::smoke::Structs::NestingImmutableStruct>{};
 }
+
 REGISTER_JNI_CLASS_CACHE("com/example/smoke/Structs$NestingImmutableStruct", com_example_smoke_Structs_00024NestingImmutableStruct, ::smoke::Structs::NestingImmutableStruct)
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const ::smoke::Structs::NestingImmutableStruct& _ninput)
 {
     auto& javaClass = CachedJavaClass<::smoke::Structs::NestingImmutableStruct>::java_class;
     auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
     auto jstruct_field = convert_to_jni(_jenv, _ninput.struct_field);
     ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "structField", "Lcom/example/smoke/Structs$AllTypesStruct;", jstruct_field);
     return _jresult;
 }
+
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Structs::NestingImmutableStruct> _ninput)
 {
     return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
 }
+
 }
 }


### PR DESCRIPTION
convert_from_jni functions use last parameter only for function overloading because
normally those functions are different by the return parameter. In all places where
function convert_from_jni is used the last parameter is nullptr which is C-casted to the desired type.
As godbolt demonstrates modern clang and gcc have to pass this parameter without any optimisation.
This can be improved if this parameter is empty object (i.e. an object of a class without any fields) and
it's passed by value. As godbolt shows in this case modern cland and gcc generate code as if there is no any parameter at all.