### PR TITLE
Warn when documentation of lambda parameters is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased:
 ### Features:
+ * Implemented validation of comments used for lambdas. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
  * Implemented validation of comments used for functions. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
 ### Bug fixes:
  * Dart: fixed a bug related to missing/superflous 'const' keyword usage in definition of default values in constructors that used collections when `@Immutable` or `PositionalDefaults` were specified.

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -41,6 +41,7 @@ import com.here.gluecodium.validator.LimeFieldConstructorsValidator
 import com.here.gluecodium.validator.LimeFunctionsValidator
 import com.here.gluecodium.validator.LimeGenericTypesValidator
 import com.here.gluecodium.validator.LimeInheritanceValidator
+import com.here.gluecodium.validator.LimeLambdaValidator
 import com.here.gluecodium.validator.LimeOptimizedListsValidator
 import com.here.gluecodium.validator.LimePropertiesValidator
 import com.here.gluecodium.validator.LimeSerializableStructsValidator
@@ -196,6 +197,7 @@ class Gluecodium(
             { LimeFunctionsValidator(limeLogger, generatorOptions).validate(it) },
             { LimeSkipValidator(limeLogger).validate(it) },
             { LimeAsyncValidator(limeLogger).validate(it) },
+            { LimeLambdaValidator(limeLogger, generatorOptions).validate(it) },
         )
 
     companion object {

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -122,6 +122,7 @@ object OptionReader {
                         GeneratorOptions.WARNING_DEPRECATED_ATTRIBUTES,
                         GeneratorOptions.WARNING_DART_OVERLOADS,
                         GeneratorOptions.WARNING_LIME_FUNCTION_DOCS,
+                        GeneratorOptions.WARNING_LIME_LAMBDA_DOCS,
                     ).joinToString(),
             )
             addOption(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
@@ -66,6 +66,7 @@ data class GeneratorOptions(
         const val WARNING_DEPRECATED_ATTRIBUTES = "DeprecatedAttributes"
         const val WARNING_DART_OVERLOADS = "DartOverloads"
         const val WARNING_LIME_FUNCTION_DOCS = "LimeFunctionDocs"
+        const val WARNING_LIME_LAMBDA_DOCS = "LimeLambdaDocs"
 
         const val DEFAULT_CPP_EXPORT_MACRO_NAME = "_GLUECODIUM_CPP"
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
@@ -29,7 +29,7 @@ import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
-import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.validator.LimeValidatorUtils.needsDocumentationComment
 
 internal class LimeFunctionsValidator(private val logger: LimeLogger, generatorOptions: GeneratorOptions = GeneratorOptions()) {
     private val werrorFunctionDocs = generatorOptions.werror.contains(GeneratorOptions.WARNING_LIME_FUNCTION_DOCS)
@@ -63,29 +63,13 @@ internal class LimeFunctionsValidator(private val logger: LimeLogger, generatorO
                 result = false
             }
         }
-        if (needsParametersDocumentation(limeFunction, referenceMap) && !validateParametersComments(limeFunction)) {
+        if (needsDocumentationComment(limeFunction, referenceMap) && !validateParametersComments(limeFunction)) {
             if (werrorFunctionDocs) {
                 result = false
             }
         }
 
         return result
-    }
-
-    private fun needsParametersDocumentation(
-        limeFunction: LimeFunction,
-        referenceMap: Map<String, LimeElement>,
-    ): Boolean {
-        val parentType = referenceMap[limeFunction.path.parent.toString()] as LimeType
-        if (limeFunction.attributes.have(LimeAttributeType.INTERNAL) ||
-            parentType.attributes.have(LimeAttributeType.INTERNAL)
-        ) {
-            return false
-        }
-
-        return generateSequence(parentType) {
-            referenceMap[it.path.parent.toString()] as? LimeType
-        }.none { it.attributes.have(LimeAttributeType.INTERNAL) }
     }
 
     private fun validateParametersComments(limeFunction: LimeFunction): Boolean {

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
@@ -21,12 +21,11 @@ package com.here.gluecodium.validator
 
 import com.here.gluecodium.common.LimeLogger
 import com.here.gluecodium.generator.common.GeneratorOptions
-import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
-import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.validator.LimeValidatorUtils.needsDocumentationComment
 
 class LimeLambdaValidator(private val logger: LimeLogger, generatorOptions: GeneratorOptions = GeneratorOptions()) {
     private val werrorLambdaDocs = generatorOptions.werror.contains(GeneratorOptions.WARNING_LIME_LAMBDA_DOCS)
@@ -71,23 +70,5 @@ class LimeLambdaValidator(private val logger: LimeLogger, generatorOptions: Gene
         }
 
         return result
-    }
-
-    private fun needsDocumentationComment(
-        limeNamedElement: LimeNamedElement,
-        referenceMap: Map<String, LimeElement>,
-    ): Boolean {
-        if (limeNamedElement.attributes.have(LimeAttributeType.INTERNAL)) {
-            return false
-        }
-
-        val parentElement = referenceMap[limeNamedElement.path.parent.toString()] as LimeNamedElement? ?: return true
-        if (parentElement.attributes.have(LimeAttributeType.INTERNAL)) {
-            return false
-        }
-
-        return generateSequence(parentElement) {
-            referenceMap[it.path.parent.toString()] as? LimeType
-        }.none { it.attributes.have(LimeAttributeType.INTERNAL) }
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.generator.common.GeneratorOptions
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeType
+
+class LimeLambdaValidator(private val logger: LimeLogger, generatorOptions: GeneratorOptions = GeneratorOptions()) {
+    private val werrorLambdaDocs = generatorOptions.werror.contains(GeneratorOptions.WARNING_LIME_LAMBDA_DOCS)
+    private val maybeError: LimeLogger.(LimeNamedElement, String) -> Unit =
+        if (werrorLambdaDocs) LimeLogger::error else LimeLogger::warning
+
+    fun validate(limeModel: LimeModel): Boolean {
+        val validationResults =
+            limeModel.referenceMap.values
+                .filterIsInstance<LimeLambda>()
+                .map { validateLambda(it, limeModel.referenceMap) }
+
+        return !validationResults.contains(false)
+    }
+
+    private fun validateLambda(
+        limeLambda: LimeLambda,
+        referenceMap: Map<String, LimeElement>,
+    ): Boolean {
+        var result = true
+        if (needsDocumentationComment(limeLambda, referenceMap) && !validateLambdaDocs(limeLambda)) {
+            if (werrorLambdaDocs) {
+                result = false
+            }
+        }
+
+        return result
+    }
+
+    private fun validateLambdaDocs(limeLambda: LimeLambda): Boolean {
+        var result = true
+        for (parameter in limeLambda.parameters) {
+            if (parameter.comment.isEmpty()) {
+                logger.maybeError(limeLambda, "Parameter '${parameter.name}' must be documented")
+                result = false
+            }
+        }
+
+        if (!limeLambda.returnType.isVoid && limeLambda.returnType.comment.isEmpty()) {
+            logger.maybeError(limeLambda, "Return must be documented")
+            result = false
+        }
+
+        return result
+    }
+
+    private fun needsDocumentationComment(
+        limeNamedElement: LimeNamedElement,
+        referenceMap: Map<String, LimeElement>,
+    ): Boolean {
+        if (limeNamedElement.attributes.have(LimeAttributeType.INTERNAL)) {
+            return false
+        }
+
+        val parentElement = referenceMap[limeNamedElement.path.parent.toString()] as LimeNamedElement? ?: return true
+        if (parentElement.attributes.have(LimeAttributeType.INTERNAL)) {
+            return false
+        }
+
+        return generateSequence(parentElement) {
+            referenceMap[it.path.parent.toString()] as? LimeType
+        }.none { it.attributes.have(LimeAttributeType.INTERNAL) }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValidatorUtils.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValidatorUtils.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2016-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeType
+
+internal object LimeValidatorUtils {
+    fun needsDocumentationComment(
+        limeNamedElement: LimeNamedElement,
+        referenceMap: Map<String, LimeElement>,
+    ): Boolean {
+        if (limeNamedElement.attributes.have(LimeAttributeType.INTERNAL)) {
+            return false
+        }
+
+        val parentElement = referenceMap[limeNamedElement.path.parent.toString()] as LimeNamedElement? ?: return true
+        if (parentElement.attributes.have(LimeAttributeType.INTERNAL)) {
+            return false
+        }
+
+        return generateSequence(parentElement) {
+            referenceMap[it.path.parent.toString()] as? LimeType
+        }.none { it.attributes.have(LimeAttributeType.INTERNAL) }
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeLambdaValidatorDocsTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeLambdaValidatorDocsTest.kt
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2016-2024 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.generator.common.GeneratorOptions
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeComment
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeLambdaParameter
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimeReturnType
+import com.here.gluecodium.model.lime.LimeStruct
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LimeLambdaValidatorDocsTest {
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+    private val limeComment = LimeComment(comment = "This is some lambda")
+    private val generatorOptions = GeneratorOptions(werror = setOf(GeneratorOptions.WARNING_LIME_LAMBDA_DOCS))
+
+    @Test
+    fun validateMissingParamsCommentsWhenWerrorIsEnabledGlobalLambda() {
+        // Given LimeLambda with parameter that isn't properly documented.
+        val lambdaPath = LimePath(listOf(), listOf("SomeLambda"))
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
+                parameters = listOf(LimeLambdaParameter(path = lambdaPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+            )
+        allElements[lambdaPath.toString()] = limeLambda
+
+        // When validating it with werror flag enabled.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(result)
+    }
+
+    @Test
+    fun validateMissingParamsCommentsWhenWerrorIsDisabledGlobalLambda() {
+        // Given LimeLambda with parameter that isn't properly documented.
+        val lambdaPath = LimePath(listOf(), listOf("SomeLambda"))
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
+                parameters = listOf(LimeLambdaParameter(path = lambdaPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+            )
+        allElements[lambdaPath.toString()] = limeLambda
+
+        // When validating it without werror flag.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true))
+        val result = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateMissingReturnCommentWhenWerrorIsEnabledGlobalLambda() {
+        // Given LimeLambda without documented return value.
+        val lambdaPath = LimePath(listOf(), listOf("SomeLambda"))
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT),
+            )
+        allElements[lambdaPath.toString()] = limeLambda
+
+        // When validating it with werror flag enabled.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(result)
+    }
+
+    @Test
+    fun validateMissingReturnCommentForVoidTypeWhenWerrorIsEnabledGlobalLambda() {
+        // Given LimeLambda without documented return value for void type.
+        val lambdaPath = LimePath(listOf(), listOf("SomeLambda"))
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType = LimeReturnType.VOID,
+            )
+        allElements[lambdaPath.toString()] = limeLambda
+
+        // When validating it with werror flag enabled.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then validation passes - the lambda returns nothing (void) --> comment for return is not needed.
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateMissingReturnCommentWhenWerrorIsDisabledGlobalLambda() {
+        // Given LimeLambda without documented return value.
+        val lambdaPath = LimePath(listOf(), listOf("SomeLambda"))
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT),
+            )
+        allElements[lambdaPath.toString()] = limeLambda
+
+        // When validating it without werror flag.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true))
+        val result = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateCorrectParamsAndReturnDocsWhenWerrorIsEnabledGlobalLambda() {
+        // Given LimeLambda with parameters and return that are properly documented.
+        val lambdaPath = LimePath(listOf(), listOf("SomeLambda"))
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType =
+                    LimeReturnType(
+                        typeRef = LimeBasicTypeRef.INT,
+                        comment = LimeComment("Important value"),
+                    ),
+                parameters =
+                    listOf(
+                        LimeLambdaParameter(
+                            path = lambdaPath.child("param1"),
+                            typeRef = LimeBasicTypeRef.FLOAT,
+                            comment = LimeComment("Some param"),
+                        ),
+                        LimeLambdaParameter(
+                            path = lambdaPath.child("param2"),
+                            typeRef = LimeBasicTypeRef.FLOAT,
+                            comment = LimeComment("Another param"),
+                        ),
+                    ),
+            )
+        allElements[lambdaPath.toString()] = limeLambda
+
+        // When validating it with werror flag enabled.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateInternalLambdaParamDocs() {
+        // Given LimeLambda with internal annotation and parameter that isn't properly documented.
+        val attributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
+
+        val lambdaPath = LimePath(listOf(), listOf("SomeLambda"))
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                attributes = attributes,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
+                parameters = listOf(LimeLambdaParameter(path = lambdaPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+            )
+        allElements[lambdaPath.toString()] = limeLambda
+
+        // When validating it with werror flag.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then docs validation passes (for internal lambdas it is skipped).
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateLambdaParamDocsFromInternalType() {
+        // Given LimeLambda from internal type and parameter that isn't properly documented.
+        val internalStructPath = LimePath(listOf(), listOf("SomeInternalStruct"))
+        val lambdaPath = internalStructPath.child("SomeLambda")
+
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
+                parameters = listOf(LimeLambdaParameter(path = lambdaPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+            )
+
+        val attributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
+        val internalStruct = LimeStruct(path = internalStructPath.parent, attributes = attributes, lambdas = listOf(limeLambda))
+
+        allElements[lambdaPath.toString()] = limeLambda
+        allElements[internalStructPath.toString()] = internalStruct
+
+        // When validating it with werror flag.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then docs validation passes (for lambdas from internal types it is skipped).
+        assertTrue(result)
+    }
+
+    @Test
+    fun validateLambdaParamDocsFromTypeNestedInInternalOne() {
+        // Given LimeLambda from type nested in internal and parameter that isn't properly documented.
+        val internalStructPath = LimePath(listOf(), listOf("SomeInternalStruct"))
+        val nestedStructPath = internalStructPath.child("SomeNestedStruct")
+        val lambdaPath = nestedStructPath.child("SomeLambda")
+
+        val limeLambda =
+            LimeLambda(
+                path = lambdaPath,
+                comment = limeComment,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT, comment = LimeComment("Important integer")),
+                parameters = listOf(LimeLambdaParameter(path = lambdaPath.child("param1"), typeRef = LimeBasicTypeRef.FLOAT)),
+            )
+
+        val nestedStruct = LimeStruct(path = nestedStructPath, lambdas = listOf(limeLambda))
+
+        val attributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
+        val internalStruct = LimeStruct(path = internalStructPath, attributes = attributes, structs = listOf(nestedStruct))
+
+        allElements[lambdaPath.toString()] = limeLambda
+        allElements[nestedStructPath.toString()] = nestedStruct
+        allElements[internalStructPath.toString()] = internalStruct
+
+        // When validating it with werror flag.
+        val validator = LimeLambdaValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then docs validation passes (for lambdas from types nested in internal ones it is skipped).
+        assertTrue(result)
+    }
+}


### PR DESCRIPTION
This change adds a new class called LimeLambdaValidator
which checks if parameters and return value are properly
documented.
    
The logic works as follows:
  - all lambda parameters need to be documented
  - return value needs to be documented (except 'void')
  - the validation is not applied for internal lambdas
     or lambdas nested in internal types (or types nested
     in internal types)
    
The user may enable treating the warning as error via
werror flag.