### PR TITLE
Embed full link to docs in printed warnings

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
@@ -29,6 +29,7 @@ import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.validator.LimeValidatorUtils.LIME_MARKDOWN_DOCS
 import com.here.gluecodium.validator.LimeValidatorUtils.needsDocumentationComment
 
 internal class LimeFunctionsValidator(private val logger: LimeLogger, generatorOptions: GeneratorOptions = GeneratorOptions()) {
@@ -73,20 +74,25 @@ internal class LimeFunctionsValidator(private val logger: LimeLogger, generatorO
     }
 
     private fun validateParametersComments(limeFunction: LimeFunction): Boolean {
+        val checkDocsMessage = "please check $FUNCTIONS_STRUCTURED_COMMENTS"
         var result = true
 
         for (parameter in limeFunction.parameters) {
             if (parameter.comment.isEmpty()) {
-                logger.maybeError(limeFunction, "Parameter '${parameter.name}' must be documented")
+                logger.maybeError(limeFunction, "Parameter '${parameter.name}' must be documented; $checkDocsMessage")
                 result = false
             }
         }
 
         if (!limeFunction.returnType.isVoid && limeFunction.returnType.comment.isEmpty()) {
-            logger.maybeError(limeFunction, "Return must be documented")
+            logger.maybeError(limeFunction, "Return must be documented; $checkDocsMessage")
             result = false
         }
 
         return result
+    }
+
+    companion object {
+        private const val FUNCTIONS_STRUCTURED_COMMENTS = "$LIME_MARKDOWN_DOCS#structured-comments-for-functions"
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeLambdaValidator.kt
@@ -25,6 +25,7 @@ import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.validator.LimeValidatorUtils.LIME_MARKDOWN_DOCS
 import com.here.gluecodium.validator.LimeValidatorUtils.needsDocumentationComment
 
 class LimeLambdaValidator(private val logger: LimeLogger, generatorOptions: GeneratorOptions = GeneratorOptions()) {
@@ -56,19 +57,25 @@ class LimeLambdaValidator(private val logger: LimeLogger, generatorOptions: Gene
     }
 
     private fun validateLambdaDocs(limeLambda: LimeLambda): Boolean {
+        val checkDocsMessage = "please check $LAMBDAS_STRUCTURED_COMMENTS"
         var result = true
+
         for (parameter in limeLambda.parameters) {
             if (parameter.comment.isEmpty()) {
-                logger.maybeError(limeLambda, "Parameter '${parameter.name}' must be documented")
+                logger.maybeError(limeLambda, "Parameter '${parameter.name}' must be documented; $checkDocsMessage")
                 result = false
             }
         }
 
         if (!limeLambda.returnType.isVoid && limeLambda.returnType.comment.isEmpty()) {
-            logger.maybeError(limeLambda, "Return must be documented")
+            logger.maybeError(limeLambda, "Return must be documented; $checkDocsMessage")
             result = false
         }
 
         return result
+    }
+
+    companion object {
+        private const val LAMBDAS_STRUCTURED_COMMENTS = "$LIME_MARKDOWN_DOCS#structured-comments-for-lambdas"
     }
 }


### PR DESCRIPTION
This change is a small improvement of warnings/errors related
to documentation of parameters and return values.

It introduces the full links to Gluecodium repository and sections,
which describe the correct syntax and the reasons of warnings.
