### PR TITLE
Fix conversion of platforms for 'Internal' annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased:
 ### Bug fixes:
+ * Fixed conversion of platforms for 'Internal' annotation to work correctly also when arguments are not in quotation marks.
  * Dart: generate omitted documentation of properties.
 
 ## 13.9.6

--- a/gluecodium/src/test/resources/smoke/visibility_platform/input/VisibilityPlatformReverse.lime
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/input/VisibilityPlatformReverse.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2022 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/DartInternalClassRev.java
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/DartInternalClassRev.java
@@ -7,7 +7,7 @@ package com.example.smoke;
 
 import com.example.NativeBase;
 
-final class DartInternalClassRev extends NativeBase {
+public final class DartInternalClassRev extends NativeBase {
 
     /**
      * For internal use only.

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/DartInternalClassRev.java
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/DartInternalClassRev.java
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke;
+
+import com.example.NativeBase;
+
+final class DartInternalClassRev extends NativeBase {
+
+    /**
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The SDK nativeHandle instance.
+     * @param dummy The SDK dummy instance.
+     */
+    protected DartInternalClassRev(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+
+    private static native void disposeNativeHandle(long nativeHandle);
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/SwiftInternalClassRev.java
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/SwiftInternalClassRev.java
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke;
+
+import com.example.NativeBase;
+
+final class SwiftInternalClassRev extends NativeBase {
+
+    /**
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The SDK nativeHandle instance.
+     * @param dummy The SDK dummy instance.
+     */
+    protected SwiftInternalClassRev(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+
+    private static native void disposeNativeHandle(long nativeHandle);
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/SwiftInternalClassRev.java
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android/com/example/smoke/SwiftInternalClassRev.java
@@ -7,7 +7,7 @@ package com.example.smoke;
 
 import com.example.NativeBase;
 
-final class SwiftInternalClassRev extends NativeBase {
+public final class SwiftInternalClassRev extends NativeBase {
 
     /**
      * For internal use only.

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/dart/lib/smoke.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/dart/lib/smoke.dart
@@ -1,3 +1,5 @@
+
+
 export 'src/smoke/dart_internal_elements.dart' show DartInternalElements;
 export 'src/smoke/dart_internal_elements_enabled.dart' show DartInternalElementsEnabled;
 export 'src/smoke/dart_internal_elements_rev.dart' show DartInternalElementsRev;
@@ -8,4 +10,7 @@ export 'src/smoke/dart_public_elements.dart' show DartPublicElements;
 export 'src/smoke/dart_public_elements_enabled.dart' show DartPublicElementsEnabled;
 export 'src/smoke/dart_public_elements_skipped.dart' show DartPublicElementsSkipped;
 export 'src/smoke/java_internal_class.dart' show JavaInternalClass;
+export 'src/smoke/java_internal_class_rev.dart' show JavaInternalClassRev;
+export 'src/smoke/java_swift_internal_class.dart' show JavaSwiftInternalClass;
 export 'src/smoke/swift_internal_class.dart' show SwiftInternalClass;
+export 'src/smoke/swift_internal_class_rev.dart' show SwiftInternalClassRev;

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/DartInternalClassRev.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/DartInternalClassRev.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-internal class DartInternalClassRev {
+public class DartInternalClassRev {
 
 
     let c_instance : _baseRef

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/DartInternalClassRev.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/DartInternalClassRev.swift
@@ -1,0 +1,106 @@
+//
+
+//
+
+import Foundation
+
+internal class DartInternalClassRev {
+
+
+    let c_instance : _baseRef
+
+    init(cDartInternalClassRev: _baseRef) {
+        guard cDartInternalClassRev != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cDartInternalClassRev
+    }
+
+    deinit {
+        smoke_DartInternalClassRev_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_DartInternalClassRev_release_handle(c_instance)
+    }
+
+
+}
+
+
+
+internal func getRef(_ ref: DartInternalClassRev?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_DartInternalClassRev_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_DartInternalClassRev_release_handle)
+        : RefHolder(handle_copy)
+}
+
+extension DartInternalClassRev: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+extension DartInternalClassRev: Hashable {
+    /// :nodoc:
+    public static func == (lhs: DartInternalClassRev, rhs: DartInternalClassRev) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+
+internal func DartInternalClassRev_copyFromCType(_ handle: _baseRef) -> DartInternalClassRev {
+    if let swift_pointer = smoke_DartInternalClassRev_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DartInternalClassRev {
+        return re_constructed
+    }
+    let result = DartInternalClassRev(cDartInternalClassRev: smoke_DartInternalClassRev_copy_handle(handle))
+    smoke_DartInternalClassRev_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+
+internal func DartInternalClassRev_moveFromCType(_ handle: _baseRef) -> DartInternalClassRev {
+    if let swift_pointer = smoke_DartInternalClassRev_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? DartInternalClassRev {
+        smoke_DartInternalClassRev_release_handle(handle)
+        return re_constructed
+    }
+    let result = DartInternalClassRev(cDartInternalClassRev: handle)
+    smoke_DartInternalClassRev_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+
+internal func DartInternalClassRev_copyFromCType(_ handle: _baseRef) -> DartInternalClassRev? {
+    guard handle != 0 else {
+        return nil
+    }
+    return DartInternalClassRev_moveFromCType(handle) as DartInternalClassRev
+}
+internal func DartInternalClassRev_moveFromCType(_ handle: _baseRef) -> DartInternalClassRev? {
+    guard handle != 0 else {
+        return nil
+    }
+    return DartInternalClassRev_moveFromCType(handle) as DartInternalClassRev
+}
+
+internal func copyToCType(_ swiftClass: DartInternalClassRev) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: DartInternalClassRev) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+internal func copyToCType(_ swiftClass: DartInternalClassRev?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: DartInternalClassRev?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/JavaInternalClassRev.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/JavaInternalClassRev.swift
@@ -1,0 +1,106 @@
+//
+
+//
+
+import Foundation
+
+internal class JavaInternalClassRev {
+
+
+    let c_instance : _baseRef
+
+    init(cJavaInternalClassRev: _baseRef) {
+        guard cJavaInternalClassRev != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cJavaInternalClassRev
+    }
+
+    deinit {
+        smoke_JavaInternalClassRev_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_JavaInternalClassRev_release_handle(c_instance)
+    }
+
+
+}
+
+
+
+internal func getRef(_ ref: JavaInternalClassRev?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_JavaInternalClassRev_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_JavaInternalClassRev_release_handle)
+        : RefHolder(handle_copy)
+}
+
+extension JavaInternalClassRev: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+extension JavaInternalClassRev: Hashable {
+    /// :nodoc:
+    public static func == (lhs: JavaInternalClassRev, rhs: JavaInternalClassRev) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+
+internal func JavaInternalClassRev_copyFromCType(_ handle: _baseRef) -> JavaInternalClassRev {
+    if let swift_pointer = smoke_JavaInternalClassRev_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? JavaInternalClassRev {
+        return re_constructed
+    }
+    let result = JavaInternalClassRev(cJavaInternalClassRev: smoke_JavaInternalClassRev_copy_handle(handle))
+    smoke_JavaInternalClassRev_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+
+internal func JavaInternalClassRev_moveFromCType(_ handle: _baseRef) -> JavaInternalClassRev {
+    if let swift_pointer = smoke_JavaInternalClassRev_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? JavaInternalClassRev {
+        smoke_JavaInternalClassRev_release_handle(handle)
+        return re_constructed
+    }
+    let result = JavaInternalClassRev(cJavaInternalClassRev: handle)
+    smoke_JavaInternalClassRev_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+
+internal func JavaInternalClassRev_copyFromCType(_ handle: _baseRef) -> JavaInternalClassRev? {
+    guard handle != 0 else {
+        return nil
+    }
+    return JavaInternalClassRev_moveFromCType(handle) as JavaInternalClassRev
+}
+internal func JavaInternalClassRev_moveFromCType(_ handle: _baseRef) -> JavaInternalClassRev? {
+    guard handle != 0 else {
+        return nil
+    }
+    return JavaInternalClassRev_moveFromCType(handle) as JavaInternalClassRev
+}
+
+internal func copyToCType(_ swiftClass: JavaInternalClassRev) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: JavaInternalClassRev) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+internal func copyToCType(_ swiftClass: JavaInternalClassRev?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: JavaInternalClassRev?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/JavaInternalClassRev.swift
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/swift/smoke/JavaInternalClassRev.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-internal class JavaInternalClassRev {
+public class JavaInternalClassRev {
 
 
     let c_instance : _baseRef

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -178,7 +178,12 @@ internal object AntlrLimeConverter {
         attributes: LimeAttributes.Builder,
         valueContext: LimeParser.AnnotationValueContext,
     ) {
-        val value = convertAnnotationValue(valueContext)
+        val value =
+            when {
+                valueContext.simpleId() != null -> valueContext.simpleId().text
+                else -> convertAnnotationValue(valueContext)
+            }
+
         if (value == true) {
             attributes.addAttribute(LimeAttributeType.INTERNAL)
             return


### PR DESCRIPTION
The conversion of platforms for 'Internal' annotation was invalid
when they were specified without quotation marks. In such a case
the converter set internal visibility for all platforms.
    
This change adjusts the converter as well as the output of smoke
tests to show that the behavior is correct now.