### PR TITLE
Improve structured comments syntax for properties 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased:
 ### Features:
+ * Implemented the new way of documenting properties via `@value` and `@description` annotations in structured comments.
+ * Implemented validation, which requires the users to use at least `@value` annotation when documenting a property.
  * Implemented validation of comments used for accessors of properties: parameter of setter and return value of getter. When the required description is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
  * Implemented validation of comments used for lambdas. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
  * Implemented validation of comments used for functions. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.

--- a/docs/lime_markdown.md
+++ b/docs/lime_markdown.md
@@ -63,18 +63,21 @@ fun process(mode: Mode, input: String): GenericResult throws SomethingWrongExcep
 
 ### Structured comments for properties
 
-Structured comments are supported for properties. The following syntax is used:
-- the lines prepending any annotation are used to document getter's
-return value and setter's parameter as well as the declaration of property
-- `@get` annotation can be used to describe the getter function
-- `@set` annotation can be used to describe the setter function
+Structured comments are supported for properties. The comment must start with annotation.
+At the moment the following annotations are supported:
+1. `@value` - short description of property (ideally single line); it is used to document getter's
+   return value and setter's parameter as well as the declaration of property
+2. `@description` - extended information about property that is required to use it correctly
+3. `@get` - can be used to describe the getter function
+4. `@set` - can be used to describe the setter function
 
->**Important:** return values of getters and parameters of setters must be documented. If appropriate documentation
-> comment is missing, then Gluecodium will raise warning or error depending on `werror` flag.
+>**Important:** `@value` annotation is required. Return values of getters and parameters of setters must be documented.
+> If appropriate documentation comment is missing, then Gluecodium will raise warning or error depending on `werror` flag.
 
 Example:
 ```
-// Time interval taken by the processing.
+// @value Time interval taken by the processing.
+// @description Time interval must be in range [100ms, 1s].
 // @get Gets the time interval taken by the processing.
 // @set Sets the time interval taken by the processing.
 property processingTime: ProcessorHelperTypes.Timestamp

--- a/functional-tests/functional/input/lime/Comments.lime
+++ b/functional-tests/functional/input/lime/Comments.lime
@@ -78,14 +78,14 @@ class comments {
         // This is some very useful instance method parameter.
         input: CommentsInstantiable
     ): /* This is some very useful instance method result. */ CommentsInstantiable
-    // Some very useful attribute.
+    // @value Some very useful attribute.
     property SomeAttribute: Usefulness {
         // Some very useful attribute.
         get
         // Some very useful attribute.
         set
     }
-    // Some very useful attribute.
+    // @value Some very useful attribute.
     property instanceAttribute: CommentsInstantiable {
         // Some very useful attribute.
         get

--- a/functional-tests/functional/input/lime/CommentsInterface.lime
+++ b/functional-tests/functional/input/lime/CommentsInterface.lime
@@ -73,7 +73,7 @@ interface CommentsInterface {
     fun someMethodWithNothing()
     // This is some very useful method that does nothing.
     fun someMethodWithoutReturnTypeOrInputParameters()
-    // Some very useful attribute.
+    // @value Some very useful attribute.
     property SomeAttribute: Usefulness {
         // Some very useful attribute.
         get

--- a/functional-tests/functional/input/lime/Inheritance.lime
+++ b/functional-tests/functional/input/lime/Inheritance.lime
@@ -23,7 +23,7 @@ interface ParentInterface {
     fun getName(): String
     // Returns the current instance that is cast to ParentInterface type.
     fun castToParent(): ParentInterface
-    // Example attribute that represents a number.
+    // @value Example attribute that represents a number.
     property luckyNumber: Int {
         // Example attribute that represents a number.
         get

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimePropertiesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimePropertiesValidator.kt
@@ -88,8 +88,8 @@ internal class LimePropertiesValidator(private val logger: LimeLogger, generator
         val checkDocsMessage = "please check $PROPERTIES_STRUCTURED_COMMENTS"
         var result = true
 
-        if (limeProperty.comment.isEmpty()) {
-            logger.maybeError(limeProperty, "property description comment is missing; $checkDocsMessage")
+        if (limeProperty.valueComment.isEmpty()) {
+            logger.maybeError(limeProperty, "property must use @value annotation; $checkDocsMessage")
             result = false
         }
 

--- a/gluecodium/src/main/resources/templates/cpp/CppFunctionDoc.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFunctionDoc.mustache
@@ -24,7 +24,10 @@
  */
 {{/ifPredicate}}{{!!
 
-}}{{+combinedComment}}{{resolveName comment}}{{#if comment.isExcluded}}
+}}{{+combinedComment}}{{resolveName comment}}{{!!
+}}{{#resolveName propertyElement.additionalDescriptionComment}}{{#unless this.isEmpty}}
+{{this}}{{/unless}}{{/resolveName}}{{!!
+}}{{#if comment.isExcluded}}
 \private{{/if}}{{!!
 }}{{#if attributes.deprecated}}
 \deprecated {{resolveName attributes.deprecated.message}}{{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartDescribeProperty.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartDescribeProperty.mustache
@@ -22,3 +22,7 @@
 {{#unless this.isEmpty}}
 {{prefix this "/// "}}
 {{/unless}}{{/resolveName}}
+{{#resolveName additionalDescriptionComment}}
+{{#unless this.isEmpty}}
+{{prefix this "/// "}}
+{{/unless}}{{/resolveName}}

--- a/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
@@ -27,6 +27,8 @@
 
 {{+combinedComment}}{{!!
 }}{{resolveName comment}}{{!!
+}}{{#resolveName property.additionalDescriptionComment}}{{#unless this.isEmpty}}
+{{this}}{{/unless}}{{/resolveName}}{{!!
 }}{{#if comment.isExcluded}}
 {{!!}}@hidden{{!!
 }}{{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/swift/SwiftProperty.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftProperty.mustache
@@ -18,7 +18,9 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{>swift/SwiftComment}}{{>swift/SwiftAttributes}}{{#if attributes.cached}}{{!!
+{{>swift/SwiftComment}}
+{{#resolveName additionalDescriptionComment}}{{#unless this.isEmpty}}{{prefix this "/// "}}{{/unless}}{{/resolveName}}
+{{>swift/SwiftAttributes}}{{#if attributes.cached}}{{!!
 }}{{resolveName "visibility"}} private(set) {{#if isStatic}}static {{/if}}{{#unless isStatic}}lazy {{/unless}}{{!!
 }}var {{resolveName}}: {{resolveName typeRef}} = {{#getter}}{{>swift/SwiftFunctionBody}}{{/getter}}(){{!!
 }}{{/if}}{{#unless attributes.cached}}{{!!

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimePropertiesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimePropertiesValidatorTest.kt
@@ -76,7 +76,7 @@ class LimePropertiesValidatorTest {
         typeRef = LimeBasicTypeRef.INT,
         getter = getter,
         setter = setter,
-        comment = valueComment,
+        valueComment = valueComment,
     )
 
     private fun getterForPath(

--- a/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
+++ b/gluecodium/src/test/resources/smoke/attributes/input/AttributesWithComments.lime
@@ -29,7 +29,7 @@ class AttributesWithComments {
     @Swift(Attribute = "OnFunctionInClass")
     @Dart(Attribute = "OnFunctionInClass")
     fun veryFun()
-    // Property comment
+    // @value Property comment
     // @get Getter comment
     // @set Setter comment
     @Cpp(Attribute = "OnPropertyInClass")

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -78,16 +78,16 @@ class comments {
     // @return nicely documented
     fun returnCommentOnly(undocumented: String): String
 
-    // Some very useful property.
-    // Note: without these comments user may not be able to use it correctly.
+    // @value Some very useful property.
+    // @description Note: without these comments user may not be able to use it correctly.
     // Note: that's serious.
     // Therefore, these lines above getter/setter need to be rendered in the output files.
     // @get Gets some very useful property.
     // @set Sets some very useful property.
     property SomeProperty: Usefulness
 
-    // OnlyGetterProperty, which does not have a setter.
-    // The generated documentation for this property should only be added to property or getter.
+    // @value OnlyGetterProperty, which does not have a setter.
+    // @description The generated documentation for this property should only be added to property or getter.
     // @get Gets OnlyGetterProperty in a very specific way.
     property OnlyGetterProperty: Int { get }
 

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -91,6 +91,23 @@ class comments {
     // @get Gets OnlyGetterProperty in a very specific way.
     property OnlyGetterProperty: Int { get }
 
+    // @value A flag that determines if [OnlyGetterProperty] is visible on the screen.
+    // @description By default it is set to `false`. In this case the mentioned thing is not visible on the
+    // screen except the case when another flag called [SomeProperty] forces it.
+    // When set to `true` then it is always visible.
+    //
+    // The additional information about usage of the visibility flag is described here. It contains a lot
+    // of references. For instance, if [SomeProperty] is {@Swift `nil`}{@Java `null`}{@Dart `null`}{@Cpp `nullptr`}
+    // then it is not visible even if flag is set to `true`.
+    //
+    // @get Returns 'true' if [OnlyGetterProperty] should be visible on the screen. Else returns false.
+    // This getter also may have additional info that is added to its comment. It can be described here.
+    // @set Sets the visibility flag that controls if [OnlyGetterProperty] should be visible on the screen.
+    property IsVisible: Boolean {
+        get
+        set
+    }
+
     // This is some very useful exception.
     exception SomethingWrong(SomeEnum)
 

--- a/gluecodium/src/test/resources/smoke/comments/input/CommentsInterface.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/CommentsInterface.lime
@@ -65,7 +65,7 @@ interface CommentsInterface {
     // This is some very useful method that does nothing.
     fun someMethodWithoutReturnTypeOrInputParameters()
 
-    // Some very useful property.
+    // @value Some very useful property.
     // @get Gets some very useful property.
     // @set Sets some very useful property.
     property SomeProperty: Usefulness

--- a/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/DeprecationComments.lime
@@ -48,7 +48,7 @@ interface DeprecationComments {
         // Very useful input parameter
         input: String
     ): /* Usefulness of the input */ Usefulness
-    // Some very useful property.
+    // @value Some very useful property.
     @Deprecated("Unfortunately, this property is deprecated.\nUse [comments.SomeProperty] instead.")
     property SomeProperty: Usefulness {
         // Gets some very useful property.
@@ -58,7 +58,7 @@ interface DeprecationComments {
         @Deprecated("Unfortunately, this property's setter is deprecated.\nUse [comments.SomeProperty.set] instead.")
         set
     }
-    // Describes the property but not accessors.
+    // @value Describes the property but not accessors.
     // @get Gets the property but not accessors.
     @Deprecated("Will be removed in v3.2.1.")
     property PropertyButNotAccessors: String

--- a/gluecodium/src/test/resources/smoke/comments/input/ExcludedComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/ExcludedComments.lime
@@ -56,7 +56,7 @@ class ExcludedComments {
     // @exclude
     fun someMethodWithoutReturnTypeOrInputParameters()
 
-    // Some very useful property.
+    // @value Some very useful property.
     // @get Gets some very useful property.
     // @set Sets some very useful property.
     // @exclude

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -281,9 +281,6 @@ public final class Comments extends NativeBase {
     /**
      * <p>Gets some very useful property.
      * @return <p>Some very useful property.
-     *     Note: without these comments user may not be able to use it correctly.
-     *     Note: that's serious.
-     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
 
 
@@ -293,9 +290,6 @@ public final class Comments extends NativeBase {
     /**
      * <p>Sets some very useful property.
      * @param value <p>Some very useful property.
-     *     Note: without these comments user may not be able to use it correctly.
-     *     Note: that's serious.
-     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
 
 
@@ -305,7 +299,6 @@ public final class Comments extends NativeBase {
     /**
      * <p>Gets OnlyGetterProperty in a very specific way.
      * @return <p>OnlyGetterProperty, which does not have a setter.
-     *     The generated documentation for this property should only be added to property or getter.
      */
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -312,6 +312,37 @@ public final class Comments extends NativeBase {
 
     public native int getOnlyGetterProperty();
 
+    /**
+     * <p>Returns 'true' if {@link com.example.smoke.Comments#getOnlyGetterProperty} should be visible on the screen. Else returns false.
+     * This getter also may have additional info that is added to its comment. It can be described here.
+     * <p>By default it is set to <code>false</code>. In this case the mentioned thing is not visible on the
+     * screen except the case when another flag called {@link com.example.smoke.Comments#isSomeProperty} forces it.
+     * When set to <code>true</code> then it is always visible.
+     * <p>The additional information about usage of the visibility flag is described here. It contains a lot
+     * of references. For instance, if {@link com.example.smoke.Comments#isSomeProperty} is <code>null</code>
+     * then it is not visible even if flag is set to <code>true</code>.
+     * @return <p>A flag that determines if {@link com.example.smoke.Comments#getOnlyGetterProperty} is visible on the screen.
+     */
+
+
+
+    public native boolean isIsVisible();
+
+    /**
+     * <p>Sets the visibility flag that controls if {@link com.example.smoke.Comments#getOnlyGetterProperty} should be visible on the screen.
+     * <p>By default it is set to <code>false</code>. In this case the mentioned thing is not visible on the
+     * screen except the case when another flag called {@link com.example.smoke.Comments#isSomeProperty} forces it.
+     * When set to <code>true</code> then it is always visible.
+     * <p>The additional information about usage of the visibility flag is described here. It contains a lot
+     * of references. For instance, if {@link com.example.smoke.Comments#isSomeProperty} is <code>null</code>
+     * then it is not visible even if flag is set to <code>true</code>.
+     * @param value <p>A flag that determines if {@link com.example.smoke.Comments#getOnlyGetterProperty} is visible on the screen.
+     */
+
+
+
+    public native void setIsVisible(final boolean value);
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/Comments.java
@@ -280,6 +280,9 @@ public final class Comments extends NativeBase {
 
     /**
      * <p>Gets some very useful property.
+     * <p>Note: without these comments user may not be able to use it correctly.
+     * Note: that's serious.
+     * Therefore, these lines above getter/setter need to be rendered in the output files.
      * @return <p>Some very useful property.
      */
 
@@ -289,6 +292,9 @@ public final class Comments extends NativeBase {
 
     /**
      * <p>Sets some very useful property.
+     * <p>Note: without these comments user may not be able to use it correctly.
+     * Note: that's serious.
+     * Therefore, these lines above getter/setter need to be rendered in the output files.
      * @param value <p>Some very useful property.
      */
 
@@ -298,6 +304,7 @@ public final class Comments extends NativeBase {
 
     /**
      * <p>Gets OnlyGetterProperty in a very specific way.
+     * <p>The generated documentation for this property should only be added to property or getter.
      * @return <p>OnlyGetterProperty, which does not have a setter.
      */
 

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -183,24 +183,17 @@ public:
     /**
      * Gets some very useful property.
      * \return Some very useful property.
-     *     Note: without these comments user may not be able to use it correctly.
-     *     Note: that's serious.
-     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
     virtual ::smoke::Comments::Usefulness is_some_property(  ) const = 0;
     /**
      * Sets some very useful property.
      * \param[in] value Some very useful property.
-     *     Note: without these comments user may not be able to use it correctly.
-     *     Note: that's serious.
-     *     Therefore, these lines above getter/setter need to be rendered in the output files.
      */
     virtual void set_some_property( const ::smoke::Comments::Usefulness value ) = 0;
 
     /**
      * Gets OnlyGetterProperty in a very specific way.
      * \return OnlyGetterProperty, which does not have a setter.
-     *     The generated documentation for this property should only be added to property or getter.
      */
     virtual int32_t get_only_getter_property(  ) const = 0;
 

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -204,6 +204,32 @@ public:
      */
     virtual int32_t get_only_getter_property(  ) const = 0;
 
+    /**
+     * Returns 'true' if ::smoke::Comments::get_only_getter_property should be visible on the screen. Else returns false.
+     * This getter also may have additional info that is added to its comment. It can be described here.
+     * By default it is set to `false`. In this case the mentioned thing is not visible on the
+     * screen except the case when another flag called ::smoke::Comments::is_some_property forces it.
+     * When set to `true` then it is always visible.
+     *
+     * The additional information about usage of the visibility flag is described here. It contains a lot
+     * of references. For instance, if ::smoke::Comments::is_some_property is `nullptr`
+     * then it is not visible even if flag is set to `true`.
+     * \return A flag that determines if ::smoke::Comments::get_only_getter_property is visible on the screen.
+     */
+    virtual bool is_is_visible(  ) const = 0;
+    /**
+     * Sets the visibility flag that controls if ::smoke::Comments::get_only_getter_property should be visible on the screen.
+     * By default it is set to `false`. In this case the mentioned thing is not visible on the
+     * screen except the case when another flag called ::smoke::Comments::is_some_property forces it.
+     * When set to `true` then it is always visible.
+     *
+     * The additional information about usage of the visibility flag is described here. It contains a lot
+     * of references. For instance, if ::smoke::Comments::is_some_property is `nullptr`
+     * then it is not visible even if flag is set to `true`.
+     * \param[in] value A flag that determines if ::smoke::Comments::get_only_getter_property is visible on the screen.
+     */
+    virtual void set_is_visible( const bool value ) = 0;
+
 };
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -182,17 +182,24 @@ public:
     virtual ::std::string return_comment_only( const ::std::string& undocumented ) = 0;
     /**
      * Gets some very useful property.
+     * Note: without these comments user may not be able to use it correctly.
+     * Note: that's serious.
+     * Therefore, these lines above getter/setter need to be rendered in the output files.
      * \return Some very useful property.
      */
     virtual ::smoke::Comments::Usefulness is_some_property(  ) const = 0;
     /**
      * Sets some very useful property.
+     * Note: without these comments user may not be able to use it correctly.
+     * Note: that's serious.
+     * Therefore, these lines above getter/setter need to be rendered in the output files.
      * \param[in] value Some very useful property.
      */
     virtual void set_some_property( const ::smoke::Comments::Usefulness value ) = 0;
 
     /**
      * Gets OnlyGetterProperty in a very specific way.
+     * The generated documentation for this property should only be added to property or getter.
      * \return OnlyGetterProperty, which does not have a setter.
      */
     virtual int32_t get_only_getter_property(  ) const = 0;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -65,20 +65,13 @@ abstract class Comments {
   ///
   String returnCommentOnly(String undocumented);
   /// Some very useful property.
-  /// Note: without these comments user may not be able to use it correctly.
-  /// Note: that's serious.
-  /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Gets some very useful property.
   bool get isSomeProperty;
   /// Some very useful property.
-  /// Note: without these comments user may not be able to use it correctly.
-  /// Note: that's serious.
-  /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Sets some very useful property.
   set isSomeProperty(bool value);
 
   /// OnlyGetterProperty, which does not have a setter.
-  /// The generated documentation for this property should only be added to property or getter.
   /// Gets OnlyGetterProperty in a very specific way.
   int get onlyGetterProperty;
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -82,6 +82,28 @@ abstract class Comments {
   /// Gets OnlyGetterProperty in a very specific way.
   int get onlyGetterProperty;
 
+  /// A flag that determines if [Comments.onlyGetterProperty] is visible on the screen.
+  /// By default it is set to `false`. In this case the mentioned thing is not visible on the
+  /// screen except the case when another flag called [Comments.isSomeProperty] forces it.
+  /// When set to `true` then it is always visible.
+  ///
+  /// The additional information about usage of the visibility flag is described here. It contains a lot
+  /// of references. For instance, if [Comments.isSomeProperty] is `null`
+  /// then it is not visible even if flag is set to `true`.
+  /// Returns 'true' if [Comments.onlyGetterProperty] should be visible on the screen. Else returns false.
+  /// This getter also may have additional info that is added to its comment. It can be described here.
+  bool get isIsVisible;
+  /// A flag that determines if [Comments.onlyGetterProperty] is visible on the screen.
+  /// By default it is set to `false`. In this case the mentioned thing is not visible on the
+  /// screen except the case when another flag called [Comments.isSomeProperty] forces it.
+  /// When set to `true` then it is always visible.
+  ///
+  /// The additional information about usage of the visibility flag is described here. It contains a lot
+  /// of references. For instance, if [Comments.isSomeProperty] is `null`
+  /// then it is not visible even if flag is set to `true`.
+  /// Sets the visibility flag that controls if [Comments.onlyGetterProperty] should be visible on the screen.
+  set isIsVisible(bool value);
+
 }
 
 /// This is some very useful enum.
@@ -667,6 +689,31 @@ class Comments$Impl extends __lib.NativeBase implements Comments {
 
 
     }
+
+  }
+
+
+  @override
+  bool get isIsVisible {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Comments_isIsVisible_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return booleanFromFfi(__resultHandle);
+    } finally {
+      booleanReleaseFfiHandle(__resultHandle);
+
+    }
+
+  }
+
+  @override
+  set isIsVisible(bool value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Comments_isIsVisible_set__Boolean'));
+    final _valueHandle = booleanToFfi(value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+    booleanReleaseFfiHandle(_valueHandle);
 
   }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -65,13 +65,20 @@ abstract class Comments {
   ///
   String returnCommentOnly(String undocumented);
   /// Some very useful property.
+  /// Note: without these comments user may not be able to use it correctly.
+  /// Note: that's serious.
+  /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Gets some very useful property.
   bool get isSomeProperty;
   /// Some very useful property.
+  /// Note: without these comments user may not be able to use it correctly.
+  /// Note: that's serious.
+  /// Therefore, these lines above getter/setter need to be rendered in the output files.
   /// Sets some very useful property.
   set isSomeProperty(bool value);
 
   /// OnlyGetterProperty, which does not have a setter.
+  /// The generated documentation for this property should only be added to property or getter.
   /// Gets OnlyGetterProperty in a very specific way.
   int get onlyGetterProperty;
 

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -44,6 +44,24 @@ public class Comments {
             return moveFromCType(c_result_handle)
         }
     }
+    /// A flag that determines if `Comments.onlyGetterProperty` is visible on the screen.
+    /// By default it is set to `false`. In this case the mentioned thing is not visible on the
+    /// screen except the case when another flag called `Comments.isSomeProperty` forces it.
+    /// When set to `true` then it is always visible.
+    ///
+    /// The additional information about usage of the visibility flag is described here. It contains a lot
+    /// of references. For instance, if `Comments.isSomeProperty` is `nil`
+    /// then it is not visible even if flag is set to `true`.
+    public var isIsVisible: Bool {
+        get {
+            let c_result_handle = smoke_Comments_isIsVisible_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_Comments_isIsVisible_set(self.c_instance, c_value.ref)
+        }
+    }
     let c_instance : _baseRef
 
     init(cComments: _baseRef) {

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -23,9 +23,6 @@ public class Comments {
     /// This is some very useful constant.
     public static let veryUseful: Comments.Usefulness = true
     /// Some very useful property.
-    /// Note: without these comments user may not be able to use it correctly.
-    /// Note: that's serious.
-    /// Therefore, these lines above getter/setter need to be rendered in the output files.
     public var isSomeProperty: Comments.Usefulness {
         get {
             let c_result_handle = smoke_Comments_isSomeProperty_get(self.c_instance)
@@ -37,7 +34,6 @@ public class Comments {
         }
     }
     /// OnlyGetterProperty, which does not have a setter.
-    /// The generated documentation for this property should only be added to property or getter.
     public var onlyGetterProperty: Int32 {
         get {
             let c_result_handle = smoke_Comments_onlyGetterProperty_get(self.c_instance)

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -23,6 +23,9 @@ public class Comments {
     /// This is some very useful constant.
     public static let veryUseful: Comments.Usefulness = true
     /// Some very useful property.
+    /// Note: without these comments user may not be able to use it correctly.
+    /// Note: that's serious.
+    /// Therefore, these lines above getter/setter need to be rendered in the output files.
     public var isSomeProperty: Comments.Usefulness {
         get {
             let c_result_handle = smoke_Comments_isSomeProperty_get(self.c_instance)
@@ -34,6 +37,7 @@ public class Comments {
         }
     }
     /// OnlyGetterProperty, which does not have a setter.
+    /// The generated documentation for this property should only be added to property or getter.
     public var onlyGetterProperty: Int32 {
         get {
             let c_result_handle = smoke_Comments_onlyGetterProperty_get(self.c_instance)

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -288,6 +288,17 @@ internal class AntlrLimeModelBuilder(
         val propertyComment = structuredCommentsStack.peek().description
         val valueComment = getComment("value", emptyList(), ctx).withExcluded(propertyComment.isExcluded)
         val additionalDescriptionComment = getComment("description", emptyList(), ctx).withExcluded(propertyComment.isExcluded)
+
+        if (!propertyComment.isEmpty() && !valueComment.isEmpty()) {
+            val position = ctx.getStart()
+            val linePrefix = "line ${position.line}:${position.charPositionInLine} --"
+            val docsReference = "Please see 'docs/lime_markdown.md'"
+            throw ParseCancellationException(
+                "$linePrefix property comments cannot start with lines without annotations " +
+                    "and use @value at the same time! $docsReference.",
+            )
+        }
+
         val propertyAttributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation())
 
         val accessorArgumentComment = if (!valueComment.isEmpty()) valueComment else propertyComment

--- a/lime-loader/src/test/java/com/here/gluecodium/loader/AntlrLimeModelBuilderTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/loader/AntlrLimeModelBuilderTest.kt
@@ -33,6 +33,7 @@ import org.antlr.v4.runtime.tree.TerminalNode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -129,5 +130,33 @@ class AntlrLimeModelBuilderTest {
 
         modelBuilder.enterProperty(propertyContext)
         modelBuilder.exitProperty(propertyContext)
+    }
+
+    @Test
+    fun exitPropertyStoresValueAndDescriptionWhenDefined() {
+        pushDocComment("@value Some property")
+        pushDocComment("@description Some description")
+
+        modelBuilder.enterProperty(propertyContext)
+        modelBuilder.exitProperty(propertyContext)
+
+        val result = contextStack.currentContext.currentResults.first() as LimeProperty
+        assertEquals(result.comment.toString(), "Some property")
+        assertEquals(result.valueComment.toString(), "Some property")
+        assertEquals(result.additionalDescriptionComment.toString(), "Some description")
+    }
+
+    @Test
+    fun exitPropertyUsesFirstLinesAsCommentWhenValueAnnotationIsNotDefined() {
+        pushDocComment("Some property")
+        pushDocComment("This is old way of documenting properties")
+
+        modelBuilder.enterProperty(propertyContext)
+        modelBuilder.exitProperty(propertyContext)
+
+        val result = contextStack.currentContext.currentResults.first() as LimeProperty
+        assertEquals(result.comment.toString(), "Some property\nThis is old way of documenting properties")
+        assertTrue(result.valueComment.isEmpty())
+        assertTrue(result.additionalDescriptionComment.isEmpty())
     }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/common/LimeModelFilter.kt
@@ -253,6 +253,8 @@ private class LimeModelFilterImpl(private val limeModel: LimeModel, predicate: (
             LimeProperty(
                 path = path,
                 comment = comment,
+                valueComment = valueComment,
+                additionalDescriptionComment = additionalDescriptionComment,
                 attributes = attributes,
                 typeRef = typeRef,
                 getter = getter,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeNamedElement.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeNamedElement.kt
@@ -21,7 +21,7 @@ package com.here.gluecodium.model.lime
 
 abstract class LimeNamedElement protected constructor(
     val path: LimePath,
-    val comment: LimeComment = LimeComment(),
+    open val comment: LimeComment = LimeComment(),
     attributes: LimeAttributes? = null,
     val external: LimeExternalDescriptor? = null,
 ) : LimeElement(attributes) {

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeProperty.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeProperty.kt
@@ -19,6 +19,31 @@
 
 package com.here.gluecodium.model.lime
 
+/*
+ *  The structured comments for properties are split in the following way:
+ *   1. '@value':
+ *       a) stored in: 'LimeProperty.valueComment'
+ *       b) purpose: short description of property (ideally single line)
+ *       c) usage: declaration of property (Swift/Dart) or setter_param/getter_return (Java/C++)
+ *   2. '@description':
+ *       a) stored in: 'LimeProperty.additionalDescriptionComment'
+ *       b) purpose: extended information about property that is required to use it correctly
+ *       c) usage: declaration of property (Swift/Dart), declaration of getter/setter (Java/C++)
+ *   3. '@get':
+ *       a) stored in: 'LimeProperty.getter.comment'
+ *       b) purpose: documents getter function
+ *       c) usage: declaration of getter function
+ *   4. '@set'
+ *       a) stored in: 'LimeProperty.setter.comment'
+ *       b) purpose: documents setter function
+ *       c) usage: declaration of setter function
+ *
+ * Moreover, if '@value' is not provided, then we try to use the first lines of the comment that
+ * are not associated with any annotation (LimeProperty.comment).
+ *
+ * Due to the fact, that the generators use the same mustache templates for many purposes 'LimeProperty.comment'
+ * getter is overridden to ensure seamless integration of value/description logic with the usual path.
+ */
 class LimeProperty(
     path: LimePath,
     comment: LimeComment = LimeComment(),
@@ -26,5 +51,10 @@ class LimeProperty(
     typeRef: LimeTypeRef,
     val getter: LimeFunction,
     val setter: LimeFunction? = null,
+    val valueComment: LimeComment = LimeComment(),
+    val additionalDescriptionComment: LimeComment = LimeComment(),
     val isStatic: Boolean = false,
-) : LimeTypedElement(path, comment, attributes, typeRef = typeRef)
+) : LimeTypedElement(path, comment, attributes, typeRef = typeRef) {
+    override val comment: LimeComment = comment
+        get() = if (!field.isEmpty()) field else valueComment
+}


### PR DESCRIPTION
The first part of comment used to describe a property (lines before get/set annotations)
was used in a few places:
- to document the property when declaring it in Swift and Dart
- to document the parameter used in setter in the case of C++ and Java
- to document the return value of getter in the case of C++ and Java

In some cases it looked strange. For instance, when the user wanted to leave some additional,
extended information about the property, that was necessary to use it correctly, then it was
appended to the description of the return type and parameters of getters and setters.

Moreover, it was hard for users to remember how these lines are rendered in the case of four
output languages.

In order to ease the documentation of properties, this change introduces two new annotations:
'value' and 'description'. The structured comments for properties can be formed as follows:

`@value`:
- **purpose:** short description of property (ideally single line)
- **usage:** declaration of property (Swift/Dart) or setter_param/getter_return (Java/C++)

`@description`:
- **purpose:** extended information about property that is required to use it correctly
- **usage:** declaration of property (Swift/Dart), declaration of getter/setter (Java/C++)

`@get`:
- **purpose:** documents getter function
- **usage:** declaration of getter function

`@set`:
- **purpose:** documents setter function
- **usage:** declaration of setter function


Moreover, the validation was implemented. The rules are as follows:
- the user cannot start a comment without annotation and then use later `@value`
- if the user forgets to use `@value` then warning will be generated
- if the user wants, the warning related to missing `@value` can be treated as error via `werror` flag
- the old way of generating comment will be used when the comment does not use `@value` but provides
  information without annotation -- however, the warning/error will be generated as well