### PR TITLE
Dart: fix problems with default values that use immutable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ### Features:
  * Implemented validation of comments used for functions. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
 ### Bug fixes:
- * Dart: fixed a bug related to missing/superflous 'const' keyword usage in definition of default values in constructors that used collections when `@Immutable` or `PositionalDefaults` were specified.
+ * Dart: fixed a bug related to missing 'const' keyword usage in definition of default values in constructors that used immutable structure types when `@Immutable` or `@PositionalDefaults` were specified.
+ * Dart: fixed a bug related to missing/superflous 'const' keyword usage in definition of default values in constructors that used collections when `@Immutable` or `@PositionalDefaults` were specified.
 
 ## 13.9.7
 Release date 2024-11-13

--- a/functional-tests/functional/input/lime/Defaults.lime
+++ b/functional-tests/functional/input/lime/Defaults.lime
@@ -77,6 +77,26 @@ class Defaults {
         @Dart("withIntegers")
         field constructor(someField, anotherField)
     }
+    @Immutable
+    struct SomeImmutableStructWithDefaults {
+        intField: Int = 42
+    }
+    @Immutable
+    struct ImmutableStructWithFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults = {}
+        someField2: ImmutableStructWithCollections = {}
+    }
+    @Immutable
+    struct ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults = {}
+        someField2: ImmutableStructWithCollections = {}
+
+        someField: Int = 5
+        anotherField: Int = 7
+
+        @Dart("withIntegers")
+        field constructor(someField, anotherField)
+    }
     struct StructWithSpecialDefaults {
         floatNanField: Float = NaN
         floatInfinityField: Float = Infinity

--- a/functional-tests/functional/input/lime/PositionalDefaults.lime
+++ b/functional-tests/functional/input/lime/PositionalDefaults.lime
@@ -60,6 +60,18 @@ struct StructWithNullableCollectionDefaults {
     nullableSetField: Set<String>? = null
 }
 
+@Immutable
+@Java(Skip) @Swift(Skip)
+struct AnotherImmutableStructWithDefaults {
+    intField: Int = 42
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct PosDefaultStructWithFieldUsingImmutableStruct {
+    someField1: AnotherImmutableStructWithDefaults = {}
+}
+
 @Dart(PositionalDefaults)
 @Java(Skip) @Swift(Skip)
 struct PosDefaultsWithDuration {

--- a/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartStructConstructors.mustache
@@ -86,6 +86,7 @@ Explicit `field constructor` definitions
 }}{{#instanceOf type "LimeList"}}const {{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeMap"}}const {{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeSet"}}const {{/instanceOf}}{{!!
+}}{{#instanceOf type "LimeStruct"}}const {{/instanceOf}}{{!!
 }}{{/set}}{{!!
 }}{{/notInstanceOf}}{{/constPrefix}}{{!!
 

--- a/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/DartPositionalDefaults.lime
@@ -50,6 +50,18 @@ struct StructWithNullableCollectionDefaults {
     nullableSetField: Set<String>? = null
 }
 
+@Immutable
+@Java(Skip) @Swift(Skip)
+struct ImmutableStructWithDefaults {
+    intField: Int = 42
+}
+
+@Dart(PositionalDefaults)
+@Java(Skip) @Swift(Skip)
+struct PosDefaultStructWithFieldUsingImmutableStruct {
+    someField1: ImmutableStructWithDefaults = {}
+}
+
 // Foo Bar this is a comment
 // @constructor buzz fizz
 @Dart(PositionalDefaults = "Sorry, this is deprecated.")

--- a/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
@@ -118,6 +118,29 @@ struct TypesWithDefaults {
         @Dart("withIntegers")
         field constructor(someField, anotherField)
     }
+
+    @Immutable
+    struct SomeImmutableStructWithDefaults {
+        intField: Int = 42
+    }
+
+    @Immutable
+    struct ImmutableStructWithFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults = {}
+        someField2: ImmutableStructWithCollections = {}
+    }
+
+    @Immutable
+    struct ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults = {}
+        someField2: ImmutableStructWithCollections = {}
+
+        someField: Int = 5
+        anotherField: Int = 7
+
+        @Dart("withIntegers")
+        field constructor(someField, anotherField)
+    }
 }
 
 struct StructWithInitializerDefaults {

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/TypesWithDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/TypesWithDefaults.java
@@ -169,6 +169,64 @@ public final class TypesWithDefaults {
 
     }
 
+    public static final class SomeImmutableStructWithDefaults {
+        public final int intField;
+
+        public SomeImmutableStructWithDefaults() {
+            this.intField = 42;
+        }
+
+        public SomeImmutableStructWithDefaults(final int intField) {
+            this.intField = intField;
+        }
+
+
+    }
+
+    public static final class ImmutableStructWithFieldUsingImmutableStruct {
+        @NonNull
+        public final TypesWithDefaults.SomeImmutableStructWithDefaults someField1;
+        @NonNull
+        public final TypesWithDefaults.ImmutableStructWithCollections someField2;
+
+        public ImmutableStructWithFieldUsingImmutableStruct() {
+            this.someField1 = new TypesWithDefaults.SomeImmutableStructWithDefaults();
+            this.someField2 = new TypesWithDefaults.ImmutableStructWithCollections();
+        }
+
+        public ImmutableStructWithFieldUsingImmutableStruct(@NonNull final TypesWithDefaults.SomeImmutableStructWithDefaults someField1, @NonNull final TypesWithDefaults.ImmutableStructWithCollections someField2) {
+            this.someField1 = someField1;
+            this.someField2 = someField2;
+        }
+
+
+    }
+
+    public static final class ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+        @NonNull
+        public final TypesWithDefaults.SomeImmutableStructWithDefaults someField1;
+        @NonNull
+        public final TypesWithDefaults.ImmutableStructWithCollections someField2;
+        public final int someField;
+        public final int anotherField;
+
+        public ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct(@NonNull final TypesWithDefaults.SomeImmutableStructWithDefaults someField1, @NonNull final TypesWithDefaults.ImmutableStructWithCollections someField2, final int someField, final int anotherField) {
+            this.someField1 = someField1;
+            this.someField2 = someField2;
+            this.someField = someField;
+            this.anotherField = anotherField;
+        }
+
+        public ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct(final int someField, final int anotherField) {
+            this.someField = someField;
+            this.anotherField = anotherField;
+            this.someField1 = new TypesWithDefaults.SomeImmutableStructWithDefaults();
+            this.someField2 = new TypesWithDefaults.ImmutableStructWithCollections();
+        }
+
+
+    }
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
@@ -83,6 +83,37 @@ struct _GLUECODIUM_CPP_EXPORT TypesWithDefaults {
 
     };
 
+    struct _GLUECODIUM_CPP_EXPORT SomeImmutableStructWithDefaults {
+        const int32_t int_field = 42;
+
+        SomeImmutableStructWithDefaults( );
+        explicit SomeImmutableStructWithDefaults( int32_t int_field );
+
+    };
+
+    struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithFieldUsingImmutableStruct {
+        const ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults some_field1 = ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults{};
+        const ::smoke::TypesWithDefaults::ImmutableStructWithCollections some_field2 = ::smoke::TypesWithDefaults::ImmutableStructWithCollections{};
+
+        ImmutableStructWithFieldUsingImmutableStruct( );
+        ImmutableStructWithFieldUsingImmutableStruct( ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults some_field1, ::smoke::TypesWithDefaults::ImmutableStructWithCollections some_field2 );
+
+    };
+
+    struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+        const ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults some_field1 = ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults{};
+        const ::smoke::TypesWithDefaults::ImmutableStructWithCollections some_field2 = ::smoke::TypesWithDefaults::ImmutableStructWithCollections{};
+        const int32_t some_field = 5;
+        const int32_t another_field = 7;
+
+        ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct( );
+
+        ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct( int32_t some_field, int32_t another_field );
+
+        ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct( ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults some_field1, ::smoke::TypesWithDefaults::ImmutableStructWithCollections some_field2, int32_t some_field, int32_t another_field );
+
+    };
+
 };
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_default_struct_with_field_using_immutable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_default_struct_with_field_using_immutable_struct.dart
@@ -8,7 +8,7 @@ import 'package:library/src/smoke/immutable_struct_with_defaults.dart';
 class PosDefaultStructWithFieldUsingImmutableStruct {
   ImmutableStructWithDefaults someField1;
 
-  PosDefaultStructWithFieldUsingImmutableStruct([ImmutableStructWithDefaults someField1 = ImmutableStructWithDefaults.withDefaults()])
+  PosDefaultStructWithFieldUsingImmutableStruct([ImmutableStructWithDefaults someField1 = const ImmutableStructWithDefaults.withDefaults()])
     : someField1 = someField1;
 }
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_default_struct_with_field_using_immutable_struct.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/pos_default_struct_with_field_using_immutable_struct.dart
@@ -1,0 +1,89 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/immutable_struct_with_defaults.dart';
+
+
+class PosDefaultStructWithFieldUsingImmutableStruct {
+  ImmutableStructWithDefaults someField1;
+
+  PosDefaultStructWithFieldUsingImmutableStruct([ImmutableStructWithDefaults someField1 = ImmutableStructWithDefaults.withDefaults()])
+    : someField1 = someField1;
+}
+
+
+// PosDefaultStructWithFieldUsingImmutableStruct "private" section, not exported.
+
+final _smokePosdefaultstructwithfieldusingimmutablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PosDefaultStructWithFieldUsingImmutableStruct_create_handle'));
+final _smokePosdefaultstructwithfieldusingimmutablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PosDefaultStructWithFieldUsingImmutableStruct_release_handle'));
+final _smokePosdefaultstructwithfieldusingimmutablestructGetFieldsomeField1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PosDefaultStructWithFieldUsingImmutableStruct_get_field_someField1'));
+
+
+
+Pointer<Void> smokePosdefaultstructwithfieldusingimmutablestructToFfi(PosDefaultStructWithFieldUsingImmutableStruct value) {
+  final _someField1Handle = smokeImmutablestructwithdefaultsToFfi(value.someField1);
+  final _result = _smokePosdefaultstructwithfieldusingimmutablestructCreateHandle(_someField1Handle);
+  smokeImmutablestructwithdefaultsReleaseFfiHandle(_someField1Handle);
+  return _result;
+}
+
+PosDefaultStructWithFieldUsingImmutableStruct smokePosdefaultstructwithfieldusingimmutablestructFromFfi(Pointer<Void> handle) {
+  final _someField1Handle = _smokePosdefaultstructwithfieldusingimmutablestructGetFieldsomeField1(handle);
+  try {
+    return PosDefaultStructWithFieldUsingImmutableStruct(
+      smokeImmutablestructwithdefaultsFromFfi(_someField1Handle)
+    );
+  } finally {
+    smokeImmutablestructwithdefaultsReleaseFfiHandle(_someField1Handle);
+  }
+}
+
+void smokePosdefaultstructwithfieldusingimmutablestructReleaseFfiHandle(Pointer<Void> handle) => _smokePosdefaultstructwithfieldusingimmutablestructReleaseHandle(handle);
+
+// Nullable PosDefaultStructWithFieldUsingImmutableStruct
+
+final _smokePosdefaultstructwithfieldusingimmutablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PosDefaultStructWithFieldUsingImmutableStruct_create_handle_nullable'));
+final _smokePosdefaultstructwithfieldusingimmutablestructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_PosDefaultStructWithFieldUsingImmutableStruct_release_handle_nullable'));
+final _smokePosdefaultstructwithfieldusingimmutablestructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_PosDefaultStructWithFieldUsingImmutableStruct_get_value_nullable'));
+
+Pointer<Void> smokePosdefaultstructwithfieldusingimmutablestructToFfiNullable(PosDefaultStructWithFieldUsingImmutableStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokePosdefaultstructwithfieldusingimmutablestructToFfi(value);
+  final result = _smokePosdefaultstructwithfieldusingimmutablestructCreateHandleNullable(_handle);
+  smokePosdefaultstructwithfieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+PosDefaultStructWithFieldUsingImmutableStruct? smokePosdefaultstructwithfieldusingimmutablestructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokePosdefaultstructwithfieldusingimmutablestructGetValueNullable(handle);
+  final result = smokePosdefaultstructwithfieldusingimmutablestructFromFfi(_handle);
+  smokePosdefaultstructwithfieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokePosdefaultstructwithfieldusingimmutablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokePosdefaultstructwithfieldusingimmutablestructReleaseHandleNullable(handle);
+
+// End of PosDefaultStructWithFieldUsingImmutableStruct "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -736,7 +736,7 @@ class TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct {
 
   const TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct(this.someField1, this.someField2);
   const TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct.withDefaults()
-    : someField1 = TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
+    : someField1 = const TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = const TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
 }
 
 
@@ -833,7 +833,7 @@ class TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutabl
 
   const TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct(this.someField1, this.someField2, this.someField, this.anotherField);
   const TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct.withIntegers(this.someField, this.anotherField)
-      : someField1 = TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
+      : someField1 = const TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = const TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
 }
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -646,6 +646,296 @@ void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsRele
   _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandcollectionsReleaseHandleNullable(handle);
 
 // End of TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections "private" section.
+@immutable
+class TypesWithDefaults_SomeImmutableStructWithDefaults {
+  final int intField;
+
+  const TypesWithDefaults_SomeImmutableStructWithDefaults(this.intField);
+  const TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults()
+    : intField = 42;
+}
+
+
+// TypesWithDefaults_SomeImmutableStructWithDefaults "private" section, not exported.
+
+final _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Int32),
+    Pointer<Void> Function(int)
+  >('library_smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_create_handle'));
+final _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_release_handle'));
+final _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsGetFieldintField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_get_field_intField'));
+
+
+
+Pointer<Void> smokeTypeswithdefaultsSomeimmutablestructwithdefaultsToFfi(TypesWithDefaults_SomeImmutableStructWithDefaults value) {
+  final _intFieldHandle = (value.intField);
+  final _result = _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsCreateHandle(_intFieldHandle);
+  
+  return _result;
+}
+
+TypesWithDefaults_SomeImmutableStructWithDefaults smokeTypeswithdefaultsSomeimmutablestructwithdefaultsFromFfi(Pointer<Void> handle) {
+  final _intFieldHandle = _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsGetFieldintField(handle);
+  try {
+    return TypesWithDefaults_SomeImmutableStructWithDefaults(
+      (_intFieldHandle)
+    );
+  } finally {
+    
+  }
+}
+
+void smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseHandle(handle);
+
+// Nullable TypesWithDefaults_SomeImmutableStructWithDefaults
+
+final _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_create_handle_nullable'));
+final _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_release_handle_nullable'));
+final _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_get_value_nullable'));
+
+Pointer<Void> smokeTypeswithdefaultsSomeimmutablestructwithdefaultsToFfiNullable(TypesWithDefaults_SomeImmutableStructWithDefaults? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeTypeswithdefaultsSomeimmutablestructwithdefaultsToFfi(value);
+  final result = _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsCreateHandleNullable(_handle);
+  smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+
+TypesWithDefaults_SomeImmutableStructWithDefaults? smokeTypeswithdefaultsSomeimmutablestructwithdefaultsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsGetValueNullable(handle);
+  final result = smokeTypeswithdefaultsSomeimmutablestructwithdefaultsFromFfi(_handle);
+  smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseHandleNullable(handle);
+
+// End of TypesWithDefaults_SomeImmutableStructWithDefaults "private" section.
+@immutable
+class TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct {
+  final TypesWithDefaults_SomeImmutableStructWithDefaults someField1;
+
+  final TypesWithDefaults_ImmutableStructWithCollections someField2;
+
+  const TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct(this.someField1, this.someField2);
+  const TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct.withDefaults()
+    : someField1 = TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
+}
+
+
+// TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct "private" section, not exported.
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_create_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_release_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructGetFieldsomeField1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_get_field_someField1'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructGetFieldsomeField2 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_get_field_someField2'));
+
+
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructToFfi(TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct value) {
+  final _someField1Handle = smokeTypeswithdefaultsSomeimmutablestructwithdefaultsToFfi(value.someField1);
+  final _someField2Handle = smokeTypeswithdefaultsImmutablestructwithcollectionsToFfi(value.someField2);
+  final _result = _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructCreateHandle(_someField1Handle, _someField2Handle);
+  smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandle(_someField1Handle);
+  smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandle(_someField2Handle);
+  return _result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructFromFfi(Pointer<Void> handle) {
+  final _someField1Handle = _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructGetFieldsomeField1(handle);
+  final _someField2Handle = _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructGetFieldsomeField2(handle);
+  try {
+    return TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct(
+      smokeTypeswithdefaultsSomeimmutablestructwithdefaultsFromFfi(_someField1Handle), 
+      smokeTypeswithdefaultsImmutablestructwithcollectionsFromFfi(_someField2Handle)
+    );
+  } finally {
+    smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandle(_someField1Handle);
+    smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandle(_someField2Handle);
+  }
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseHandle(handle);
+
+// Nullable TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_create_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_release_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_get_value_nullable'));
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructToFfiNullable(TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructToFfi(value);
+  final result = _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructCreateHandleNullable(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct? smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructGetValueNullable(handle);
+  final result = smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructFromFfi(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTypeswithdefaultsImmutablestructwithfieldusingimmutablestructReleaseHandleNullable(handle);
+
+// End of TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct "private" section.
+@immutable
+class TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+  final TypesWithDefaults_SomeImmutableStructWithDefaults someField1;
+
+  final TypesWithDefaults_ImmutableStructWithCollections someField2;
+
+  final int someField;
+
+  final int anotherField;
+
+  const TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct(this.someField1, this.someField2, this.someField, this.anotherField);
+  const TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct.withIntegers(this.someField, this.anotherField)
+      : someField1 = TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
+}
+
+
+// TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct "private" section, not exported.
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Int32, Int32),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, int, int)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_create_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_release_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldsomeField1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_get_field_someField1'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldsomeField2 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_get_field_someField2'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_get_field_someField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldanotherField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_get_field_anotherField'));
+
+
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructToFfi(TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct value) {
+  final _someField1Handle = smokeTypeswithdefaultsSomeimmutablestructwithdefaultsToFfi(value.someField1);
+  final _someField2Handle = smokeTypeswithdefaultsImmutablestructwithcollectionsToFfi(value.someField2);
+  final _someFieldHandle = (value.someField);
+  final _anotherFieldHandle = (value.anotherField);
+  final _result = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructCreateHandle(_someField1Handle, _someField2Handle, _someFieldHandle, _anotherFieldHandle);
+  smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandle(_someField1Handle);
+  smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandle(_someField2Handle);
+  
+  
+  return _result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructFromFfi(Pointer<Void> handle) {
+  final _someField1Handle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldsomeField1(handle);
+  final _someField2Handle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldsomeField2(handle);
+  final _someFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldsomeField(handle);
+  final _anotherFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetFieldanotherField(handle);
+  try {
+    return TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct(
+      smokeTypeswithdefaultsSomeimmutablestructwithdefaultsFromFfi(_someField1Handle), 
+      smokeTypeswithdefaultsImmutablestructwithcollectionsFromFfi(_someField2Handle), 
+      (_someFieldHandle), 
+      (_anotherFieldHandle)
+    );
+  } finally {
+    smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandle(_someField1Handle);
+    smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandle(_someField2Handle);
+    
+    
+  }
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseHandle(handle);
+
+// Nullable TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_create_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_release_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_get_value_nullable'));
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructToFfiNullable(TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructToFfi(value);
+  final result = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructCreateHandleNullable(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct? smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructGetValueNullable(handle);
+  final result = smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructFromFfi(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseHandleNullable(handle);
+
+// End of TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct "private" section.
 
 // TypesWithDefaults "private" section, not exported.
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/TypesWithDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/TypesWithDefaults.swift
@@ -184,6 +184,69 @@ public struct TypesWithDefaults {
     }
 
 
+    public struct SomeImmutableStructWithDefaults {
+
+        public let intField: Int32
+
+        public init(intField: Int32 = 42) {
+            self.intField = intField
+        }
+        internal init(cHandle: _baseRef) {
+            intField = moveFromCType(smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_intField_get(cHandle))
+        }
+    }
+
+
+    public struct ImmutableStructWithFieldUsingImmutableStruct {
+
+        public let someField1: TypesWithDefaults.SomeImmutableStructWithDefaults
+
+        public let someField2: TypesWithDefaults.ImmutableStructWithCollections
+
+        public init(someField1: TypesWithDefaults.SomeImmutableStructWithDefaults = TypesWithDefaults.SomeImmutableStructWithDefaults(), someField2: TypesWithDefaults.ImmutableStructWithCollections = TypesWithDefaults.ImmutableStructWithCollections()) {
+            self.someField1 = someField1
+            self.someField2 = someField2
+        }
+        internal init(cHandle: _baseRef) {
+            someField1 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_someField1_get(cHandle))
+            someField2 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_someField2_get(cHandle))
+        }
+    }
+
+
+    public struct ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+
+        public let someField1: TypesWithDefaults.SomeImmutableStructWithDefaults
+
+        public let someField2: TypesWithDefaults.ImmutableStructWithCollections
+
+        public let someField: Int32
+
+        public let anotherField: Int32
+
+
+        public init(someField: Int32, anotherField: Int32) {
+            self.someField = someField
+            self.anotherField = anotherField
+            self.someField1 = TypesWithDefaults.SomeImmutableStructWithDefaults()
+            self.someField2 = TypesWithDefaults.ImmutableStructWithCollections()
+        }
+
+        public init(someField1: TypesWithDefaults.SomeImmutableStructWithDefaults = TypesWithDefaults.SomeImmutableStructWithDefaults(), someField2: TypesWithDefaults.ImmutableStructWithCollections = TypesWithDefaults.ImmutableStructWithCollections(), someField: Int32 = 5, anotherField: Int32 = 7) {
+            self.someField1 = someField1
+            self.someField2 = someField2
+            self.someField = someField
+            self.anotherField = anotherField
+        }
+        internal init(cHandle: _baseRef) {
+            someField1 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_someField1_get(cHandle))
+            someField2 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_someField2_get(cHandle))
+            someField = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_someField_get(cHandle))
+            anotherField = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_anotherField_get(cHandle))
+        }
+    }
+
+
 }
 
 
@@ -410,6 +473,140 @@ internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFiel
 }
 internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndCollections?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndCollections_release_optional_handle)
+}
+
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.SomeImmutableStructWithDefaults {
+    return TypesWithDefaults.SomeImmutableStructWithDefaults(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.SomeImmutableStructWithDefaults {
+    defer {
+        smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.SomeImmutableStructWithDefaults) -> RefHolder {
+    let c_intField = moveToCType(swiftType.intField)
+    return RefHolder(smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_create_handle(c_intField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.SomeImmutableStructWithDefaults) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.SomeImmutableStructWithDefaults? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_unwrap_optional_handle(handle)
+    return TypesWithDefaults.SomeImmutableStructWithDefaults(cHandle: unwrappedHandle) as TypesWithDefaults.SomeImmutableStructWithDefaults
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.SomeImmutableStructWithDefaults? {
+    defer {
+        smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.SomeImmutableStructWithDefaults?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_intField = moveToCType(swiftType.intField)
+    return RefHolder(smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_create_optional_handle(c_intField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.SomeImmutableStructWithDefaults?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_SomeImmutableStructWithDefaults_release_optional_handle)
+}
+
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct {
+    return TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct) -> RefHolder {
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_create_handle(c_someField1.ref, c_someField2.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_unwrap_optional_handle(handle)
+    return TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct(cHandle: unwrappedHandle) as TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct? {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_create_optional_handle(c_someField1.ref, c_someField2.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldUsingImmutableStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldUsingImmutableStruct_release_optional_handle)
+}
+
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+    return TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct) -> RefHolder {
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    let c_someField = moveToCType(swiftType.someField)
+    let c_anotherField = moveToCType(swiftType.anotherField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_create_handle(c_someField1.ref, c_someField2.ref, c_someField.ref, c_anotherField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_unwrap_optional_handle(handle)
+    return TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct(cHandle: unwrappedHandle) as TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct? {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    let c_someField = moveToCType(swiftType.someField)
+    let c_anotherField = moveToCType(swiftType.anotherField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_create_optional_handle(c_someField1.ref, c_someField2.ref, c_someField.ref, c_anotherField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_release_optional_handle)
 }
 
 


### PR DESCRIPTION
This series fixes problems that occur when either 'Immutable'
or 'PositionalDefaults' annotation is used in combination with
immutable types that have default value.

In both cases the resulting code did not contain the required
'const' keyword.

-------- Content of change --------

- New smoke and functional tests that were used to confirm
   the invalid behavior.
- Adjustments of 'DartStructConstructors.mustache' file to
   correctly prepend 'const' keyword when needed for immutable
   struct fields.