### PR TITLE
Dart: generate omitted documentation of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased:
+### Bug fixes:
+ * Dart: generate omitted documentation of properties.
+
 ## 13.9.6
 Release date: 2024-10-31
 ### Bug fixes:

--- a/gluecodium/src/main/resources/templates/dart/DartDescribeProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartDescribeProperty.mustache
@@ -18,14 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#set property=this}}{{>dart/DartDescribeProperty}}{{#getter}}
-{{>dart/DartDocumentation}}{{>dart/DartAttributes}}{{!!
-}}{{#if isStatic}}static {{/if}}{{!!
-}}{{resolveName property.typeRef}} get {{resolveName property}}{{!!
-}}{{#if isStatic}} => $prototype.{{resolveName property}}{{/if}};
-{{/getter}}
-{{#if setter}}{{>dart/DartDescribeProperty}}{{/if}}{{#setter}}
-{{>dart/DartDocumentation}}{{>dart/DartAttributes}}{{!!
-}}{{#if isStatic}}static {{/if}}set {{resolveName property}}({{resolveName property.typeRef}} value){{!!
-}}{{#if isStatic}} { $prototype.{{resolveName property}} = value; }{{/if}}{{#unless isStatic}};{{/unless}}
-{{/setter}}{{/set}}
+{{#resolveName comment}}
+{{#unless this.isEmpty}}
+{{prefix this "/// "}}
+{{/unless}}{{/resolveName}}

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -1,34 +1,48 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// Class comment
 @OnClass
 abstract class AttributesWithComments {
+
   /// Const comment
   @OnConstInClass
   static final bool pi = false;
+
   /// Function comment
   ///
   @OnFunctionInClass
   void veryFun();
+  /// Property comment
   /// Getter comment
   @OnPropertyInClass
   String get prop;
+  /// Property comment
   /// Setter comment
   @OnPropertyInClass
   set prop(String value);
+
 }
+
+
 class AttributesWithComments_SomeStruct {
   /// Field comment
   @OnField
   String field;
+
   AttributesWithComments_SomeStruct._(this.field);
   AttributesWithComments_SomeStruct()
     : field = "";
 }
+
+
 // AttributesWithComments_SomeStruct "private" section, not exported.
+
 final _smokeAttributeswithcommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -41,12 +55,16 @@ final _smokeAttributeswithcommentsSomestructGetFieldfield = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_get_field_field'));
+
+
+
 Pointer<Void> smokeAttributeswithcommentsSomestructToFfi(AttributesWithComments_SomeStruct value) {
   final _fieldHandle = stringToFfi(value.field);
   final _result = _smokeAttributeswithcommentsSomestructCreateHandle(_fieldHandle);
   stringReleaseFfiHandle(_fieldHandle);
   return _result;
 }
+
 AttributesWithComments_SomeStruct smokeAttributeswithcommentsSomestructFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeAttributeswithcommentsSomestructGetFieldfield(handle);
   try {
@@ -57,8 +75,11 @@ AttributesWithComments_SomeStruct smokeAttributeswithcommentsSomestructFromFfi(P
     stringReleaseFfiHandle(_fieldHandle);
   }
 }
+
 void smokeAttributeswithcommentsSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeAttributeswithcommentsSomestructReleaseHandle(handle);
+
 // Nullable AttributesWithComments_SomeStruct
+
 final _smokeAttributeswithcommentsSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -71,6 +92,7 @@ final _smokeAttributeswithcommentsSomestructGetValueNullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeAttributeswithcommentsSomestructToFfiNullable(AttributesWithComments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeAttributeswithcommentsSomestructToFfi(value);
@@ -78,6 +100,7 @@ Pointer<Void> smokeAttributeswithcommentsSomestructToFfiNullable(AttributesWithC
   smokeAttributeswithcommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 AttributesWithComments_SomeStruct? smokeAttributeswithcommentsSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeAttributeswithcommentsSomestructGetValueNullable(handle);
@@ -85,10 +108,14 @@ AttributesWithComments_SomeStruct? smokeAttributeswithcommentsSomestructFromFfiN
   smokeAttributeswithcommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeAttributeswithcommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributeswithcommentsSomestructReleaseHandleNullable(handle);
+
 // End of AttributesWithComments_SomeStruct "private" section.
+
 // AttributesWithComments "private" section, not exported.
+
 final _smokeAttributeswithcommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -101,14 +128,21 @@ final _smokeAttributeswithcommentsReleaseHandle = __lib.catchArgumentError(() =>
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithComments_release_handle'));
+
+
+
 class AttributesWithComments$Impl extends __lib.NativeBase implements AttributesWithComments {
+
   AttributesWithComments$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithComments_veryFun'));
     final _handle = this.handle;
     _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @OnPropertyInClass
   @override
   String get prop {
@@ -119,8 +153,11 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @OnPropertyInClass
   @override
   set prop(String value) {
@@ -129,26 +166,40 @@ class AttributesWithComments$Impl extends __lib.NativeBase implements Attributes
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeAttributeswithcommentsToFfi(AttributesWithComments value) =>
   _smokeAttributeswithcommentsCopyHandle((value as __lib.NativeBase).handle);
+
 AttributesWithComments smokeAttributeswithcommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesWithComments) return instance;
+
   final _copiedHandle = _smokeAttributeswithcommentsCopyHandle(handle);
   final result = AttributesWithComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeAttributeswithcommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeAttributeswithcommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAttributeswithcommentsReleaseHandle(handle);
+
 Pointer<Void> smokeAttributeswithcommentsToFfiNullable(AttributesWithComments? value) =>
   value != null ? smokeAttributeswithcommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 AttributesWithComments? smokeAttributeswithcommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeAttributeswithcommentsFromFfi(handle) : null;
+
 void smokeAttributeswithcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributeswithcommentsReleaseHandle(handle);
+
 // End of AttributesWithComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -79,9 +79,17 @@ class comments {
     fun returnCommentOnly(undocumented: String): String
 
     // Some very useful property.
+    // Note: without these comments user may not be able to use it correctly.
+    // Note: that's serious.
+    // Therefore, these lines above getter/setter need to be rendered in the output files.
     // @get Gets some very useful property.
     // @set Sets some very useful property.
     property SomeProperty: Usefulness
+
+    // OnlyGetterProperty, which does not have a setter.
+    // The generated documentation for this property should only be added to property or getter.
+    // @get Gets OnlyGetterProperty in a very specific way.
+    property OnlyGetterProperty: Int { get }
 
     // This is some very useful exception.
     exception SomethingWrong(SomeEnum)

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -281,6 +281,9 @@ public final class Comments extends NativeBase {
     /**
      * <p>Gets some very useful property.
      * @return <p>Some very useful property.
+     *     Note: without these comments user may not be able to use it correctly.
+     *     Note: that's serious.
+     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
 
 
@@ -290,11 +293,24 @@ public final class Comments extends NativeBase {
     /**
      * <p>Sets some very useful property.
      * @param value <p>Some very useful property.
+     *     Note: without these comments user may not be able to use it correctly.
+     *     Note: that's serious.
+     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
 
 
 
     public native void setSomeProperty(final boolean value);
+
+    /**
+     * <p>Gets OnlyGetterProperty in a very specific way.
+     * @return <p>OnlyGetterProperty, which does not have a setter.
+     *     The generated documentation for this property should only be added to property or getter.
+     */
+
+
+
+    public native int getOnlyGetterProperty();
 
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -183,13 +183,26 @@ public:
     /**
      * Gets some very useful property.
      * \return Some very useful property.
+     *     Note: without these comments user may not be able to use it correctly.
+     *     Note: that's serious.
+     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
     virtual ::smoke::Comments::Usefulness is_some_property(  ) const = 0;
     /**
      * Sets some very useful property.
      * \param[in] value Some very useful property.
+     *     Note: without these comments user may not be able to use it correctly.
+     *     Note: that's serious.
+     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
     virtual void set_some_property( const ::smoke::Comments::Usefulness value ) = 0;
+
+    /**
+     * Gets OnlyGetterProperty in a very specific way.
+     * \return OnlyGetterProperty, which does not have a setter.
+     *     The generated documentation for this property should only be added to property or getter.
+     */
+    virtual int32_t get_only_getter_property(  ) const = 0;
 
 };
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -1,13 +1,18 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
+
 /// This is some very useful interface.
 abstract class Comments {
+
   /// This is some very useful constant.
   static final bool veryUseful = true;
+
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [inputParameter] Very useful input parameter
@@ -46,21 +51,39 @@ abstract class Comments {
   /// This is some very useful method that measures the usefulness of something.
   ///
   bool someMethodWithoutInputParametersWithNoComments();
+
   void someMethodWithNothing();
   /// This is some very useful method that does nothing.
   ///
   void someMethodWithoutReturnTypeOrInputParameters();
+
   /// [documented] nicely documented
   ///
   String oneParameterCommentOnly(String undocumented, String documented);
+
   /// Returns [String]. nicely documented
   ///
   String returnCommentOnly(String undocumented);
+  /// Some very useful property.
+  /// Note: without these comments user may not be able to use it correctly.
+  /// Note: that's serious.
+  /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Gets some very useful property.
   bool get isSomeProperty;
+  /// Some very useful property.
+  /// Note: without these comments user may not be able to use it correctly.
+  /// Note: that's serious.
+  /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Sets some very useful property.
   set isSomeProperty(bool value);
+
+  /// OnlyGetterProperty, which does not have a setter.
+  /// The generated documentation for this property should only be added to property or getter.
+  /// Gets OnlyGetterProperty in a very specific way.
+  int get onlyGetterProperty;
+
 }
+
 /// This is some very useful enum.
 enum Comments_SomeEnum {
     /// Not quite useful
@@ -68,7 +91,9 @@ enum Comments_SomeEnum {
     /// Somewhat useful
     useful
 }
+
 // Comments_SomeEnum "private" section, not exported.
+
 int smokeCommentsSomeenumToFfi(Comments_SomeEnum value) {
   switch (value) {
   case Comments_SomeEnum.useless:
@@ -79,6 +104,7 @@ int smokeCommentsSomeenumToFfi(Comments_SomeEnum value) {
     throw StateError("Invalid enum value $value for Comments_SomeEnum enum.");
   }
 }
+
 Comments_SomeEnum smokeCommentsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -89,7 +115,9 @@ Comments_SomeEnum smokeCommentsSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Comments_SomeEnum enum.");
   }
 }
+
 void smokeCommentsSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeCommentsSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -102,6 +130,7 @@ final _smokeCommentsSomeenumGetValueNullable = __lib.catchArgumentError(() => __
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeCommentsSomeenumToFfiNullable(Comments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCommentsSomeenumToFfi(value);
@@ -109,6 +138,7 @@ Pointer<Void> smokeCommentsSomeenumToFfiNullable(Comments_SomeEnum? value) {
   smokeCommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Comments_SomeEnum? smokeCommentsSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCommentsSomeenumGetValueNullable(handle);
@@ -116,25 +146,35 @@ Comments_SomeEnum? smokeCommentsSomeenumFromFfiNullable(Pointer<Void> handle) {
   smokeCommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCommentsSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsSomeenumReleaseHandleNullable(handle);
+
 // End of Comments_SomeEnum "private" section.
 /// This is some very useful exception.
 class Comments_SomethingWrongException implements Exception {
   final Comments_SomeEnum error;
   Comments_SomethingWrongException(this.error);
 }
+
+
 /// This is some very useful struct.
+
 class Comments_SomeStruct {
   /// How useful this struct is
   /// remains to be seen
   bool someField;
+
   /// Can be `null`
   String? nullableField;
+
   /// This is how easy it is to construct.
+
   /// [someField] How useful this struct is
   /// remains to be seen
+
   /// [nullableField] Can be `null`
+
   Comments_SomeStruct._(this.someField, this.nullableField);
   Comments_SomeStruct(bool someField)
     : someField = someField, nullableField = null;
@@ -144,11 +184,15 @@ class Comments_SomeStruct {
   /// This is some static struct method that does nothing.
   ///
   static void someStaticStructMethod() => $prototype.someStaticStructMethod();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Comments_SomeStruct$Impl();
 }
+
+
 // Comments_SomeStruct "private" section, not exported.
+
 final _smokeCommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
@@ -165,6 +209,9 @@ final _smokeCommentsSomestructGetFieldnullableField = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_get_field_nullableField'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class Comments_SomeStruct$Impl {
@@ -173,12 +220,17 @@ class Comments_SomeStruct$Impl {
     final _handle = smokeCommentsSomestructToFfi($that);
     _someStructMethodFfi(_handle, __lib.LibraryContext.isolateId);
     smokeCommentsSomestructReleaseFfiHandle(_handle);
+
   }
+
   void someStaticStructMethod() {
     final _someStaticStructMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_Comments_SomeStruct_someStaticStructMethod'));
     _someStaticStructMethodFfi(__lib.LibraryContext.isolateId);
+
   }
+
 }
+
 Pointer<Void> smokeCommentsSomestructToFfi(Comments_SomeStruct value) {
   final _someFieldHandle = booleanToFfi(value.someField);
   final _nullableFieldHandle = stringToFfiNullable(value.nullableField);
@@ -187,12 +239,13 @@ Pointer<Void> smokeCommentsSomestructToFfi(Comments_SomeStruct value) {
   stringReleaseFfiHandleNullable(_nullableFieldHandle);
   return _result;
 }
+
 Comments_SomeStruct smokeCommentsSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeCommentsSomestructGetFieldsomeField(handle);
   final _nullableFieldHandle = _smokeCommentsSomestructGetFieldnullableField(handle);
   try {
     return Comments_SomeStruct._(
-      booleanFromFfi(_someFieldHandle),
+      booleanFromFfi(_someFieldHandle), 
       stringFromFfiNullable(_nullableFieldHandle)
     );
   } finally {
@@ -200,8 +253,11 @@ Comments_SomeStruct smokeCommentsSomestructFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandleNullable(_nullableFieldHandle);
   }
 }
+
 void smokeCommentsSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeCommentsSomestructReleaseHandle(handle);
+
 // Nullable Comments_SomeStruct
+
 final _smokeCommentsSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -214,6 +270,7 @@ final _smokeCommentsSomestructGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeCommentsSomestructToFfiNullable(Comments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCommentsSomestructToFfi(value);
@@ -221,6 +278,7 @@ Pointer<Void> smokeCommentsSomestructToFfiNullable(Comments_SomeStruct? value) {
   smokeCommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Comments_SomeStruct? smokeCommentsSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCommentsSomestructGetValueNullable(handle);
@@ -228,8 +286,10 @@ Comments_SomeStruct? smokeCommentsSomestructFromFfiNullable(Pointer<Void> handle
   smokeCommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsSomestructReleaseHandleNullable(handle);
+
 // End of Comments_SomeStruct "private" section.
 /// This is some very useful lambda that does it.
 ///
@@ -239,7 +299,9 @@ void smokeCommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
 ///
 /// Returns Usefulness of the input
 typedef Comments_SomeLambda = double Function(String, int);
+
 // Comments_SomeLambda "private" section, not exported.
+
 final _smokeCommentsSomelambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -256,9 +318,11 @@ final _smokeCommentsSomelambdaCreateProxy = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Comments_SomeLambda_create_proxy'));
+
 class Comments_SomeLambda$Impl {
   final Pointer<Void> handle;
   Comments_SomeLambda$Impl(this.handle);
+
   double call(String p0, int p1) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_Comments_SomeLambda_call__String_Int'));
     final _p0Handle = stringToFfi(p0);
@@ -266,12 +330,18 @@ class Comments_SomeLambda$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
 }
+
 int _smokeCommentsSomelambdacallStatic(Object _obj, Pointer<Void> p0, int p1, Pointer<Double> _result) {
   double? _resultObject;
   try {
@@ -279,9 +349,11 @@ int _smokeCommentsSomelambdacallStatic(Object _obj, Pointer<Void> p0, int p1, Po
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeCommentsSomelambdaToFfi(Comments_SomeLambda value) =>
   _smokeCommentsSomelambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -289,6 +361,7 @@ Pointer<Void> smokeCommentsSomelambdaToFfi(Comments_SomeLambda value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Int32, Pointer<Double>)>(_smokeCommentsSomelambdacallStatic, __lib.unknownError)
   );
+
 Comments_SomeLambda smokeCommentsSomelambdaFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeCommentsSomelambdaCopyHandle(handle);
   final _impl = Comments_SomeLambda$Impl(_copiedHandle);
@@ -296,9 +369,12 @@ Comments_SomeLambda smokeCommentsSomelambdaFromFfi(Pointer<Void> handle) {
   _smokeCommentsSomelambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCommentsSomelambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCommentsSomelambdaReleaseHandle(handle);
+
 // Nullable Comments_SomeLambda
+
 final _smokeCommentsSomelambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -311,6 +387,7 @@ final _smokeCommentsSomelambdaGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Comments_SomeLambda_get_value_nullable'));
+
 Pointer<Void> smokeCommentsSomelambdaToFfiNullable(Comments_SomeLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCommentsSomelambdaToFfi(value);
@@ -318,6 +395,7 @@ Pointer<Void> smokeCommentsSomelambdaToFfiNullable(Comments_SomeLambda? value) {
   smokeCommentsSomelambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 Comments_SomeLambda? smokeCommentsSomelambdaFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCommentsSomelambdaGetValueNullable(handle);
@@ -325,10 +403,14 @@ Comments_SomeLambda? smokeCommentsSomelambdaFromFfiNullable(Pointer<Void> handle
   smokeCommentsSomelambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCommentsSomelambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsSomelambdaReleaseHandleNullable(handle);
+
 // End of Comments_SomeLambda "private" section.
+
 // Comments "private" section, not exported.
+
 final _smokeCommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -341,6 +423,8 @@ final _smokeCommentsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Comments_release_handle'));
+
+
 final _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -357,8 +441,23 @@ final _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringRetu
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error'));
+
+
+
+
+
+
+
+
+
+
+
+
+
 class Comments$Impl extends __lib.NativeBase implements Comments {
+
   Comments$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithAllComments__String'));
@@ -381,8 +480,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithInputComments(String input) {
     final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithInputComments__String'));
@@ -394,8 +496,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithOutputComments(String input) {
     final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithOutputComments__String'));
@@ -407,8 +512,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithNoComments(String input) {
     final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithNoComments__String'));
@@ -420,8 +528,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void someMethodWithoutReturnTypeWithAllComments(String input) {
     final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithAllComments__String'));
@@ -429,7 +540,9 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     final _handle = this.handle;
     _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
+
   }
+
   @override
   void someMethodWithoutReturnTypeWithNoComments(String input) {
     final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_someMethodWithoutReturnTypeWithNoComments__String'));
@@ -437,7 +550,9 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     final _handle = this.handle;
     _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
+
   }
+
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithAllComments'));
@@ -447,8 +562,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutInputParametersWithNoComments'));
@@ -458,20 +576,27 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void someMethodWithNothing() {
     final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithNothing'));
     final _handle = this.handle;
     _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Comments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   String oneParameterCommentOnly(String undocumented, String documented) {
     final _oneParameterCommentOnlyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_Comments_oneParameterCommentOnly__String_String'));
@@ -485,8 +610,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   String returnCommentOnly(String undocumented) {
     final _returnCommentOnlyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Comments_returnCommentOnly__String'));
@@ -498,8 +626,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isSomeProperty_get'));
@@ -509,8 +640,11 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set isSomeProperty(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isSomeProperty_set__Boolean'));
@@ -518,26 +652,55 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
+  @override
+  int get onlyGetterProperty {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_onlyGetterProperty_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+
+
 }
+
 Pointer<Void> smokeCommentsToFfi(Comments value) =>
   _smokeCommentsCopyHandle((value as __lib.NativeBase).handle);
+
 Comments smokeCommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Comments) return instance;
+
   final _copiedHandle = _smokeCommentsCopyHandle(handle);
   final result = Comments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCommentsReleaseHandle(handle);
+
 Pointer<Void> smokeCommentsToFfiNullable(Comments? value) =>
   value != null ? smokeCommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Comments? smokeCommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCommentsFromFfi(handle) : null;
+
 void smokeCommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsReleaseHandle(handle);
+
 // End of Comments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -1,12 +1,16 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// This is some very useful interface.
 abstract class CommentsInterface {
   /// This is some very useful interface.
+
   factory CommentsInterface(
     bool Function(String) someMethodWithAllCommentsLambda,
     bool Function(String) someMethodWithInputCommentsLambda,
@@ -37,6 +41,7 @@ abstract class CommentsInterface {
 
   /// This is some very useful constant.
   static final bool veryUseful = true;
+
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
@@ -73,15 +78,20 @@ abstract class CommentsInterface {
   /// This is some very useful method that measures the usefulness of something.
   ///
   bool someMethodWithoutInputParametersWithNoComments();
+
   void someMethodWithNothing();
   /// This is some very useful method that does nothing.
   ///
   void someMethodWithoutReturnTypeOrInputParameters();
+  /// Some very useful property.
   /// Gets some very useful property.
   bool get isSomeProperty;
+  /// Some very useful property.
   /// Sets some very useful property.
   set isSomeProperty(bool value);
+
 }
+
 /// This is some very useful enum.
 enum CommentsInterface_SomeEnum {
     /// Not quite useful
@@ -89,7 +99,9 @@ enum CommentsInterface_SomeEnum {
     /// Somewhat useful
     useful
 }
+
 // CommentsInterface_SomeEnum "private" section, not exported.
+
 int smokeCommentsinterfaceSomeenumToFfi(CommentsInterface_SomeEnum value) {
   switch (value) {
   case CommentsInterface_SomeEnum.useless:
@@ -100,6 +112,7 @@ int smokeCommentsinterfaceSomeenumToFfi(CommentsInterface_SomeEnum value) {
     throw StateError("Invalid enum value $value for CommentsInterface_SomeEnum enum.");
   }
 }
+
 CommentsInterface_SomeEnum smokeCommentsinterfaceSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -110,7 +123,9 @@ CommentsInterface_SomeEnum smokeCommentsinterfaceSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for CommentsInterface_SomeEnum enum.");
   }
 }
+
 void smokeCommentsinterfaceSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeCommentsinterfaceSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -123,6 +138,7 @@ final _smokeCommentsinterfaceSomeenumGetValueNullable = __lib.catchArgumentError
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeCommentsinterfaceSomeenumToFfiNullable(CommentsInterface_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCommentsinterfaceSomeenumToFfi(value);
@@ -130,6 +146,7 @@ Pointer<Void> smokeCommentsinterfaceSomeenumToFfiNullable(CommentsInterface_Some
   smokeCommentsinterfaceSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 CommentsInterface_SomeEnum? smokeCommentsinterfaceSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCommentsinterfaceSomeenumGetValueNullable(handle);
@@ -137,16 +154,23 @@ CommentsInterface_SomeEnum? smokeCommentsinterfaceSomeenumFromFfiNullable(Pointe
   smokeCommentsinterfaceSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCommentsinterfaceSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsinterfaceSomeenumReleaseHandleNullable(handle);
+
 // End of CommentsInterface_SomeEnum "private" section.
 /// This is some very useful struct.
+
 class CommentsInterface_SomeStruct {
   /// How useful this struct is
   bool someField;
+
   CommentsInterface_SomeStruct(this.someField);
 }
+
+
 // CommentsInterface_SomeStruct "private" section, not exported.
+
 final _smokeCommentsinterfaceSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
@@ -159,12 +183,16 @@ final _smokeCommentsinterfaceSomestructGetFieldsomeField = __lib.catchArgumentEr
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeCommentsinterfaceSomestructToFfi(CommentsInterface_SomeStruct value) {
   final _someFieldHandle = booleanToFfi(value.someField);
   final _result = _smokeCommentsinterfaceSomestructCreateHandle(_someFieldHandle);
   booleanReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 CommentsInterface_SomeStruct smokeCommentsinterfaceSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeCommentsinterfaceSomestructGetFieldsomeField(handle);
   try {
@@ -175,8 +203,11 @@ CommentsInterface_SomeStruct smokeCommentsinterfaceSomestructFromFfi(Pointer<Voi
     booleanReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeCommentsinterfaceSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeCommentsinterfaceSomestructReleaseHandle(handle);
+
 // Nullable CommentsInterface_SomeStruct
+
 final _smokeCommentsinterfaceSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -189,6 +220,7 @@ final _smokeCommentsinterfaceSomestructGetValueNullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeCommentsinterfaceSomestructToFfiNullable(CommentsInterface_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCommentsinterfaceSomestructToFfi(value);
@@ -196,6 +228,7 @@ Pointer<Void> smokeCommentsinterfaceSomestructToFfiNullable(CommentsInterface_So
   smokeCommentsinterfaceSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 CommentsInterface_SomeStruct? smokeCommentsinterfaceSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCommentsinterfaceSomestructGetValueNullable(handle);
@@ -203,10 +236,14 @@ CommentsInterface_SomeStruct? smokeCommentsinterfaceSomestructFromFfiNullable(Po
   smokeCommentsinterfaceSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCommentsinterfaceSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsinterfaceSomestructReleaseHandleNullable(handle);
+
 // End of CommentsInterface_SomeStruct "private" section.
+
 // CommentsInterface "private" section, not exported.
+
 final _smokeCommentsinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -227,6 +264,17 @@ final _smokeCommentsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsInterface_get_type_id'));
+
+
+
+
+
+
+
+
+
+
+
 class CommentsInterface$Lambdas implements CommentsInterface {
   bool Function(String) someMethodWithAllCommentsLambda;
   bool Function(String) someMethodWithInputCommentsLambda;
@@ -240,6 +288,7 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   void Function() someMethodWithoutReturnTypeOrInputParametersLambda;
   bool Function() isSomePropertyGetLambda;
   void Function(bool) isSomePropertySetLambda;
+
   CommentsInterface$Lambdas(
     this.someMethodWithAllCommentsLambda,
     this.someMethodWithInputCommentsLambda,
@@ -290,7 +339,9 @@ class CommentsInterface$Lambdas implements CommentsInterface {
   @override
   set isSomeProperty(bool value) => isSomePropertySetLambda(value);
 }
+
 class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterface {
+
   CommentsInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -304,8 +355,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithInputComments(String input) {
     final _someMethodWithInputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithInputComments__String'));
@@ -317,8 +371,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithOutputComments(String input) {
     final _someMethodWithOutputCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithOutputComments__String'));
@@ -330,8 +387,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithNoComments(String input) {
     final _someMethodWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithNoComments__String'));
@@ -343,8 +403,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void someMethodWithoutReturnTypeWithAllComments(String input) {
     final _someMethodWithoutReturnTypeWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithAllComments__String'));
@@ -352,7 +415,9 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     final _handle = this.handle;
     _someMethodWithoutReturnTypeWithAllCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
+
   }
+
   @override
   void someMethodWithoutReturnTypeWithNoComments(String input) {
     final _someMethodWithoutReturnTypeWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeWithNoComments__String'));
@@ -360,7 +425,9 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     final _handle = this.handle;
     _someMethodWithoutReturnTypeWithNoCommentsFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
+
   }
+
   @override
   bool someMethodWithoutInputParametersWithAllComments() {
     final _someMethodWithoutInputParametersWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithAllComments'));
@@ -370,8 +437,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool someMethodWithoutInputParametersWithNoComments() {
     final _someMethodWithoutInputParametersWithNoCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutInputParametersWithNoComments'));
@@ -381,20 +451,27 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void someMethodWithNothing() {
     final _someMethodWithNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithNothing'));
     final _handle = this.handle;
     _someMethodWithNothingFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   /// Gets some very useful property.
   bool get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_CommentsInterface_isSomeProperty_get'));
@@ -404,8 +481,11 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   /// Sets some very useful property.
   ///
   /// [value] Some very useful property.
@@ -416,8 +496,13 @@ class CommentsInterface$Impl extends __lib.NativeBase implements CommentsInterfa
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeCommentsinterfacesomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
   bool? _resultObject;
   try {
@@ -459,6 +544,7 @@ int _smokeCommentsinterfacesomeMethodWithNoCommentsStatic(Object _obj, Pointer<V
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithoutReturnTypeWithAllCommentsStatic(Object _obj, Pointer<Void> input) {
+
   try {
     (_obj as CommentsInterface).someMethodWithoutReturnTypeWithAllComments(stringFromFfi(input));
   } finally {
@@ -467,6 +553,7 @@ int _smokeCommentsinterfacesomeMethodWithoutReturnTypeWithAllCommentsStatic(Obje
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithoutReturnTypeWithNoCommentsStatic(Object _obj, Pointer<Void> input) {
+
   try {
     (_obj as CommentsInterface).someMethodWithoutReturnTypeWithNoComments(stringFromFfi(input));
   } finally {
@@ -493,6 +580,7 @@ int _smokeCommentsinterfacesomeMethodWithoutInputParametersWithNoCommentsStatic(
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithNothingStatic(Object _obj) {
+
   try {
     (_obj as CommentsInterface).someMethodWithNothing();
   } finally {
@@ -500,16 +588,19 @@ int _smokeCommentsinterfacesomeMethodWithNothingStatic(Object _obj) {
   return 0;
 }
 int _smokeCommentsinterfacesomeMethodWithoutReturnTypeOrInputParametersStatic(Object _obj) {
+
   try {
     (_obj as CommentsInterface).someMethodWithoutReturnTypeOrInputParameters();
   } finally {
   }
   return 0;
 }
+
 int _smokeCommentsinterfaceisSomePropertyGetStatic(Object _obj, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((_obj as CommentsInterface).isSomeProperty);
   return 0;
 }
+
 int _smokeCommentsinterfaceisSomePropertySetStatic(Object _obj, int _value) {
   try {
     (_obj as CommentsInterface).isSomeProperty =
@@ -519,8 +610,10 @@ int _smokeCommentsinterfaceisSomePropertySetStatic(Object _obj, int _value) {
   }
   return 0;
 }
+
 Pointer<Void> smokeCommentsinterfaceToFfi(CommentsInterface value) {
   if (value is __lib.NativeBase) return _smokeCommentsinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeCommentsinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -538,15 +631,19 @@ Pointer<Void> smokeCommentsinterfaceToFfi(CommentsInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Uint8>)>(_smokeCommentsinterfaceisSomePropertyGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeCommentsinterfaceisSomePropertySetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 CommentsInterface smokeCommentsinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsInterface) return instance;
+
   final _typeIdHandle = _smokeCommentsinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeCommentsinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -555,12 +652,19 @@ CommentsInterface smokeCommentsinterfaceFromFfi(Pointer<Void> handle) {
   _smokeCommentsinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCommentsinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCommentsinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeCommentsinterfaceToFfiNullable(CommentsInterface? value) =>
   value != null ? smokeCommentsinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CommentsInterface? smokeCommentsinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCommentsinterfaceFromFfi(handle) : null;
+
 void smokeCommentsinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsinterfaceReleaseHandle(handle);
+
 // End of CommentsInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -1,14 +1,18 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 abstract class DeprecationComments {
   /// This is some very useful interface.
   @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
+
   factory DeprecationComments(
     bool Function(String) someMethodWithAllCommentsLambda,
     bool Function() isSomePropertyGetLambda,
@@ -22,9 +26,11 @@ abstract class DeprecationComments {
     propertyButNotAccessorsGetLambda,
     propertyButNotAccessorsSetLambda
   );
+
   /// This is some very useful constant.
   @Deprecated("Unfortunately, this constant is deprecated. Use [Comments.veryUseful] instead.")
   static final bool veryUseful = true;
+
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [input] Very useful input parameter
@@ -32,19 +38,27 @@ abstract class DeprecationComments {
   /// Returns [bool]. Usefulness of the input
   ///
   @Deprecated("Unfortunately, this method is deprecated.\nUse [Comments.someMethodWithAllComments] instead.")
+
   bool someMethodWithAllComments(String input);
+  /// Some very useful property.
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   bool get isSomeProperty;
+  /// Some very useful property.
   /// Sets some very useful property.
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   set isSomeProperty(bool value);
+
+  /// Describes the property but not accessors.
   /// Gets the property but not accessors.
   @Deprecated("Will be removed in v3.2.1.")
   String get propertyButNotAccessors;
+  /// Describes the property but not accessors.
   @Deprecated("Will be removed in v3.2.1.")
   set propertyButNotAccessors(String value);
+
 }
+
 /// This is some very useful enum.
 @Deprecated("Unfortunately, this enum is deprecated. Use [Comments_SomeEnum] instead.")
 enum DeprecationComments_SomeEnum {
@@ -52,7 +66,9 @@ enum DeprecationComments_SomeEnum {
     @Deprecated("Unfortunately, this item is deprecated.\nUse [Comments_SomeEnum.useless] instead.")
     useless
 }
+
 // DeprecationComments_SomeEnum "private" section, not exported.
+
 int smokeDeprecationcommentsSomeenumToFfi(DeprecationComments_SomeEnum value) {
   switch (value) {
   case DeprecationComments_SomeEnum.useless:
@@ -61,6 +77,7 @@ int smokeDeprecationcommentsSomeenumToFfi(DeprecationComments_SomeEnum value) {
     throw StateError("Invalid enum value $value for DeprecationComments_SomeEnum enum.");
   }
 }
+
 DeprecationComments_SomeEnum smokeDeprecationcommentsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -69,7 +86,9 @@ DeprecationComments_SomeEnum smokeDeprecationcommentsSomeenumFromFfi(int handle)
     throw StateError("Invalid numeric value $handle for DeprecationComments_SomeEnum enum.");
   }
 }
+
 void smokeDeprecationcommentsSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeDeprecationcommentsSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -82,6 +101,7 @@ final _smokeDeprecationcommentsSomeenumGetValueNullable = __lib.catchArgumentErr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeDeprecationcommentsSomeenumToFfiNullable(DeprecationComments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsSomeenumToFfi(value);
@@ -89,6 +109,7 @@ Pointer<Void> smokeDeprecationcommentsSomeenumToFfiNullable(DeprecationComments_
   smokeDeprecationcommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 DeprecationComments_SomeEnum? smokeDeprecationcommentsSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsSomeenumGetValueNullable(handle);
@@ -96,8 +117,10 @@ DeprecationComments_SomeEnum? smokeDeprecationcommentsSomeenumFromFfiNullable(Po
   smokeDeprecationcommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDeprecationcommentsSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDeprecationcommentsSomeenumReleaseHandleNullable(handle);
+
 // End of DeprecationComments_SomeEnum "private" section.
 @Deprecated("Unfortunately, this exception is deprecated, please use [Comments_SomethingWrongException] instead.")
 class DeprecationComments_SomethingWrongException implements Exception {
@@ -106,15 +129,20 @@ class DeprecationComments_SomethingWrongException implements Exception {
 }
 /// This is some very useful struct.
 @Deprecated("Unfortunately, this struct is deprecated. Use [Comments_SomeStruct] instead.")
+
 class DeprecationComments_SomeStruct {
   /// How useful this struct is.
   @Deprecated("Unfortunately, this field is deprecated.\nUse [Comments_SomeStruct.someField] instead.")
   bool someField;
+
   DeprecationComments_SomeStruct._(this.someField);
   DeprecationComments_SomeStruct()
     : someField = false;
 }
+
+
 // DeprecationComments_SomeStruct "private" section, not exported.
+
 final _smokeDeprecationcommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
@@ -127,12 +155,16 @@ final _smokeDeprecationcommentsSomestructGetFieldsomeField = __lib.catchArgument
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeDeprecationcommentsSomestructToFfi(DeprecationComments_SomeStruct value) {
   final _someFieldHandle = booleanToFfi(value.someField);
   final _result = _smokeDeprecationcommentsSomestructCreateHandle(_someFieldHandle);
   booleanReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 DeprecationComments_SomeStruct smokeDeprecationcommentsSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeDeprecationcommentsSomestructGetFieldsomeField(handle);
   try {
@@ -143,8 +175,11 @@ DeprecationComments_SomeStruct smokeDeprecationcommentsSomestructFromFfi(Pointer
     booleanReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeDeprecationcommentsSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeDeprecationcommentsSomestructReleaseHandle(handle);
+
 // Nullable DeprecationComments_SomeStruct
+
 final _smokeDeprecationcommentsSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -157,6 +192,7 @@ final _smokeDeprecationcommentsSomestructGetValueNullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeDeprecationcommentsSomestructToFfiNullable(DeprecationComments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsSomestructToFfi(value);
@@ -164,6 +200,7 @@ Pointer<Void> smokeDeprecationcommentsSomestructToFfiNullable(DeprecationComment
   smokeDeprecationcommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 DeprecationComments_SomeStruct? smokeDeprecationcommentsSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsSomestructGetValueNullable(handle);
@@ -171,10 +208,14 @@ DeprecationComments_SomeStruct? smokeDeprecationcommentsSomestructFromFfiNullabl
   smokeDeprecationcommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDeprecationcommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDeprecationcommentsSomestructReleaseHandleNullable(handle);
+
 // End of DeprecationComments_SomeStruct "private" section.
+
 // DeprecationComments "private" section, not exported.
+
 final _smokeDeprecationcommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -195,12 +236,15 @@ final _smokeDeprecationcommentsGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationComments_get_type_id'));
+
+
 class DeprecationComments$Lambdas implements DeprecationComments {
   bool Function(String) someMethodWithAllCommentsLambda;
   bool Function() isSomePropertyGetLambda;
   void Function(bool) isSomePropertySetLambda;
   String Function() propertyButNotAccessorsGetLambda;
   void Function(String) propertyButNotAccessorsSetLambda;
+
   DeprecationComments$Lambdas(
     this.someMethodWithAllCommentsLambda,
     this.isSomePropertyGetLambda,
@@ -208,6 +252,7 @@ class DeprecationComments$Lambdas implements DeprecationComments {
     this.propertyButNotAccessorsGetLambda,
     this.propertyButNotAccessorsSetLambda
   );
+
   @override
   bool someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
@@ -220,8 +265,11 @@ class DeprecationComments$Lambdas implements DeprecationComments {
   @override
   set propertyButNotAccessors(String value) => propertyButNotAccessorsSetLambda(value);
 }
+
 class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationComments {
+
   DeprecationComments$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_someMethodWithAllComments__String'));
@@ -233,8 +281,11 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   /// Gets some very useful property.
   @Deprecated("Unfortunately, this property's getter is deprecated.\nUse [Comments.isSomeProperty] instead.")
   bool get isSomeProperty {
@@ -245,20 +296,27 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   /// Sets some very useful property.
   ///
   /// [value] Some very useful property.
   ///
   @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [Comments.isSomeProperty] instead.")
+
   set isSomeProperty(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationComments_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
   /// Gets the property but not accessors.
   @Deprecated("Will be removed in v3.2.1.")
   String get propertyButNotAccessors {
@@ -269,19 +327,29 @@ class DeprecationComments$Impl extends __lib.NativeBase implements DeprecationCo
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   /// [value] Describes the property but not accessors.
   ///
   @Deprecated("Will be removed in v3.2.1.")
+
   set propertyButNotAccessors(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationComments_propertyButNotAccessors_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
   bool? _resultObject;
   try {
@@ -292,10 +360,12 @@ int _smokeDeprecationcommentssomeMethodWithAllCommentsStatic(Object _obj, Pointe
   }
   return 0;
 }
+
 int _smokeDeprecationcommentsisSomePropertyGetStatic(Object _obj, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((_obj as DeprecationComments).isSomeProperty);
   return 0;
 }
+
 int _smokeDeprecationcommentsisSomePropertySetStatic(Object _obj, int _value) {
   try {
     (_obj as DeprecationComments).isSomeProperty =
@@ -309,6 +379,7 @@ int _smokeDeprecationcommentspropertyButNotAccessorsGetStatic(Object _obj, Point
   _result.value = stringToFfi((_obj as DeprecationComments).propertyButNotAccessors);
   return 0;
 }
+
 int _smokeDeprecationcommentspropertyButNotAccessorsSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as DeprecationComments).propertyButNotAccessors =
@@ -318,8 +389,10 @@ int _smokeDeprecationcommentspropertyButNotAccessorsSetStatic(Object _obj, Point
   }
   return 0;
 }
+
 Pointer<Void> smokeDeprecationcommentsToFfi(DeprecationComments value) {
   if (value is __lib.NativeBase) return _smokeDeprecationcommentsCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeDeprecationcommentsCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -330,15 +403,19 @@ Pointer<Void> smokeDeprecationcommentsToFfi(DeprecationComments value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeDeprecationcommentspropertyButNotAccessorsGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeDeprecationcommentspropertyButNotAccessorsSetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 DeprecationComments smokeDeprecationcommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DeprecationComments) return instance;
+
   final _typeIdHandle = _smokeDeprecationcommentsGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeDeprecationcommentsCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -347,12 +424,19 @@ DeprecationComments smokeDeprecationcommentsFromFfi(Pointer<Void> handle) {
   _smokeDeprecationcommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeDeprecationcommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDeprecationcommentsReleaseHandle(handle);
+
 Pointer<Void> smokeDeprecationcommentsToFfiNullable(DeprecationComments? value) =>
   value != null ? smokeDeprecationcommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 DeprecationComments? smokeDeprecationcommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDeprecationcommentsFromFfi(handle) : null;
+
 void smokeDeprecationcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDeprecationcommentsReleaseHandle(handle);
+
 // End of DeprecationComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -1,14 +1,19 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// This is some very useful class.
 /// @nodoc
 abstract class ExcludedComments {
+
   /// This is some very useful constant.
   /// @nodoc
   static final bool veryUseful = true;
+
   /// This is some very useful method that measures the usefulness of its input.
   ///
   /// [inputParameter] Very useful input parameter
@@ -23,13 +28,17 @@ abstract class ExcludedComments {
   ///
   /// @nodoc
   void someMethodWithoutReturnTypeOrInputParameters();
+  /// Some very useful property.
   /// Gets some very useful property.
   /// @nodoc
   bool get isSomeProperty;
+  /// Some very useful property.
   /// Sets some very useful property.
   /// @nodoc
   set isSomeProperty(bool value);
+
 }
+
 /// This is some very useful enum.
 /// @nodoc
 enum ExcludedComments_SomeEnum {
@@ -37,7 +46,9 @@ enum ExcludedComments_SomeEnum {
     /// @nodoc
     useless
 }
+
 // ExcludedComments_SomeEnum "private" section, not exported.
+
 int smokeExcludedcommentsSomeenumToFfi(ExcludedComments_SomeEnum value) {
   switch (value) {
   case ExcludedComments_SomeEnum.useless:
@@ -46,6 +57,7 @@ int smokeExcludedcommentsSomeenumToFfi(ExcludedComments_SomeEnum value) {
     throw StateError("Invalid enum value $value for ExcludedComments_SomeEnum enum.");
   }
 }
+
 ExcludedComments_SomeEnum smokeExcludedcommentsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -54,7 +66,9 @@ ExcludedComments_SomeEnum smokeExcludedcommentsSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for ExcludedComments_SomeEnum enum.");
   }
 }
+
 void smokeExcludedcommentsSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeExcludedcommentsSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -67,6 +81,7 @@ final _smokeExcludedcommentsSomeenumGetValueNullable = __lib.catchArgumentError(
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeExcludedcommentsSomeenumToFfiNullable(ExcludedComments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExcludedcommentsSomeenumToFfi(value);
@@ -74,6 +89,7 @@ Pointer<Void> smokeExcludedcommentsSomeenumToFfiNullable(ExcludedComments_SomeEn
   smokeExcludedcommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ExcludedComments_SomeEnum? smokeExcludedcommentsSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExcludedcommentsSomeenumGetValueNullable(handle);
@@ -81,8 +97,10 @@ ExcludedComments_SomeEnum? smokeExcludedcommentsSomeenumFromFfiNullable(Pointer<
   smokeExcludedcommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExcludedcommentsSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsSomeenumReleaseHandleNullable(handle);
+
 // End of ExcludedComments_SomeEnum "private" section.
 /// This is some very useful exception.
 /// @nodoc
@@ -92,17 +110,24 @@ class ExcludedComments_SomethingWrongException implements Exception {
 }
 /// This is some very useful struct.
 /// @nodoc
+
 class ExcludedComments_SomeStruct {
   /// How useful this struct is
   /// remains to be seen
   /// @nodoc
   bool someField;
+
   /// This is how easy it is to construct.
+
   /// [someField] How useful this struct is
   /// remains to be seen
+
   ExcludedComments_SomeStruct(this.someField);
 }
+
+
 // ExcludedComments_SomeStruct "private" section, not exported.
+
 final _smokeExcludedcommentsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
@@ -115,12 +140,16 @@ final _smokeExcludedcommentsSomestructGetFieldsomeField = __lib.catchArgumentErr
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeExcludedcommentsSomestructToFfi(ExcludedComments_SomeStruct value) {
   final _someFieldHandle = booleanToFfi(value.someField);
   final _result = _smokeExcludedcommentsSomestructCreateHandle(_someFieldHandle);
   booleanReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 ExcludedComments_SomeStruct smokeExcludedcommentsSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeExcludedcommentsSomestructGetFieldsomeField(handle);
   try {
@@ -131,8 +160,11 @@ ExcludedComments_SomeStruct smokeExcludedcommentsSomestructFromFfi(Pointer<Void>
     booleanReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeExcludedcommentsSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeExcludedcommentsSomestructReleaseHandle(handle);
+
 // Nullable ExcludedComments_SomeStruct
+
 final _smokeExcludedcommentsSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -145,6 +177,7 @@ final _smokeExcludedcommentsSomestructGetValueNullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeExcludedcommentsSomestructToFfiNullable(ExcludedComments_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExcludedcommentsSomestructToFfi(value);
@@ -152,6 +185,7 @@ Pointer<Void> smokeExcludedcommentsSomestructToFfiNullable(ExcludedComments_Some
   smokeExcludedcommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 ExcludedComments_SomeStruct? smokeExcludedcommentsSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExcludedcommentsSomestructGetValueNullable(handle);
@@ -159,8 +193,10 @@ ExcludedComments_SomeStruct? smokeExcludedcommentsSomestructFromFfiNullable(Poin
   smokeExcludedcommentsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExcludedcommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsSomestructReleaseHandleNullable(handle);
+
 // End of ExcludedComments_SomeStruct "private" section.
 /// This is some very useful lambda that does it.
 /// @nodoc
@@ -171,7 +207,9 @@ void smokeExcludedcommentsSomestructReleaseFfiHandleNullable(Pointer<Void> handl
 ///
 /// Returns Usefulness of the input
 typedef ExcludedComments_SomeLambda = double Function(String, int);
+
 // ExcludedComments_SomeLambda "private" section, not exported.
+
 final _smokeExcludedcommentsSomelambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -188,9 +226,11 @@ final _smokeExcludedcommentsSomelambdaCreateProxy = __lib.catchArgumentError(() 
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_ExcludedComments_SomeLambda_create_proxy'));
+
 class ExcludedComments_SomeLambda$Impl {
   final Pointer<Void> handle;
   ExcludedComments_SomeLambda$Impl(this.handle);
+
   double call(String p0, int p1) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_ExcludedComments_SomeLambda_call__String_Int'));
     final _p0Handle = stringToFfi(p0);
@@ -198,12 +238,18 @@ class ExcludedComments_SomeLambda$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
 }
+
 int _smokeExcludedcommentsSomelambdacallStatic(Object _obj, Pointer<Void> p0, int p1, Pointer<Double> _result) {
   double? _resultObject;
   try {
@@ -211,9 +257,11 @@ int _smokeExcludedcommentsSomelambdacallStatic(Object _obj, Pointer<Void> p0, in
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeExcludedcommentsSomelambdaToFfi(ExcludedComments_SomeLambda value) =>
   _smokeExcludedcommentsSomelambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -221,6 +269,7 @@ Pointer<Void> smokeExcludedcommentsSomelambdaToFfi(ExcludedComments_SomeLambda v
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Int32, Pointer<Double>)>(_smokeExcludedcommentsSomelambdacallStatic, __lib.unknownError)
   );
+
 ExcludedComments_SomeLambda smokeExcludedcommentsSomelambdaFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeExcludedcommentsSomelambdaCopyHandle(handle);
   final _impl = ExcludedComments_SomeLambda$Impl(_copiedHandle);
@@ -228,9 +277,12 @@ ExcludedComments_SomeLambda smokeExcludedcommentsSomelambdaFromFfi(Pointer<Void>
   _smokeExcludedcommentsSomelambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExcludedcommentsSomelambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExcludedcommentsSomelambdaReleaseHandle(handle);
+
 // Nullable ExcludedComments_SomeLambda
+
 final _smokeExcludedcommentsSomelambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -243,6 +295,7 @@ final _smokeExcludedcommentsSomelambdaGetValueNullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_SomeLambda_get_value_nullable'));
+
 Pointer<Void> smokeExcludedcommentsSomelambdaToFfiNullable(ExcludedComments_SomeLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExcludedcommentsSomelambdaToFfi(value);
@@ -250,6 +303,7 @@ Pointer<Void> smokeExcludedcommentsSomelambdaToFfiNullable(ExcludedComments_Some
   smokeExcludedcommentsSomelambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 ExcludedComments_SomeLambda? smokeExcludedcommentsSomelambdaFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExcludedcommentsSomelambdaGetValueNullable(handle);
@@ -257,10 +311,14 @@ ExcludedComments_SomeLambda? smokeExcludedcommentsSomelambdaFromFfiNullable(Poin
   smokeExcludedcommentsSomelambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExcludedcommentsSomelambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsSomelambdaReleaseHandleNullable(handle);
+
 // End of ExcludedComments_SomeLambda "private" section.
+
 // ExcludedComments "private" section, not exported.
+
 final _smokeExcludedcommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -273,6 +331,8 @@ final _smokeExcludedcommentsReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_release_handle'));
+
+
 final _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -289,8 +349,13 @@ final _someMethodWithAllCommentssmokeExcludedcommentsSomemethodwithallcommentsSt
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedComments_someMethodWithAllComments__String_return_has_error'));
+
+
+
 class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments {
+
   ExcludedComments$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedComments_someMethodWithAllComments__String'));
@@ -313,14 +378,19 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   bool get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedComments_isSomeProperty_get'));
@@ -330,8 +400,11 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set isSomeProperty(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedComments_isSomeProperty_set__Boolean'));
@@ -339,26 +412,40 @@ class ExcludedComments$Impl extends __lib.NativeBase implements ExcludedComments
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeExcludedcommentsToFfi(ExcludedComments value) =>
   _smokeExcludedcommentsCopyHandle((value as __lib.NativeBase).handle);
+
 ExcludedComments smokeExcludedcommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExcludedComments) return instance;
+
   final _copiedHandle = _smokeExcludedcommentsCopyHandle(handle);
   final result = ExcludedComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeExcludedcommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExcludedcommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExcludedcommentsReleaseHandle(handle);
+
 Pointer<Void> smokeExcludedcommentsToFfiNullable(ExcludedComments? value) =>
   value != null ? smokeExcludedcommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExcludedComments? smokeExcludedcommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExcludedcommentsFromFfi(handle) : null;
+
 void smokeExcludedcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsReleaseHandle(handle);
+
 // End of ExcludedComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -1,20 +1,31 @@
 //
+
 //
+
 import Foundation
+
 /// This is some very useful interface.
 public class Comments {
+
     /// This is some very useful typedef.
     public typealias Usefulness = Bool
+
     /// This is some very useful exception.
     public typealias SomethingWrongError = Comments.SomeEnum
+
     /// This is some very useful lambda that does it.
     /// - Parameter p0: Very useful input parameter
     /// - Parameter p1: Slightly less useful input parameter
     /// - Returns: Usefulness of the input
     public typealias SomeLambda = (String, Int32) -> Double
+
+
     /// This is some very useful constant.
     public static let veryUseful: Comments.Usefulness = true
     /// Some very useful property.
+    /// Note: without these comments user may not be able to use it correctly.
+    /// Note: that's serious.
+    /// Therefore, these lines above getter/setter need to be rendered in the output files.
     public var isSomeProperty: Comments.Usefulness {
         get {
             let c_result_handle = smoke_Comments_isSomeProperty_get(self.c_instance)
@@ -25,31 +36,47 @@ public class Comments {
             smoke_Comments_isSomeProperty_set(self.c_instance, c_value.ref)
         }
     }
+    /// OnlyGetterProperty, which does not have a setter.
+    /// The generated documentation for this property should only be added to property or getter.
+    public var onlyGetterProperty: Int32 {
+        get {
+            let c_result_handle = smoke_Comments_onlyGetterProperty_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+    }
     let c_instance : _baseRef
+
     init(cComments: _baseRef) {
         guard cComments != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cComments
     }
+
     deinit {
         smoke_Comments_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_Comments_release_handle(c_instance)
     }
+
     /// This is some very useful enum.
     public enum SomeEnum : UInt32, CaseIterable, Codable {
         /// Not quite useful
+
         case useless
         /// Somewhat useful
+
         case useful
     }
     /// This is some very useful struct.
     public struct SomeStruct {
         /// How useful this struct is
         /// remains to be seen
+
         public var someField: Comments.Usefulness
         /// Can be `nil`
+
         public var nullableField: String?
+
         /// This is how easy it is to construct.
         /// - Parameters
         ///   - someField: How useful this struct is
@@ -63,6 +90,7 @@ public class Comments {
             someField = moveFromCType(smoke_Comments_SomeStruct_someField_get(cHandle))
             nullableField = moveFromCType(smoke_Comments_SomeStruct_nullableField_get(cHandle))
         }
+
         /// This is some struct method that does nothing.
         public func someStructMethod() -> Void {
             let c_self_handle = moveToCType(self)
@@ -73,6 +101,7 @@ public class Comments {
             smoke_Comments_SomeStruct_someStaticStructMethod()
         }
     }
+
     /// This is some very useful method that measures the usefulness of its input.
     /// - Parameter inputParameter: Very useful input parameter
     /// - Returns: Usefulness of the input
@@ -160,7 +189,11 @@ public class Comments {
         let c_result_handle = smoke_Comments_returnCommentOnly(self.c_instance, c_undocumented.ref)
         return moveFromCType(c_result_handle)
     }
+
 }
+
+
+
 internal func getRef(_ ref: Comments?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {
         return RefHolder(0)
@@ -170,6 +203,7 @@ internal func getRef(_ ref: Comments?, owning: Bool = true) -> RefHolder {
         ? RefHolder(ref: handle_copy, release: smoke_Comments_release_handle)
         : RefHolder(handle_copy)
 }
+
 extension Comments: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -179,11 +213,13 @@ extension Comments: Hashable {
     public static func == (lhs: Comments, rhs: Comments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+
     /// :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
 }
+
 internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments {
     if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {
@@ -193,6 +229,7 @@ internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments {
     smoke_Comments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments {
     if let swift_pointer = smoke_Comments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Comments {
@@ -203,6 +240,7 @@ internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments {
     smoke_Comments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func Comments_copyFromCType(_ handle: _baseRef) -> Comments? {
     guard handle != 0 else {
         return nil
@@ -215,18 +253,23 @@ internal func Comments_moveFromCType(_ handle: _baseRef) -> Comments? {
     }
     return Comments_moveFromCType(handle) as Comments
 }
+
 internal func copyToCType(_ swiftClass: Comments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: Comments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: Comments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: Comments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func Comments_SomeLambda_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda {
     return Comments_SomeLambda_moveFromCType(smoke_Comments_SomeLambda_copy_handle(handle))
 }
@@ -238,6 +281,7 @@ internal func Comments_SomeLambda_moveFromCType(_ handle: _baseRef) -> Comments.
         return moveFromCType(smoke_Comments_SomeLambda_call(refHolder.ref, _p0.ref, _p1.ref))
     }
 }
+
 internal func Comments_SomeLambda_copyFromCType(_ handle: _baseRef) -> Comments.SomeLambda? {
     guard handle != 0 else {
         return nil
@@ -250,6 +294,7 @@ internal func Comments_SomeLambda_moveFromCType(_ handle: _baseRef) -> Comments.
     }
     return Comments_SomeLambda_moveFromCType(handle) as Comments.SomeLambda
 }
+
 internal func Comments_SomeLambda_createFunctionalTable(_ swiftType: @escaping Comments.SomeLambda) -> smoke_Comments_SomeLambda_FunctionTable {
     class smoke_Comments_SomeLambda_Holder {
         let closure: Comments.SomeLambda
@@ -257,6 +302,7 @@ internal func Comments_SomeLambda_createFunctionalTable(_ swiftType: @escaping C
             self.closure = closure
         }
     }
+
     var functions = smoke_Comments_SomeLambda_FunctionTable()
     functions.swift_pointer = Unmanaged<AnyObject>.passRetained(smoke_Comments_SomeLambda_Holder(swiftType)).toOpaque()
     functions.release = { swift_closure_pointer in
@@ -268,8 +314,10 @@ internal func Comments_SomeLambda_createFunctionalTable(_ swiftType: @escaping C
         let closure_holder = Unmanaged<AnyObject>.fromOpaque(swift_closure_pointer!).takeUnretainedValue() as! smoke_Comments_SomeLambda_Holder
         return copyToCType(closure_holder.closure(moveFromCType(p0), moveFromCType(p1))).ref
     }
+
     return functions
 }
+
 internal func Comments_SomeLambda_copyToCType(_ swiftType: @escaping Comments.SomeLambda) -> RefHolder {
     let handle = smoke_Comments_SomeLambda_create_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
@@ -278,10 +326,12 @@ internal func Comments_SomeLambda_moveToCType(_ swiftType: @escaping Comments.So
     let handle = smoke_Comments_SomeLambda_create_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
 }
+
 internal func Comments_SomeLambda_copyToCType(_ swiftType: Comments.SomeLambda?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
+
     let handle = smoke_Comments_SomeLambda_create_optional_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(handle)
 }
@@ -289,6 +339,7 @@ internal func Comments_SomeLambda_moveToCType(_ swiftType: Comments.SomeLambda?)
     guard let swiftType = swiftType else {
         return RefHolder(0)
     }
+
     let handle = smoke_Comments_SomeLambda_create_optional_proxy(Comments_SomeLambda_createFunctionalTable(swiftType))
     return RefHolder(ref: handle, release: smoke_Comments_SomeLambda_release_handle)
 }
@@ -301,6 +352,7 @@ internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeStruct {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: Comments.SomeStruct) -> RefHolder {
     let c_someField = moveToCType(swiftType.someField)
     let c_nullableField = moveToCType(swiftType.nullableField)
@@ -322,6 +374,7 @@ internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeStruct? {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -333,24 +386,28 @@ internal func copyToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
 internal func moveToCType(_ swiftType: Comments.SomeStruct?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_Comments_SomeStruct_release_optional_handle)
 }
+
 internal func copyToCType(_ swiftEnum: Comments.SomeEnum) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
 internal func moveToCType(_ swiftEnum: Comments.SomeEnum) -> PrimitiveHolder<UInt32> {
     return copyToCType(swiftEnum)
 }
+
 internal func copyToCType(_ swiftEnum: Comments.SomeEnum?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
 internal func moveToCType(_ swiftEnum: Comments.SomeEnum?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
+
 internal func copyFromCType(_ cValue: UInt32) -> Comments.SomeEnum {
     return Comments.SomeEnum(rawValue: cValue)!
 }
 internal func moveFromCType(_ cValue: UInt32) -> Comments.SomeEnum {
     return copyFromCType(cValue)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> Comments.SomeEnum? {
     guard handle != 0 else {
         return nil
@@ -363,5 +420,7 @@ internal func moveFromCType(_ handle: _baseRef) -> Comments.SomeEnum? {
     }
     return copyFromCType(handle)
 }
+
+
 extension Comments.SomeEnum : Error {
 }


### PR DESCRIPTION
When users want to document a property
in LIME files, they can use structured
comments, which consist of the general
information about property and annotations
related to getters and setters.

In the case of Dart generator, the output
contained only comments related to getters
and setters. The general information about
property was not stored in the output files.

This change adjusts 'DartRedirectProperty'
mustache template to output also the general
information about property if present.

The behaviour in the case of Dart generator
has been aligned with C++ and Java generators.
The general information about property is added
to comments of getter and setter.