### PR TITLE
Dart: do not export nested types defined in internal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Bug fixes:
  * Added missing generation of conversion functions for lambdas defined in structs for Swift.
+ * Fixed a bug related to exporting nested types defined in a type annotated as internal.
 
 ## 13.9.5
 Release date: 2024-10-22

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartVisibilityResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartVisibilityResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,30 +19,8 @@
 
 package com.here.gluecodium.generator.dart
 
-import com.here.gluecodium.cli.GluecodiumExecutionException
-import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.common.NameResolver
-import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
-import com.here.gluecodium.model.lime.LimeAttributeType.DART
-import com.here.gluecodium.model.lime.LimeElement
-import com.here.gluecodium.model.lime.LimeNamedElement
-import com.here.gluecodium.model.lime.LimeType
 
-internal class DartVisibilityResolver(limeReferenceMap: Map<String, LimeElement>) :
-    ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
-    override fun resolveName(element: Any): String =
-        when (element) {
-            // Dart has no type nesting, so all types are "outside" and have to check for an internal outer type.
-            is LimeType -> {
-                val isInternal =
-                    generateSequence(element) {
-                        limeReferenceMap[it.path.parent.toString()] as? LimeType
-                    }.any { CommonGeneratorPredicates.isInternal(it, DART) }
-                getVisibilityPrefix(isInternal)
-            }
-            is LimeNamedElement -> getVisibilityPrefix(CommonGeneratorPredicates.isInternal(element, DART))
-            else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
-        }
-
-    private fun getVisibilityPrefix(isInternal: Boolean) = if (isInternal) "_" else ""
+internal class DartVisibilityResolver(val dartIsInternalPredicate: (Any) -> Boolean) : NameResolver {
+    override fun resolveName(element: Any) = if (dartIsInternalPredicate(element)) "_" else ""
 }

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/input/VisibilityInternal.lime
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/input/VisibilityInternal.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,4 +104,32 @@ class InternalClassWithStaticProperty {
 class InternalPropertyOnly {
     @Internal
     property foo: String
+}
+
+@Internal
+struct OuterStructWithInternalAttribute {
+    struct StructNestedInInternalStruct {
+        someField: Int = 1
+    }
+
+    class ClassNestedInInternalStruct {
+
+    }
+
+    lambda LambdaNestedInInternalStruct = () -> Void
+
+    inner: StructNestedInInternalStruct = {}
+}
+
+@Internal
+class OuterClassWithInternalAttribute {
+    struct StructNestedInInternalClass {
+        someField: Int = 2
+    }
+
+    class ClassNestedInInternalClass {
+
+    }
+
+    lambda LambdaNestedInInternalClass = () -> Void
 }

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/smoke.dart
@@ -1,8 +1,6 @@
 
 
 export 'src/smoke/internal_property_only.dart' show InternalPropertyOnly;
-export 'src/smoke/outer_class_with_internal_attribute.dart' show OuterClassWithInternalAttribute_ClassNestedInInternalClass, OuterClassWithInternalAttribute_LambdaNestedInInternalClass, OuterClassWithInternalAttribute_StructNestedInInternalClass;
-export 'src/smoke/outer_struct_with_internal_attribute.dart' show OuterStructWithInternalAttribute_ClassNestedInInternalStruct, OuterStructWithInternalAttribute_LambdaNestedInInternalStruct, OuterStructWithInternalAttribute_StructNestedInInternalStruct;
 export 'src/smoke/public_class.dart' show PublicClass, PublicClass_PublicStruct, PublicClass_PublicStructWithInternalDefaults;
 export 'src/smoke/public_interface.dart' show PublicInterface;
 export 'src/smoke/public_struct_with_non_default_internal_field.dart' show PublicStructWithNonDefaultInternalField;

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/smoke.dart
@@ -1,4 +1,8 @@
+
+
 export 'src/smoke/internal_property_only.dart' show InternalPropertyOnly;
+export 'src/smoke/outer_class_with_internal_attribute.dart' show OuterClassWithInternalAttribute_ClassNestedInInternalClass, OuterClassWithInternalAttribute_LambdaNestedInInternalClass, OuterClassWithInternalAttribute_StructNestedInInternalClass;
+export 'src/smoke/outer_struct_with_internal_attribute.dart' show OuterStructWithInternalAttribute_ClassNestedInInternalStruct, OuterStructWithInternalAttribute_LambdaNestedInInternalStruct, OuterStructWithInternalAttribute_StructNestedInInternalStruct;
 export 'src/smoke/public_class.dart' show PublicClass, PublicClass_PublicStruct, PublicClass_PublicStructWithInternalDefaults;
 export 'src/smoke/public_interface.dart' show PublicInterface;
 export 'src/smoke/public_struct_with_non_default_internal_field.dart' show PublicStructWithNonDefaultInternalField;

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_class_with_internal_attribute.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_class_with_internal_attribute.dart
@@ -1,0 +1,301 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+
+/// @nodoc
+abstract class OuterClassWithInternalAttribute {
+
+}
+
+
+class OuterClassWithInternalAttribute_StructNestedInInternalClass {
+  int someField;
+
+  OuterClassWithInternalAttribute_StructNestedInInternalClass._(this.someField);
+  OuterClassWithInternalAttribute_StructNestedInInternalClass()
+    : someField = 2;
+}
+
+
+// OuterClassWithInternalAttribute_StructNestedInInternalClass "private" section, not exported.
+
+final _smokeOuterclasswithinternalattributeStructnestedininternalclassCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32),
+    Pointer<Void> Function(int)
+  >('library_smoke_OuterClassWithInternalAttribute_StructNestedInInternalClass_create_handle'));
+final _smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_StructNestedInInternalClass_release_handle'));
+final _smokeOuterclasswithinternalattributeStructnestedininternalclassGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_StructNestedInInternalClass_get_field_someField'));
+
+
+
+Pointer<Void> smokeOuterclasswithinternalattributeStructnestedininternalclassToFfi(OuterClassWithInternalAttribute_StructNestedInInternalClass value) {
+  final _someFieldHandle = (value.someField);
+  final _result = _smokeOuterclasswithinternalattributeStructnestedininternalclassCreateHandle(_someFieldHandle);
+  
+  return _result;
+}
+
+OuterClassWithInternalAttribute_StructNestedInInternalClass smokeOuterclasswithinternalattributeStructnestedininternalclassFromFfi(Pointer<Void> handle) {
+  final _someFieldHandle = _smokeOuterclasswithinternalattributeStructnestedininternalclassGetFieldsomeField(handle);
+  try {
+    return OuterClassWithInternalAttribute_StructNestedInInternalClass._(
+      (_someFieldHandle)
+    );
+  } finally {
+    
+  }
+}
+
+void smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseFfiHandle(Pointer<Void> handle) => _smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseHandle(handle);
+
+// Nullable OuterClassWithInternalAttribute_StructNestedInInternalClass
+
+final _smokeOuterclasswithinternalattributeStructnestedininternalclassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_StructNestedInInternalClass_create_handle_nullable'));
+final _smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_StructNestedInInternalClass_release_handle_nullable'));
+final _smokeOuterclasswithinternalattributeStructnestedininternalclassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_StructNestedInInternalClass_get_value_nullable'));
+
+Pointer<Void> smokeOuterclasswithinternalattributeStructnestedininternalclassToFfiNullable(OuterClassWithInternalAttribute_StructNestedInInternalClass? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuterclasswithinternalattributeStructnestedininternalclassToFfi(value);
+  final result = _smokeOuterclasswithinternalattributeStructnestedininternalclassCreateHandleNullable(_handle);
+  smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseFfiHandle(_handle);
+  return result;
+}
+
+OuterClassWithInternalAttribute_StructNestedInInternalClass? smokeOuterclasswithinternalattributeStructnestedininternalclassFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuterclasswithinternalattributeStructnestedininternalclassGetValueNullable(handle);
+  final result = smokeOuterclasswithinternalattributeStructnestedininternalclassFromFfi(_handle);
+  smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseHandleNullable(handle);
+
+// End of OuterClassWithInternalAttribute_StructNestedInInternalClass "private" section.
+abstract class OuterClassWithInternalAttribute_ClassNestedInInternalClass {
+
+}
+
+
+// OuterClassWithInternalAttribute_ClassNestedInInternalClass "private" section, not exported.
+
+final _smokeOuterclasswithinternalattributeClassnestedininternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_OuterClassWithInternalAttribute_ClassNestedInInternalClass_register_finalizer'));
+final _smokeOuterclasswithinternalattributeClassnestedininternalclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_ClassNestedInInternalClass_copy_handle'));
+final _smokeOuterclasswithinternalattributeClassnestedininternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_ClassNestedInInternalClass_release_handle'));
+
+
+class OuterClassWithInternalAttribute_ClassNestedInInternalClass$Impl extends __lib.NativeBase implements OuterClassWithInternalAttribute_ClassNestedInInternalClass {
+
+  OuterClassWithInternalAttribute_ClassNestedInInternalClass$Impl(Pointer<Void> handle) : super(handle);
+
+
+}
+
+Pointer<Void> smokeOuterclasswithinternalattributeClassnestedininternalclassToFfi(OuterClassWithInternalAttribute_ClassNestedInInternalClass value) =>
+  _smokeOuterclasswithinternalattributeClassnestedininternalclassCopyHandle((value as __lib.NativeBase).handle);
+
+OuterClassWithInternalAttribute_ClassNestedInInternalClass smokeOuterclasswithinternalattributeClassnestedininternalclassFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is OuterClassWithInternalAttribute_ClassNestedInInternalClass) return instance;
+
+  final _copiedHandle = _smokeOuterclasswithinternalattributeClassnestedininternalclassCopyHandle(handle);
+  final result = OuterClassWithInternalAttribute_ClassNestedInInternalClass$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeOuterclasswithinternalattributeClassnestedininternalclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeOuterclasswithinternalattributeClassnestedininternalclassReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeOuterclasswithinternalattributeClassnestedininternalclassReleaseHandle(handle);
+
+Pointer<Void> smokeOuterclasswithinternalattributeClassnestedininternalclassToFfiNullable(OuterClassWithInternalAttribute_ClassNestedInInternalClass? value) =>
+  value != null ? smokeOuterclasswithinternalattributeClassnestedininternalclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
+OuterClassWithInternalAttribute_ClassNestedInInternalClass? smokeOuterclasswithinternalattributeClassnestedininternalclassFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeOuterclasswithinternalattributeClassnestedininternalclassFromFfi(handle) : null;
+
+void smokeOuterclasswithinternalattributeClassnestedininternalclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterclasswithinternalattributeClassnestedininternalclassReleaseHandle(handle);
+
+// End of OuterClassWithInternalAttribute_ClassNestedInInternalClass "private" section.
+typedef OuterClassWithInternalAttribute_LambdaNestedInInternalClass = void Function();
+
+// OuterClassWithInternalAttribute_LambdaNestedInInternalClass "private" section, not exported.
+
+final _smokeOuterclasswithinternalattributeLambdanestedininternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_register_finalizer'));
+final _smokeOuterclasswithinternalattributeLambdanestedininternalclassCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_copy_handle'));
+final _smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_release_handle'));
+final _smokeOuterclasswithinternalattributeLambdanestedininternalclassCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer)
+  >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_create_proxy'));
+
+class OuterClassWithInternalAttribute_LambdaNestedInInternalClass$Impl {
+  final Pointer<Void> handle;
+  OuterClassWithInternalAttribute_LambdaNestedInInternalClass$Impl(this.handle);
+
+  void call() {
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_call'));
+    final _handle = this.handle;
+    _callFfi(_handle, __lib.LibraryContext.isolateId);
+
+  }
+
+}
+
+int _smokeOuterclasswithinternalattributeLambdanestedininternalclasscallStatic(Object _obj) {
+  
+  try {
+    (_obj as OuterClassWithInternalAttribute_LambdaNestedInInternalClass)();
+  } finally {
+  }
+  return 0;
+}
+
+Pointer<Void> smokeOuterclasswithinternalattributeLambdanestedininternalclassToFfi(OuterClassWithInternalAttribute_LambdaNestedInInternalClass value) =>
+  _smokeOuterclasswithinternalattributeLambdanestedininternalclassCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Int64 Function(Handle)>(_smokeOuterclasswithinternalattributeLambdanestedininternalclasscallStatic, __lib.unknownError)
+  );
+
+OuterClassWithInternalAttribute_LambdaNestedInInternalClass smokeOuterclasswithinternalattributeLambdanestedininternalclassFromFfi(Pointer<Void> handle) {
+  final _copiedHandle = _smokeOuterclasswithinternalattributeLambdanestedininternalclassCopyHandle(handle);
+  final _impl = OuterClassWithInternalAttribute_LambdaNestedInInternalClass$Impl(_copiedHandle);
+  final result = () => _impl.call();
+  _smokeOuterclasswithinternalattributeLambdanestedininternalclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseHandle(handle);
+
+// Nullable OuterClassWithInternalAttribute_LambdaNestedInInternalClass
+
+final _smokeOuterclasswithinternalattributeLambdanestedininternalclassCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_create_handle_nullable'));
+final _smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_release_handle_nullable'));
+final _smokeOuterclasswithinternalattributeLambdanestedininternalclassGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_get_value_nullable'));
+
+Pointer<Void> smokeOuterclasswithinternalattributeLambdanestedininternalclassToFfiNullable(OuterClassWithInternalAttribute_LambdaNestedInInternalClass? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuterclasswithinternalattributeLambdanestedininternalclassToFfi(value);
+  final result = _smokeOuterclasswithinternalattributeLambdanestedininternalclassCreateHandleNullable(_handle);
+  smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseFfiHandle(_handle);
+  return result;
+}
+
+OuterClassWithInternalAttribute_LambdaNestedInInternalClass? smokeOuterclasswithinternalattributeLambdanestedininternalclassFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuterclasswithinternalattributeLambdanestedininternalclassGetValueNullable(handle);
+  final result = smokeOuterclasswithinternalattributeLambdanestedininternalclassFromFfi(_handle);
+  smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterclasswithinternalattributeLambdanestedininternalclassReleaseHandleNullable(handle);
+
+// End of OuterClassWithInternalAttribute_LambdaNestedInInternalClass "private" section.
+
+// OuterClassWithInternalAttribute "private" section, not exported.
+
+final _smokeOuterclasswithinternalattributeRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_OuterClassWithInternalAttribute_register_finalizer'));
+final _smokeOuterclasswithinternalattributeCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_copy_handle'));
+final _smokeOuterclasswithinternalattributeReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterClassWithInternalAttribute_release_handle'));
+
+
+class OuterClassWithInternalAttribute$Impl extends __lib.NativeBase implements OuterClassWithInternalAttribute {
+
+  OuterClassWithInternalAttribute$Impl(Pointer<Void> handle) : super(handle);
+
+
+}
+
+Pointer<Void> smokeOuterclasswithinternalattributeToFfi(OuterClassWithInternalAttribute value) =>
+  _smokeOuterclasswithinternalattributeCopyHandle((value as __lib.NativeBase).handle);
+
+OuterClassWithInternalAttribute smokeOuterclasswithinternalattributeFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is OuterClassWithInternalAttribute) return instance;
+
+  final _copiedHandle = _smokeOuterclasswithinternalattributeCopyHandle(handle);
+  final result = OuterClassWithInternalAttribute$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeOuterclasswithinternalattributeRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeOuterclasswithinternalattributeReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeOuterclasswithinternalattributeReleaseHandle(handle);
+
+Pointer<Void> smokeOuterclasswithinternalattributeToFfiNullable(OuterClassWithInternalAttribute? value) =>
+  value != null ? smokeOuterclasswithinternalattributeToFfi(value) : Pointer<Void>.fromAddress(0);
+
+OuterClassWithInternalAttribute? smokeOuterclasswithinternalattributeFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeOuterclasswithinternalattributeFromFfi(handle) : null;
+
+void smokeOuterclasswithinternalattributeReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterclasswithinternalattributeReleaseHandle(handle);
+
+// End of OuterClassWithInternalAttribute "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_struct_with_internal_attribute.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_struct_with_internal_attribute.dart
@@ -1,0 +1,327 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+
+/// @nodoc
+
+class OuterStructWithInternalAttribute {
+  OuterStructWithInternalAttribute_StructNestedInInternalStruct inner;
+
+  OuterStructWithInternalAttribute._(this.inner);
+  OuterStructWithInternalAttribute()
+    : inner = OuterStructWithInternalAttribute_StructNestedInInternalStruct();
+}
+
+
+class OuterStructWithInternalAttribute_StructNestedInInternalStruct {
+  int someField;
+
+  OuterStructWithInternalAttribute_StructNestedInInternalStruct._(this.someField);
+  OuterStructWithInternalAttribute_StructNestedInInternalStruct()
+    : someField = 1;
+}
+
+
+// OuterStructWithInternalAttribute_StructNestedInInternalStruct "private" section, not exported.
+
+final _smokeOuterstructwithinternalattributeStructnestedininternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32),
+    Pointer<Void> Function(int)
+  >('library_smoke_OuterStructWithInternalAttribute_StructNestedInInternalStruct_create_handle'));
+final _smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_StructNestedInInternalStruct_release_handle'));
+final _smokeOuterstructwithinternalattributeStructnestedininternalstructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_StructNestedInInternalStruct_get_field_someField'));
+
+
+
+Pointer<Void> smokeOuterstructwithinternalattributeStructnestedininternalstructToFfi(OuterStructWithInternalAttribute_StructNestedInInternalStruct value) {
+  final _someFieldHandle = (value.someField);
+  final _result = _smokeOuterstructwithinternalattributeStructnestedininternalstructCreateHandle(_someFieldHandle);
+  
+  return _result;
+}
+
+OuterStructWithInternalAttribute_StructNestedInInternalStruct smokeOuterstructwithinternalattributeStructnestedininternalstructFromFfi(Pointer<Void> handle) {
+  final _someFieldHandle = _smokeOuterstructwithinternalattributeStructnestedininternalstructGetFieldsomeField(handle);
+  try {
+    return OuterStructWithInternalAttribute_StructNestedInInternalStruct._(
+      (_someFieldHandle)
+    );
+  } finally {
+    
+  }
+}
+
+void smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseHandle(handle);
+
+// Nullable OuterStructWithInternalAttribute_StructNestedInInternalStruct
+
+final _smokeOuterstructwithinternalattributeStructnestedininternalstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_StructNestedInInternalStruct_create_handle_nullable'));
+final _smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_StructNestedInInternalStruct_release_handle_nullable'));
+final _smokeOuterstructwithinternalattributeStructnestedininternalstructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_StructNestedInInternalStruct_get_value_nullable'));
+
+Pointer<Void> smokeOuterstructwithinternalattributeStructnestedininternalstructToFfiNullable(OuterStructWithInternalAttribute_StructNestedInInternalStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuterstructwithinternalattributeStructnestedininternalstructToFfi(value);
+  final result = _smokeOuterstructwithinternalattributeStructnestedininternalstructCreateHandleNullable(_handle);
+  smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseFfiHandle(_handle);
+  return result;
+}
+
+OuterStructWithInternalAttribute_StructNestedInInternalStruct? smokeOuterstructwithinternalattributeStructnestedininternalstructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuterstructwithinternalattributeStructnestedininternalstructGetValueNullable(handle);
+  final result = smokeOuterstructwithinternalattributeStructnestedininternalstructFromFfi(_handle);
+  smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseHandleNullable(handle);
+
+// End of OuterStructWithInternalAttribute_StructNestedInInternalStruct "private" section.
+abstract class OuterStructWithInternalAttribute_ClassNestedInInternalStruct {
+
+}
+
+
+// OuterStructWithInternalAttribute_ClassNestedInInternalStruct "private" section, not exported.
+
+final _smokeOuterstructwithinternalattributeClassnestedininternalstructRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_OuterStructWithInternalAttribute_ClassNestedInInternalStruct_register_finalizer'));
+final _smokeOuterstructwithinternalattributeClassnestedininternalstructCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_ClassNestedInInternalStruct_copy_handle'));
+final _smokeOuterstructwithinternalattributeClassnestedininternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_ClassNestedInInternalStruct_release_handle'));
+
+
+class OuterStructWithInternalAttribute_ClassNestedInInternalStruct$Impl extends __lib.NativeBase implements OuterStructWithInternalAttribute_ClassNestedInInternalStruct {
+
+  OuterStructWithInternalAttribute_ClassNestedInInternalStruct$Impl(Pointer<Void> handle) : super(handle);
+
+
+}
+
+Pointer<Void> smokeOuterstructwithinternalattributeClassnestedininternalstructToFfi(OuterStructWithInternalAttribute_ClassNestedInInternalStruct value) =>
+  _smokeOuterstructwithinternalattributeClassnestedininternalstructCopyHandle((value as __lib.NativeBase).handle);
+
+OuterStructWithInternalAttribute_ClassNestedInInternalStruct smokeOuterstructwithinternalattributeClassnestedininternalstructFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is OuterStructWithInternalAttribute_ClassNestedInInternalStruct) return instance;
+
+  final _copiedHandle = _smokeOuterstructwithinternalattributeClassnestedininternalstructCopyHandle(handle);
+  final result = OuterStructWithInternalAttribute_ClassNestedInInternalStruct$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeOuterstructwithinternalattributeClassnestedininternalstructRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeOuterstructwithinternalattributeClassnestedininternalstructReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeOuterstructwithinternalattributeClassnestedininternalstructReleaseHandle(handle);
+
+Pointer<Void> smokeOuterstructwithinternalattributeClassnestedininternalstructToFfiNullable(OuterStructWithInternalAttribute_ClassNestedInInternalStruct? value) =>
+  value != null ? smokeOuterstructwithinternalattributeClassnestedininternalstructToFfi(value) : Pointer<Void>.fromAddress(0);
+
+OuterStructWithInternalAttribute_ClassNestedInInternalStruct? smokeOuterstructwithinternalattributeClassnestedininternalstructFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeOuterstructwithinternalattributeClassnestedininternalstructFromFfi(handle) : null;
+
+void smokeOuterstructwithinternalattributeClassnestedininternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterstructwithinternalattributeClassnestedininternalstructReleaseHandle(handle);
+
+// End of OuterStructWithInternalAttribute_ClassNestedInInternalStruct "private" section.
+typedef OuterStructWithInternalAttribute_LambdaNestedInInternalStruct = void Function();
+
+// OuterStructWithInternalAttribute_LambdaNestedInInternalStruct "private" section, not exported.
+
+final _smokeOuterstructwithinternalattributeLambdanestedininternalstructRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_register_finalizer'));
+final _smokeOuterstructwithinternalattributeLambdanestedininternalstructCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_copy_handle'));
+final _smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_release_handle'));
+final _smokeOuterstructwithinternalattributeLambdanestedininternalstructCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer)
+  >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_create_proxy'));
+
+class OuterStructWithInternalAttribute_LambdaNestedInInternalStruct$Impl {
+  final Pointer<Void> handle;
+  OuterStructWithInternalAttribute_LambdaNestedInInternalStruct$Impl(this.handle);
+
+  void call() {
+    final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_call'));
+    final _handle = this.handle;
+    _callFfi(_handle, __lib.LibraryContext.isolateId);
+
+  }
+
+}
+
+int _smokeOuterstructwithinternalattributeLambdanestedininternalstructcallStatic(Object _obj) {
+  
+  try {
+    (_obj as OuterStructWithInternalAttribute_LambdaNestedInInternalStruct)();
+  } finally {
+  }
+  return 0;
+}
+
+Pointer<Void> smokeOuterstructwithinternalattributeLambdanestedininternalstructToFfi(OuterStructWithInternalAttribute_LambdaNestedInInternalStruct value) =>
+  _smokeOuterstructwithinternalattributeLambdanestedininternalstructCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Int64 Function(Handle)>(_smokeOuterstructwithinternalattributeLambdanestedininternalstructcallStatic, __lib.unknownError)
+  );
+
+OuterStructWithInternalAttribute_LambdaNestedInInternalStruct smokeOuterstructwithinternalattributeLambdanestedininternalstructFromFfi(Pointer<Void> handle) {
+  final _copiedHandle = _smokeOuterstructwithinternalattributeLambdanestedininternalstructCopyHandle(handle);
+  final _impl = OuterStructWithInternalAttribute_LambdaNestedInInternalStruct$Impl(_copiedHandle);
+  final result = () => _impl.call();
+  _smokeOuterstructwithinternalattributeLambdanestedininternalstructRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseHandle(handle);
+
+// Nullable OuterStructWithInternalAttribute_LambdaNestedInInternalStruct
+
+final _smokeOuterstructwithinternalattributeLambdanestedininternalstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_create_handle_nullable'));
+final _smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_release_handle_nullable'));
+final _smokeOuterstructwithinternalattributeLambdanestedininternalstructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_get_value_nullable'));
+
+Pointer<Void> smokeOuterstructwithinternalattributeLambdanestedininternalstructToFfiNullable(OuterStructWithInternalAttribute_LambdaNestedInInternalStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuterstructwithinternalattributeLambdanestedininternalstructToFfi(value);
+  final result = _smokeOuterstructwithinternalattributeLambdanestedininternalstructCreateHandleNullable(_handle);
+  smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseFfiHandle(_handle);
+  return result;
+}
+
+OuterStructWithInternalAttribute_LambdaNestedInInternalStruct? smokeOuterstructwithinternalattributeLambdanestedininternalstructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuterstructwithinternalattributeLambdanestedininternalstructGetValueNullable(handle);
+  final result = smokeOuterstructwithinternalattributeLambdanestedininternalstructFromFfi(_handle);
+  smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterstructwithinternalattributeLambdanestedininternalstructReleaseHandleNullable(handle);
+
+// End of OuterStructWithInternalAttribute_LambdaNestedInInternalStruct "private" section.
+
+// OuterStructWithInternalAttribute "private" section, not exported.
+
+final _smokeOuterstructwithinternalattributeCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_create_handle'));
+final _smokeOuterstructwithinternalattributeReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_release_handle'));
+final _smokeOuterstructwithinternalattributeGetFieldinner = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_get_field_inner'));
+
+
+
+Pointer<Void> smokeOuterstructwithinternalattributeToFfi(OuterStructWithInternalAttribute value) {
+  final _innerHandle = smokeOuterstructwithinternalattributeStructnestedininternalstructToFfi(value.inner);
+  final _result = _smokeOuterstructwithinternalattributeCreateHandle(_innerHandle);
+  smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseFfiHandle(_innerHandle);
+  return _result;
+}
+
+OuterStructWithInternalAttribute smokeOuterstructwithinternalattributeFromFfi(Pointer<Void> handle) {
+  final _innerHandle = _smokeOuterstructwithinternalattributeGetFieldinner(handle);
+  try {
+    return OuterStructWithInternalAttribute._(
+      smokeOuterstructwithinternalattributeStructnestedininternalstructFromFfi(_innerHandle)
+    );
+  } finally {
+    smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseFfiHandle(_innerHandle);
+  }
+}
+
+void smokeOuterstructwithinternalattributeReleaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructwithinternalattributeReleaseHandle(handle);
+
+// Nullable OuterStructWithInternalAttribute
+
+final _smokeOuterstructwithinternalattributeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_create_handle_nullable'));
+final _smokeOuterstructwithinternalattributeReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_release_handle_nullable'));
+final _smokeOuterstructwithinternalattributeGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_OuterStructWithInternalAttribute_get_value_nullable'));
+
+Pointer<Void> smokeOuterstructwithinternalattributeToFfiNullable(OuterStructWithInternalAttribute? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeOuterstructwithinternalattributeToFfi(value);
+  final result = _smokeOuterstructwithinternalattributeCreateHandleNullable(_handle);
+  smokeOuterstructwithinternalattributeReleaseFfiHandle(_handle);
+  return result;
+}
+
+OuterStructWithInternalAttribute? smokeOuterstructwithinternalattributeFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeOuterstructwithinternalattributeGetValueNullable(handle);
+  final result = smokeOuterstructwithinternalattributeFromFfi(_handle);
+  smokeOuterstructwithinternalattributeReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeOuterstructwithinternalattributeReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeOuterstructwithinternalattributeReleaseHandleNullable(handle);
+
+// End of OuterStructWithInternalAttribute "private" section.
+
+


### PR DESCRIPTION
In the case of Dart the nested types defined in types
annotated as `@Internal` were exported. This was invalid
behaviour -- such types shall not have been exported.
    
The root cause for that was usage of 'CommonGeneratorPredicates'
to check if type is internal. In the case of Dart there is no
type nesting and all types are outside. The common version of
predicate did not check if any of parent types uses `@Internal`.
    
This change:
 - moves Dart specific logic responsible for checking if LimeType
    is internal from DartVisibilityResolver.kt to DartGeneratorPredicates.kt
 - injects the predicate to DartVisibilityResolver via constructor in order
    to preserve the existing behaviour of checking if type is internal
 - fixes the way how DartGenerator.generateDart() selects types to export by
    using Dart specific predicate instead of the generic one
    
Note: this change adjusts smoke tests to show, that the internal types like
          structs, classes and lambdas are no longer exported when their parent
          type is `@Internal`.