### PR TITLE
Ensure that common utilities are always exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased:
 ### Bug fixes:
+ * Fixed visibilty of symbols from common code (JNI, Dart FFI) in order to resolve problems with build that uses hidden visibility preset.
  * Fixed conversion of platforms for 'Internal' annotation to work correctly also when arguments are not in quotation marks.
  * Dart: generate omitted documentation of properties.
 

--- a/cmake/tests/unit/gluecodium_generate/shared-modules-depend-on-object-libs/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/shared-modules-depend-on-object-libs/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 HERE Europe B.V.
+# Copyright (C) 2020-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,14 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
+else()
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
@@ -47,7 +53,8 @@ gluecodium_target_lime_sources(object.module.with.common
                                PUBLIC "${CMAKE_CURRENT_LIST_DIR}/lime/common_main_foo.lime")
 
 add_library(shared.module.with.common SHARED)
-target_link_libraries(shared.module.with.common PUBLIC object.module.with.common)
+target_link_libraries(shared.module.with.common PUBLIC object.module.with.common
+                                                PRIVATE Threads::Threads)
 target_sources(
   shared.module.with.common PRIVATE "${CMAKE_CURRENT_LIST_DIR}/cpp/CommonMainFooImpl.cpp"
   PUBLIC "${CMAKE_CURRENT_LIST_DIR}/cpp/Dummy.h")

--- a/cmake/tests/unit/gluecodium_generate/two-shared-modules/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/two-shared-modules/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 HERE Europe B.V.
+# Copyright (C) 2020-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,14 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
+else()
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
@@ -37,6 +43,7 @@ add_library(shared.module.with.common SHARED)
 target_sources(
   shared.module.with.common PRIVATE "${CMAKE_CURRENT_LIST_DIR}/cpp/CommonMainFooImpl.cpp"
   PUBLIC "${CMAKE_CURRENT_LIST_DIR}/cpp/Dummy.h")
+target_link_libraries(shared.module.with.common PRIVATE Threads::Threads)
 
 gluecodium_generate(shared.module.with.common GENERATORS ${_gluecodium_generator})
 set_target_properties(shared.module.with.common PROPERTIES GLUECODIUM_SYNCHRONIZE_ACCESS_CLASS_CACHE ON)

--- a/cmake/tests/unit/gluecodium_target_link_frameworks/dependent-frameworks-with-shared-modules-dependent-on-object-libs/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_target_link_frameworks/dependent-frameworks-with-shared-modules-dependent-on-object-libs/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 if(NOT APPLE OR NOT CMAKE_GENERATOR STREQUAL "Xcode")
   return()
+else()
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
 endif()
 
 enable_language(Swift)
@@ -33,6 +35,12 @@ gluecodium_generate(ObjectWithMainAndCommon GENERATORS cpp swift)
 gluecodium_target_lime_sources(ObjectWithMainAndCommon
                                PUBLIC "${CMAKE_CURRENT_LIST_DIR}/lime/common_main_foo.lime")
 set_target_properties(ObjectWithMainAndCommon PROPERTIES GLUECODIUM_SWIFT_EXPOSE_INTERNALS ON)
+
+# Ensure, that required external symbols related to CBridge code are exposed. By default they are
+# unconditionally exported only for `SHARED` target. Please check scenario 2 in 'Generate.cmake'.
+gluecodium_get_target_compile_definitions(ObjectWithMainAndCommon
+                                          RESULT_PUBLIC _public_common RESULT_PRIVATE _private_common)
+target_compile_definitions(ObjectWithMainAndCommon PUBLIC ${_public_common} PRIVATE ${_private_common})
 
 add_library(ModuleWithMainAndCommon SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/CommonMainFooImpl.cpp")
 add_library(test::ModuleWithMainAndCommon ALIAS ModuleWithMainAndCommon)

--- a/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiCallbacksQueueHeader.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
 {{>ffi/FfiCopyrightHeader}}
 
 #pragma once
+
+#include "Export.h"
 
 #include <chrono>
 #include <functional>
@@ -92,7 +94,7 @@ public:
 /**
  * Manages a set of CallbackQueues identified by int ids.
  */
-class CallbackQueueManager
+class _GLUECODIUM_FFI_EXPORT CallbackQueueManager
 {
 private:
     mutable std::mutex m_mutex;
@@ -127,7 +129,7 @@ public:
 /**
  * Global static instance of CallbackQueueManager.
  **/
-extern CallbackQueueManager cbqm;
+_GLUECODIUM_FFI_EXPORT extern CallbackQueueManager cbqm;
 }
 {{#internalNamespace}}
 }

--- a/gluecodium/src/main/resources/templates/ffi/FfiDartDLInitImpl.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiDartDLInitImpl.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@
   !
   !}}
 {{>ffi/FfiCopyrightHeader}}
+
+#include "Export.h"
 
 #include "DartDLInit.h"
 #include "dart_api_dl.h"
@@ -40,7 +42,7 @@ typedef struct {
   const ApiEntry* const functions;
 } ApiData;
 
-#define API_DL_DEFINITION(name, R, A) name##_Type name##_DL = NULL;
+#define API_DL_DEFINITION(name, R, A) _GLUECODIUM_FFI_EXPORT name##_Type name##_DL = NULL;
 DART_API_ALL_DL_SYMBOLS(API_DL_DEFINITION)
 
 void*

--- a/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheHeader.mustache
+++ b/gluecodium/src/main/resources/templates/ffi/FfiProxyCacheHeader.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#include "Export.h"
+
 #include <memory>
 #include <string>
 
@@ -32,9 +34,9 @@ namespace {{.}}
 namespace ffi
 {
 
-void cache_proxy_impl(uint64_t token, int32_t isolate_id, const std::string& type_key, std::shared_ptr<void> proxy);
-void remove_cached_proxy(uint64_t token, int32_t isolate_id, const std::string& type_key);
-std::shared_ptr<void> get_cached_proxy_impl(uint64_t token, int32_t isolate_id, const std::string& type_key);
+_GLUECODIUM_FFI_EXPORT void cache_proxy_impl(uint64_t token, int32_t isolate_id, const std::string& type_key, std::shared_ptr<void> proxy);
+_GLUECODIUM_FFI_EXPORT void remove_cached_proxy(uint64_t token, int32_t isolate_id, const std::string& type_key);
+_GLUECODIUM_FFI_EXPORT std::shared_ptr<void> get_cached_proxy_impl(uint64_t token, int32_t isolate_id, const std::string& type_key);
 
 template<class T>
 void

--- a/gluecodium/src/main/resources/templates/jni/utils/JniBaseHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniBaseHeader.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 // JNI_OnLoad to allow for a custom implementation or similar. In that case the user
 // needs to ensure it is called manually. If it has a custom name, declare the function.
 #ifdef GLUECODIUM_JNI_ONLOAD
-jint GLUECODIUM_JNI_ONLOAD( JavaVM* vm, void* );
+JNIEXPORT jint GLUECODIUM_JNI_ONLOAD( JavaVM* vm, void* );
 #else
 # define GLUECODIUM_JNI_ONLOAD JNI_OnLoad
 #endif

--- a/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniBaseImplementation.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ initialize_thread_data_key( )
 // To make this work neither 'static' keyword (causes "static declaration of 'JNI_OnLoad' follows
 // non-static declaration" - error) nor adding to anonymous namespace (prevents method from being
 // called) is allowed.
-jint
+JNIEXPORT jint
 GLUECODIUM_JNI_ONLOAD( JavaVM* vm, void* )
 {
     JNIEnv* env = nullptr;

--- a/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniCppConversionUtilsHeader.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@ JNIEXPORT std::optional<std::shared_ptr<::std::vector<uint8_t>>> convert_from_jn
  * Converts a Java Date object to an std::chrono::time_point.
  */
 
-jlong get_time_ms_epoch(JNIEnv* const env, const JniReference<jobject>& jvalue) noexcept;
+JNIEXPORT jlong get_time_ms_epoch(JNIEnv* const env, const JniReference<jobject>& jvalue) noexcept;
 
 template<class Clock, class Duration>
 std::chrono::time_point<Clock, Duration>
@@ -106,7 +106,7 @@ convert_from_jni(
  * Converts a Java Duration object to an std::chrono::duration<>.
  */
 
-std::intmax_t get_duration_from_java_duration(JNIEnv* const env,
+JNIEXPORT std::intmax_t get_duration_from_java_duration(JNIEnv* const env,
                                               const JniReference<jobject>& jvalue,
                                               std::intmax_t dest_den,
                                               std::intmax_t dest_num);
@@ -167,7 +167,7 @@ JNIEXPORT JniReference<jbyteArray> convert_to_jni(
  * Converts an std::chrono::time_point to a Java Date object.
  */
 
-JniReference<jobject> create_date_new_object(JNIEnv* const env, const std::chrono::milliseconds& time_epoch);
+JNIEXPORT JniReference<jobject> create_date_new_object(JNIEnv* const env, const std::chrono::milliseconds& time_epoch);
 
 template<class Clock, class Duration>
 JniReference<jobject>
@@ -187,7 +187,7 @@ convert_to_jni(JNIEnv* const env, const std::optional<std::chrono::time_point<Cl
  * Converts an std::chrono::duration<> to a Java Duration object.
  */
 
-JniReference<jobject>
+JNIEXPORT JniReference<jobject>
 create_duration_new_object(JNIEnv* const env, std::intmax_t seconds, std::intmax_t nanos) noexcept;
 
 template<class Rep, class Period>

--- a/gluecodium/src/main/resources/templates/jni/utils/JniJavaContainersHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniJavaContainersHeader.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ namespace {{.}}
 namespace jni
 {
 
-struct JavaContainer
+struct JNIEXPORT JavaContainer
 {
     JavaContainer(JNIEnv* const env, const char* class_name) noexcept;
     JavaContainer(JNIEnv* const env, JniReference<jclass> container_class, JniReference<jobject> instance) noexcept;
@@ -45,7 +45,7 @@ struct JavaContainer
     JniReference<jobject> instance;
 };
 
-class JavaContainerAdder
+class JNIEXPORT JavaContainerAdder
 {
 protected:
     JavaContainerAdder(JNIEnv* const env,
@@ -66,13 +66,13 @@ private:
     const jmethodID m_add_method_id;
 };
 
-class JavaArrayListAdder final : public JavaContainerAdder
+class JNIEXPORT JavaArrayListAdder final : public JavaContainerAdder
 {
 public:
     JavaArrayListAdder(JNIEnv* const env) noexcept;
 };
 
-class JavaListIterator final
+class JNIEXPORT JavaListIterator final
 {
 public:
     JavaListIterator(JNIEnv* const env, const JniReference<jobject>& array_list) noexcept;
@@ -89,7 +89,7 @@ private:
     const jint m_length;
 };
 
-class JavaHashMapAdder final
+class JNIEXPORT JavaHashMapAdder final
 {
 public:
     JavaHashMapAdder(JNIEnv* const env) noexcept;
@@ -103,7 +103,7 @@ private:
     const jmethodID m_put_method_id;
 };
 
-class JavaSetIterator final
+class JNIEXPORT JavaSetIterator final
 {
 public:
     JavaSetIterator(JNIEnv* const env, const JniReference<jobject>& java_set) noexcept;
@@ -121,7 +121,7 @@ private:
     const jmethodID m_next_method_id;
 };
 
-class JavaMapIterator final
+class JNIEXPORT JavaMapIterator final
 {
 public:
     JavaMapIterator(JNIEnv* const env, const JniReference<jobject>& java_map) noexcept;
@@ -142,7 +142,7 @@ private:
     const jmethodID m_get_value_method_id;
 };
 
-class JavaHashSetAdder final : public JavaContainerAdder
+class JNIEXPORT JavaHashSetAdder final : public JavaContainerAdder
 {
 public:
     JavaHashSetAdder(JNIEnv* const env) noexcept;

--- a/gluecodium/src/main/resources/templates/jni/utils/JniReferenceHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/utils/JniReferenceHeader.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@ JniReference<JniType> new_global_ref(JNIEnv* jni_env, JniType jobj) noexcept
     return make_global_ref(static_cast<JniType>(jni_env->NewGlobalRef( jobj )));
 }
 
-JniReference<jclass> find_class(JNIEnv* jni_env, const char* name) noexcept;
+JNIEXPORT JniReference<jclass> find_class(JNIEnv* jni_env, const char* name) noexcept;
 
 template<class JniType>
 JniReference<jclass> get_object_class(JNIEnv* jni_env, const JniType& java_instance) noexcept
@@ -133,13 +133,13 @@ JniReference<jobject> new_object(JNIEnv* env,
     return new_object_impl(env, jni_reference_unwrap(java_class), constructor_id, jni_reference_unwrap(args)...);
 }
 
-JniReference<jobject>
+JNIEXPORT JniReference<jobject>
 create_object( JNIEnv* env, const JniReference<jclass>& javaClass ) noexcept;
 
-JniReference<jobject>
+JNIEXPORT JniReference<jobject>
 create_instance_object( JNIEnv* env, const JniReference<jclass>& javaClass, jlong instancePointer ) noexcept;
 
-JniReference<jobject>
+JNIEXPORT JniReference<jobject>
 alloc_object( JNIEnv* env, const JniReference<jclass>& javaClass ) noexcept;
 
 } // namespace jni


### PR DESCRIPTION
If the user builds the code with visibility hidden,
then certain common utilities may not be visible.
    
This change adds appropriate export macro to the
required functions and types to ensure, that they
are always exported.