### PR TITLE
Add missing includes for Android

### DIFF
--- a/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
@@ -24,6 +24,10 @@
 #include "JniClassCache.h"
 
 #include <pthread.h>
+/* Definition of PR_* constants */
+#include <linux/prctl.h>
+/* Declaration of prctl */
+#include <sys/prctl.h>
 
 namespace
 {

--- a/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
@@ -24,10 +24,13 @@
 #include "JniClassCache.h"
 
 #include <pthread.h>
+
+#ifdef __ANDROID__
 /* Definition of PR_* constants */
 #include <linux/prctl.h>
 /* Declaration of prctl */
 #include <sys/prctl.h>
+#endif
 
 namespace
 {


### PR DESCRIPTION
Add platform specific includes for `prctl` and `PR_GET_NAME` on Android.
