### PR TITLE
C++: add missing export macro to 'CppEnumeration.mustache'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Bug fixes:
+ * C++: Added generation of missing export macro for enumerations.
  * C++: Fixed generation of getters and setters for accessors attribute -- non-trivial types use references now.
  * Added missing generation of conversion functions for lambdas defined in structs for Swift.
  * Fixed a bug related to exporting nested types defined in a type annotated as internal.

--- a/gluecodium/src/main/resources/templates/cpp/CppEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppEnumeration.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   !}}
 {{#unless external.cpp}}
 {{>cpp/CppDocComment}}
-enum class {{>cpp/CppAttributesInline}}{{resolveName}} {
+enum class {{>cpp/CppExportMacro}}{{>cpp/CppAttributesInline}}{{resolveName}} {
 {{#enumerators}}
 {{prefixPartial "cpp/CppDocComment" "    "}}{{prefixPartial "cpp/CppAttributes" "    "}}{{!!
 }}    {{resolveName}}{{#explicitValue}} = {{resolveName}}{{/explicitValue}}{{#if iter.hasNext}},{{/if}}

--- a/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesEnum.h
+++ b/gluecodium/src/test/resources/smoke/attributes/output/cpp/include/smoke/AttributesEnum.h
@@ -1,13 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
+
 namespace smoke {
-enum class [[OnEnumeration]] AttributesEnum {
+enum class _GLUECODIUM_CPP_EXPORT [[OnEnumeration]] AttributesEnum {
     [[OnEnumerator]]
     NOPE
 };
+
+
+
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/cpp/include/smoke/CppRefReturnType.h
@@ -22,7 +22,7 @@ public:
 
 
 public:
-    enum class InternalError {
+    enum class _GLUECODIUM_CPP_EXPORT InternalError {
         FOO,
         BAR
     };

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -30,7 +30,7 @@ public:
      * This is some very useful enum.
 
      */
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         /**
          * Not quite useful
 

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationComments.h
@@ -28,7 +28,7 @@ public:
      * This is some very useful enum.
      * \deprecated Unfortunately, this enum is deprecated. Use ::smoke::Comments::SomeEnum instead.
      */
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         /**
          * Not quite useful
          * \deprecated Unfortunately, this item is deprecated.

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/DeprecationCommentsOnly.h
@@ -25,7 +25,7 @@ public:
     /**
      * \deprecated Unfortunately, this enum is deprecated.
      */
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         /**
          * \deprecated Unfortunately, this item is deprecated.
          */

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedComments.h
@@ -31,7 +31,7 @@ public:
      * \private
 
      */
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         /**
          * Not quite useful
          * \private

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/ExcludedCommentsOnly.h
@@ -29,7 +29,7 @@ public:
      * \private
 
      */
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         /**
          * \private
 

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/PlatformComments.h
@@ -24,7 +24,7 @@ public:
      * An error code when something goes wrong.
 
      */
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         USELESS,
         USEFUL
     };

--- a/gluecodium/src/test/resources/smoke/constants/output/cpp/include/smoke/Constants.h
+++ b/gluecodium/src/test/resources/smoke/constants/output/cpp/include/smoke/Constants.h
@@ -1,23 +1,38 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <string>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT Constants {
     static const bool BOOL_CONSTANT;
+
     static const int32_t INT_CONSTANT;
+
     static const uint32_t UINT_CONSTANT;
+
     static const float FLOAT_CONSTANT;
+
     static const double DOUBLE_CONSTANT;
+
     static const ::std::string STRING_CONSTANT;
-    enum class StateEnum {
+
+    enum class _GLUECODIUM_CPP_EXPORT StateEnum {
         OFF,
         ON
     };
+
+
     static const ::smoke::Constants::StateEnum ENUM_CONSTANT;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/cpp/include/smoke/Constructors.h
+++ b/gluecodium/src/test/resources/smoke/constructors/output/cpp/include/smoke/Constructors.h
@@ -24,7 +24,7 @@ public:
 
 
 public:
-    enum class ErrorEnum {
+    enum class _GLUECODIUM_CPP_EXPORT ErrorEnum {
         NONE,
         CRASHED
     };

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrder.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/DeclarationOrder.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/UnorderedMapHash.h"
 #include "gluecodium/VectorHash.h"
@@ -10,28 +13,42 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT DeclarationOrder {
     struct _GLUECODIUM_CPP_EXPORT NestedStruct {
         ::std::string some_field;
+
         NestedStruct( );
         explicit NestedStruct( ::std::string some_field );
+
     };
-    enum class SomeEnum {
+
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         FOO,
         BAR = 7
     };
+
+
     using SomeTypeDef = int32_t;
+
     using NestedStructArray = ::std::vector< ::smoke::DeclarationOrder::NestedStruct >;
+
     using ErrorCodeToMessageMap = ::std::unordered_map< int32_t, ::smoke::DeclarationOrder::NestedStructArray >;
+
     struct _GLUECODIUM_CPP_EXPORT MainStruct {
         ::smoke::DeclarationOrder::NestedStruct struct_field;
         ::smoke::DeclarationOrder::SomeTypeDef type_def_field;
         ::smoke::DeclarationOrder::NestedStructArray struct_array_field;
         ::smoke::DeclarationOrder::ErrorCodeToMessageMap map_field;
         ::smoke::DeclarationOrder::SomeEnum enum_field;
+
         MainStruct( );
         MainStruct( ::smoke::DeclarationOrder::NestedStruct struct_field, ::smoke::DeclarationOrder::SomeTypeDef type_def_field, ::smoke::DeclarationOrder::NestedStructArray struct_array_field, ::smoke::DeclarationOrder::ErrorCodeToMessageMap map_field, ::smoke::DeclarationOrder::SomeEnum enum_field );
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInClass.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInClass.h
@@ -22,7 +22,7 @@ public:
 
 
 public:
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         FOO,
         BAR = 7
     };

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStruct.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStruct.h
@@ -1,25 +1,38 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <string>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT OrderInStruct {
     struct _GLUECODIUM_CPP_EXPORT NestedStruct {
         ::std::string some_field;
+
         NestedStruct( );
         explicit NestedStruct( ::std::string some_field );
+
     };
-    enum class SomeEnum {
+
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         FOO,
         BAR = 7
     };
+
+
     ::smoke::OrderInStruct::NestedStruct struct_field;
     ::smoke::OrderInStruct::SomeEnum enum_field;
+
     OrderInStruct( );
     OrderInStruct( ::smoke::OrderInStruct::NestedStruct struct_field, ::smoke::OrderInStruct::SomeEnum enum_field );
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStructWithFunctions.h
+++ b/gluecodium/src/test/resources/smoke/declaration_order/output/cpp/include/smoke/OrderInStructWithFunctions.h
@@ -1,25 +1,39 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <string>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT OrderInStructWithFunctions {
     struct _GLUECODIUM_CPP_EXPORT NestedStruct {
         ::std::string some_field;
+
         NestedStruct( );
         explicit NestedStruct( ::std::string some_field );
+
     };
-    enum class SomeEnum {
+
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         FOO,
         BAR = 7
     };
+
+
     ::std::string some_field;
+
     OrderInStructWithFunctions( );
     explicit OrderInStructWithFunctions( ::std::string some_field );
+
     ::smoke::OrderInStructWithFunctions::SomeEnum do_stuff( const ::smoke::OrderInStructWithFunctions::NestedStruct& struct_foo ) const;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAlias.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithAlias.h
@@ -1,21 +1,29 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <system_error>
+
 namespace smoke {
-enum class EnumWithAlias {
+enum class _GLUECODIUM_CPP_EXPORT EnumWithAlias {
     ONE = 2,
     TWO,
     THREE,
     FIRST = ::smoke::EnumWithAlias::ONE,
     THE_BEST = ::smoke::EnumWithAlias::FIRST
 };
+
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::EnumWithAlias value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithToStringHelper.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumWithToStringHelper.h
@@ -1,16 +1,23 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <string_view>
+
 namespace smoke {
-enum class EnumWithToStringHelper {
+enum class _GLUECODIUM_CPP_EXPORT EnumWithToStringHelper {
     FIRST,
     SECOND
 };
+
 std::string_view
 _GLUECODIUM_CPP_EXPORT to_string(EnumWithToStringHelper enumeration);
+
+
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/Enums.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/Enums.h
@@ -21,13 +21,13 @@ public:
 
 
 public:
-    enum class SimpleEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SimpleEnum {
         FIRST,
         SECOND
     };
 
 
-    enum class InternalErrorCode {
+    enum class _GLUECODIUM_CPP_EXPORT InternalErrorCode {
         ERROR_NONE,
         ERROR_FATAL = 999
     };

--- a/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumsInTypeCollection.h
+++ b/gluecodium/src/test/resources/smoke/enums/output/cpp/include/smoke/EnumsInTypeCollection.h
@@ -1,15 +1,23 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT EnumsInTypeCollection {
-    enum class TCEnum {
+    enum class _GLUECODIUM_CPP_EXPORT TCEnum {
         FIRST,
         SECOND
     };
+
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/Equatable.h
+++ b/gluecodium/src/test/resources/smoke/equatable/output/cpp/include/smoke/Equatable.h
@@ -1,8 +1,11 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Hash.h"
 #include "gluecodium/UnorderedMapHash.h"
@@ -12,20 +15,28 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT Equatable {
     struct _GLUECODIUM_CPP_EXPORT NestedEquatableStruct {
         ::std::string foo_field;
+
         NestedEquatableStruct( );
         explicit NestedEquatableStruct( ::std::string foo_field );
+
         bool operator==( const NestedEquatableStruct& rhs ) const;
         bool operator!=( const NestedEquatableStruct& rhs ) const;
+
     };
-    enum class SomeEnum {
+
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         FOO,
         BAR
     };
+
+
     using ErrorCodeToMessageMap = ::std::unordered_map< int32_t, ::std::string >;
+
     struct _GLUECODIUM_CPP_EXPORT EquatableStruct {
         bool bool_field;
         int32_t int_field;
@@ -37,11 +48,15 @@ struct _GLUECODIUM_CPP_EXPORT Equatable {
         ::smoke::Equatable::SomeEnum enum_field;
         ::std::vector< ::std::string > array_field;
         ::smoke::Equatable::ErrorCodeToMessageMap map_field;
+
         EquatableStruct( );
         EquatableStruct( bool bool_field, int32_t int_field, int64_t long_field, float float_field, double double_field, ::std::string string_field, ::smoke::Equatable::NestedEquatableStruct struct_field, ::smoke::Equatable::SomeEnum enum_field, ::std::vector< ::std::string > array_field, ::smoke::Equatable::ErrorCodeToMessageMap map_field );
+
         bool operator==( const EquatableStruct& rhs ) const;
         bool operator!=( const EquatableStruct& rhs ) const;
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT EquatableNullableStruct {
         std::optional< bool > bool_field = std::optional< bool >();
         std::optional< int32_t > int_field = std::optional< int32_t >();
@@ -52,13 +67,20 @@ struct _GLUECODIUM_CPP_EXPORT Equatable {
         std::optional< ::smoke::Equatable::SomeEnum > enum_field = std::optional< ::smoke::Equatable::SomeEnum >();
         std::optional< ::std::vector< ::std::string > > array_field = std::optional< ::std::vector< ::std::string > >();
         std::optional< ::smoke::Equatable::ErrorCodeToMessageMap > map_field = std::optional< ::smoke::Equatable::ErrorCodeToMessageMap >();
+
         EquatableNullableStruct( );
         EquatableNullableStruct( std::optional< bool > bool_field, std::optional< int32_t > int_field, std::optional< uint16_t > uint_field, std::optional< float > float_field, std::optional< ::std::string > string_field, std::optional< ::smoke::Equatable::NestedEquatableStruct > struct_field, std::optional< ::smoke::Equatable::SomeEnum > enum_field, std::optional< ::std::vector< ::std::string > > array_field, std::optional< ::smoke::Equatable::ErrorCodeToMessageMap > map_field );
+
         bool operator==( const EquatableNullableStruct& rhs ) const;
         bool operator!=( const EquatableNullableStruct& rhs ) const;
+
     };
+
 };
+
+
 }
+
 namespace gluecodium {
 template<>
 struct hash< ::smoke::Equatable::EquatableStruct > {

--- a/gluecodium/src/test/resources/smoke/errors/output/cpp/include/smoke/Errors.h
+++ b/gluecodium/src/test/resources/smoke/errors/output/cpp/include/smoke/Errors.h
@@ -22,7 +22,7 @@ public:
 
 
 public:
-    enum class InternalErrorCode {
+    enum class _GLUECODIUM_CPP_EXPORT InternalErrorCode {
         ERROR_NONE,
         ERROR_FATAL
     };

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Types.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/cpp/include/package/Types.h
@@ -1,28 +1,42 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/VectorHash.h"
 #include <cstdint>
 #include <system_error>
 #include <vector>
+
 namespace package {
 struct _GLUECODIUM_CPP_EXPORT Types {
-    enum class Enum {
+    enum class _GLUECODIUM_CPP_EXPORT Enum {
         NA_N
     };
+
+
     struct _GLUECODIUM_CPP_EXPORT Struct {
         ::package::Types::Enum null = ::package::Types::Enum::NA_N;
+
         Struct( );
         explicit Struct( ::package::Types::Enum null );
+
     };
+
     static const ::package::Types::Enum CONST;
+
     using ULong = ::std::vector< ::package::Types::Struct >;
+
 };
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::package::Types::Enum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithCompoundTypes.h
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/cpp/include/smoke/GenericTypesWithCompoundTypes.h
@@ -38,7 +38,7 @@ public:
 
 
 public:
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         FOO,
         BAR
     };

--- a/gluecodium/src/test/resources/smoke/name_rules/output/cpp/include/namerules/NameRules.h
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/cpp/include/namerules/NameRules.h
@@ -23,7 +23,7 @@ public:
 
 
 public:
-    enum class ExampleErrorCode {
+    enum class _GLUECODIUM_CPP_EXPORT ExampleErrorCode {
         NONE,
         FATAL
     };

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/FreeEnum.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/FreeEnum.h
@@ -1,18 +1,26 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <system_error>
+
 namespace smoke {
-enum class FreeEnum {
+enum class _GLUECODIUM_CPP_EXPORT FreeEnum {
     FOO,
     BAR
 };
+
+
+
 _GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::FreeEnum value ) noexcept;
 }
+
 namespace std
 {
 template <>

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/LevelOne.h
@@ -35,7 +35,7 @@ public:
 
 
         public:
-            enum class LevelFourEnum {
+            enum class _GLUECODIUM_CPP_EXPORT LevelFourEnum {
                 NONE
             };
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
+++ b/gluecodium/src/test/resources/smoke/nesting/output/cpp/include/smoke/OuterStruct.h
@@ -35,7 +35,7 @@ struct _GLUECODIUM_CPP_EXPORT OuterStruct {
 
     };
 
-    enum class InnerEnum {
+    enum class _GLUECODIUM_CPP_EXPORT InnerEnum {
         FOO,
         BAR
     };

--- a/gluecodium/src/test/resources/smoke/nullable/output/cpp/include/smoke/Nullable.h
+++ b/gluecodium/src/test/resources/smoke/nullable/output/cpp/include/smoke/Nullable.h
@@ -32,7 +32,7 @@ public:
 
 
 public:
-    enum class SomeEnum {
+    enum class _GLUECODIUM_CPP_EXPORT SomeEnum {
         ON,
         OFF
     };

--- a/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooTypes.h
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/cpp/include/smoke/fooTypes.h
@@ -1,22 +1,35 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
 #include <string>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT fooTypes {
     struct _GLUECODIUM_CPP_EXPORT fooStruct {
         ::std::string FOO_FIELD;
+
         fooStruct( );
         explicit fooStruct( ::std::string FOO_FIELD );
+
         static ::smoke::fooTypes::fooStruct FooCreate( const ::std::string& FooParameter );
+
     };
-    enum class fooEnum {
+
+    enum class _GLUECODIUM_CPP_EXPORT fooEnum {
         foo_item
     };
+
+
     using fooTypedef = double;
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/cpp/include/smoke/Properties.h
+++ b/gluecodium/src/test/resources/smoke/properties/output/cpp/include/smoke/Properties.h
@@ -29,7 +29,7 @@ public:
 
 
 public:
-    enum class InternalErrorCode {
+    enum class _GLUECODIUM_CPP_EXPORT InternalErrorCode {
         ERROR_NONE,
         ERROR_FATAL = 999
     };

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfTypesEnabled.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/EnableIfTypesEnabled.h
@@ -1,20 +1,32 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT EnableIfTypesEnabled {
     static const bool PLACE_HOLDER_ENABLED;
-    enum class EnableMe {
+
+    enum class _GLUECODIUM_CPP_EXPORT EnableMe {
         NOPE
     };
+
+
     struct _GLUECODIUM_CPP_EXPORT EnableMeToo {
         ::smoke::EnableIfTypesEnabled::EnableMe field;
+
         EnableMeToo( );
         explicit EnableMeToo( ::smoke::EnableIfTypesEnabled::EnableMe field );
+
     };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorAutoTag.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorAutoTag.h
@@ -1,13 +1,20 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
+
 namespace smoke {
-enum class SkipEnumeratorAutoTag {
+enum class _GLUECODIUM_CPP_EXPORT SkipEnumeratorAutoTag {
     ONE,
     THREE
 };
+
+
+
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorExplicitTag.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cpp/include/smoke/SkipEnumeratorExplicitTag.h
@@ -1,14 +1,21 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include <cstdint>
+
 namespace smoke {
-enum class SkipEnumeratorExplicitTag {
+enum class _GLUECODIUM_CPP_EXPORT SkipEnumeratorExplicitTag {
     ZERO,
     ONE = 3,
     THREE
 };
+
+
+
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
@@ -23,7 +23,7 @@ public:
 
 
 public:
-    enum class FooBar {
+    enum class _GLUECODIUM_CPP_EXPORT FooBar {
         FOO,
         BAR
     };


### PR DESCRIPTION
Generated files for C++ did not contain export macro for enumerations.
That was not the case of structs and classes. The reason for that was
missing inclusion of 'CppExportMacro' in 'CppEnumeration.mustache'.

Note: the change in logic is only a single line.
The remaining changes in the commit are related
to smoke tests -- the expected generated files
with enumerations have been adjusted.