### PR TITLE
Warn when documentation of accessors' parameters is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased:
 ### Features:
+ * Implemented validation of comments used for accessors of properties: parameter of setter and return value of getter. When the required description is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
  * Implemented validation of comments used for lambdas. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
  * Implemented validation of comments used for functions. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
 ### Bug fixes:

--- a/docs/lime_markdown.md
+++ b/docs/lime_markdown.md
@@ -39,7 +39,18 @@ Documentation comments also support structured comments for some elements (i.e. 
 for child elements in the comment of the parent element). Structured comments can be specified in
 both `//` and `/*` style comments (or even in a combination of those).
 
-Structured comments are supported for functions. Example:
+### Structured comments for functions
+
+Structured comments are supported for functions. The following syntax is used:
+- the lines prepending any annotation are used as description of the function
+- `@param[<NAME>]` annotation can be used to document the parameters of the function
+- `@return` annotation can be used to document a return value of the function
+- `@throws` annotation can be used to document exceptions that are raised
+
+>**Important:** return values (except `Void`) and parameters of functions must be documented. If appropriate comment is
+> missing for any parameter or return value, then Gluecodium will raise warning or error depending on `werror` flag.
+
+Example:
 ```
 // Process the input in the given mode.
 // A lot of multi-line text can be said about it.
@@ -50,13 +61,26 @@ Structured comments are supported for functions. Example:
 fun process(mode: Mode, input: String): GenericResult throws SomethingWrongException
 ```
 
-Structured comments are supported for properties. Example:
+### Structured comments for properties
+
+Structured comments are supported for properties. The following syntax is used:
+- the lines prepending any annotation are used to document getter's
+return value and setter's parameter as well as the declaration of property
+- `@get` annotation can be used to describe the getter function
+- `@set` annotation can be used to describe the setter function
+
+>**Important:** return values of getters and parameters of setters must be documented. If appropriate documentation
+> comment is missing, then Gluecodium will raise warning or error depending on `werror` flag.
+
+Example:
 ```
 // Time interval taken by the processing.
 // @get Gets the time interval taken by the processing.
 // @set Sets the time interval taken by the processing.
 property processingTime: ProcessorHelperTypes.Timestamp
 ```
+
+### Structured comments for structs
 
 Structured comments for structs allow specifying documentation for the struct's auto-generated
 constructor. Example:
@@ -77,7 +101,15 @@ The comment after the `@constructor` tag will be used for the documentation of t
 used for the documentation of the struct itself. The parameter documentation of the constructor will use the same
 documentation as for the fields of the struct. A default value will make it possible to omit a field from a constructor.
 
-Structured comments for lambdas allow specifying comments for lambda parameters. 
+### Structured comments for lambdas
+
+Structured comments for lambdas offer the following capabilities:
+- lambda parameters can be documented via `@param[<NAME>]` annotation
+- return value of lambda can be documented via `@return` annotation
+
+>**Important:** all parameters and return value (except `Void`) of lambda must be documented. If appropriate documentation
+> comment is missing, then Gluecodium will raise warning or error depending on `werror` flag.
+
 For unnamed parameters that have only types specified, positional names can be used to document parameters: `p0`, `p1`,
 and so on. For example:
 ```

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -193,7 +193,7 @@ class Gluecodium(
         listOf<(LimeModel) -> Boolean>(
             { LimeConstantRefsValidator(limeLogger).validate(it) },
             { LimeExternalTypesValidator(limeLogger).validate(it) },
-            { LimePropertiesValidator(limeLogger).validate(it) },
+            { LimePropertiesValidator(limeLogger, generatorOptions).validate(it) },
             { LimeSkipValidator(limeLogger).validate(it) },
             { LimeAsyncValidator(limeLogger).validate(it) },
             { LimeLambdaValidator(limeLogger, generatorOptions).validate(it) },

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2019 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,6 +123,7 @@ object OptionReader {
                         GeneratorOptions.WARNING_DART_OVERLOADS,
                         GeneratorOptions.WARNING_LIME_FUNCTION_DOCS,
                         GeneratorOptions.WARNING_LIME_LAMBDA_DOCS,
+                        GeneratorOptions.WARNING_LIME_PROPERTIES_DOCS,
                     ).joinToString(),
             )
             addOption(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2021 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ data class GeneratorOptions(
         const val WARNING_DART_OVERLOADS = "DartOverloads"
         const val WARNING_LIME_FUNCTION_DOCS = "LimeFunctionDocs"
         const val WARNING_LIME_LAMBDA_DOCS = "LimeLambdaDocs"
+        const val WARNING_LIME_PROPERTIES_DOCS = "LimePropertiesDocs"
 
         const val DEFAULT_CPP_EXPORT_MACRO_NAME = "_GLUECODIUM_CPP"
     }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimePropertiesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimePropertiesValidator.kt
@@ -30,6 +30,7 @@ import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.validator.LimeValidatorUtils.LIME_MARKDOWN_DOCS
 import com.here.gluecodium.validator.LimeValidatorUtils.needsDocumentationComment
 
 internal class LimePropertiesValidator(private val logger: LimeLogger, generatorOptions: GeneratorOptions = GeneratorOptions()) {
@@ -84,27 +85,31 @@ internal class LimePropertiesValidator(private val logger: LimeLogger, generator
     }
 
     private fun validateComments(limeProperty: LimeProperty): Boolean {
-        val propertiesDocsErrorMessage = "property must be documented; check 'docs/lime_markdown.md'"
+        val checkDocsMessage = "please check $PROPERTIES_STRUCTURED_COMMENTS"
         var result = true
 
         if (limeProperty.comment.isEmpty()) {
-            logger.maybeError(limeProperty, "main comment is empty; $propertiesDocsErrorMessage")
+            logger.maybeError(limeProperty, "property description comment is missing; $checkDocsMessage")
             result = false
         }
 
         if (limeProperty.getter.returnType.comment.isEmpty()) {
-            logger.maybeError(limeProperty, "return of getter is not documented; $propertiesDocsErrorMessage")
+            logger.maybeError(limeProperty, "return value of getter is not documented for property; $checkDocsMessage")
             result = false
         }
 
         if (limeProperty.setter != null) {
             val isSetterCommentEmpty = limeProperty.setter?.parameters?.firstOrNull()?.comment?.isEmpty()
             if (isSetterCommentEmpty == null || isSetterCommentEmpty) {
-                logger.maybeError(limeProperty, "parameter of setter is not documented; $propertiesDocsErrorMessage")
+                logger.maybeError(limeProperty, "parameter of setter is not documented for property; $checkDocsMessage")
                 result = false
             }
         }
 
         return result
+    }
+
+    companion object {
+        private const val PROPERTIES_STRUCTURED_COMMENTS = "$LIME_MARKDOWN_DOCS#structured-comments-for-properties"
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimePropertiesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimePropertiesValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,28 +20,39 @@
 package com.here.gluecodium.validator
 
 import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.model.lime.LimeAttributeType.CACHED
 import com.here.gluecodium.model.lime.LimeAttributeType.CPP
 import com.here.gluecodium.model.lime.LimeAttributeValueType.REF
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.validator.LimeValidatorUtils.needsDocumentationComment
 
-internal class LimePropertiesValidator(private val logger: LimeLogger) {
+internal class LimePropertiesValidator(private val logger: LimeLogger, generatorOptions: GeneratorOptions = GeneratorOptions()) {
+    private val werrorPropertiesDocs = generatorOptions.werror.contains(GeneratorOptions.WARNING_LIME_PROPERTIES_DOCS)
+    private val maybeError: LimeLogger.(LimeNamedElement, String) -> Unit =
+        if (werrorPropertiesDocs) LimeLogger::error else LimeLogger::warning
+
     fun validate(limeModel: LimeModel): Boolean {
         val validationResults =
             limeModel.referenceMap.values
                 .filterIsInstance<LimeContainerWithInheritance>()
-                .map { validateProperties(it) }
+                .map { validateProperties(it, limeModel.referenceMap) }
 
         return !validationResults.contains(false)
     }
 
-    private fun validateProperties(limeContainer: LimeContainerWithInheritance): Boolean {
+    private fun validateProperties(
+        limeContainer: LimeContainerWithInheritance,
+        referenceMap: Map<String, LimeElement>,
+    ): Boolean {
         val allPropertyNames = (limeContainer.properties + limeContainer.inheritedProperties).map { it.name }
         return !limeContainer.properties
-            .map { validateProperty(it, allPropertyNames, limeContainer) }
+            .map { validateProperty(it, allPropertyNames, limeContainer, referenceMap) }
             .contains(false)
     }
 
@@ -49,6 +60,7 @@ internal class LimePropertiesValidator(private val logger: LimeLogger) {
         limeProperty: LimeProperty,
         allPropertyNames: List<String>,
         parentElement: LimeContainerWithInheritance,
+        referenceMap: Map<String, LimeElement>,
     ): Boolean {
         var result = true
         if (allPropertyNames.filter { it == limeProperty.name }.size > 1) {
@@ -63,6 +75,36 @@ internal class LimePropertiesValidator(private val logger: LimeLogger) {
             logger.error(limeProperty, "property in an interface cannot be marked with @Cpp(Ref)")
             result = false
         }
+        if (needsDocumentationComment(limeProperty, referenceMap) && !validateComments(limeProperty)) {
+            if (werrorPropertiesDocs) {
+                result = false
+            }
+        }
+        return result
+    }
+
+    private fun validateComments(limeProperty: LimeProperty): Boolean {
+        val propertiesDocsErrorMessage = "property must be documented; check 'docs/lime_markdown.md'"
+        var result = true
+
+        if (limeProperty.comment.isEmpty()) {
+            logger.maybeError(limeProperty, "main comment is empty; $propertiesDocsErrorMessage")
+            result = false
+        }
+
+        if (limeProperty.getter.returnType.comment.isEmpty()) {
+            logger.maybeError(limeProperty, "return of getter is not documented; $propertiesDocsErrorMessage")
+            result = false
+        }
+
+        if (limeProperty.setter != null) {
+            val isSetterCommentEmpty = limeProperty.setter?.parameters?.firstOrNull()?.comment?.isEmpty()
+            if (isSetterCommentEmpty == null || isSetterCommentEmpty) {
+                logger.maybeError(limeProperty, "parameter of setter is not documented; $propertiesDocsErrorMessage")
+                result = false
+            }
+        }
+
         return result
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValidatorUtils.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeValidatorUtils.kt
@@ -25,6 +25,8 @@ import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeType
 
 internal object LimeValidatorUtils {
+    const val LIME_MARKDOWN_DOCS = "https://github.com/heremaps/gluecodium/blob/master/docs/lime_markdown.md"
+
     fun needsDocumentationComment(
         limeNamedElement: LimeNamedElement,
         referenceMap: Map<String, LimeElement>,

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimePropertiesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimePropertiesValidatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,20 +19,23 @@
 
 package com.here.gluecodium.validator
 
+import com.here.gluecodium.generator.common.GeneratorOptions
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeBasicTypeRef
 import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeDirectTypeRef
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimePath
-import com.here.gluecodium.model.lime.LimePath.Companion.EMPTY_PATH
 import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeReturnType
 import io.mockk.mockk
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -42,58 +45,79 @@ import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
 class LimePropertiesValidatorTest {
+    private val generatorOptions = GeneratorOptions(werror = setOf(GeneratorOptions.WARNING_LIME_PROPERTIES_DOCS))
     private val allElements = mutableMapOf<String, LimeElement>()
-    private val fooPath = LimePath(emptyList(), listOf("foo"))
     private val limeModel = LimeModel(allElements, emptyList())
-    private val limeFunction = LimeFunction(EMPTY_PATH)
-    private val limePropertyFoo =
-        LimeProperty(
-            fooPath,
-            typeRef = LimeBasicTypeRef.INT,
-            getter = limeFunction,
-        )
-    private val limePropertyBar =
-        LimeProperty(
-            LimePath(emptyList(), listOf("bar")),
-            typeRef = LimeBasicTypeRef.INT,
-            getter = limeFunction,
-        )
-    private val limePropertyFoo2 =
-        LimeProperty(
-            LimePath(listOf("baz"), listOf("foo")),
-            typeRef = LimeBasicTypeRef.INT,
-            getter = limeFunction,
-        )
-    private val limeContainerDoubleFoo =
-        object : LimeContainerWithInheritance(
-            EMPTY_PATH,
-            properties = listOf(limePropertyFoo, limePropertyFoo2),
-        ) {}
+    private val validator = LimePropertiesValidator(mockk(relaxed = true))
+
+    private val typePath = LimePath(emptyList(), listOf("someOuterType", "someType"))
+    private val propertyPath = typePath.child("someProperty")
+
+    private val fooPath = typePath.child("foo")
+    private val barPath = typePath.child("bar")
+    private val anotherTypePath = LimePath(listOf("baz"), listOf("anotherType"))
+    private val anotherFooPath = anotherTypePath.child("foo")
+    private val anotherBarPath = anotherTypePath.child("bar")
+
     private val cachedAttributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.CACHED).build()
     private val cppRefAttributes =
         LimeAttributes.Builder().addAttribute(LimeAttributeType.CPP, LimeAttributeValueType.REF).build()
-    private val cppRefProperty =
-        LimeProperty(
-            fooPath.child("bar"),
-            typeRef = LimeBasicTypeRef.INT,
-            getter = limeFunction,
-            attributes = cppRefAttributes,
-        )
+    private val internalAttributes = LimeAttributes.Builder().addAttribute(LimeAttributeType.INTERNAL).build()
 
-    private val validator = LimePropertiesValidator(mockk(relaxed = true))
+    private fun propertyForPath(
+        path: LimePath,
+        attributes: LimeAttributes? = null,
+        getter: LimeFunction = getterForPath(path),
+        setter: LimeFunction? = null,
+        valueComment: LimeComment = LimeComment("Some property"),
+    ) = LimeProperty(
+        path = path,
+        attributes = attributes,
+        typeRef = LimeBasicTypeRef.INT,
+        getter = getter,
+        setter = setter,
+        comment = valueComment,
+    )
+
+    private fun getterForPath(
+        path: LimePath,
+        comment: LimeComment = LimeComment("Integer"),
+    ) = LimeFunction(
+        path = path.child("get"),
+        returnType = LimeReturnType(LimeBasicTypeRef.INT, comment = comment),
+    )
+
+    private fun setterForPath(
+        path: LimePath,
+        comment: LimeComment = LimeComment("Integer"),
+    ) = LimeFunction(
+        path = path.child("set"),
+        parameters =
+            listOf(
+                LimeParameter(
+                    path = propertyPath.child("set").child("param"),
+                    typeRef = LimeBasicTypeRef.INT,
+                    comment = comment,
+                ),
+            ),
+    )
 
     @Test
     fun validateNoProperties() {
-        allElements[""] = object : LimeContainerWithInheritance(EMPTY_PATH) {}
-
+        allElements[typePath.toString()] = object : LimeContainerWithInheritance(typePath) {}
         assertTrue(validator.validate(limeModel))
     }
 
     @Test
     fun validatePropertiesNoNameClash() {
-        allElements[""] =
+        val limePropertyFoo = propertyForPath(fooPath)
+        val limePropertyBar = propertyForPath(barPath)
+
+        allElements[fooPath.toString()] = limePropertyFoo
+        allElements[barPath.toString()] = limePropertyBar
+        allElements[typePath.toString()] =
             object : LimeContainerWithInheritance(
-                EMPTY_PATH,
+                path = typePath,
                 properties = listOf(limePropertyFoo, limePropertyBar),
             ) {}
 
@@ -102,29 +126,72 @@ class LimePropertiesValidatorTest {
 
     @Test
     fun validatePropertiesWithNameClash() {
-        allElements[""] = limeContainerDoubleFoo
+        // When model is built and two properties have the same name, then their paths are disambiguated via withSuffix().
+        val firstFooProperty = propertyForPath(fooPath)
+        val secondFooPath = fooPath.withSuffix("1")
+        val secondFooProperty = propertyForPath(secondFooPath)
+
+        allElements[fooPath.toString()] = firstFooProperty
+        allElements[secondFooPath.toString()] = secondFooProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(
+                path = typePath,
+                properties = listOf(firstFooProperty, secondFooProperty),
+            ) {}
 
         assertFalse(validator.validate(limeModel))
     }
 
     @Test
     fun validateInheritanceNoOwnProperties() {
-        allElements[""] =
+        // When model is built and two properties have the same name, then their paths are disambiguated via withSuffix().
+        val firstFooProperty = propertyForPath(anotherFooPath)
+        val secondFooPath = anotherFooPath.withSuffix("1")
+        val secondFooProperty = propertyForPath(secondFooPath)
+
+        // This parent type has name clash.
+        val invalidParentType =
             object : LimeContainerWithInheritance(
-                EMPTY_PATH,
-                parents = listOf(LimeDirectTypeRef(limeContainerDoubleFoo)),
+                path = anotherTypePath,
+                properties = listOf(firstFooProperty, secondFooProperty),
             ) {}
 
+        // Note: parent type is not added to the model, because it would cause the validation to fail.
+        // In this test case we want to check, that for derived type the validation passes.
+
+        // The derived type does not have any properties.
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(
+                typePath,
+                parents = listOf(LimeDirectTypeRef(invalidParentType)),
+            ) {}
+
+        // Validation passes, because validator iterates over own properties of a given type.
+        // The error should be returned when validating the parent type (not current one).
+        // Parent type is not included in the model (if it was, then validation would fail).
         assertTrue(validator.validate(limeModel))
     }
 
     @Test
     fun validatePropertiesInheritanceNoNameClash() {
-        allElements[""] =
+        // Base type has its own 'bar' property.
+        val anotherBarProperty = propertyForPath(anotherBarPath)
+        val parentTypeWithAnotherBar =
             object : LimeContainerWithInheritance(
-                EMPTY_PATH,
-                parents = listOf(LimeDirectTypeRef(limeContainerDoubleFoo)),
-                properties = listOf(limePropertyBar),
+                path = anotherTypePath,
+                properties = listOf(anotherBarProperty),
+            ) {}
+        allElements[anotherBarPath.toString()] = anotherBarProperty
+        allElements[anotherTypePath.toString()] = parentTypeWithAnotherBar
+
+        // Derived type has its own 'foo' property and 'bar' property from base type.
+        val fooProperty = propertyForPath(fooPath)
+        allElements[fooPath.toString()] = fooProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(
+                typePath,
+                parents = listOf(LimeDirectTypeRef(parentTypeWithAnotherBar)),
+                properties = listOf(fooProperty),
             ) {}
 
         assertTrue(validator.validate(limeModel))
@@ -132,11 +199,28 @@ class LimePropertiesValidatorTest {
 
     @Test
     fun validatePropertiesInheritanceWithNameClash() {
-        allElements[""] =
+        // Base type has its own 'foo' property.
+        val anotherFooProperty = propertyForPath(anotherFooPath)
+        val parentTypeWithAnotherFoo =
             object : LimeContainerWithInheritance(
-                EMPTY_PATH,
-                parents = listOf(LimeDirectTypeRef(limeContainerDoubleFoo)),
-                properties = listOf(limePropertyFoo),
+                path = anotherTypePath,
+                properties = listOf(anotherFooProperty),
+            ) {}
+        allElements[anotherFooPath.toString()] = anotherFooProperty
+        allElements[anotherTypePath.toString()] = parentTypeWithAnotherFoo
+
+        // If only base class is in the model, then validation passes.
+        assertTrue(validator.validate(limeModel))
+
+        // However, when derived type is added to the model it should fail, because
+        // the derived type has two 'foo' variables: its own and from base.
+        val fooProperty = propertyForPath(fooPath)
+        allElements[fooPath.toString()] = fooProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(
+                typePath,
+                parents = listOf(LimeDirectTypeRef(parentTypeWithAnotherFoo)),
+                properties = listOf(fooProperty),
             ) {}
 
         assertFalse(validator.validate(limeModel))
@@ -144,46 +228,168 @@ class LimePropertiesValidatorTest {
 
     @Test
     fun validateCachedReadOnlyProperty() {
-        val limeProperty =
-            LimeProperty(
-                path = fooPath,
-                typeRef = LimeBasicTypeRef.INT,
-                getter = limeFunction,
-                attributes = cachedAttributes,
-            )
-        allElements[""] =
-            object : LimeContainerWithInheritance(EMPTY_PATH, properties = listOf(limeProperty)) {}
+        val readOnlyCachedProperty = propertyForPath(path = propertyPath, attributes = cachedAttributes)
+
+        allElements[propertyPath.toString()] = readOnlyCachedProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(readOnlyCachedProperty)) {}
 
         assertTrue(validator.validate(limeModel))
     }
 
     @Test
     fun validateCachedReadWriteProperty() {
-        val limeProperty =
-            LimeProperty(
-                path = fooPath,
-                typeRef = LimeBasicTypeRef.INT,
-                getter = limeFunction,
-                setter = limeFunction,
-                attributes = cachedAttributes,
-            )
-        allElements[""] =
-            object : LimeContainerWithInheritance(EMPTY_PATH, properties = listOf(limeProperty)) {}
+        val readWriteCachedProperty =
+            propertyForPath(path = propertyPath, attributes = cachedAttributes, setter = setterForPath(propertyPath))
+
+        allElements[propertyPath.toString()] = readWriteCachedProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(readWriteCachedProperty)) {}
 
         assertFalse(validator.validate(limeModel))
     }
 
     @Test
     fun validateRefsAttributeInClass() {
-        allElements["foo"] = LimeClass(EMPTY_PATH, properties = listOf(cppRefProperty))
+        val cppRefProperty = propertyForPath(path = propertyPath, attributes = cppRefAttributes)
+
+        allElements[propertyPath.toString()] = cppRefProperty
+        allElements[typePath.toString()] = LimeClass(typePath, properties = listOf(cppRefProperty))
 
         assertTrue(validator.validate(limeModel))
     }
 
     @Test
     fun validateRefsAttributeInInterface() {
-        allElements["foo"] = LimeInterface(EMPTY_PATH, properties = listOf(cppRefProperty))
+        val cppRefProperty = propertyForPath(path = propertyPath, attributes = cppRefAttributes)
+
+        allElements[propertyPath.toString()] = cppRefProperty
+        allElements[typePath.toString()] = LimeInterface(typePath, properties = listOf(cppRefProperty))
 
         assertFalse(validator.validate(limeModel))
+    }
+
+    @Test
+    fun validateEmptyValueCommentWerrorEnabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true), generatorOptions)
+        val noValueCommentProperty = propertyForPath(path = propertyPath, valueComment = LimeComment())
+
+        allElements[propertyPath.toString()] = noValueCommentProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(noValueCommentProperty)) {}
+
+        assertFalse(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateEmptyValueCommentWerrorDisabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true))
+        val noValueCommentProperty = propertyForPath(path = propertyPath, valueComment = LimeComment())
+
+        allElements[propertyPath.toString()] = noValueCommentProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(noValueCommentProperty)) {}
+
+        assertTrue(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateMissingGetterReturnDocsWerrorEnabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true), generatorOptions)
+        val notDocumentedGetter = getterForPath(path = propertyPath, comment = LimeComment())
+        val propertyWithNotDocumentedGetter = propertyForPath(path = propertyPath, getter = notDocumentedGetter)
+
+        allElements[propertyPath.toString()] = propertyWithNotDocumentedGetter
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(propertyWithNotDocumentedGetter)) {}
+
+        assertFalse(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateMissingGetterReturnDocsWerrorDisabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true))
+        val notDocumentedGetter = getterForPath(path = propertyPath, comment = LimeComment())
+        val propertyWithNotDocumentedGetter = propertyForPath(path = propertyPath, getter = notDocumentedGetter)
+
+        allElements[propertyPath.toString()] = propertyWithNotDocumentedGetter
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(propertyWithNotDocumentedGetter)) {}
+
+        assertTrue(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateMissingSetterParamDocsWerrorEnabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true), generatorOptions)
+        val notDocumentedSetter = setterForPath(path = propertyPath, comment = LimeComment())
+        val propertyWithNotDocumentedSetterParam = propertyForPath(path = propertyPath, setter = notDocumentedSetter)
+
+        allElements[propertyPath.toString()] = propertyWithNotDocumentedSetterParam
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(propertyWithNotDocumentedSetterParam)) {}
+
+        assertFalse(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateMissingSetterParamDocsWerrorDisabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true))
+        val notDocumentedSetter = setterForPath(path = propertyPath, comment = LimeComment())
+        val propertyWithNotDocumentedSetterParam = propertyForPath(path = propertyPath, setter = notDocumentedSetter)
+
+        allElements[propertyPath.toString()] = propertyWithNotDocumentedSetterParam
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(propertyWithNotDocumentedSetterParam)) {}
+
+        assertTrue(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateEmptyValueCommentInternalPropertyWerrorEnabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true), generatorOptions)
+        val noValueCommentProperty = propertyForPath(path = propertyPath, attributes = internalAttributes, valueComment = LimeComment())
+
+        allElements[propertyPath.toString()] = noValueCommentProperty
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(noValueCommentProperty)) {}
+
+        // Validation passes, because documentation check is skipped for internal properties.
+        assertTrue(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateMissingGetterReturnDocsForPropertyOfInternalTypeDocsWerrorEnabled() {
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true), generatorOptions)
+        val notDocumentedGetter = getterForPath(path = propertyPath, comment = LimeComment())
+        val propertyWithNotDocumentedGetterReturn = propertyForPath(path = propertyPath, getter = notDocumentedGetter)
+
+        allElements[propertyPath.toString()] = propertyWithNotDocumentedGetterReturn
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(
+                path = typePath,
+                attributes = internalAttributes,
+                properties = listOf(propertyWithNotDocumentedGetterReturn),
+            ) {}
+
+        // Validation passes, because documentation check is skipped for properties of internal types.
+        assertTrue(werrorValidator.validate(limeModel))
+    }
+
+    @Test
+    fun validateMissingSetterParamDocsForPropertyOfTypeNestedInInternalOneWerrorEnabled() {
+        val internalOuterType = object : LimeContainerWithInheritance(typePath.parent, attributes = internalAttributes) {}
+        allElements[typePath.parent.toString()] = internalOuterType
+
+        val werrorValidator = LimePropertiesValidator(mockk(relaxed = true), generatorOptions)
+        val notDocumentedSetter = setterForPath(path = propertyPath, comment = LimeComment())
+        val propertyWithNotDocumentedSetterParam = propertyForPath(path = propertyPath, setter = notDocumentedSetter)
+
+        allElements[propertyPath.toString()] = propertyWithNotDocumentedSetterParam
+        allElements[typePath.toString()] =
+            object : LimeContainerWithInheritance(typePath, properties = listOf(propertyWithNotDocumentedSetterParam)) {}
+
+        // Validation passes, because documentation check is skipped because the type hierarchy above property has internal attribute.
+        assertTrue(werrorValidator.validate(limeModel))
     }
 }


### PR DESCRIPTION
This change extends LimePropertiesValidator class to warn
when parameters or return types used by accessors of properties
are missing.

The logic works as follows:
 - all properties need to be documented
 - return value of getter needs to be documented
 - parameter of setter needs to be documented
 - the validation is not applied for internal properties
    or properties nested in internal types (or types
    nested in internal types)

The user may enable treating the warning as error via werror flag.