### PR TITLE
HERESDK-3466: Preserve thread name after attaching it to JVM

### DIFF
--- a/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
@@ -35,7 +35,7 @@ static pthread_key_t s_thread_key;
 const char *get_thread_name()
 {
 #ifdef __ANDROID__
-    static __thread char name[17] = {0};
+    thread_local char name[17] = {0};
     if (prctl(PR_GET_NAME, name) == 0)
     {
         return name;

--- a/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
@@ -32,6 +32,18 @@ static JavaVM* jvm;
 
 static pthread_key_t s_thread_key;
 
+const char *get_thread_name()
+{
+#ifdef __ANDROID__
+    static __thread char name[17] = {0};
+    if (prctl(PR_GET_NAME, name) == 0)
+    {
+        return name;
+    }
+#endif
+    return nullptr;
+}
+
 JNIEnv*
 attach_current_thread( )
 {
@@ -39,10 +51,14 @@ attach_current_thread( )
     int envState = jvm->GetEnv( reinterpret_cast< void** >( &jniEnv ), JNI_VERSION_1_6 );
     if ( envState == JNI_EDETACHED )
     {
+        JavaVMAttachArgs args;
+        args.version = JNI_VERSION_1_6;
+        args.group = NULL;
+        args.name = get_thread_name();
 #ifdef __ANDROID__
-        jvm->AttachCurrentThread( &jniEnv, nullptr );
+        jvm->AttachCurrentThread( &jniEnv, &args );
 #else   // ifdef __ANDROID__
-        jvm->AttachCurrentThread( reinterpret_cast< void** >( &jniEnv ), nullptr );
+        jvm->AttachCurrentThread( reinterpret_cast< void** >( &jniEnv ), &args );
 #endif  // ifdef __ANDROID__
     }
 

--- a/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
@@ -32,7 +32,7 @@ static JavaVM* jvm;
 
 static pthread_key_t s_thread_key;
 
-const char *get_thread_name()
+char *get_thread_name()
 {
 #ifdef __ANDROID__
     thread_local char name[17] = {0};


### PR DESCRIPTION
When native thread is attached to JVM, then it's name is taken from `JavaVMAttachArgs`. When no `JavaVMAttachArgs`, or no `JavaVMAttachArgs::name` passed, then JVM on its own decides on naming the thread. Those names are not descriptive. To preserve thread name, pass the currently set thread name in `JavaVMAttachArgs::name`. 

`pthread_getname_np` was introduced in API 26, hence use more generic approach.