### PR TITLE
Remove mismatch between default value of struct field in C++ and other languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Implemented validation of comments used for lambdas. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
  * Implemented validation of comments used for functions. When the description of parameters or return value is missing, then warning is generated. The user may also treat the warning as error via 'werror' flag.
 ### Bug fixes:
+ * C++: fixed a bug related to invalid default value of nullable field, which uses struct type. When field was nullable and its default value was set to default-constructed structure, then the generated code was invalid, because the field was initialized to std::nullopt instead to default-constructed struct.
  * Gluecodium.kt: fixed a bug related to running 'LimeFunctionsValidator' twice. It was not needed - running the validator once is sufficient.
  * Dart: fixed a bug related to missing 'const' keyword usage in definition of default values in constructors that used immutable structure types when `@Immutable` or `@PositionalDefaults` were specified.
  * Dart: fixed a bug related to missing/superflous 'const' keyword usage in definition of default values in constructors that used collections when `@Immutable` or `@PositionalDefaults` were specified.

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -640,5 +640,7 @@ elseif(dart IN_LIST GLUECODIUM_GENERATORS_DEFAULT)
         )
 endif()
 
+set(CPP_INPUT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/input/src/cpp")
+
 add_subdirectory(cpp)
 add_subdirectory(dart)

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/DefaultsTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/DefaultsTest.java
@@ -19,6 +19,7 @@
 package com.here.android.test;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 import android.os.Build;
@@ -246,5 +247,22 @@ public final class DefaultsTest {
 
     assertEquals(42, result.field1.intField);
     assertEquals(-1, result.field2.intField);
+  }
+
+  @Test
+  public void testDefaultsOfNullableFieldOfImmutableStruct() {
+    // Case 1: struct without explicit field constructor.
+    Defaults.ImmutableStructWithNullableFieldUsingImmutableStruct first =
+        new Defaults.ImmutableStructWithNullableFieldUsingImmutableStruct();
+
+    assertFalse(first.someField1 == null);
+    assertEquals(first.someField1.intField, 42);
+
+    // Case 2: struct with explicit field constructor.
+    Defaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct second =
+        new Defaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(123, 456);
+
+    assertFalse(second.someField1 == null);
+    assertEquals(second.someField1.intField, 42);
   }
 }

--- a/functional-tests/functional/cpp/CMakeLists.txt
+++ b/functional-tests/functional/cpp/CMakeLists.txt
@@ -64,6 +64,7 @@ set(SOURCES
 set(CMAKE_INSTALL_RPATH $ORIGIN/../lib)
 
 add_executable(test_cpp ${SOURCES})
+target_include_directories(test_cpp PRIVATE ${CPP_INPUT_DIR})
 target_compile_definitions(test_cpp PRIVATE -DTEST_CPP_VERSION=Cxx${TEST_CPP_VERSION})
 target_link_libraries(test_cpp PRIVATE functional gmock_main)
 

--- a/functional-tests/functional/cpp/tests/ImmutableStructsTest.cpp
+++ b/functional-tests/functional/cpp/tests/ImmutableStructsTest.cpp
@@ -18,6 +18,7 @@
 //
 // -------------------------------------------------------------------------------------------------
 
+#include "test/Defaults.h"
 #include "test/PlainDataStructuresImmutable.h"
 #include <gmock/gmock.h>
 
@@ -42,6 +43,25 @@ TEST( ImmutableStructsTest, struct_with_accessors_is_copy_assignable )
 
     EXPECT_EQ(another_struct.get_string_field(), "foo");
     EXPECT_NE(&another_struct, &some_struct);
+}
+
+TEST ( ImmutableStructsTest, nullable_field_that_has_default_value_has_correct_default )
+{
+    // Case 1: struct without explicit field constructor.
+    test::Defaults::ImmutableStructWithNullableFieldUsingImmutableStruct some_struct{};
+
+    ASSERT_TRUE(some_struct.some_field1.has_value());
+    EXPECT_EQ(42, some_struct.some_field1->int_field);
+
+    // Case 2: struct with explicit field constructor.
+    int field_constructor_param1 = 123;
+    int field_constructor_param2 = 456;
+    test::Defaults::ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct another_struct{
+        field_constructor_param1, field_constructor_param2
+    };
+
+    ASSERT_TRUE(another_struct.some_field1.has_value());
+    EXPECT_EQ(42, another_struct.some_field1->int_field);
 }
 
 }  // test

--- a/functional-tests/functional/dart/test/Defaults_test.dart
+++ b/functional-tests/functional/dart/test/Defaults_test.dart
@@ -117,4 +117,13 @@ void main() {
     expect(result.field1.intField, 42);
     expect(result.field2.intField, -2);
   });
+  _testSuite.test("Check defaults of nullable field of immutable struct", () {
+      // Case 1: struct without explicit field constructor.
+      final first = DefaultsImmutableStructWithNullableFieldUsingImmutableStruct.withDefaults();
+      expect(first.someField1?.intField, 42);
+
+      // Case 2: struct with explicit field constructor.
+      final second = DefaultsImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct.withIntegers(123, 456);
+      expect(second.someField1?.intField, 42);
+  });
 }

--- a/functional-tests/functional/input/lime/Defaults.lime
+++ b/functional-tests/functional/input/lime/Defaults.lime
@@ -97,6 +97,22 @@ class Defaults {
         @Dart("withIntegers")
         field constructor(someField, anotherField)
     }
+    @Immutable
+    struct ImmutableStructWithNullableFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults? = {}
+        someField2: ImmutableStructWithCollections? = {}
+    }
+    @Immutable
+    struct ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults? = {}
+        someField2: ImmutableStructWithCollections? = {}
+
+        someField: Int = 5
+        anotherField: Int = 7
+
+        @Dart("withIntegers")
+        field constructor(someField, anotherField)
+    }
     struct StructWithSpecialDefaults {
         floatNanField: Float = NaN
         floatInfinityField: Float = Infinity

--- a/functional-tests/functional/swift/Tests/DefaultsTests.swift
+++ b/functional-tests/functional/swift/Tests/DefaultsTests.swift
@@ -153,6 +153,23 @@ class DefaultsTests: XCTestCase {
       XCTAssertEqual(result.field2.intField, -2)
     }
 
+    func testDefaultsOfNullableFieldOfImmutableStruct() {
+      // Case 1: struct without explicit field constructor.
+      let first = Defaults.ImmutableStructWithNullableFieldUsingImmutableStruct()
+
+      XCTAssertNotNil(first.someField1)
+      XCTAssertEqual(42, first.someField1?.intField)
+
+      // Case 2: struct with explicit field constructor.
+      let second = Defaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(
+          someField: 123,
+          anotherField: 456
+      )
+
+      XCTAssertNotNil(second.someField1)
+      XCTAssertEqual(42, second.someField1?.intField)
+    }
+
     static var allTests = [
         ("testGetDefault", testGetDefault),
         ("testWithAllButOneDefaultFields", testWithAllButOneDefaultFields),
@@ -166,6 +183,7 @@ class DefaultsTests: XCTestCase {
         ("testSwiftInitializerDefaults", testSwiftInitializerDefaults),
         ("testCppInitializerDefaults", testCppInitializerDefaults),
         ("testPositionalEnumeratorDefaults", testPositionalEnumeratorDefaults),
-        ("testConstantDefaults", testConstantDefaults)
+        ("testConstantDefaults", testConstantDefaults),
+        ("testDefaultsOfNullableFieldOfImmutableStruct", testDefaultsOfNullableFieldOfImmutableStruct)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppNameResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2020 HERE Europe B.V.
+ * Copyright (C) 2016-2024 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -184,11 +184,15 @@ internal class CppNameResolver(
             }
             is LimeValue.Null -> "${resolveName(limeValue.typeRef)}()"
             is LimeValue.InitializerList -> resolveListValue(limeValue)
-            is LimeValue.StructInitializer ->
-                limeValue.values.joinToString(", ", "${resolveName(limeValue.typeRef)}{", "}") { resolveValue(it) }
+            is LimeValue.StructInitializer -> resolveStructInitializer(limeValue)
             is LimeValue.KeyValuePair -> "{${resolveValue(limeValue.key)}, ${resolveValue(limeValue.value)}}"
             is LimeValue.Duration -> resolveDurationValue(limeValue)
         }
+
+    private fun resolveStructInitializer(limeValue: LimeValue.StructInitializer): String {
+        val typeName = resolveTypeName(limeValue.typeRef.type, isFullName = true, limeValue.typeRef.attributes)
+        return limeValue.values.joinToString(", ", "$typeName{", "}") { resolveValue(it) }
+    }
 
     private fun resolveLiteralValue(limeValue: LimeValue.Literal): String {
         val valueType = limeValue.typeRef.type.actualType

--- a/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/Defaults.lime
@@ -141,6 +141,24 @@ struct TypesWithDefaults {
         @Dart("withIntegers")
         field constructor(someField, anotherField)
     }
+
+    @Immutable
+    struct ImmutableStructWithNullableFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults? = {}
+        someField2: ImmutableStructWithCollections? = {}
+    }
+
+    @Immutable
+    struct ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+        someField1: SomeImmutableStructWithDefaults? = {}
+        someField2: ImmutableStructWithCollections? = {}
+
+        someField: Int = 5
+        anotherField: Int = 7
+
+        @Dart("withIntegers")
+        field constructor(someField, anotherField)
+    }
 }
 
 struct StructWithInitializerDefaults {

--- a/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/TypesWithDefaults.java
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android/com/example/smoke/TypesWithDefaults.java
@@ -227,6 +227,50 @@ public final class TypesWithDefaults {
 
     }
 
+    public static final class ImmutableStructWithNullableFieldUsingImmutableStruct {
+        @Nullable
+        public final TypesWithDefaults.SomeImmutableStructWithDefaults someField1;
+        @Nullable
+        public final TypesWithDefaults.ImmutableStructWithCollections someField2;
+
+        public ImmutableStructWithNullableFieldUsingImmutableStruct() {
+            this.someField1 = new TypesWithDefaults.SomeImmutableStructWithDefaults();
+            this.someField2 = new TypesWithDefaults.ImmutableStructWithCollections();
+        }
+
+        public ImmutableStructWithNullableFieldUsingImmutableStruct(@Nullable final TypesWithDefaults.SomeImmutableStructWithDefaults someField1, @Nullable final TypesWithDefaults.ImmutableStructWithCollections someField2) {
+            this.someField1 = someField1;
+            this.someField2 = someField2;
+        }
+
+
+    }
+
+    public static final class ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+        @Nullable
+        public final TypesWithDefaults.SomeImmutableStructWithDefaults someField1;
+        @Nullable
+        public final TypesWithDefaults.ImmutableStructWithCollections someField2;
+        public final int someField;
+        public final int anotherField;
+
+        public ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(@Nullable final TypesWithDefaults.SomeImmutableStructWithDefaults someField1, @Nullable final TypesWithDefaults.ImmutableStructWithCollections someField2, final int someField, final int anotherField) {
+            this.someField1 = someField1;
+            this.someField2 = someField2;
+            this.someField = someField;
+            this.anotherField = anotherField;
+        }
+
+        public ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(final int someField, final int anotherField) {
+            this.someField = someField;
+            this.anotherField = anotherField;
+            this.someField1 = new TypesWithDefaults.SomeImmutableStructWithDefaults();
+            this.someField2 = new TypesWithDefaults.ImmutableStructWithCollections();
+        }
+
+
+    }
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
@@ -115,8 +115,8 @@ struct _GLUECODIUM_CPP_EXPORT TypesWithDefaults {
     };
 
     struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithNullableFieldUsingImmutableStruct {
-        const std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1 = std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults >{};
-        const std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 = std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections >{};
+        const std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1 = ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults{};
+        const std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 = ::smoke::TypesWithDefaults::ImmutableStructWithCollections{};
 
         ImmutableStructWithNullableFieldUsingImmutableStruct( );
         ImmutableStructWithNullableFieldUsingImmutableStruct( std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1, std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 );
@@ -124,8 +124,8 @@ struct _GLUECODIUM_CPP_EXPORT TypesWithDefaults {
     };
 
     struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
-        const std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1 = std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults >{};
-        const std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 = std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections >{};
+        const std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1 = ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults{};
+        const std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 = ::smoke::TypesWithDefaults::ImmutableStructWithCollections{};
         const int32_t some_field = 5;
         const int32_t another_field = 7;
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
+++ b/gluecodium/src/test/resources/smoke/defaults/output/cpp/include/smoke/TypesWithDefaults.h
@@ -114,6 +114,29 @@ struct _GLUECODIUM_CPP_EXPORT TypesWithDefaults {
 
     };
 
+    struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithNullableFieldUsingImmutableStruct {
+        const std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1 = std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults >{};
+        const std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 = std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections >{};
+
+        ImmutableStructWithNullableFieldUsingImmutableStruct( );
+        ImmutableStructWithNullableFieldUsingImmutableStruct( std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1, std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 );
+
+    };
+
+    struct _GLUECODIUM_CPP_EXPORT ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+        const std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1 = std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults >{};
+        const std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2 = std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections >{};
+        const int32_t some_field = 5;
+        const int32_t another_field = 7;
+
+        ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct( );
+
+        ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct( int32_t some_field, int32_t another_field );
+
+        ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct( std::optional< ::smoke::TypesWithDefaults::SomeImmutableStructWithDefaults > some_field1, std::optional< ::smoke::TypesWithDefaults::ImmutableStructWithCollections > some_field2, int32_t some_field, int32_t another_field );
+
+    };
+
 };
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/types_with_defaults.dart
@@ -936,6 +936,214 @@ void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmut
   _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandfieldusingimmutablestructReleaseHandleNullable(handle);
 
 // End of TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct "private" section.
+@immutable
+class TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct {
+  final TypesWithDefaults_SomeImmutableStructWithDefaults? someField1;
+
+  final TypesWithDefaults_ImmutableStructWithCollections? someField2;
+
+  const TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct(this.someField1, this.someField2);
+  const TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct.withDefaults()
+    : someField1 = const TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = const TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
+}
+
+
+// TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct "private" section, not exported.
+
+final _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_create_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_release_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructGetFieldsomeField1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_get_field_someField1'));
+final _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructGetFieldsomeField2 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_get_field_someField2'));
+
+
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructToFfi(TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct value) {
+  final _someField1Handle = smokeTypeswithdefaultsSomeimmutablestructwithdefaultsToFfiNullable(value.someField1);
+  final _someField2Handle = smokeTypeswithdefaultsImmutablestructwithcollectionsToFfiNullable(value.someField2);
+  final _result = _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructCreateHandle(_someField1Handle, _someField2Handle);
+  smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandleNullable(_someField1Handle);
+  smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandleNullable(_someField2Handle);
+  return _result;
+}
+
+TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructFromFfi(Pointer<Void> handle) {
+  final _someField1Handle = _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructGetFieldsomeField1(handle);
+  final _someField2Handle = _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructGetFieldsomeField2(handle);
+  try {
+    return TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct(
+      smokeTypeswithdefaultsSomeimmutablestructwithdefaultsFromFfiNullable(_someField1Handle), 
+      smokeTypeswithdefaultsImmutablestructwithcollectionsFromFfiNullable(_someField2Handle)
+    );
+  } finally {
+    smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandleNullable(_someField1Handle);
+    smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandleNullable(_someField2Handle);
+  }
+}
+
+void smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseHandle(handle);
+
+// Nullable TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct
+
+final _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_create_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_release_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_get_value_nullable'));
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructToFfiNullable(TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructToFfi(value);
+  final result = _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructCreateHandleNullable(_handle);
+  smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct? smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructGetValueNullable(handle);
+  final result = smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructFromFfi(_handle);
+  smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTypeswithdefaultsImmutablestructwithnullablefieldusingimmutablestructReleaseHandleNullable(handle);
+
+// End of TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct "private" section.
+@immutable
+class TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+  final TypesWithDefaults_SomeImmutableStructWithDefaults? someField1;
+
+  final TypesWithDefaults_ImmutableStructWithCollections? someField2;
+
+  final int someField;
+
+  final int anotherField;
+
+  const TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(this.someField1, this.someField2, this.someField, this.anotherField);
+  const TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct.withIntegers(this.someField, this.anotherField)
+      : someField1 = const TypesWithDefaults_SomeImmutableStructWithDefaults.withDefaults(), someField2 = const TypesWithDefaults_ImmutableStructWithCollections.withDefaults();
+}
+
+
+// TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct "private" section, not exported.
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Int32, Int32),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Void>, int, int)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_create_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_release_handle'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldsomeField1 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_get_field_someField1'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldsomeField2 = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_get_field_someField2'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldsomeField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_get_field_someField'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldanotherField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_get_field_anotherField'));
+
+
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructToFfi(TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct value) {
+  final _someField1Handle = smokeTypeswithdefaultsSomeimmutablestructwithdefaultsToFfiNullable(value.someField1);
+  final _someField2Handle = smokeTypeswithdefaultsImmutablestructwithcollectionsToFfiNullable(value.someField2);
+  final _someFieldHandle = (value.someField);
+  final _anotherFieldHandle = (value.anotherField);
+  final _result = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructCreateHandle(_someField1Handle, _someField2Handle, _someFieldHandle, _anotherFieldHandle);
+  smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandleNullable(_someField1Handle);
+  smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandleNullable(_someField2Handle);
+  
+  
+  return _result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructFromFfi(Pointer<Void> handle) {
+  final _someField1Handle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldsomeField1(handle);
+  final _someField2Handle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldsomeField2(handle);
+  final _someFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldsomeField(handle);
+  final _anotherFieldHandle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetFieldanotherField(handle);
+  try {
+    return TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(
+      smokeTypeswithdefaultsSomeimmutablestructwithdefaultsFromFfiNullable(_someField1Handle), 
+      smokeTypeswithdefaultsImmutablestructwithcollectionsFromFfiNullable(_someField2Handle), 
+      (_someFieldHandle), 
+      (_anotherFieldHandle)
+    );
+  } finally {
+    smokeTypeswithdefaultsSomeimmutablestructwithdefaultsReleaseFfiHandleNullable(_someField1Handle);
+    smokeTypeswithdefaultsImmutablestructwithcollectionsReleaseFfiHandleNullable(_someField2Handle);
+    
+    
+  }
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseHandle(handle);
+
+// Nullable TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct
+
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_create_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_release_handle_nullable'));
+final _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_get_value_nullable'));
+
+Pointer<Void> smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructToFfiNullable(TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructToFfi(value);
+  final result = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructCreateHandleNullable(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct? smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructGetValueNullable(handle);
+  final result = smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructFromFfi(_handle);
+  smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTypeswithdefaultsImmutablestructwithfieldconstructorandnullablefieldusingimmutablestructReleaseHandleNullable(handle);
+
+// End of TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct "private" section.
 
 // TypesWithDefaults "private" section, not exported.
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/TypesWithDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/defaults/output/swift/smoke/TypesWithDefaults.swift
@@ -247,6 +247,56 @@ public struct TypesWithDefaults {
     }
 
 
+    public struct ImmutableStructWithNullableFieldUsingImmutableStruct {
+
+        public let someField1: TypesWithDefaults.SomeImmutableStructWithDefaults?
+
+        public let someField2: TypesWithDefaults.ImmutableStructWithCollections?
+
+        public init(someField1: TypesWithDefaults.SomeImmutableStructWithDefaults? = TypesWithDefaults.SomeImmutableStructWithDefaults(), someField2: TypesWithDefaults.ImmutableStructWithCollections? = TypesWithDefaults.ImmutableStructWithCollections()) {
+            self.someField1 = someField1
+            self.someField2 = someField2
+        }
+        internal init(cHandle: _baseRef) {
+            someField1 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_someField1_get(cHandle))
+            someField2 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_someField2_get(cHandle))
+        }
+    }
+
+
+    public struct ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+
+        public let someField1: TypesWithDefaults.SomeImmutableStructWithDefaults?
+
+        public let someField2: TypesWithDefaults.ImmutableStructWithCollections?
+
+        public let someField: Int32
+
+        public let anotherField: Int32
+
+
+        public init(someField: Int32, anotherField: Int32) {
+            self.someField = someField
+            self.anotherField = anotherField
+            self.someField1 = TypesWithDefaults.SomeImmutableStructWithDefaults()
+            self.someField2 = TypesWithDefaults.ImmutableStructWithCollections()
+        }
+
+        public init(someField1: TypesWithDefaults.SomeImmutableStructWithDefaults? = TypesWithDefaults.SomeImmutableStructWithDefaults(), someField2: TypesWithDefaults.ImmutableStructWithCollections? = TypesWithDefaults.ImmutableStructWithCollections(), someField: Int32 = 5, anotherField: Int32 = 7) {
+            self.someField1 = someField1
+            self.someField2 = someField2
+            self.someField = someField
+            self.anotherField = anotherField
+        }
+        internal init(cHandle: _baseRef) {
+            someField1 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_someField1_get(cHandle))
+            someField2 = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_someField2_get(cHandle))
+            someField = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_someField_get(cHandle))
+            anotherField = moveFromCType(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_anotherField_get(cHandle))
+        }
+    }
+
+
 }
 
 
@@ -607,6 +657,98 @@ internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFiel
 }
 internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndFieldUsingImmutableStruct_release_optional_handle)
+}
+
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct {
+    return TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct) -> RefHolder {
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_create_handle(c_someField1.ref, c_someField2.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_unwrap_optional_handle(handle)
+    return TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct(cHandle: unwrappedHandle) as TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct? {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_create_optional_handle(c_someField1.ref, c_someField2.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithNullableFieldUsingImmutableStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithNullableFieldUsingImmutableStruct_release_optional_handle)
+}
+
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+    return TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct) -> RefHolder {
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    let c_someField = moveToCType(swiftType.someField)
+    let c_anotherField = moveToCType(swiftType.anotherField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_create_handle(c_someField1.ref, c_someField2.ref, c_someField.ref, c_anotherField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_unwrap_optional_handle(handle)
+    return TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct(cHandle: unwrappedHandle) as TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct
+}
+internal func moveFromCType(_ handle: _baseRef) -> TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct? {
+    defer {
+        smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_someField1 = moveToCType(swiftType.someField1)
+    let c_someField2 = moveToCType(swiftType.someField2)
+    let c_someField = moveToCType(swiftType.someField)
+    let c_anotherField = moveToCType(swiftType.anotherField)
+    return RefHolder(smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_create_optional_handle(c_someField1.ref, c_someField2.ref, c_someField.ref, c_anotherField.ref))
+}
+internal func moveToCType(_ swiftType: TypesWithDefaults.ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_TypesWithDefaults_ImmutableStructWithFieldConstructorAndNullableFieldUsingImmutableStruct_release_optional_handle)
 }
 
 


### PR DESCRIPTION
---------- Motivation ----------

This change fixes a bug related to invalid default value of nullable
field, which uses struct type. When field was nullable and its default
value was set to default-constructed structure, then the generated
code in C++ was invalid, because the field was initialized to std::nullopt
instead of default-constructed struct.


---------- Contents of the change ----------

This change:
 - implements new functional tests to confirm the invalid behavior
 - adds new LIME input to smoke tests to point out which lines are
    invalid
 - implements a fix in `CppNameResolver.kt` to remove superflous
    `std::optional` prefix when resolving default value 