### PR TITLE
Dart: fix problems with default values that use collection types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased:
 ### Features:
  * Implemented validation of comments used for functions. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
+### Bug fixes:
+ * Dart: fixed a bug related to missing/superflous 'const' keyword usage in definition of default values in constructors that used collections when `@Immutable` or `PositionalDefaults` were specified.
 
 ## 13.9.7
 Release date 2024-11-13

--- a/functional-tests/functional/input/lime/Defaults.lime
+++ b/functional-tests/functional/input/lime/Defaults.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 # 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,6 +42,40 @@ class Defaults {
         boolField: Boolean
         stringField: String = "some string"
         enumField: SomeEnum = SomeEnum.BarValue
+    }
+    @Immutable
+    struct ImmutableStructWithCollections {
+        nullableListField: List<Int>? = null
+        emptyListField: List<Int> = []
+        valuesListField: List<Int> = [1, 2, 3]
+
+        nullableMapField: Map<Int, String>? = null
+        emptyMapField: Map<Int, String> = []
+        valuesMapField: Map<Int, String> = [9: "baz", 27: "bar"]
+
+        nullableSetField: Set<String>? = null
+        emptySetField: Set<String> = []
+        valuesSetField: Set<String> = ["bar", "baz"]
+    }
+    @Immutable
+    struct ImmutableStructWithFieldConstructorAndCollections {
+        nullableListField: List<Int>? = null
+        emptyListField: List<Int> = []
+        valuesListField: List<Int> = [1, 2, 3]
+
+        nullableMapField: Map<Int, String>? = null
+        emptyMapField: Map<Int, String> = []
+        valuesMapField: Map<Int, String> = [9: "baz", 27: "bar"]
+
+        nullableSetField: Set<String>? = null
+        emptySetField: Set<String> = []
+        valuesSetField: Set<String> = ["bar", "baz"]
+
+        someField: Int = 5
+        anotherField: Int = 7
+
+        @Dart("withIntegers")
+        field constructor(someField, anotherField)
     }
     struct StructWithSpecialDefaults {
         floatNanField: Float = NaN

--- a/functional-tests/functional/input/lime/PositionalDefaults.lime
+++ b/functional-tests/functional/input/lime/PositionalDefaults.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -50,6 +50,14 @@ struct StructWithCollectionDefaults {
     listField: List<String> = ["foo", "bar"]
     mapField: Map<String, String> = ["foo": "bar"]
     setField: Set<String> = ["foo", "bar"]
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithNullableCollectionDefaults {
+    nullableListField: List<String>? = null
+    nullableMapField: Map<String, String>? = null
+    nullableSetField: Set<String>? = null
 }
 
 @Dart(PositionalDefaults)

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -79,11 +79,13 @@ Explicit `field constructor` definitions
       : {{#omittedFields}}{{resolveName "visibility"}}{{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/omittedFields}}{{/if}};
 {{/fieldConstructors}}{{/set}}{{!!
 
-}}{{+constPrefix}}{{#set type=typeRef.type.actualType}}{{!!
+}}{{+constPrefix}}{{#notInstanceOf defaultValue "Null"}}{{!!
+}}{{#set type=typeRef.type.actualType}}{{!!
 }}{{#instanceOf type "LimeList"}}const {{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeMap"}}const {{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeSet"}}const {{/instanceOf}}{{!!
-}}{{/set}}{{/constPrefix}}{{!!
+}}{{/set}}{{!!
+}}{{/notInstanceOf}}{{/constPrefix}}{{!!
 
 }}{{+constructorComment}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{!!
 }}{{prefix this "  /// "}}

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -43,13 +43,14 @@ All fields constructor
 
 Initialized fields constructor
 
-}}{{#unless constructors}}{{#unless fieldConstructors}}{{#if initializedFields}}
+}}{{#unless constructors}}{{#unless fieldConstructors}}{{#if initializedFields}}{{#set struct=this}}{{#struct}}
   {{#if attributes.immutable}}const {{/if}}{{resolveName}}{{#if external.dart.converter}}Internal{{/if}}{{!!
 }}{{#ifPredicate "allFieldsCtorIsPublic"}}.withDefaults{{/ifPredicate}}({{!!
 }}{{#uninitializedFields}}{{resolveName typeRef}} {{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/uninitializedFields}})
-    : {{#fields}}{{resolveName "visibility"}}{{resolveName}} = {{#if defaultValue}}{{resolveName defaultValue}}{{/if}}{{!!
+    : {{#fields}}{{resolveName "visibility"}}{{resolveName}} = {{!!
+    }}{{#if defaultValue}}{{#if struct.attributes.immutable}}{{>constPrefix}}{{/if}}{{resolveName defaultValue}}{{/if}}{{!!
     }}{{#unless defaultValue}}{{resolveName}}{{/unless}}{{#if iter.hasNext}}, {{/if}}{{/fields}};
-{{/if}}{{/unless}}{{/unless}}{{!!
+{{/struct}}{{/set}}{{/if}}{{/unless}}{{/unless}}{{!!
 
 }}{{/unless}}{{/if}}{{!!
 
@@ -76,7 +77,8 @@ Explicit `field constructor` definitions
 {{/if}}{{prefixPartial "dart/DartAttributes" "  "}}{{!!
 }}  {{#if struct.attributes.immutable}}const {{/if}}{{resolveName struct}}{{#if external.dart.converter}}Internal{{/if}}{{!!
 }}{{>dart/DartConstructorName}}({{>thisDotFields}}){{#if omittedFields}}
-      : {{#omittedFields}}{{resolveName "visibility"}}{{resolveName}} = {{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/omittedFields}}{{/if}};
+      : {{#omittedFields}}{{resolveName "visibility"}}{{resolveName}} = {{!!
+      }}{{#if struct.attributes.immutable}}{{>constPrefix}}{{/if}}{{resolveName defaultValue}}{{#if iter.hasNext}}, {{/if}}{{/omittedFields}}{{/if}};
 {{/fieldConstructors}}{{/set}}{{!!
 
 }}{{+constPrefix}}{{#notInstanceOf defaultValue "Null"}}{{!!

--- a/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2021 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,14 @@ struct StructWithCollectionDefaults {
     listField: List<String> = ["foo", "bar"]
     mapField: Map<String, String> = ["foo": "bar"]
     setField: Set<String> = ["foo", "bar"]
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct StructWithNullableCollectionDefaults {
+    nullableListField: List<String>? = null
+    nullableMapField: Map<String, String>? = null
+    nullableSetField: Set<String>? = null
 }
 
 // Foo Bar this is a comment

--- a/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
@@ -1,4 +1,4 @@
-# Copyright (C) 2016-2019 HERE Europe B.V.
+# Copyright (C) 2016-2024 HERE Europe B.V.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -81,6 +81,42 @@ struct TypesWithDefaults {
         doubleField: Double = -1.4142
         boolField: Boolean
         stringField: String = "\\Jonny \"Magic\" Smith\n"
+    }
+
+    @Immutable
+    struct ImmutableStructWithCollections {
+        nullableListField: List<Int>? = null
+        emptyListField: List<Int> = []
+        valuesListField: List<Int> = [1, 2, 3]
+
+        nullableMapField: Map<Int, String>? = null
+        emptyMapField: Map<Int, String> = []
+        valuesMapField: Map<Int, String> = [9: "baz", 27: "bar"]
+
+        nullableSetField: Set<String>? = null
+        emptySetField: Set<String> = []
+        valuesSetField: Set<String> = ["bar", "baz"]
+    }
+
+    @Immutable
+    struct ImmutableStructWithFieldConstructorAndCollections {
+        nullableListField: List<Int>? = null
+        emptyListField: List<Int> = []
+        valuesListField: List<Int> = [1, 2, 3]
+
+        nullableMapField: Map<Int, String>? = null
+        emptyMapField: Map<Int, String> = []
+        valuesMapField: Map<Int, String> = [9: "baz", 27: "bar"]
+
+        nullableSetField: Set<String>? = null
+        emptySetField: Set<String> = []
+        valuesSetField: Set<String> = ["bar", "baz"]
+
+        someField: Int = 5
+        anotherField: Int = 7
+
+        @Dart("withIntegers")
+        field constructor(someField, anotherField)
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/TypesWithDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/TypesWithDefaults.java
@@ -1,8 +1,22 @@
 /*
+
  *
  */
+
 package com.example.smoke;
+
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import com.example.HashMapBuilder;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 public final class TypesWithDefaults {
     public static final class StructWithDefaults {
         public int intField;
@@ -12,6 +26,7 @@ public final class TypesWithDefaults {
         public boolean boolField;
         @NonNull
         public String stringField;
+
         public StructWithDefaults() {
             this.intField = 42;
             this.uintField = 4294967295L;
@@ -20,7 +35,10 @@ public final class TypesWithDefaults {
             this.boolField = true;
             this.stringField = "\\Jonny \"Magic\" Smith\n";
         }
+
+
     }
+
     public static final class ImmutableStructWithDefaults {
         public final int intField;
         public final long uintField;
@@ -29,6 +47,7 @@ public final class TypesWithDefaults {
         public final boolean boolField;
         @NonNull
         public final String stringField;
+
         public ImmutableStructWithDefaults(final long uintField, final boolean boolField) {
             this.intField = 42;
             this.uintField = uintField;
@@ -37,6 +56,7 @@ public final class TypesWithDefaults {
             this.boolField = boolField;
             this.stringField = "\\Jonny \"Magic\" Smith\n";
         }
+
         public ImmutableStructWithDefaults(final int intField, final long uintField, final float floatField, final double doubleField, final boolean boolField, @NonNull final String stringField) {
             this.intField = intField;
             this.uintField = uintField;
@@ -45,5 +65,111 @@ public final class TypesWithDefaults {
             this.boolField = boolField;
             this.stringField = stringField;
         }
+
+
     }
+
+    public static final class ImmutableStructWithCollections {
+        @Nullable
+        public final List<Integer> nullableListField;
+        @NonNull
+        public final List<Integer> emptyListField;
+        @NonNull
+        public final List<Integer> valuesListField;
+        @Nullable
+        public final Map<Integer, String> nullableMapField;
+        @NonNull
+        public final Map<Integer, String> emptyMapField;
+        @NonNull
+        public final Map<Integer, String> valuesMapField;
+        @Nullable
+        public final Set<String> nullableSetField;
+        @NonNull
+        public final Set<String> emptySetField;
+        @NonNull
+        public final Set<String> valuesSetField;
+
+        public ImmutableStructWithCollections() {
+            this.nullableListField = null;
+            this.emptyListField = new ArrayList<>();
+            this.valuesListField = new ArrayList<>(Arrays.asList(1, 2, 3));
+            this.nullableMapField = null;
+            this.emptyMapField = new HashMap<>();
+            this.valuesMapField = new HashMapBuilder<Integer, String>().put(9, "baz").put(27, "bar").build();
+            this.nullableSetField = null;
+            this.emptySetField = new HashSet<>();
+            this.valuesSetField = new HashSet<>(Arrays.asList("bar", "baz"));
+        }
+
+        public ImmutableStructWithCollections(@Nullable final List<Integer> nullableListField, @NonNull final List<Integer> emptyListField, @NonNull final List<Integer> valuesListField, @Nullable final Map<Integer, String> nullableMapField, @NonNull final Map<Integer, String> emptyMapField, @NonNull final Map<Integer, String> valuesMapField, @Nullable final Set<String> nullableSetField, @NonNull final Set<String> emptySetField, @NonNull final Set<String> valuesSetField) {
+            this.nullableListField = nullableListField;
+            this.emptyListField = emptyListField;
+            this.valuesListField = valuesListField;
+            this.nullableMapField = nullableMapField;
+            this.emptyMapField = emptyMapField;
+            this.valuesMapField = valuesMapField;
+            this.nullableSetField = nullableSetField;
+            this.emptySetField = emptySetField;
+            this.valuesSetField = valuesSetField;
+        }
+
+
+    }
+
+    public static final class ImmutableStructWithFieldConstructorAndCollections {
+        @Nullable
+        public final List<Integer> nullableListField;
+        @NonNull
+        public final List<Integer> emptyListField;
+        @NonNull
+        public final List<Integer> valuesListField;
+        @Nullable
+        public final Map<Integer, String> nullableMapField;
+        @NonNull
+        public final Map<Integer, String> emptyMapField;
+        @NonNull
+        public final Map<Integer, String> valuesMapField;
+        @Nullable
+        public final Set<String> nullableSetField;
+        @NonNull
+        public final Set<String> emptySetField;
+        @NonNull
+        public final Set<String> valuesSetField;
+        public final int someField;
+        public final int anotherField;
+
+        public ImmutableStructWithFieldConstructorAndCollections(@Nullable final List<Integer> nullableListField, @NonNull final List<Integer> emptyListField, @NonNull final List<Integer> valuesListField, @Nullable final Map<Integer, String> nullableMapField, @NonNull final Map<Integer, String> emptyMapField, @NonNull final Map<Integer, String> valuesMapField, @Nullable final Set<String> nullableSetField, @NonNull final Set<String> emptySetField, @NonNull final Set<String> valuesSetField, final int someField, final int anotherField) {
+            this.nullableListField = nullableListField;
+            this.emptyListField = emptyListField;
+            this.valuesListField = valuesListField;
+            this.nullableMapField = nullableMapField;
+            this.emptyMapField = emptyMapField;
+            this.valuesMapField = valuesMapField;
+            this.nullableSetField = nullableSetField;
+            this.emptySetField = emptySetField;
+            this.valuesSetField = valuesSetField;
+            this.someField = someField;
+            this.anotherField = anotherField;
+        }
+
+        public ImmutableStructWithFieldConstructorAndCollections(final int someField, final int anotherField) {
+            this.someField = someField;
+            this.anotherField = anotherField;
+            this.nullableListField = null;
+            this.emptyListField = new ArrayList<>();
+            this.valuesListField = new ArrayList<>(Arrays.asList(1, 2, 3));
+            this.nullableMapField = null;
+            this.emptyMapField = new HashMap<>();
+            this.valuesMapField = new HashMapBuilder<Integer, String>().put(9, "baz").put(27, "bar").build();
+            this.nullableSetField = null;
+            this.emptySetField = new HashSet<>();
+            this.valuesSetField = new HashSet<>(Arrays.asList("bar", "baz"));
+        }
+
+
+    }
+
+
+
 }
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
@@ -1,11 +1,22 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/UnorderedMapHash.h"
+#include "gluecodium/UnorderedSetHash.h"
+#include "gluecodium/VectorHash.h"
 #include <cstdint>
+#include <optional>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT TypesWithDefaults {
     struct _GLUECODIUM_CPP_EXPORT StructWithDefaults {
@@ -15,9 +26,12 @@ struct _GLUECODIUM_CPP_EXPORT TypesWithDefaults {
         double double_field = -1.4142;
         bool bool_field = true;
         ::std::string string_field = "\\Jonny \"Magic\" Smith\n";
+
         StructWithDefaults( );
         StructWithDefaults( int32_t int_field, uint32_t uint_field, float float_field, double double_field, bool bool_field, ::std::string string_field );
+
     };
+
     struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithDefaults {
         const int32_t int_field = 42;
         const uint32_t uint_field;
@@ -25,8 +39,51 @@ struct _GLUECODIUM_CPP_EXPORT TypesWithDefaults {
         const double double_field = -1.4142;
         const bool bool_field;
         const ::std::string string_field = "\\Jonny \"Magic\" Smith\n";
+
+
         ImmutableStructWithDefaults( uint32_t uint_field, bool bool_field );
         ImmutableStructWithDefaults( int32_t int_field, uint32_t uint_field, float float_field, double double_field, bool bool_field, ::std::string string_field );
+
     };
+
+    struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithCollections {
+        const std::optional< ::std::vector< int32_t > > nullable_list_field = std::optional< ::std::vector< int32_t > >();
+        const ::std::vector< int32_t > empty_list_field = {};
+        const ::std::vector< int32_t > values_list_field = {1, 2, 3};
+        const std::optional< ::std::unordered_map< int32_t, ::std::string > > nullable_map_field = std::optional< ::std::unordered_map< int32_t, ::std::string > >();
+        const ::std::unordered_map< int32_t, ::std::string > empty_map_field = {};
+        const ::std::unordered_map< int32_t, ::std::string > values_map_field = {{9, "baz"}, {27, "bar"}};
+        const std::optional< ::std::unordered_set< ::std::string > > nullable_set_field = std::optional< ::std::unordered_set< ::std::string > >();
+        const ::std::unordered_set< ::std::string > empty_set_field = {};
+        const ::std::unordered_set< ::std::string > values_set_field = {"bar", "baz"};
+
+        ImmutableStructWithCollections( );
+        ImmutableStructWithCollections( std::optional< ::std::vector< int32_t > > nullable_list_field, ::std::vector< int32_t > empty_list_field, ::std::vector< int32_t > values_list_field, std::optional< ::std::unordered_map< int32_t, ::std::string > > nullable_map_field, ::std::unordered_map< int32_t, ::std::string > empty_map_field, ::std::unordered_map< int32_t, ::std::string > values_map_field, std::optional< ::std::unordered_set< ::std::string > > nullable_set_field, ::std::unordered_set< ::std::string > empty_set_field, ::std::unordered_set< ::std::string > values_set_field );
+
+    };
+
+    struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithFieldConstructorAndCollections {
+        const std::optional< ::std::vector< int32_t > > nullable_list_field = std::optional< ::std::vector< int32_t > >();
+        const ::std::vector< int32_t > empty_list_field = {};
+        const ::std::vector< int32_t > values_list_field = {1, 2, 3};
+        const std::optional< ::std::unordered_map< int32_t, ::std::string > > nullable_map_field = std::optional< ::std::unordered_map< int32_t, ::std::string > >();
+        const ::std::unordered_map< int32_t, ::std::string > empty_map_field = {};
+        const ::std::unordered_map< int32_t, ::std::string > values_map_field = {{9, "baz"}, {27, "bar"}};
+        const std::optional< ::std::unordered_set< ::std::string > > nullable_set_field = std::optional< ::std::unordered_set< ::std::string > >();
+        const ::std::unordered_set< ::std::string > empty_set_field = {};
+        const ::std::unordered_set< ::std::string > values_set_field = {"bar", "baz"};
+        const int32_t some_field = 5;
+        const int32_t another_field = 7;
+
+        ImmutableStructWithFieldConstructorAndCollections( );
+
+        ImmutableStructWithFieldConstructorAndCollections( int32_t some_field, int32_t another_field );
+
+        ImmutableStructWithFieldConstructorAndCollections( std::optional< ::std::vector< int32_t > > nullable_list_field, ::std::vector< int32_t > empty_list_field, ::std::vector< int32_t > values_list_field, std::optional< ::std::unordered_map< int32_t, ::std::string > > nullable_map_field, ::std::unordered_map< int32_t, ::std::string > empty_map_field, ::std::unordered_map< int32_t, ::std::string > values_map_field, std::optional< ::std::unordered_set< ::std::string > > nullable_set_field, ::std::unordered_set< ::std::string > empty_set_field, ::std::unordered_set< ::std::string > values_set_field, int32_t some_field, int32_t another_field );
+
+    };
+
 };
+
+
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_nullable_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_nullable_collection_defaults.dart
@@ -1,0 +1,111 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/generic_types__conversion.dart';
+
+
+class StructWithNullableCollectionDefaults {
+  List<String>? nullableListField;
+
+  Map<String, String>? nullableMapField;
+
+  Set<String>? nullableSetField;
+
+  StructWithNullableCollectionDefaults([List<String>? nullableListField = const null, Map<String, String>? nullableMapField = const null, Set<String>? nullableSetField = const null])
+    : nullableListField = nullableListField, nullableMapField = nullableMapField, nullableSetField = nullableSetField;
+}
+
+
+// StructWithNullableCollectionDefaults "private" section, not exported.
+
+final _smokeStructwithnullablecollectiondefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_create_handle'));
+final _smokeStructwithnullablecollectiondefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_release_handle'));
+final _smokeStructwithnullablecollectiondefaultsGetFieldnullableListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_get_field_nullableListField'));
+final _smokeStructwithnullablecollectiondefaultsGetFieldnullableMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_get_field_nullableMapField'));
+final _smokeStructwithnullablecollectiondefaultsGetFieldnullableSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_get_field_nullableSetField'));
+
+
+
+Pointer<Void> smokeStructwithnullablecollectiondefaultsToFfi(StructWithNullableCollectionDefaults value) {
+  final _nullableListFieldHandle = foobarListofStringToFfiNullable(value.nullableListField);
+  final _nullableMapFieldHandle = foobarMapofStringToStringToFfiNullable(value.nullableMapField);
+  final _nullableSetFieldHandle = foobarSetofStringToFfiNullable(value.nullableSetField);
+  final _result = _smokeStructwithnullablecollectiondefaultsCreateHandle(_nullableListFieldHandle, _nullableMapFieldHandle, _nullableSetFieldHandle);
+  foobarListofStringReleaseFfiHandleNullable(_nullableListFieldHandle);
+  foobarMapofStringToStringReleaseFfiHandleNullable(_nullableMapFieldHandle);
+  foobarSetofStringReleaseFfiHandleNullable(_nullableSetFieldHandle);
+  return _result;
+}
+
+StructWithNullableCollectionDefaults smokeStructwithnullablecollectiondefaultsFromFfi(Pointer<Void> handle) {
+  final _nullableListFieldHandle = _smokeStructwithnullablecollectiondefaultsGetFieldnullableListField(handle);
+  final _nullableMapFieldHandle = _smokeStructwithnullablecollectiondefaultsGetFieldnullableMapField(handle);
+  final _nullableSetFieldHandle = _smokeStructwithnullablecollectiondefaultsGetFieldnullableSetField(handle);
+  try {
+    return StructWithNullableCollectionDefaults(
+      foobarListofStringFromFfiNullable(_nullableListFieldHandle), 
+      foobarMapofStringToStringFromFfiNullable(_nullableMapFieldHandle), 
+      foobarSetofStringFromFfiNullable(_nullableSetFieldHandle)
+    );
+  } finally {
+    foobarListofStringReleaseFfiHandleNullable(_nullableListFieldHandle);
+    foobarMapofStringToStringReleaseFfiHandleNullable(_nullableMapFieldHandle);
+    foobarSetofStringReleaseFfiHandleNullable(_nullableSetFieldHandle);
+  }
+}
+
+void smokeStructwithnullablecollectiondefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeStructwithnullablecollectiondefaultsReleaseHandle(handle);
+
+// Nullable StructWithNullableCollectionDefaults
+
+final _smokeStructwithnullablecollectiondefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_create_handle_nullable'));
+final _smokeStructwithnullablecollectiondefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_release_handle_nullable'));
+final _smokeStructwithnullablecollectiondefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_StructWithNullableCollectionDefaults_get_value_nullable'));
+
+Pointer<Void> smokeStructwithnullablecollectiondefaultsToFfiNullable(StructWithNullableCollectionDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeStructwithnullablecollectiondefaultsToFfi(value);
+  final result = _smokeStructwithnullablecollectiondefaultsCreateHandleNullable(_handle);
+  smokeStructwithnullablecollectiondefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+
+StructWithNullableCollectionDefaults? smokeStructwithnullablecollectiondefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeStructwithnullablecollectiondefaultsGetValueNullable(handle);
+  final result = smokeStructwithnullablecollectiondefaultsFromFfi(_handle);
+  smokeStructwithnullablecollectiondefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeStructwithnullablecollectiondefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeStructwithnullablecollectiondefaultsReleaseHandleNullable(handle);
+
+// End of StructWithNullableCollectionDefaults "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_nullable_collection_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/struct_with_nullable_collection_defaults.dart
@@ -12,7 +12,7 @@ class StructWithNullableCollectionDefaults {
 
   Set<String>? nullableSetField;
 
-  StructWithNullableCollectionDefaults([List<String>? nullableListField = const null, Map<String, String>? nullableMapField = const null, Set<String>? nullableSetField = const null])
+  StructWithNullableCollectionDefaults([List<String>? nullableListField = null, Map<String, String>? nullableMapField = null, Set<String>? nullableSetField = null])
     : nullableListField = nullableListField, nullableMapField = nullableMapField, nullableSetField = nullableSetField;
 }
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -306,7 +306,7 @@ class TypesWithDefaults_ImmutableStructWithCollections {
 
   const TypesWithDefaults_ImmutableStructWithCollections(this.nullableListField, this.emptyListField, this.valuesListField, this.nullableMapField, this.emptyMapField, this.valuesMapField, this.nullableSetField, this.emptySetField, this.valuesSetField);
   const TypesWithDefaults_ImmutableStructWithCollections.withDefaults()
-    : nullableListField = null, emptyListField = [], valuesListField = [1, 2, 3], nullableMapField = null, emptyMapField = {}, valuesMapField = {9: "baz", 27: "bar"}, nullableSetField = null, emptySetField = {}, valuesSetField = {"bar", "baz"};
+    : nullableListField = null, emptyListField = const [], valuesListField = const [1, 2, 3], nullableMapField = null, emptyMapField = const {}, valuesMapField = const {9: "baz", 27: "bar"}, nullableSetField = null, emptySetField = const {}, valuesSetField = const {"bar", "baz"};
 }
 
 
@@ -480,7 +480,7 @@ class TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections {
 
   const TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections(this.nullableListField, this.emptyListField, this.valuesListField, this.nullableMapField, this.emptyMapField, this.valuesMapField, this.nullableSetField, this.emptySetField, this.valuesSetField, this.someField, this.anotherField);
   const TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections.withIntegers(this.someField, this.anotherField)
-      : nullableListField = null, emptyListField = [], valuesListField = [1, 2, 3], nullableMapField = null, emptyMapField = {}, valuesMapField = {9: "baz", 27: "bar"}, nullableSetField = null, emptySetField = {}, valuesSetField = {"bar", "baz"};
+      : nullableListField = null, emptyListField = const [], valuesListField = const [1, 2, 3], nullableMapField = null, emptyMapField = const {}, valuesMapField = const {9: "baz", 27: "bar"}, nullableSetField = null, emptySetField = const {}, valuesSetField = const {"bar", "baz"};
 }
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -1,21 +1,37 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
+
+
 class TypesWithDefaults {
 }
+
+
 class TypesWithDefaults_StructWithDefaults {
   int intField;
+
   int uintField;
+
   double floatField;
+
   double doubleField;
+
   bool boolField;
+
   String stringField;
+
   TypesWithDefaults_StructWithDefaults._(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField);
   TypesWithDefaults_StructWithDefaults()
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n";
 }
+
+
 // TypesWithDefaults_StructWithDefaults "private" section, not exported.
+
 final _smokeTypeswithdefaultsStructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>)
@@ -48,6 +64,9 @@ final _smokeTypeswithdefaultsStructwithdefaultsGetFieldstringField = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_field_stringField'));
+
+
+
 Pointer<Void> smokeTypeswithdefaultsStructwithdefaultsToFfi(TypesWithDefaults_StructWithDefaults value) {
   final _intFieldHandle = (value.intField);
   final _uintFieldHandle = (value.uintField);
@@ -56,10 +75,15 @@ Pointer<Void> smokeTypeswithdefaultsStructwithdefaultsToFfi(TypesWithDefaults_St
   final _boolFieldHandle = booleanToFfi(value.boolField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeTypeswithdefaultsStructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle);
+  
+  
+  
+  
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 TypesWithDefaults_StructWithDefaults smokeTypeswithdefaultsStructwithdefaultsFromFfi(Pointer<Void> handle) {
   final _intFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldintField(handle);
   final _uintFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFielduintField(handle);
@@ -69,20 +93,27 @@ TypesWithDefaults_StructWithDefaults smokeTypeswithdefaultsStructwithdefaultsFro
   final _stringFieldHandle = _smokeTypeswithdefaultsStructwithdefaultsGetFieldstringField(handle);
   try {
     return TypesWithDefaults_StructWithDefaults._(
-      (_intFieldHandle),
-      (_uintFieldHandle),
-      (_floatFieldHandle),
-      (_doubleFieldHandle),
-      booleanFromFfi(_boolFieldHandle),
+      (_intFieldHandle), 
+      (_uintFieldHandle), 
+      (_floatFieldHandle), 
+      (_doubleFieldHandle), 
+      booleanFromFfi(_boolFieldHandle), 
       stringFromFfi(_stringFieldHandle)
     );
   } finally {
+    
+    
+    
+    
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeTypeswithdefaultsStructwithdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsStructwithdefaultsReleaseHandle(handle);
+
 // Nullable TypesWithDefaults_StructWithDefaults
+
 final _smokeTypeswithdefaultsStructwithdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -95,6 +126,7 @@ final _smokeTypeswithdefaultsStructwithdefaultsGetValueNullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_StructWithDefaults_get_value_nullable'));
+
 Pointer<Void> smokeTypeswithdefaultsStructwithdefaultsToFfiNullable(TypesWithDefaults_StructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeTypeswithdefaultsStructwithdefaultsToFfi(value);
@@ -102,6 +134,7 @@ Pointer<Void> smokeTypeswithdefaultsStructwithdefaultsToFfiNullable(TypesWithDef
   smokeTypeswithdefaultsStructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 TypesWithDefaults_StructWithDefaults? smokeTypeswithdefaultsStructwithdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeTypeswithdefaultsStructwithdefaultsGetValueNullable(handle);
@@ -109,22 +142,33 @@ TypesWithDefaults_StructWithDefaults? smokeTypeswithdefaultsStructwithdefaultsFr
   smokeTypeswithdefaultsStructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeTypeswithdefaultsStructwithdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeTypeswithdefaultsStructwithdefaultsReleaseHandleNullable(handle);
+
 // End of TypesWithDefaults_StructWithDefaults "private" section.
 @immutable
 class TypesWithDefaults_ImmutableStructWithDefaults {
   final int intField;
+
   final int uintField;
+
   final double floatField;
+
   final double doubleField;
+
   final bool boolField;
+
   final String stringField;
+
   const TypesWithDefaults_ImmutableStructWithDefaults(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField);
   const TypesWithDefaults_ImmutableStructWithDefaults.withDefaults(int uintField, bool boolField)
     : intField = 42, uintField = uintField, floatField = 3.14, doubleField = -1.4142, boolField = boolField, stringField = "\\Jonny \"Magic\" Smith\n";
 }
+
+
 // TypesWithDefaults_ImmutableStructWithDefaults "private" section, not exported.
+
 final _smokeTypeswithdefaultsImmutablestructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>)
@@ -157,6 +201,9 @@ final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldstringField = __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_field_stringField'));
+
+
+
 Pointer<Void> smokeTypeswithdefaultsImmutablestructwithdefaultsToFfi(TypesWithDefaults_ImmutableStructWithDefaults value) {
   final _intFieldHandle = (value.intField);
   final _uintFieldHandle = (value.uintField);
@@ -165,10 +212,15 @@ Pointer<Void> smokeTypeswithdefaultsImmutablestructwithdefaultsToFfi(TypesWithDe
   final _boolFieldHandle = booleanToFfi(value.boolField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeTypeswithdefaultsImmutablestructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle);
+  
+  
+  
+  
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 TypesWithDefaults_ImmutableStructWithDefaults smokeTypeswithdefaultsImmutablestructwithdefaultsFromFfi(Pointer<Void> handle) {
   final _intFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldintField(handle);
   final _uintFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFielduintField(handle);
@@ -178,20 +230,27 @@ TypesWithDefaults_ImmutableStructWithDefaults smokeTypeswithdefaultsImmutablestr
   final _stringFieldHandle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetFieldstringField(handle);
   try {
     return TypesWithDefaults_ImmutableStructWithDefaults(
-      (_intFieldHandle),
-      (_uintFieldHandle),
-      (_floatFieldHandle),
-      (_doubleFieldHandle),
-      booleanFromFfi(_boolFieldHandle),
+      (_intFieldHandle), 
+      (_uintFieldHandle), 
+      (_floatFieldHandle), 
+      (_doubleFieldHandle), 
+      booleanFromFfi(_boolFieldHandle), 
       stringFromFfi(_stringFieldHandle)
     );
   } finally {
+    
+    
+    
+    
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseHandle(handle);
+
 // Nullable TypesWithDefaults_ImmutableStructWithDefaults
+
 final _smokeTypeswithdefaultsImmutablestructwithdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -204,6 +263,7 @@ final _smokeTypeswithdefaultsImmutablestructwithdefaultsGetValueNullable = __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_ImmutableStructWithDefaults_get_value_nullable'));
+
 Pointer<Void> smokeTypeswithdefaultsImmutablestructwithdefaultsToFfiNullable(TypesWithDefaults_ImmutableStructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeTypeswithdefaultsImmutablestructwithdefaultsToFfi(value);
@@ -211,6 +271,7 @@ Pointer<Void> smokeTypeswithdefaultsImmutablestructwithdefaultsToFfiNullable(Typ
   smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 TypesWithDefaults_ImmutableStructWithDefaults? smokeTypeswithdefaultsImmutablestructwithdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeTypeswithdefaultsImmutablestructwithdefaultsGetValueNullable(handle);
@@ -218,10 +279,376 @@ TypesWithDefaults_ImmutableStructWithDefaults? smokeTypeswithdefaultsImmutablest
   smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeTypeswithdefaultsImmutablestructwithdefaultsReleaseHandleNullable(handle);
+
 // End of TypesWithDefaults_ImmutableStructWithDefaults "private" section.
+@immutable
+class TypesWithDefaults_ImmutableStructWithCollections {
+  final List<int>? nullableListField;
+
+  final List<int> emptyListField;
+
+  final List<int> valuesListField;
+
+  final Map<int, String>? nullableMapField;
+
+  final Map<int, String> emptyMapField;
+
+  final Map<int, String> valuesMapField;
+
+  final Set<String>? nullableSetField;
+
+  final Set<String> emptySetField;
+
+  final Set<String> valuesSetField;
+
+  const TypesWithDefaults_ImmutableStructWithCollections(this.nullableListField, this.emptyListField, this.valuesListField, this.nullableMapField, this.emptyMapField, this.valuesMapField, this.nullableSetField, this.emptySetField, this.valuesSetField);
+  const TypesWithDefaults_ImmutableStructWithCollections.withDefaults()
+    : nullableListField = null, emptyListField = [], valuesListField = [1, 2, 3], nullableMapField = null, emptyMapField = {}, valuesMapField = {9: "baz", 27: "bar"}, nullableSetField = null, emptySetField = {}, valuesSetField = {"bar", "baz"};
+}
+
+
+// TypesWithDefaults_ImmutableStructWithCollections "private" section, not exported.
+
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_create_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_release_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldnullableListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_nullableListField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldemptyListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_emptyListField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldvaluesListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_valuesListField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldnullableMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_nullableMapField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldemptyMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_emptyMapField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldvaluesMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_valuesMapField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldnullableSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_nullableSetField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldemptySetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_emptySetField'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldvaluesSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_field_valuesSetField'));
+
+
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithcollectionsToFfi(TypesWithDefaults_ImmutableStructWithCollections value) {
+  final _nullableListFieldHandle = foobarListofIntToFfiNullable(value.nullableListField);
+  final _emptyListFieldHandle = foobarListofIntToFfi(value.emptyListField);
+  final _valuesListFieldHandle = foobarListofIntToFfi(value.valuesListField);
+  final _nullableMapFieldHandle = foobarMapofIntToStringToFfiNullable(value.nullableMapField);
+  final _emptyMapFieldHandle = foobarMapofIntToStringToFfi(value.emptyMapField);
+  final _valuesMapFieldHandle = foobarMapofIntToStringToFfi(value.valuesMapField);
+  final _nullableSetFieldHandle = foobarSetofStringToFfiNullable(value.nullableSetField);
+  final _emptySetFieldHandle = foobarSetofStringToFfi(value.emptySetField);
+  final _valuesSetFieldHandle = foobarSetofStringToFfi(value.valuesSetField);
+  final _result = _smokeTypeswithdefaultsImmutablestructwithcollectionsCreateHandle(_nullableListFieldHandle, _emptyListFieldHandle, _valuesListFieldHandle, _nullableMapFieldHandle, _emptyMapFieldHandle, _valuesMapFieldHandle, _nullableSetFieldHandle, _emptySetFieldHandle, _valuesSetFieldHandle);
+  foobarListofIntReleaseFfiHandleNullable(_nullableListFieldHandle);
+  foobarListofIntReleaseFfiHandle(_emptyListFieldHandle);
+  foobarListofIntReleaseFfiHandle(_valuesListFieldHandle);
+  foobarMapofIntToStringReleaseFfiHandleNullable(_nullableMapFieldHandle);
+  foobarMapofIntToStringReleaseFfiHandle(_emptyMapFieldHandle);
+  foobarMapofIntToStringReleaseFfiHandle(_valuesMapFieldHandle);
+  foobarSetofStringReleaseFfiHandleNullable(_nullableSetFieldHandle);
+  foobarSetofStringReleaseFfiHandle(_emptySetFieldHandle);
+  foobarSetofStringReleaseFfiHandle(_valuesSetFieldHandle);
+  return _result;
+}
+
+TypesWithDefaults_ImmutableStructWithCollections smokeTypeswithdefaultsImmutablestructwithcollectionsFromFfi(Pointer<Void> handle) {
+  final _nullableListFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldnullableListField(handle);
+  final _emptyListFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldemptyListField(handle);
+  final _valuesListFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldvaluesListField(handle);
+  final _nullableMapFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldnullableMapField(handle);
+  final _emptyMapFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldemptyMapField(handle);
+  final _valuesMapFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldvaluesMapField(handle);
+  final _nullableSetFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldnullableSetField(handle);
+  final _emptySetFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldemptySetField(handle);
+  final _valuesSetFieldHandle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetFieldvaluesSetField(handle);
+  try {
+    return TypesWithDefaults_ImmutableStructWithCollections(
+      foobarListofIntFromFfiNullable(_nullableListFieldHandle), 
+      foobarListofIntFromFfi(_emptyListFieldHandle), 
+      foobarListofIntFromFfi(_valuesListFieldHandle), 
+      foobarMapofIntToStringFromFfiNullable(_nullableMapFieldHandle), 
+      foobarMapofIntToStringFromFfi(_emptyMapFieldHandle), 
+      foobarMapofIntToStringFromFfi(_valuesMapFieldHandle), 
+      foobarSetofStringFromFfiNullable(_nullableSetFieldHandle), 
+      foobarSetofStringFromFfi(_emptySetFieldHandle), 
+      foobarSetofStringFromFfi(_valuesSetFieldHandle)
+    );
+  } finally {
+    foobarListofIntReleaseFfiHandleNullable(_nullableListFieldHandle);
+    foobarListofIntReleaseFfiHandle(_emptyListFieldHandle);
+    foobarListofIntReleaseFfiHandle(_valuesListFieldHandle);
+    foobarMapofIntToStringReleaseFfiHandleNullable(_nullableMapFieldHandle);
+    foobarMapofIntToStringReleaseFfiHandle(_emptyMapFieldHandle);
+    foobarMapofIntToStringReleaseFfiHandle(_valuesMapFieldHandle);
+    foobarSetofStringReleaseFfiHandleNullable(_nullableSetFieldHandle);
+    foobarSetofStringReleaseFfiHandle(_emptySetFieldHandle);
+    foobarSetofStringReleaseFfiHandle(_valuesSetFieldHandle);
+  }
+}
+
+void smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseHandle(handle);
+
+// Nullable TypesWithDefaults_ImmutableStructWithCollections
+
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_create_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_release_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithcollectionsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithCollections_get_value_nullable'));
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithcollectionsToFfiNullable(TypesWithDefaults_ImmutableStructWithCollections? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeTypeswithdefaultsImmutablestructwithcollectionsToFfi(value);
+  final result = _smokeTypeswithdefaultsImmutablestructwithcollectionsCreateHandleNullable(_handle);
+  smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandle(_handle);
+  return result;
+}
+
+TypesWithDefaults_ImmutableStructWithCollections? smokeTypeswithdefaultsImmutablestructwithcollectionsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeTypeswithdefaultsImmutablestructwithcollectionsGetValueNullable(handle);
+  final result = smokeTypeswithdefaultsImmutablestructwithcollectionsFromFfi(_handle);
+  smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseHandleNullable(handle);
+
+// End of TypesWithDefaults_ImmutableStructWithCollections "private" section.
+@immutable
+class TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections {
+  final List<int>? nullableListField;
+
+  final List<int> emptyListField;
+
+  final List<int> valuesListField;
+
+  final Map<int, String>? nullableMapField;
+
+  final Map<int, String> emptyMapField;
+
+  final Map<int, String> valuesMapField;
+
+  final Set<String>? nullableSetField;
+
+  final Set<String> emptySetField;
+
+  final Set<String> valuesSetField;
+
+  final int someField;
+
+  final int anotherField;
+
+  const TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections(this.nullableListField, this.emptyListField, this.valuesListField, this.nullableMapField, this.emptyMapField, this.valuesMapField, this.nullableSetField, this.emptySetField, this.valuesSetField, this.someField, this.anotherField);
+  const TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections.withIntegers(this.someField, this.anotherField)
+      : nullableListField = null, emptyListField = [], valuesListField = [1, 2, 3], nullableMapField = null, emptyMapField = {}, valuesMapField = {9: "baz", 27: "bar"}, nullableSetField = null, emptySetField = {}, valuesSetField = {"bar", "baz"};
+}
+
+
+// TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections "private" section, not exported.
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Int32, Int32),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, int, int)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_create_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_release_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldnullableListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_nullableListField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldemptyListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_emptyListField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldvaluesListField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_valuesListField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldnullableMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_nullableMapField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldemptyMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_emptyMapField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldvaluesMapField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_valuesMapField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldnullableSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_nullableSetField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldemptySetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_emptySetField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldvaluesSetField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_valuesSetField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_someField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldanotherField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_field_anotherField'));
+
+
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsToFfi(TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections value) {
+  final _nullableListFieldHandle = foobarListofIntToFfiNullable(value.nullableListField);
+  final _emptyListFieldHandle = foobarListofIntToFfi(value.emptyListField);
+  final _valuesListFieldHandle = foobarListofIntToFfi(value.valuesListField);
+  final _nullableMapFieldHandle = foobarMapofIntToStringToFfiNullable(value.nullableMapField);
+  final _emptyMapFieldHandle = foobarMapofIntToStringToFfi(value.emptyMapField);
+  final _valuesMapFieldHandle = foobarMapofIntToStringToFfi(value.valuesMapField);
+  final _nullableSetFieldHandle = foobarSetofStringToFfiNullable(value.nullableSetField);
+  final _emptySetFieldHandle = foobarSetofStringToFfi(value.emptySetField);
+  final _valuesSetFieldHandle = foobarSetofStringToFfi(value.valuesSetField);
+  final _someFieldHandle = (value.someField);
+  final _anotherFieldHandle = (value.anotherField);
+  final _result = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsCreateHandle(_nullableListFieldHandle, _emptyListFieldHandle, _valuesListFieldHandle, _nullableMapFieldHandle, _emptyMapFieldHandle, _valuesMapFieldHandle, _nullableSetFieldHandle, _emptySetFieldHandle, _valuesSetFieldHandle, _someFieldHandle, _anotherFieldHandle);
+  foobarListofIntReleaseFfiHandleNullable(_nullableListFieldHandle);
+  foobarListofIntReleaseFfiHandle(_emptyListFieldHandle);
+  foobarListofIntReleaseFfiHandle(_valuesListFieldHandle);
+  foobarMapofIntToStringReleaseFfiHandleNullable(_nullableMapFieldHandle);
+  foobarMapofIntToStringReleaseFfiHandle(_emptyMapFieldHandle);
+  foobarMapofIntToStringReleaseFfiHandle(_valuesMapFieldHandle);
+  foobarSetofStringReleaseFfiHandleNullable(_nullableSetFieldHandle);
+  foobarSetofStringReleaseFfiHandle(_emptySetFieldHandle);
+  foobarSetofStringReleaseFfiHandle(_valuesSetFieldHandle);
+  
+  
+  return _result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsFromFfi(Pointer<Void> handle) {
+  final _nullableListFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldnullableListField(handle);
+  final _emptyListFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldemptyListField(handle);
+  final _valuesListFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldvaluesListField(handle);
+  final _nullableMapFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldnullableMapField(handle);
+  final _emptyMapFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldemptyMapField(handle);
+  final _valuesMapFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldvaluesMapField(handle);
+  final _nullableSetFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldnullableSetField(handle);
+  final _emptySetFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldemptySetField(handle);
+  final _valuesSetFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldvaluesSetField(handle);
+  final _someFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldsomeField(handle);
+  final _anotherFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetFieldanotherField(handle);
+  try {
+    return TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections(
+      foobarListofIntFromFfiNullable(_nullableListFieldHandle), 
+      foobarListofIntFromFfi(_emptyListFieldHandle), 
+      foobarListofIntFromFfi(_valuesListFieldHandle), 
+      foobarMapofIntToStringFromFfiNullable(_nullableMapFieldHandle), 
+      foobarMapofIntToStringFromFfi(_emptyMapFieldHandle), 
+      foobarMapofIntToStringFromFfi(_valuesMapFieldHandle), 
+      foobarSetofStringFromFfiNullable(_nullableSetFieldHandle), 
+      foobarSetofStringFromFfi(_emptySetFieldHandle), 
+      foobarSetofStringFromFfi(_valuesSetFieldHandle), 
+      (_someFieldHandle), 
+      (_anotherFieldHandle)
+    );
+  } finally {
+    foobarListofIntReleaseFfiHandleNullable(_nullableListFieldHandle);
+    foobarListofIntReleaseFfiHandle(_emptyListFieldHandle);
+    foobarListofIntReleaseFfiHandle(_valuesListFieldHandle);
+    foobarMapofIntToStringReleaseFfiHandleNullable(_nullableMapFieldHandle);
+    foobarMapofIntToStringReleaseFfiHandle(_emptyMapFieldHandle);
+    foobarMapofIntToStringReleaseFfiHandle(_valuesMapFieldHandle);
+    foobarSetofStringReleaseFfiHandleNullable(_nullableSetFieldHandle);
+    foobarSetofStringReleaseFfiHandle(_emptySetFieldHandle);
+    foobarSetofStringReleaseFfiHandle(_valuesSetFieldHandle);
+    
+    
+  }
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseHandle(handle);
+
+// Nullable TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_create_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_release_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_get_value_nullable'));
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsToFfiNullable(TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsToFfi(value);
+  final result = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsCreateHandleNullable(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseFfiHandle(_handle);
+  return result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections? smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsGetValueNullable(handle);
+  final result = smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsFromFfi(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseHandleNullable(handle);
+
+// End of TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections "private" section.
+
 // TypesWithDefaults "private" section, not exported.
+
 final _smokeTypeswithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -230,10 +657,14 @@ final _smokeTypeswithdefaultsReleaseHandle = __lib.catchArgumentError(() => __li
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_release_handle'));
+
+
+
 Pointer<Void> smokeTypeswithdefaultsToFfi(TypesWithDefaults value) {
   final _result = _smokeTypeswithdefaultsCreateHandle();
   return _result;
 }
+
 TypesWithDefaults smokeTypeswithdefaultsFromFfi(Pointer<Void> handle) {
   try {
     return TypesWithDefaults(
@@ -241,8 +672,11 @@ TypesWithDefaults smokeTypeswithdefaultsFromFfi(Pointer<Void> handle) {
   } finally {
   }
 }
+
 void smokeTypeswithdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsReleaseHandle(handle);
+
 // Nullable TypesWithDefaults
+
 final _smokeTypeswithdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -255,6 +689,7 @@ final _smokeTypeswithdefaultsGetValueNullable = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypesWithDefaults_get_value_nullable'));
+
 Pointer<Void> smokeTypeswithdefaultsToFfiNullable(TypesWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeTypeswithdefaultsToFfi(value);
@@ -262,6 +697,7 @@ Pointer<Void> smokeTypeswithdefaultsToFfiNullable(TypesWithDefaults? value) {
   smokeTypeswithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 TypesWithDefaults? smokeTypeswithdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeTypeswithdefaultsGetValueNullable(handle);
@@ -269,6 +705,10 @@ TypesWithDefaults? smokeTypeswithdefaultsFromFfiNullable(Pointer<Void> handle) {
   smokeTypeswithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeTypeswithdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeTypeswithdefaultsReleaseHandleNullable(handle);
+
 // End of TypesWithDefaults "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/TypesWithDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/TypesWithDefaults.swift
@@ -1,14 +1,24 @@
 //
+
 //
+
 import Foundation
+
 public struct TypesWithDefaults {
     public struct StructWithDefaults {
+
         public var intField: Int32
+
         public var uintField: UInt32
+
         public var floatField: Float
+
         public var doubleField: Double
+
         public var boolField: Bool
+
         public var stringField: String
+
         public init(intField: Int32 = 42, uintField: UInt32 = 4294967295, floatField: Float = 3.14, doubleField: Double = -1.4142, boolField: Bool = true, stringField: String = "\\Jonny \"Magic\" Smith\n") {
             self.intField = intField
             self.uintField = uintField
@@ -26,13 +36,22 @@ public struct TypesWithDefaults {
             stringField = moveFromCType(smoke_TypesWithDefaults_StructWithDefaults_stringField_get(cHandle))
         }
     }
+
+
     public struct ImmutableStructWithDefaults {
+
         public let intField: Int32
+
         public let uintField: UInt32
+
         public let floatField: Float
+
         public let doubleField: Double
+
         public let boolField: Bool
+
         public let stringField: String
+
         public init(intField: Int32 = 42, uintField: UInt32, floatField: Float = 3.14, doubleField: Double = -1.4142, boolField: Bool, stringField: String = "\\Jonny \"Magic\" Smith\n") {
             self.intField = intField
             self.uintField = uintField
@@ -50,7 +69,125 @@ public struct TypesWithDefaults {
             stringField = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithDefaults_stringField_get(cHandle))
         }
     }
+
+
+    public struct ImmutableStructWithCollections {
+
+        public let nullableListField: [Int32]?
+
+        public let emptyListField: [Int32]
+
+        public let valuesListField: [Int32]
+
+        public let nullableMapField: [Int32: String]?
+
+        public let emptyMapField: [Int32: String]
+
+        public let valuesMapField: [Int32: String]
+
+        public let nullableSetField: Set<String>?
+
+        public let emptySetField: Set<String>
+
+        public let valuesSetField: Set<String>
+
+        public init(nullableListField: [Int32]? = nil, emptyListField: [Int32] = [], valuesListField: [Int32] = [1, 2, 3], nullableMapField: [Int32: String]? = nil, emptyMapField: [Int32: String] = [:], valuesMapField: [Int32: String] = [9: "baz", 27: "bar"], nullableSetField: Set<String>? = nil, emptySetField: Set<String> = [], valuesSetField: Set<String> = ["bar", "baz"]) {
+            self.nullableListField = nullableListField
+            self.emptyListField = emptyListField
+            self.valuesListField = valuesListField
+            self.nullableMapField = nullableMapField
+            self.emptyMapField = emptyMapField
+            self.valuesMapField = valuesMapField
+            self.nullableSetField = nullableSetField
+            self.emptySetField = emptySetField
+            self.valuesSetField = valuesSetField
+        }
+        internal init(cHandle: _baseRef) {
+            nullableListField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_nullableListField_get(cHandle))
+            emptyListField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_emptyListField_get(cHandle))
+            valuesListField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_valuesListField_get(cHandle))
+            nullableMapField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_nullableMapField_get(cHandle))
+            emptyMapField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_emptyMapField_get(cHandle))
+            valuesMapField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_valuesMapField_get(cHandle))
+            nullableSetField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_nullableSetField_get(cHandle))
+            emptySetField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_emptySetField_get(cHandle))
+            valuesSetField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithCollections_valuesSetField_get(cHandle))
+        }
+    }
+
+
+    public struct ImmutableStructWithFieldConstructorAndCollections {
+
+        public let nullableListField: [Int32]?
+
+        public let emptyListField: [Int32]
+
+        public let valuesListField: [Int32]
+
+        public let nullableMapField: [Int32: String]?
+
+        public let emptyMapField: [Int32: String]
+
+        public let valuesMapField: [Int32: String]
+
+        public let nullableSetField: Set<String>?
+
+        public let emptySetField: Set<String>
+
+        public let valuesSetField: Set<String>
+
+        public let someField: Int32
+
+        public let anotherField: Int32
+
+
+        public init(someField: Int32, anotherField: Int32) {
+            self.someField = someField
+            self.anotherField = anotherField
+            self.nullableListField = nil
+            self.emptyListField = []
+            self.valuesListField = [1, 2, 3]
+            self.nullableMapField = nil
+            self.emptyMapField = [:]
+            self.valuesMapField = [9: "baz", 27: "bar"]
+            self.nullableSetField = nil
+            self.emptySetField = []
+            self.valuesSetField = ["bar", "baz"]
+        }
+
+        public init(nullableListField: [Int32]? = nil, emptyListField: [Int32] = [], valuesListField: [Int32] = [1, 2, 3], nullableMapField: [Int32: String]? = nil, emptyMapField: [Int32: String] = [:], valuesMapField: [Int32: String] = [9: "baz", 27: "bar"], nullableSetField: Set<String>? = nil, emptySetField: Set<String> = [], valuesSetField: Set<String> = ["bar", "baz"], someField: Int32 = 5, anotherField: Int32 = 7) {
+            self.nullableListField = nullableListField
+            self.emptyListField = emptyListField
+            self.valuesListField = valuesListField
+            self.nullableMapField = nullableMapField
+            self.emptyMapField = emptyMapField
+            self.valuesMapField = valuesMapField
+            self.nullableSetField = nullableSetField
+            self.emptySetField = emptySetField
+            self.valuesSetField = valuesSetField
+            self.someField = someField
+            self.anotherField = anotherField
+        }
+        internal init(cHandle: _baseRef) {
+            nullableListField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_nullableListField_get(cHandle))
+            emptyListField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_emptyListField_get(cHandle))
+            valuesListField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_valuesListField_get(cHandle))
+            nullableMapField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_nullableMapField_get(cHandle))
+            emptyMapField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_emptyMapField_get(cHandle))
+            valuesMapField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_valuesMapField_get(cHandle))
+            nullableSetField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_nullableSetField_get(cHandle))
+            emptySetField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_emptySetField_get(cHandle))
+            valuesSetField = foobar_moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_valuesSetField_get(cHandle))
+            someField = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_someField_get(cHandle))
+            anotherField = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_anotherField_get(cHandle))
+        }
+    }
+
+
 }
+
+
+
 internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.StructWithDefaults {
     return TypesWithDefaults.StructWithDefaults(cHandle: handle)
 }
@@ -60,6 +197,7 @@ internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.StructWithD
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: TypesWithDefaults.StructWithDefaults) -> RefHolder {
     let c_intField = moveToCType(swiftType.intField)
     let c_uintField = moveToCType(swiftType.uintField)
@@ -85,6 +223,7 @@ internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.StructWithD
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: TypesWithDefaults.StructWithDefaults?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -100,6 +239,7 @@ internal func copyToCType(_ swiftType: TypesWithDefaults.StructWithDefaults?) ->
 internal func moveToCType(_ swiftType: TypesWithDefaults.StructWithDefaults?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_StructWithDefaults_release_optional_handle)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithDefaults {
     return TypesWithDefaults.ImmutableStructWithDefaults(cHandle: handle)
 }
@@ -109,6 +249,7 @@ internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableSt
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithDefaults) -> RefHolder {
     let c_intField = moveToCType(swiftType.intField)
     let c_uintField = moveToCType(swiftType.uintField)
@@ -134,6 +275,7 @@ internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableSt
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithDefaults?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -149,3 +291,126 @@ internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithDefa
 internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithDefaults?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithDefaults_release_optional_handle)
 }
+
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithCollections {
+    return TypesWithDefaults.ImmutableStructWithCollections(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithCollections {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithCollections_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithCollections) -> RefHolder {
+    let c_nullableListField = foobar_moveToCType(swiftType.nullableListField)
+    let c_emptyListField = foobar_moveToCType(swiftType.emptyListField)
+    let c_valuesListField = foobar_moveToCType(swiftType.valuesListField)
+    let c_nullableMapField = foobar_moveToCType(swiftType.nullableMapField)
+    let c_emptyMapField = foobar_moveToCType(swiftType.emptyMapField)
+    let c_valuesMapField = foobar_moveToCType(swiftType.valuesMapField)
+    let c_nullableSetField = foobar_moveToCType(swiftType.nullableSetField)
+    let c_emptySetField = foobar_moveToCType(swiftType.emptySetField)
+    let c_valuesSetField = foobar_moveToCType(swiftType.valuesSetField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithCollections_create_handle(c_nullableListField.ref, c_emptyListField.ref, c_valuesListField.ref, c_nullableMapField.ref, c_emptyMapField.ref, c_valuesMapField.ref, c_nullableSetField.ref, c_emptySetField.ref, c_valuesSetField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithCollections) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithCollections_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithCollections? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_TypesWithDefaults_ImmutableStructWithCollections_unwrap_optional_handle(handle)
+    return TypesWithDefaults.ImmutableStructWithCollections(cHandle: unwrappedHandle) as TypesWithDefaults.ImmutableStructWithCollections
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithCollections? {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithCollections_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithCollections?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_nullableListField = foobar_moveToCType(swiftType.nullableListField)
+    let c_emptyListField = foobar_moveToCType(swiftType.emptyListField)
+    let c_valuesListField = foobar_moveToCType(swiftType.valuesListField)
+    let c_nullableMapField = foobar_moveToCType(swiftType.nullableMapField)
+    let c_emptyMapField = foobar_moveToCType(swiftType.emptyMapField)
+    let c_valuesMapField = foobar_moveToCType(swiftType.valuesMapField)
+    let c_nullableSetField = foobar_moveToCType(swiftType.nullableSetField)
+    let c_emptySetField = foobar_moveToCType(swiftType.emptySetField)
+    let c_valuesSetField = foobar_moveToCType(swiftType.valuesSetField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithCollections_create_optional_handle(c_nullableListField.ref, c_emptyListField.ref, c_valuesListField.ref, c_nullableMapField.ref, c_emptyMapField.ref, c_valuesMapField.ref, c_nullableSetField.ref, c_emptySetField.ref, c_valuesSetField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithCollections?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithCollections_release_optional_handle)
+}
+
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections {
+    return TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections) -> RefHolder {
+    let c_nullableListField = foobar_moveToCType(swiftType.nullableListField)
+    let c_emptyListField = foobar_moveToCType(swiftType.emptyListField)
+    let c_valuesListField = foobar_moveToCType(swiftType.valuesListField)
+    let c_nullableMapField = foobar_moveToCType(swiftType.nullableMapField)
+    let c_emptyMapField = foobar_moveToCType(swiftType.emptyMapField)
+    let c_valuesMapField = foobar_moveToCType(swiftType.valuesMapField)
+    let c_nullableSetField = foobar_moveToCType(swiftType.nullableSetField)
+    let c_emptySetField = foobar_moveToCType(swiftType.emptySetField)
+    let c_valuesSetField = foobar_moveToCType(swiftType.valuesSetField)
+    let c_someField = moveToCType(swiftType.someField)
+    let c_anotherField = moveToCType(swiftType.anotherField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_create_handle(c_nullableListField.ref, c_emptyListField.ref, c_valuesListField.ref, c_nullableMapField.ref, c_emptyMapField.ref, c_valuesMapField.ref, c_nullableSetField.ref, c_emptySetField.ref, c_valuesSetField.ref, c_someField.ref, c_anotherField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_unwrap_optional_handle(handle)
+    return TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections(cHandle: unwrappedHandle) as TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections? {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_nullableListField = foobar_moveToCType(swiftType.nullableListField)
+    let c_emptyListField = foobar_moveToCType(swiftType.emptyListField)
+    let c_valuesListField = foobar_moveToCType(swiftType.valuesListField)
+    let c_nullableMapField = foobar_moveToCType(swiftType.nullableMapField)
+    let c_emptyMapField = foobar_moveToCType(swiftType.emptyMapField)
+    let c_valuesMapField = foobar_moveToCType(swiftType.valuesMapField)
+    let c_nullableSetField = foobar_moveToCType(swiftType.nullableSetField)
+    let c_emptySetField = foobar_moveToCType(swiftType.emptySetField)
+    let c_valuesSetField = foobar_moveToCType(swiftType.valuesSetField)
+    let c_someField = moveToCType(swiftType.someField)
+    let c_anotherField = moveToCType(swiftType.anotherField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_create_optional_handle(c_nullableListField.ref, c_emptyListField.ref, c_valuesListField.ref, c_nullableMapField.ref, c_emptyMapField.ref, c_valuesMapField.ref, c_nullableSetField.ref, c_emptySetField.ref, c_valuesSetField.ref, c_someField.ref, c_anotherField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_release_optional_handle)
+}
+
+
+


### PR DESCRIPTION
This series fixes problems that occur when either `@Immutable`
or `@PositionalDefaults` annotation is used in combination with
collection types.

-------- `@PositionalDefaults` --------
The usage of 'PositionalDefaults' annotation
combined with nullable collection field that has 'null'
default value yields the code that does not compile.

The generator blindly applies 'const' keyword before
the default value for collections. A special 'null' value is
not taken into account.

-------- `@Immutable` --------
Usage of 'Immutable' annotation combined
with collection fields that have default values yields the
code that does not compile.
    
The generator does not apply 'const' keyword before the calls
to constructors of collections. It is required, because the
constructor of 'Immutable' structure is marked as 'const'.
    
The same happens when an explicit field constructor is used.
Because of 'Immutable' usage it is marked as a const, but
the default values are not initialized with values prepended
by 'const'.


-------- Content of change --------
- New smoke and functional tests that were used to confirm
   the invalid behavior.
- Adjustments of 'DartStructConstructors.mustache' file to
   correctly prepend 'const' keyword when needed and to treat
   'null' as it should be treated.