### PR TITLE
Do not use deprecated 'ExpectedException' JUnit rule

### DIFF
--- a/gluecodium-gradle/src/test/java/com/here/gluecodium/gradle/GluecodiumRunnerTest.kt
+++ b/gluecodium-gradle/src/test/java/com/here/gluecodium/gradle/GluecodiumRunnerTest.kt
@@ -26,19 +26,14 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import org.gradle.api.GradleException
+import org.junit.Assert.assertThrows
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 internal class GluecodiumRunnerTest {
-    @JvmField
-    @Rule
-    val expectedException: ExpectedException = ExpectedException.none()
-
     @MockK lateinit var gluecodium: Gluecodium
     private val defaultGluecodiumOptions = GluecodiumOptions()
     private val defaultGeneratorOptions = GeneratorOptions()
@@ -62,8 +57,9 @@ internal class GluecodiumRunnerTest {
     @Test
     fun executeReturningFalseThrows() {
         every { gluecodium.execute() } returns false
-        expectedException.expect(GradleException::class.java)
 
-        runner.run(defaultGluecodiumOptions, defaultGeneratorOptions)
+        assertThrows(GradleException::class.java) {
+            runner.run(defaultGluecodiumOptions, defaultGeneratorOptions)
+        }
     }
 }

--- a/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
@@ -22,10 +22,10 @@ package com.here.gluecodium.cli
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -35,10 +35,6 @@ import java.io.PrintStream
 
 @RunWith(JUnit4::class)
 class OptionReaderTest {
-    @JvmField
-    @Rule
-    val expectedException: ExpectedException = ExpectedException.none()
-
     @JvmField
     @Rule
     val temporaryFolder = TemporaryFolder()
@@ -145,8 +141,7 @@ class OptionReaderTest {
         val toRead = prepareToRead("-someUnknownOption", "")
 
         // Act, Assert
-        expectedException.expect(OptionReaderException::class.java)
-        OptionReader.read(toRead)
+        assertThrows(OptionReaderException::class.java) { OptionReader.read(toRead) }
     }
 
     @Test

--- a/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/TopologicalSortCycleTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/generator/cpp/TopologicalSortCycleTest.kt
@@ -25,24 +25,13 @@ import com.here.gluecodium.generator.cpp.TopologicalSortTestHelper.createTypeRef
 import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeAlias
-import org.junit.Before
-import org.junit.Rule
+import org.junit.Assert.assertThrows
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class TopologicalSortCycleTest {
-    @JvmField
-    @Rule
-    val expectedException: ExpectedException = ExpectedException.none()
-
-    @Before
-    fun setUp() {
-        expectedException.expect(GluecodiumExecutionException::class.java)
-    }
-
     @Test
     fun cycleWithStructs() {
         val fooField = LimeField(createPath("fooField"), typeRef = createTypeRef("foo"))
@@ -50,7 +39,9 @@ class TopologicalSortCycleTest {
         val fooStruct = LimeStruct(createPath("foo"), fields = listOf(barField))
         val barStruct = LimeStruct(createPath("bar"), fields = listOf(fooField))
 
-        TopologicalSort(listOf(fooStruct, barStruct)).sort()
+        assertThrows(GluecodiumExecutionException::class.java) {
+            TopologicalSort(listOf(fooStruct, barStruct)).sort()
+        }
     }
 
     @Test
@@ -58,7 +49,9 @@ class TopologicalSortCycleTest {
         val fooUsing = LimeTypeAlias(createPath("foo"), typeRef = createTypeRef("bar"))
         val barUsing = LimeTypeAlias(createPath("bar"), typeRef = createTypeRef("foo"))
 
-        TopologicalSort(listOf(fooUsing, barUsing)).sort()
+        assertThrows(GluecodiumExecutionException::class.java) {
+            TopologicalSort(listOf(fooUsing, barUsing)).sort()
+        }
     }
 
     @Test
@@ -67,6 +60,8 @@ class TopologicalSortCycleTest {
         val fooStruct = LimeStruct(createPath("foo"), fields = listOf(barField))
         val barUsing = LimeTypeAlias(createPath("bar"), typeRef = createTypeRef("foo"))
 
-        TopologicalSort(listOf(fooStruct, barUsing)).sort()
+        assertThrows(GluecodiumExecutionException::class.java) {
+            TopologicalSort(listOf(fooStruct, barUsing)).sort()
+        }
     }
 }

--- a/gluecodium/src/test/java/com/here/gluecodium/output/FileRemoveTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/output/FileRemoveTest.kt
@@ -30,10 +30,9 @@ import io.mockk.unmockkAll
 import io.mockk.verify
 import junit.framework.TestCase.assertTrue
 import org.junit.After
+import org.junit.Assert.assertThrows
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.io.File
@@ -44,10 +43,6 @@ import java.nio.file.Paths
 
 @RunWith(JUnit4::class)
 class FileRemoveTest {
-    @JvmField
-    @Rule
-    var exception: ExpectedException = ExpectedException.none()
-
     @MockK private lateinit var rootFile: File
 
     @Before
@@ -70,10 +65,10 @@ class FileRemoveTest {
         every { rootFile.exists() } returns false
         every { rootFile.isDirectory } returns true
 
-        exception.expect(FileNotFoundException::class.java)
-
         // Act
-        FileRemove(rootFile).removeFiles(emptyList())
+        assertThrows(FileNotFoundException::class.java) {
+            FileRemove(rootFile).removeFiles(emptyList())
+        }
     }
 
     @Test
@@ -83,10 +78,10 @@ class FileRemoveTest {
         every { rootFile.exists() } returns true
         every { rootFile.isDirectory } returns false
 
-        exception.expect(FileNotFoundException::class.java)
-
         // Act
-        FileRemove(rootFile).removeFiles(emptyList())
+        assertThrows(FileNotFoundException::class.java) {
+            FileRemove(rootFile).removeFiles(emptyList())
+        }
     }
 
     @Test

--- a/lime-runtime/src/test/java/com/here/gluecodium/model/lime/LimeAmbiguityResolverTest.kt
+++ b/lime-runtime/src/test/java/com/here/gluecodium/model/lime/LimeAmbiguityResolverTest.kt
@@ -20,18 +20,13 @@
 package com.here.gluecodium.model.lime
 
 import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
-import org.junit.Rule
+import org.junit.Assert.assertThrows
 import org.junit.Test
-import org.junit.rules.ExpectedException
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class LimeAmbiguityResolverTest {
-    @JvmField
-    @Rule
-    val exception: ExpectedException = ExpectedException.none()
-
     private val fooPath = LimePath(listOf("foo"), emptyList())
     private val limeElement = object : LimeNamedElement(EMPTY_PATH) {}
 
@@ -51,9 +46,9 @@ class LimeAmbiguityResolverTest {
 
     @Test
     fun resolveWithNoPaths() {
-        exception.expect(LimeModelLoaderException::class.java)
-
-        doResolve()
+        assertThrows(LimeModelLoaderException::class.java) {
+            doResolve()
+        }
     }
 
     @Test
@@ -80,49 +75,54 @@ class LimeAmbiguityResolverTest {
 
     @Test
     fun resolveWithParentPathEmptyMap() {
-        exception.expect(LimeModelLoaderException::class.java)
         referenceMap.clear()
         parentPaths += fooPath
 
-        doResolve()
+        assertThrows(LimeModelLoaderException::class.java) {
+            doResolve()
+        }
     }
 
     @Test
     fun resolveWithImportEmptyMap() {
-        exception.expect(LimeModelLoaderException::class.java)
         referenceMap.clear()
         imports += fooPath.child("Bar")
 
-        doResolve()
+        assertThrows(LimeModelLoaderException::class.java) {
+            doResolve()
+        }
     }
 
     @Test
     fun resolveWithAmbiguousImports() {
-        exception.expect(LimeModelLoaderException::class.java)
         imports += fooPath.child("Bar")
         imports += fooPath.child("Buzz").child("Bar")
         referenceMap["foo.Buzz.Bar"] = object : LimeType(EMPTY_PATH) {}
 
-        doResolve()
+        assertThrows(LimeModelLoaderException::class.java) {
+            doResolve()
+        }
     }
 
     @Test
     fun resolveWithAmbiguousLocalObjects() {
-        exception.expect(LimeModelLoaderException::class.java)
         parentPaths += fooPath
         parentPaths += fooPath.child("Buzz")
         referenceMap["foo.Buzz.Bar"] = object : LimeNamedElement(EMPTY_PATH) {}
 
-        doResolve()
+        assertThrows(LimeModelLoaderException::class.java) {
+            doResolve()
+        }
     }
 
     @Test
     fun resolveWithCombinedAmbiguity() {
-        exception.expect(LimeModelLoaderException::class.java)
         parentPaths += fooPath
         imports += fooPath.child("Buzz").child("Bar")
         referenceMap["foo.Buzz.Bar"] = object : LimeNamedElement(EMPTY_PATH) {}
 
-        doResolve()
+        assertThrows(LimeModelLoaderException::class.java) {
+            doResolve()
+        }
     }
 }


### PR DESCRIPTION
The mentioned rule has been deprecated.
When the tests are compiled the warnings are visible.

Adjusted the code to use 'assertThrows()' assertion.
It is suggested by the deprecation message.

With this change the warnings are not visible
when the tests are compiled.