### PR TITLE
cmake-tests: Do not allow missing symbols in libraries

### DIFF
--- a/cmake/tests/run_tests.cmake
+++ b/cmake/tests/run_tests.cmake
@@ -93,7 +93,8 @@ function (get_parameters_for_build_environment result)
             -GXcode
             -DCMAKE_OSX_ARCHITECTURES=x86_64
             -DCMAKE_OSX_SYSROOT=iphonesimulator
-            -DCMAKE_SYSTEM_NAME=iOS)
+            -DCMAKE_SYSTEM_NAME=iOS
+            -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-undefined,error)
     elseif (GLUECODIUM_BUILD_ENVIRONMENT STREQUAL "android-x86_64")
         foreach(env_variable ANDROID_HOME ANDROID_NDK_HOME)
             if (NOT DEFINED ENV{${env_variable}})
@@ -106,14 +107,16 @@ function (get_parameters_for_build_environment result)
             -DANDROID_PLATFORM=android-${TEST_ANDROID_API_LEVEL_VERSION}
             -DANDROID_HOME=$ENV{ANDROID_HOME}
             -DANDROID_STL=c++_shared
-            -DCMAKE_TOOLCHAIN_FILE=$ENV{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake)
+            -DCMAKE_TOOLCHAIN_FILE=$ENV{ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake
+            -DCMAKE_SHARED_LINKER_FLAGS=-Wl,--no-undefined)
     elseif(GLUECODIUM_BUILD_ENVIRONMENT STREQUAL "android-host")
         # Pretend as if we really going to build for Android
         list (APPEND _params
             -GNinja
             -DANDROID=ON
             -DANDROID_PLATFORM=android-${TEST_ANDROID_API_LEVEL_VERSION}
-            -DANDROID_HOME=$ENV{ANDROID_HOME})
+            -DANDROID_HOME=$ENV{ANDROID_HOME}
+            -DCMAKE_SHARED_LINKER_FLAGS=-Wl,--no-undefined)
     else ()
         message(FATAL_ERROR "Unknown build environment: ${GLUECODIUM_BUILD_ENVIRONMENT}")
     endif ()

--- a/cmake/tests/unit/gluecodium_generate/cpp-export/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/cpp-export/CMakeLists.txt
@@ -21,6 +21,9 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 if(CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
 endif()
@@ -35,6 +38,7 @@ get_supported_gluecodium_generators(_gluecodium_generator)
 # Module 1, includes MAIN and COMMON source set
 add_library(shared.module1 SHARED)
 target_sources(shared.module1 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/cpp/CommonMainFooImpl.cpp")
+target_link_libraries(shared.module1 PRIVATE Threads::Threads)
 
 gluecodium_generate(shared.module1 GENERATORS ${_gluecodium_generator})
 gluecodium_target_lime_sources(shared.module1

--- a/cmake/tests/unit/gluecodium_generate/internal-prefix/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/internal-prefix/CMakeLists.txt
@@ -21,6 +21,9 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
 
 include(gluecodium/Gluecodium)
@@ -57,6 +60,7 @@ endfunction()
 
 function(_create_and_configure_target _target _expected_dart_symbol _expected_swift_symbol)
   add_library(${_target} SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+  target_link_libraries(${_target} PRIVATE Threads::Threads)
   gluecodium_generate(${_target} GENERATORS ${_gluecodium_generators})
   gluecodium_target_lime_sources(${_target} PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
 
@@ -84,6 +88,7 @@ set_target_properties(SingleModule3 PROPERTIES GLUECODIUM_INTERNAL_PREFIX "Renam
 # as internal prefix
 add_library(SingleModule4 SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
 set_target_properties(SingleModule4 PROPERTIES GLUECODIUM_INTERNAL_PREFIX "RenamedInternalPrefix")
+target_link_libraries(SingleModule4 PRIVATE Threads::Threads)
 gluecodium_generate(SingleModule4 GENERATORS ${_gluecodium_generators})
 gluecodium_target_lime_sources(SingleModule4 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
 _setup_framework_if_swift(SingleModule4)
@@ -108,6 +113,7 @@ _create_and_configure_target(SingleModule6 "DartLibrary_SingleModule6MapOf_Strin
 # If OUTPUT_NAME is set before gluecodium_generate then it's used as internal prefix
 add_library(SingleModule7 SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
 set_target_properties(SingleModule7 PROPERTIES OUTPUT_NAME "RenamedOutputName2")
+target_link_libraries(SingleModule7 PRIVATE Threads::Threads)
 gluecodium_generate(SingleModule7 GENERATORS ${_gluecodium_generators})
 gluecodium_target_lime_sources(SingleModule7 PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
 _setup_framework_if_swift(SingleModule7)

--- a/cmake/tests/unit/gluecodium_generate/relative-paths/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/relative-paths/CMakeLists.txt
@@ -4,6 +4,9 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
 
 include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/assert.cmake)
@@ -13,6 +16,7 @@ include(gluecodium/Gluecodium)
 get_supported_gluecodium_generators(_gluecodium_generator)
 
 add_library(single.module.package SHARED "cpp/FooImpl.cpp")
+target_link_libraries(single.module.package PRIVATE Threads::Threads)
 
 gluecodium_generate(single.module.package GENERATORS ${_gluecodium_generator}
                     OUTPUT_DIR "relative/output/path")

--- a/cmake/tests/unit/gluecodium_generate/shared-modules-depend-on-object-libs/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/shared-modules-depend-on-object-libs/CMakeLists.txt
@@ -26,9 +26,6 @@ find_package(Threads REQUIRED)
 
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
-else()
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")

--- a/cmake/tests/unit/gluecodium_generate/single-module-mandatory-params/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/single-module-mandatory-params/CMakeLists.txt
@@ -4,6 +4,9 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
 endif()
@@ -23,6 +26,7 @@ elseif(CMAKE_GENERATOR STREQUAL "Xcode")
 endif()
 
 add_library(single.module SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(single.module PRIVATE Threads::Threads)
 
 gluecodium_generate(single.module GENERATORS ${_gluecodium_generator})
 set_property(TARGET single.module APPEND PROPERTY GLUECODIUM_LIME_SOURCES

--- a/cmake/tests/unit/gluecodium_generate/transit-object-dependency/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/transit-object-dependency/CMakeLists.txt
@@ -21,6 +21,9 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
 endif()
@@ -53,6 +56,12 @@ add_library(intermediate.module ${INTERMEDIATE_LIBRARY_TYPE}
                                 "${CMAKE_CURRENT_LIST_DIR}/cpp/Dummy.cpp")
 target_sources(intermediate.module ${INTERMEDIATE_SOURCES_VISIBILITY}
                $<TARGET_OBJECTS:generated.module>)
+
+if(${INTERMEDIATE_LIBRARY_TYPE} STREQUAL "INTERFACE")
+  target_link_libraries(intermediate.module INTERFACE Threads::Threads)
+else()
+  target_link_libraries(intermediate.module PRIVATE Threads::Threads)
+endif()
 
 # Final target
 add_library(shared.module SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/Dummy.cpp")

--- a/cmake/tests/unit/gluecodium_generate/two-interface-libs-in-one-module/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/two-interface-libs-in-one-module/CMakeLists.txt
@@ -21,6 +21,9 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
 endif()
@@ -44,6 +47,7 @@ get_supported_gluecodium_generators(_gluecodium_generator)
 add_library(interface.module.with.common INTERFACE)
 target_sources(interface.module.with.common
                PUBLIC "${CMAKE_CURRENT_LIST_DIR}/cpp/CommonMainFooImpl.cpp")
+target_link_libraries(interface.module.with.common INTERFACE Threads::Threads)
 
 gluecodium_generate(interface.module.with.common GENERATORS ${_gluecodium_generator})
 gluecodium_target_lime_sources(interface.module.with.common

--- a/cmake/tests/unit/gluecodium_generate/two-object-libs-in-one-module/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/two-object-libs-in-one-module/CMakeLists.txt
@@ -21,6 +21,9 @@ project(gluecodium.test)
 
 set(CMAKE_CXX_STANDARD 17)
 
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
 endif()
@@ -44,6 +47,7 @@ get_supported_gluecodium_generators(_gluecodium_generator)
 add_library(object.module.with.common OBJECT)
 target_sources(object.module.with.common
                PRIVATE "${CMAKE_CURRENT_LIST_DIR}/cpp/CommonMainFooImpl.cpp")
+target_link_libraries(object.module.with.common PRIVATE Threads::Threads)
 
 gluecodium_generate(object.module.with.common GENERATORS ${_gluecodium_generator})
 gluecodium_target_lime_sources(object.module.with.common

--- a/cmake/tests/unit/gluecodium_generate/two-shared-modules/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/two-shared-modules/CMakeLists.txt
@@ -26,9 +26,6 @@ find_package(Threads REQUIRED)
 
 if(APPLE AND CMAKE_GENERATOR STREQUAL "Xcode")
   enable_language(Swift)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-undefined,error")
-else()
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--no-undefined")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")


### PR DESCRIPTION
CMake tests executed on CI did not force linker to
report errors when symbols were missing. Therefore,
certain tests were false-positive in the past.

This change adds '--no-undefined' or '-undefined,error'
depending on the compiler and platform.

In some cases threads library was missing. Therefore,
after adding the mentioned flags, some tests started to
fail. This change adds CMake commands to link threads library
to avoid tests errors.