### PR TITLE
HERESDK-3802: Synchronize map access for modularization

### DIFF
--- a/cmake/modules/gluecodium/gluecodium/GetTargetCompileDefinitions.cmake
+++ b/cmake/modules/gluecodium/gluecodium/GetTargetCompileDefinitions.cmake
@@ -67,8 +67,10 @@ function(gluecodium_get_target_compile_definitions _target)
     endif()
 
     if("COMMON" IN_LIST _source_sets)
+      set(_sync_cache_property "$<TARGET_PROPERTY:${_target},GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE>")
       list(APPEND _public $<$<NOT:$<STREQUAL:${_common},${_main}>>:${_common}_SHARED>)
-      list(APPEND _private $<$<NOT:$<STREQUAL:${_common},${_main}>>:${_common}_INTERNAL>)
+      list(APPEND _private $<$<NOT:$<STREQUAL:${_common},${_main}>>:${_common}_INTERNAL>
+                           $<$<BOOL:${_sync_cache_property}>:GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE>)
     endif()
 
     if(_args_RESULT_PUBLIC)

--- a/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
@@ -44,7 +44,7 @@ function(_gluecodium_define_target_property property_name)
 
   if (GLUECODIUM_PRINT_KNOWN_PROPERTIES)
     message("\nGluecodium property: ${property_name} - ${_args_BRIEF_DOCS}\n"
-            "${_args_FULL_DOCS}")    
+            "${_args_FULL_DOCS}")
   endif ()
 endfunction()
 
@@ -252,6 +252,15 @@ _gluecodium_define_target_property(
   FULL_DOCS
     "The list of frameworks to import all over generated code. This property might be used to construct dependencies"
     "This property is initialized by the value of the GLUECODIUM_IMPORT_FRAMEWORKS_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
+_gluecodium_define_target_property(
+  GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE
+  BRIEF_DOCS "Option to enable synchronization for JNIClassCache hash map."
+  FULL_DOCS
+    "Generates code for synchronized access to the hash map with cached information about JNI classes if this option is set to ON."
+    "This property is initialized by the value of the GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE variable if it is set when the function gluecodium_add_generate_command is called."
+    "Such synchronisation might be necessary when Java/JNI generated code is located in several libraries and the libraries are loaded on-demand."
 )
 
 # TODO: Add read-only properties

--- a/cmake/tests/unit/gluecodium_generate/single-module-mandatory-params/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/single-module-mandatory-params/cpp/FooImpl.cpp
@@ -20,6 +20,10 @@
 
 #include "unit/test/Foo.h"
 
+#ifdef GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE
+#error "GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE shouldn't be defined."
+#endif
+
 namespace unit::test {
 std::shared_ptr<Foo>
 Foo::make_foo()

--- a/cmake/tests/unit/gluecodium_generate/two-shared-modules/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/two-shared-modules/CMakeLists.txt
@@ -39,6 +39,7 @@ target_sources(
   PUBLIC "${CMAKE_CURRENT_LIST_DIR}/cpp/Dummy.h")
 
 gluecodium_generate(shared.module.with.common GENERATORS ${_gluecodium_generator})
+set_target_properties(shared.module.with.common PROPERTIES GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE ON)
 gluecodium_target_lime_sources(shared.module.with.common
                                PUBLIC "${CMAKE_CURRENT_LIST_DIR}/lime/common_main_foo.lime")
 

--- a/cmake/tests/unit/gluecodium_generate/two-shared-modules/cpp/CommonMainFooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/two-shared-modules/cpp/CommonMainFooImpl.cpp
@@ -18,6 +18,10 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+#ifndef GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE
+#error "GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE is not defined."
+#endif
+
 #include "unit/test/CommonMainFoo.h"
 
 namespace unit::test {

--- a/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniClassCacheImplementation.mustache
@@ -26,6 +26,10 @@
 #include <list>
 #include <unordered_map>
 
+#ifdef GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE
+#include <mutex>
+#endif
+
 {{#internalNamespace}}
 namespace {{.}}
 {
@@ -47,11 +51,23 @@ std::unordered_map<std::string_view, jni::JniReference<jclass>*>& get_instance_c
     return classes;
 }
 
+#ifdef GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE
+std::mutex& get_mutex_instance_class_map()
+{
+    static std::mutex map_mutex;
+    return map_mutex;
+}
+#endif
+
 }
 
 void
 CachedJavaClassBase::init(JNIEnv* env)
 {
+#ifdef GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE
+    const std::lock_guard<std::mutex> lock(get_mutex_instance_class_map());
+#endif
+
     for (auto registered_class_base : get_registered_class_cache_list())
     {
         registered_class_base->do_init(env);
@@ -74,6 +90,11 @@ CachedJavaClassBase::CachedJavaClassBase(const char* name, const char* cpp_name)
 jni::JniReference<jclass>*
 CachedJavaClassBase::get_java_class_for_instance(const std::string_view& id) {
     const auto& classes = get_instance_class_map();
+
+#ifdef GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE
+    const std::lock_guard<std::mutex> lock(get_mutex_instance_class_map());
+#endif
+
     const auto& found = classes.find(id);
     return found != classes.end() ? found->second : nullptr;
 }
@@ -83,6 +104,15 @@ CachedJavaClassBase::~CachedJavaClassBase() = default;
 void
 CachedJavaClassBase::do_init(JNIEnv* env)
 {
+#if defined(DEBUG) && defined(GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE)
+    std::mutex& map_mutex = get_mutex_instance_class_map();
+    if (!map_mutex.try_lock())
+    {
+        throw_new_runtime_exception(env, "Class cache mutex is expected to be locked.");
+        map_mutex.unlock();
+    }
+#endif
+
     auto global_ref = new_global_ref(env, find_class(env, m_name).get());
     auto java_class = set_java_class(make_non_releasing_ref(global_ref.release()));
     if (m_cpp_name) {


### PR DESCRIPTION
Synchronize access to map with cached Java classes for modularized build.
In case of modularization, there are cases when the map can be accessed from different threads, what will lead to at least a data race scenario.