### PR TITLE
 LimeFunctionsValidator: do not warn when 'void' return is not documented

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
@@ -98,7 +98,7 @@ internal class LimeFunctionsValidator(private val logger: LimeLogger, generatorO
             }
         }
 
-        if (limeFunction.returnType.comment.isEmpty()) {
+        if (!limeFunction.returnType.isVoid && limeFunction.returnType.comment.isEmpty()) {
             logger.maybeError(limeFunction, "Return must be documented")
             result = false
         }

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorDocsTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorDocsTest.kt
@@ -110,6 +110,26 @@ class LimeFunctionsValidatorDocsTest {
     }
 
     @Test
+    fun validateMissingReturnCommentForVoidTypeWhenWerrorIsEnabled() {
+        // Given LimeFunction without documented return value for void type.
+        val limeFunction =
+            LimeFunction(
+                path = limePath,
+                comment = limeComment,
+                returnType = LimeReturnType.VOID,
+            )
+        allElements[""] = limeFunction
+        allElements["foo"] = LimeStruct(EMPTY_PATH)
+
+        // When validating it with werror flag enabled.
+        val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then validation passes - the function returns nothing (void).
+        assertTrue(result)
+    }
+
+    @Test
     fun validateMissingReturnCommentWhenWerrorIsDisabled() {
         // Given LimeFunction without documented return value.
         val limeFunction =

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorDocsTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorDocsTest.kt
@@ -29,7 +29,6 @@ import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimePath
-import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeStruct
 import io.mockk.mockk
@@ -43,7 +42,8 @@ import org.junit.runners.JUnit4
 class LimeFunctionsValidatorDocsTest {
     private val allElements = mutableMapOf<String, LimeElement>()
     private val limeModel = LimeModel(allElements, emptyList())
-    private val limePath = LimePath(emptyList(), listOf("foo", "bar"))
+    private val limeStructPath = LimePath(emptyList(), listOf("foo", "bar"))
+    private val limeFunctionPath = limeStructPath.child("baz")
     private val limeComment = LimeComment(comment = "This is some function")
     private val generatorOptions = GeneratorOptions(werror = setOf(GeneratorOptions.WARNING_LIME_FUNCTION_DOCS))
 
@@ -52,13 +52,13 @@ class LimeFunctionsValidatorDocsTest {
         // Given LimeFunction with parameter that isn't properly documented.
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
-                parameters = listOf(LimeParameter(path = limePath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+                parameters = listOf(LimeParameter(path = limeFunctionPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = LimeStruct(EMPTY_PATH)
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
 
         // When validating it with werror flag enabled.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
@@ -73,13 +73,13 @@ class LimeFunctionsValidatorDocsTest {
         // Given LimeFunction with parameter that isn't properly documented.
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
-                parameters = listOf(LimeParameter(path = limePath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+                parameters = listOf(LimeParameter(path = limeFunctionPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = LimeStruct(EMPTY_PATH)
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
 
         // When validating it without werror flag.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true))
@@ -94,12 +94,12 @@ class LimeFunctionsValidatorDocsTest {
         // Given LimeFunction without documented return value.
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = LimeStruct(EMPTY_PATH)
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
 
         // When validating it with werror flag enabled.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
@@ -114,12 +114,12 @@ class LimeFunctionsValidatorDocsTest {
         // Given LimeFunction without documented return value for void type.
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType = LimeReturnType.VOID,
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = LimeStruct(EMPTY_PATH)
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
 
         // When validating it with werror flag enabled.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
@@ -134,12 +134,12 @@ class LimeFunctionsValidatorDocsTest {
         // Given LimeFunction without documented return value.
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = LimeStruct(EMPTY_PATH)
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
 
         // When validating it without werror flag.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true))
@@ -154,7 +154,7 @@ class LimeFunctionsValidatorDocsTest {
         // Given LimeFunction with parameters and return that are properly documented.
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType =
                     LimeReturnType(
@@ -164,19 +164,19 @@ class LimeFunctionsValidatorDocsTest {
                 parameters =
                     listOf(
                         LimeParameter(
-                            path = limePath.child("param1"),
+                            path = limeFunctionPath.child("param1"),
                             typeRef = LimeBasicTypeRef.FLOAT,
                             comment = LimeComment("Some param"),
                         ),
                         LimeParameter(
-                            path = limePath.child("param2"),
+                            path = limeFunctionPath.child("param2"),
                             typeRef = LimeBasicTypeRef.FLOAT,
                             comment = LimeComment("Another param"),
                         ),
                     ),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = LimeStruct(EMPTY_PATH)
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
 
         // When validating it with werror flag enabled.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
@@ -193,14 +193,14 @@ class LimeFunctionsValidatorDocsTest {
 
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 attributes = attributes,
                 returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
-                parameters = listOf(LimeParameter(path = limePath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+                parameters = listOf(LimeParameter(path = limeFunctionPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = LimeStruct(EMPTY_PATH)
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
 
         // When validating it with werror flag.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
@@ -213,18 +213,19 @@ class LimeFunctionsValidatorDocsTest {
     @Test
     fun validateFunctionParamDocsFromInternalType() {
         // Given LimeFunction from internal type and parameter that isn't properly documented.
-        val attributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
-        val internalStruct = LimeStruct(path = limePath.parent, attributes = attributes)
-
         val limeFunction =
             LimeFunction(
-                path = limePath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
-                parameters = listOf(LimeParameter(path = limePath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+                parameters = listOf(LimeParameter(path = limeFunctionPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = internalStruct
+
+        val attributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
+        val internalStruct = LimeStruct(path = limeStructPath, attributes = attributes, functions = listOf(limeFunction))
+
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = internalStruct
 
         // When validating it with werror flag.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
@@ -237,21 +238,22 @@ class LimeFunctionsValidatorDocsTest {
     @Test
     fun validateFunctionParamDocsFromTypeNestedInInternalOne() {
         // Given LimeFunction from type nested in internal and parameter that isn't properly documented.
-        val attributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
-        val internalStruct = LimeStruct(path = limePath.parent, attributes = attributes)
-        val nestedStruct = LimeStruct(path = limePath)
-
-        val functionPath = limePath.child("baz")
         val limeFunction =
             LimeFunction(
-                path = functionPath,
+                path = limeFunctionPath,
                 comment = limeComment,
                 returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
-                parameters = listOf(LimeParameter(path = functionPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+                parameters = listOf(LimeParameter(path = limeFunctionPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
             )
-        allElements[""] = limeFunction
-        allElements["foo"] = internalStruct
-        allElements["foo.bar"] = nestedStruct
+
+        val nestedStruct = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
+
+        val attributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
+        val internalStruct = LimeStruct(path = limeStructPath.parent, attributes = attributes, structs = listOf(nestedStruct))
+
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = nestedStruct
+        allElements[limeStructPath.parent.toString()] = internalStruct
 
         // When validating it with werror flag.
         val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)


### PR DESCRIPTION
This change adjusts the logic of validator
to ensure that the warning/error is not raised
when the function returns nothing (void).
The change in logic is covered by a new unit test.

Moreover, the commit adjusts unit tests to use more
realistic paths to elements from LIME model.

The adjusted paths are better, because the validator
uses 'needsParametersDocumentation()' to check if the
validation of docs needs to be run.
    
The adjusted paths correspond to the ones that would
be built by AntlrLimeModelBuilder.kt.