### PR TITLE
Ensure that conversions are defined for lambdas defined in struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+ * Added missing generation of conversion functions for lambdas defined in structs for Swift.
+
 ## 13.9.5
 Release date: 2024-10-22
 ### Features:

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/LambdasTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/LambdasTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,5 +159,13 @@ public class LambdasTest {
     String result = CallOverloadedLambda.invokeOverloadedLambda(lambda, 42);
 
     assertEquals("42", result);
+  }
+
+  @Test
+  public void callJavaLambdaFromCppForLambdaDefinedInStruct() {
+    StructWithLambda.LambdaCallback callback = (String arg) -> arg;
+    String result = StructWithLambda.invokeCallback(callback);
+
+    assertEquals("some callback argument", result);
   }
 }

--- a/functional-tests/functional/dart/test/Lambdas_test.dart
+++ b/functional-tests/functional/dart/test/Lambdas_test.dart
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------------------------------------
-// Copyright (C) 2016-2020 HERE Europe B.V.
+// Copyright (C) 2016-2024 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -129,5 +129,12 @@ void main() {
     final result = Lambdas.applyNullableConfuser(lambda, null);
 
     expect(result, isNull);
+  });
+  _testSuite.test("Call Dart lambda in C++ for lambda defined in struct", () {
+    final callback = (String? arg) => arg;
+
+    final result = StructWithLambda.invokeCallback(callback);
+
+    expect(result!, "some callback argument");
   });
 }

--- a/functional-tests/functional/input/lime/Lambdas.lime
+++ b/functional-tests/functional/input/lime/Lambdas.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,6 +59,12 @@ class LambdasDeclarationOrder {
     struct SomeStruct {
         someField: String
     }
+}
+
+struct StructWithLambda {
+    lambda LambdaCallback = (String?) -> String?
+
+    static fun invoke_callback(callback: LambdaCallback?): String?
 }
 
 interface LambdasInterface {

--- a/functional-tests/functional/input/src/cpp/Lambdas.cpp
+++ b/functional-tests/functional/input/src/cpp/Lambdas.cpp
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------------------------------------
-// Copyright (C) 2016-2019 HERE Europe B.V.
+// Copyright (C) 2016-2024 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,7 +20,10 @@
 
 #include "test/CallOverloadedLambda.h"
 #include "test/ClassWithInternalLambda.h"
+#include "test/StructWithLambda.h"
 #include "test/Lambdas.h"
+
+#include <functional>
 
 namespace test
 {
@@ -150,6 +153,15 @@ std::string
 CallOverloadedLambda::invoke_overloaded_lambda(const OverloadedLambda& lambda,
                                                const int32_t value) {
     return lambda(value);
+}
+
+std::optional<std::string>
+StructWithLambda::invoke_callback(const std::optional<LambdaCallback>& callback) {
+    if (callback) {
+        return std::invoke(*callback, "some callback argument");
+    }
+
+    return {};
 }
 
 }

--- a/functional-tests/functional/swift/Tests/LambdasTests.swift
+++ b/functional-tests/functional/swift/Tests/LambdasTests.swift
@@ -1,5 +1,5 @@
 // -------------------------------------------------------------------------------------------------
-// Copyright (C) 2016-2019 HERE Europe B.V.
+// Copyright (C) 2016-2024 HERE Europe B.V.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,13 @@ class LambdasTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func testCallingSwiftLambdaFromCppForLambdaDefinedInStruct() {
+        let callback = { (arg: String?) in return arg }
+        let result = StructWithLambda.invokeCallback(callback: callback)
+
+        XCTAssertEqual(result, "some callback argument");
+    }
+
     static var allTests = [
         ("testCppLambdaInSwift", testCppLambdaInSwift),
         ("testSwiftLambdaInCpp", testSwiftLambdaInCpp),
@@ -143,6 +150,7 @@ class LambdasTests: XCTestCase {
         ("testCppNullableLambdaInSwiftWithValue", testCppNullableLambdaInSwiftWithValue),
         ("testCppNullableLambdaInSwiftWithNil", testCppNullableLambdaInSwiftWithNil),
         ("testSwiftNullableLambdaInCppWithValue", testSwiftNullableLambdaInCppWithValue),
-        ("testSwiftNullableLambdaInCppWithNil", testSwiftNullableLambdaInCppWithNil)
+        ("testSwiftNullableLambdaInCppWithNil", testSwiftNullableLambdaInCppWithNil),
+        ("testCallingSwiftLambdaFromCppForLambdaDefinedInStruct", testCallingSwiftLambdaFromCppForLambdaDefinedInStruct)
     ]
 }

--- a/gluecodium/src/main/resources/templates/swift/SwiftStructConversion.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftStructConversion.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -95,6 +95,9 @@ Optionals
 {{#structs}}
 {{>swift/SwiftStructConversion}}{{!!
 }}{{/structs}}
+{{#lambdas}}
+{{>swift/SwiftLambdaConversion}}{{!!
+}}{{/lambdas}}
 {{#enumerations}}
 {{>swift/SwiftEnumConversion}}{{!!
 }}{{/enumerations}}

--- a/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
+++ b/gluecodium/src/test/resources/smoke/nesting/output/swift/smoke/OuterStruct.swift
@@ -1,8 +1,13 @@
 //
+
 //
+
 import Foundation
+
 public struct OuterStruct {
+
     public var field: String
+
     public init(field: String) {
         self.field = field
     }
@@ -10,42 +15,62 @@ public struct OuterStruct {
         field = moveFromCType(smoke_OuterStruct_field_get(cHandle))
     }
     public enum InnerEnum : UInt32, CaseIterable, Codable {
+
         case foo
+
         case bar
     }
+
     public typealias TypeAlias = OuterStruct.InnerEnum
+
     public typealias InstantiationError = OuterStruct.TypeAlias
+
     public typealias InnerLambda = () -> Void
+
     public struct InnerStruct {
+
         public var otherField: [Date]
+
         public init(otherField: [Date]) {
             self.otherField = otherField
         }
         internal init(cHandle: _baseRef) {
             otherField = foobar_moveFromCType(smoke_OuterStruct_InnerStruct_otherField_get(cHandle))
         }
+
         public func doSomething() -> Void {
             let c_self_handle = moveToCType(self)
             smoke_OuterStruct_InnerStruct_doSomething(c_self_handle.ref)
         }
     }
+
+
     public class InnerClass {
+
+
         let c_instance : _baseRef
+
         init(cInnerClass: _baseRef) {
             guard cInnerClass != 0 else {
                 fatalError("Nullptr value is not supported for initializers")
             }
             c_instance = cInnerClass
         }
+
         deinit {
             smoke_OuterStruct_InnerClass_remove_swift_object_from_wrapper_cache(c_instance)
             smoke_OuterStruct_InnerClass_release_handle(c_instance)
         }
+
         public func fooBar() -> Set<Locale> {
             let c_result_handle = smoke_OuterStruct_InnerClass_fooBar(self.c_instance)
             return foobar_moveFromCType(c_result_handle)
         }
+
     }
+
+
+
     public func doNothing() throws -> Void {
         let c_self_handle = moveToCType(self)
         let RESULT = smoke_OuterStruct_doNothing(c_self_handle.ref)
@@ -54,26 +79,40 @@ public struct OuterStruct {
         }
     }
 }
+
 public protocol InnerInterface : AnyObject {
+
     func barBaz() -> [String: Data]
 }
+
 internal class _InnerInterface: InnerInterface {
+
     let c_instance : _baseRef
+
     init(cInnerInterface: _baseRef) {
         guard cInnerInterface != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cInnerInterface
     }
+
     deinit {
         smoke_OuterStruct_InnerInterface_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_OuterStruct_InnerInterface_release_handle(c_instance)
     }
+
     public func barBaz() -> [String: Data] {
         let c_result_handle = smoke_OuterStruct_InnerInterface_barBaz(self.c_instance)
         return foobar_moveFromCType(c_result_handle)
     }
+
 }
+
+
+
+
+
+
 internal func copyFromCType(_ handle: _baseRef) -> OuterStruct {
     return OuterStruct(cHandle: handle)
 }
@@ -83,6 +122,7 @@ internal func moveFromCType(_ handle: _baseRef) -> OuterStruct {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: OuterStruct) -> RefHolder {
     let c_field = moveToCType(swiftType.field)
     return RefHolder(smoke_OuterStruct_create_handle(c_field.ref))
@@ -103,6 +143,7 @@ internal func moveFromCType(_ handle: _baseRef) -> OuterStruct? {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: OuterStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -113,6 +154,7 @@ internal func copyToCType(_ swiftType: OuterStruct?) -> RefHolder {
 internal func moveToCType(_ swiftType: OuterStruct?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_release_optional_handle)
 }
+
 internal func getRef(_ ref: OuterStruct.InnerClass?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {
         return RefHolder(0)
@@ -122,6 +164,7 @@ internal func getRef(_ ref: OuterStruct.InnerClass?, owning: Bool = true) -> Ref
         ? RefHolder(ref: handle_copy, release: smoke_OuterStruct_InnerClass_release_handle)
         : RefHolder(handle_copy)
 }
+
 extension OuterStruct.InnerClass: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -131,11 +174,13 @@ extension OuterStruct.InnerClass: Hashable {
     public static func == (lhs: OuterStruct.InnerClass, rhs: OuterStruct.InnerClass) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+
     /// :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
 }
+
 internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
     if let swift_pointer = smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterStruct.InnerClass {
@@ -145,6 +190,7 @@ internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterS
     smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass {
     if let swift_pointer = smoke_OuterStruct_InnerClass_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? OuterStruct.InnerClass {
@@ -155,6 +201,7 @@ internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterS
     smoke_OuterStruct_InnerClass_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func OuterStruct_InnerClass_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerClass? {
     guard handle != 0 else {
         return nil
@@ -167,33 +214,42 @@ internal func OuterStruct_InnerClass_moveFromCType(_ handle: _baseRef) -> OuterS
     }
     return OuterStruct_InnerClass_moveFromCType(handle) as OuterStruct.InnerClass
 }
+
 internal func copyToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: OuterStruct.InnerClass) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: OuterStruct.InnerClass?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 @_cdecl("_CBridgeInitsmoke_OuterStruct_InnerInterface")
 internal func _CBridgeInitsmoke_OuterStruct_InnerInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
     let reference = _InnerInterface(cInnerInterface: handle)
     return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
 }
+
 internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
+
     guard let reference = ref else {
         return RefHolder(0)
     }
+
     if let instanceReference = reference as? NativeBase {
         let handle_copy = smoke_OuterStruct_InnerInterface_copy_handle(instanceReference.c_handle)
         return owning
             ? RefHolder(ref: handle_copy, release: smoke_OuterStruct_InnerInterface_release_handle)
             : RefHolder(handle_copy)
     }
+
     var functions = smoke_OuterStruct_InnerInterface_FunctionTable()
     functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
     functions.release = {swift_class_pointer in
@@ -201,13 +257,18 @@ internal func getRef(_ ref: InnerInterface?, owning: Bool = true) -> RefHolder {
             Unmanaged<AnyObject>.fromOpaque(swift_class).release()
         }
     }
+
+
     functions.smoke_OuterStruct_InnerInterface_barBaz = {(swift_class_pointer) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! InnerInterface
+
         return foobar_copyToCType(swift_class.barBaz()).ref
     }
     let proxy = smoke_OuterStruct_InnerInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_OuterStruct_InnerInterface_release_handle) : RefHolder(proxy)
 }
+
 extension _InnerInterface: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -228,6 +289,7 @@ internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
+
 internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface {
     if let swift_pointer = smoke_OuterStruct_InnerInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? InnerInterface {
@@ -246,6 +308,7 @@ internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface
     }
     fatalError("Failed to initialize Swift object")
 }
+
 internal func InnerInterface_copyFromCType(_ handle: _baseRef) -> InnerInterface? {
     guard handle != 0 else {
         return nil
@@ -258,18 +321,23 @@ internal func InnerInterface_moveFromCType(_ handle: _baseRef) -> InnerInterface
     }
     return InnerInterface_moveFromCType(handle) as InnerInterface
 }
+
 internal func copyToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: InnerInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: InnerInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
     return OuterStruct.InnerStruct(cHandle: handle)
 }
@@ -279,6 +347,7 @@ internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: OuterStruct.InnerStruct) -> RefHolder {
     let c_otherField = foobar_moveToCType(swiftType.otherField)
     return RefHolder(smoke_OuterStruct_InnerStruct_create_handle(c_otherField.ref))
@@ -299,6 +368,7 @@ internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerStruct? {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -309,24 +379,99 @@ internal func copyToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
 internal func moveToCType(_ swiftType: OuterStruct.InnerStruct?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_OuterStruct_InnerStruct_release_optional_handle)
 }
+
+internal func OuterStruct_InnerLambda_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerLambda {
+    return OuterStruct_InnerLambda_moveFromCType(smoke_OuterStruct_InnerLambda_copy_handle(handle))
+}
+internal func OuterStruct_InnerLambda_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerLambda {
+    let refHolder = RefHolder(ref: handle, release: smoke_OuterStruct_InnerLambda_release_handle)
+    return { () -> Void in
+        return moveFromCType(smoke_OuterStruct_InnerLambda_call(refHolder.ref))
+    }
+}
+
+internal func OuterStruct_InnerLambda_copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterStruct_InnerLambda_copyFromCType(handle) as OuterStruct.InnerLambda
+}
+internal func OuterStruct_InnerLambda_moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerLambda? {
+    guard handle != 0 else {
+        return nil
+    }
+    return OuterStruct_InnerLambda_moveFromCType(handle) as OuterStruct.InnerLambda
+}
+
+internal func OuterStruct_InnerLambda_createFunctionalTable(_ swiftType: @escaping OuterStruct.InnerLambda) -> smoke_OuterStruct_InnerLambda_FunctionTable {
+    class smoke_OuterStruct_InnerLambda_Holder {
+        let closure: OuterStruct.InnerLambda
+        init(_ closure: @escaping OuterStruct.InnerLambda) {
+            self.closure = closure
+        }
+    }
+
+    var functions = smoke_OuterStruct_InnerLambda_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(smoke_OuterStruct_InnerLambda_Holder(swiftType)).toOpaque()
+    functions.release = { swift_closure_pointer in
+        if let swift_closure = swift_closure_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_closure).release()
+        }
+    }
+    functions.smoke_OuterStruct_InnerLambda_call = { swift_closure_pointer in
+        let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_OuterStruct_InnerLambda_Holder
+        return copyToCType(closure_holder.closure()).ref
+    }
+
+    return functions
+}
+
+internal func OuterStruct_InnerLambda_copyToCType(_ swiftType: @escaping OuterStruct.InnerLambda) -> RefHolder {
+    let handle = smoke_OuterStruct_InnerLambda_create_proxy(OuterStruct_InnerLambda_createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func OuterStruct_InnerLambda_moveToCType(_ swiftType: @escaping OuterStruct.InnerLambda) -> RefHolder {
+    let handle = smoke_OuterStruct_InnerLambda_create_proxy(OuterStruct_InnerLambda_createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_OuterStruct_InnerLambda_release_handle)
+}
+
+internal func OuterStruct_InnerLambda_copyToCType(_ swiftType: OuterStruct.InnerLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+
+    let handle = smoke_OuterStruct_InnerLambda_create_optional_proxy(OuterStruct_InnerLambda_createFunctionalTable(swiftType))
+    return RefHolder(handle)
+}
+internal func OuterStruct_InnerLambda_moveToCType(_ swiftType: OuterStruct.InnerLambda?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+
+    let handle = smoke_OuterStruct_InnerLambda_create_optional_proxy(OuterStruct_InnerLambda_createFunctionalTable(swiftType))
+    return RefHolder(ref: handle, release: smoke_OuterStruct_InnerLambda_release_handle)
+}
 internal func copyToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
 internal func moveToCType(_ swiftEnum: OuterStruct.InnerEnum) -> PrimitiveHolder<UInt32> {
     return copyToCType(swiftEnum)
 }
+
 internal func copyToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
 internal func moveToCType(_ swiftEnum: OuterStruct.InnerEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
+
 internal func copyFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
     return OuterStruct.InnerEnum(rawValue: cValue)!
 }
 internal func moveFromCType(_ cValue: UInt32) -> OuterStruct.InnerEnum {
     return copyFromCType(cValue)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
     guard handle != 0 else {
         return nil
@@ -339,5 +484,7 @@ internal func moveFromCType(_ handle: _baseRef) -> OuterStruct.InnerEnum? {
     }
     return copyFromCType(handle)
 }
+
+
 extension OuterStruct.InnerEnum : Error {
 }


### PR DESCRIPTION
In the case of Swift language, when lambda was defined in a structure, then the code could not compile because of missing conversion functions. Interestingly, that was not the case for classes.

After investigation it turned out, that the root cause is related to missing inclusion of SwiftLambdaConversion template in SwiftStructConversion.

This change:
 - adds missing inclusion of lambda conversions in the mentioned template (SwiftStructConversion.mustache)
 - implements functional tests for Swift to check that the fix works as expected
 - implements functional tests for Dart and Android to also cover the tested case in these technologies
 - updates the reference files for smoke tests related to definition of nested fields in structs
