### PR TITLE
Do not warn when constructor does not document return value

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeFunctionsValidator.kt
@@ -84,7 +84,7 @@ internal class LimeFunctionsValidator(private val logger: LimeLogger, generatorO
             }
         }
 
-        if (!limeFunction.returnType.isVoid && limeFunction.returnType.comment.isEmpty()) {
+        if (!limeFunction.isConstructor && !limeFunction.returnType.isVoid && limeFunction.returnType.comment.isEmpty()) {
             logger.maybeError(limeFunction, "Return must be documented; $checkDocsMessage")
             result = false
         }

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorDocsTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeFunctionsValidatorDocsTest.kt
@@ -130,6 +130,27 @@ class LimeFunctionsValidatorDocsTest {
     }
 
     @Test
+    fun validateMissingReturnCommentForConstructorWhenWerrorIsEnabled() {
+        // Given LimeFunction that is constructor without documented return value.
+        val limeFunction =
+            LimeFunction(
+                path = limeFunctionPath,
+                comment = limeComment,
+                isConstructor = true,
+                returnType = LimeReturnType(typeRef = LimeBasicTypeRef.INT),
+            )
+        allElements[limeFunctionPath.toString()] = limeFunction
+        allElements[limeStructPath.toString()] = LimeStruct(path = limeStructPath, functions = listOf(limeFunction))
+
+        // When validating it with werror flag enabled.
+        val validator = LimeFunctionsValidator(logger = mockk(relaxed = true), generatorOptions = generatorOptions)
+        val result = validator.validate(limeModel)
+
+        // Then validation passes - the constructor does not need to document return value.
+        assertTrue(result)
+    }
+
+    @Test
     fun validateMissingReturnCommentWhenWerrorIsDisabled() {
         // Given LimeFunction without documented return value.
         val limeFunction =


### PR DESCRIPTION
The warning does not need to be printed when
constructor does not document return value.