### PR TITLE
Release version 13.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Gluecodium project Release Notes
 
-## Unreleased:
+## 13.9.7
+Release date 2024-11-13
 ### Bug fixes:
  * Fixed visibilty of symbols from common code (JNI, Dart FFI) in order to resolve problems with build that uses hidden visibility preset.
  * Fixed conversion of platforms for 'Internal' annotation to work correctly also when arguments are not in quotation marks.

--- a/gluecodium/src/main/resources/version.properties
+++ b/gluecodium/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version = 13.9.6
+version = 13.9.7


### PR DESCRIPTION
Bug fixes:
 * Common: fixed visibilty of symbols from common code (JNI, Dart FFI) in order to
                     resolve problems with build that uses hidden visibility preset.
 * AntlrLimeConverter: fixed conversion of platforms for 'Internal' annotation to work
                                       correctly also when arguments are not in quotation marks.
 * Dart: generate omitted documentation of properties.