### PR TITLE
Dart: fix race condition between garbage collection of finalizable objects and native function calls

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Install Dart SDK
         run: |
           DART_RELEASE_CHANNEL=stable
-          DART_VERSION=2.12.0
+          DART_VERSION=2.18.1
           wget -nv https://storage.googleapis.com/dart-archive/channels/${DART_RELEASE_CHANNEL}/release/${DART_VERSION}/linux_packages/dart_${DART_VERSION}-1_amd64.deb
           sudo apt -y install ./dart_${DART_VERSION}-1_amd64.deb
       - name: Build and run functional tests
@@ -373,7 +373,7 @@ jobs:
       - name: Install Dart SDK
         run: |
           DART_RELEASE_CHANNEL=stable
-          DART_VERSION=2.12.0
+          DART_VERSION=2.18.1
           wget -nv https://storage.googleapis.com/dart-archive/channels/${DART_RELEASE_CHANNEL}/release/${DART_VERSION}/linux_packages/dart_${DART_VERSION}-1_amd64.deb
           sudo apt -y install ./dart_${DART_VERSION}-1_amd64.deb
       - name: Build and run functional tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+ * Dart: fixed race condition between garbage collector (which could trigger finalizer) and native method calls in finalizable classes.
+
 ## 13.10.0
 Release date 2024-11-28
 ### Features:

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 abstract class {{resolveName}}{{!!
-}}{{#if this.parents}} implements {{#this.parents}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}} {
+}} implements {{#if this.parents}}{{#this.parents}}{{resolveName}}, {{/this.parents}}{{/if}}Finalizable {
 {{#set parent=this container=this}}{{#constructors}}
 {{prefixPartial "dart/DartFunctionDocs" "  "}}
   factory {{resolveName parent}}{{>dart/DartConstructorName}}({{!!

--- a/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartInterface.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   !}}
 {{>dart/DartDocumentation}}{{>dart/DartAttributes}}
 abstract class {{resolveName}}{{!!
-}}{{#if this.parents}} implements {{#this.parents}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/this.parents}}{{/if}} {
+}} implements {{#if this.parents}}{{#this.parents}}{{resolveName}}, {{/this.parents}}{{/if}}Finalizable {
 {{#if inheritedFunctions functions inheritedProperties properties logic="or"}}
 {{prefixPartial "dart/DartDocumentation" "  "}}
   factory {{resolveName}}(

--- a/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLambda.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2020 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ final _{{resolveName "Ffi"}}CreateProxy = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(int, int, Object, Pointer)
   >('{{libraryName}}_{{resolveName "FfiSnakeCase"}}_create_proxy'));
 
-class {{resolveName}}$Impl {
+class {{resolveName}}$Impl implements Finalizable {
   final Pointer<Void> handle;
   {{resolveName}}$Impl(this.handle);
 

--- a/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartLazyList.mustache
@@ -1,6 +1,6 @@
 {{!!
   !
-  ! Copyright (C) 2016-2021 HERE Europe B.V.
+  ! Copyright (C) 2016-2024 HERE Europe B.V.
   !
   ! Licensed under the Apache License, Version 2.0 (the "License");
   ! you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class _LazyIterator<E> implements Iterator<E> {
 }
 
 /// @nodoc
-class LazyList<E> extends Iterable<E> implements List<E> {
+class LazyList<E> extends Iterable<E> implements List<E>, Finalizable {
   static final _cannotModify = "Cannot modify an unmodifiable list";
 
   final Pointer<Void> handle;

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
@@ -211,7 +211,7 @@ final _smokeAsyncclassAsyncvoidresultlambdaCreateProxy = __lib.catchArgumentErro
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncvoidResultlambda_create_proxy'));
 
-class AsyncClass_asyncVoid__resultLambda$Impl {
+class AsyncClass_asyncVoid__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncClass_asyncVoid__resultLambda$Impl(this.handle);
 
@@ -260,7 +260,7 @@ final _smokeAsyncclassAsyncvoidthrowsresultlambdaCreateProxy = __lib.catchArgume
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncvoidthrowsResultlambda_create_proxy'));
 
-class AsyncClass_asyncVoidThrows__resultLambda$Impl {
+class AsyncClass_asyncVoidThrows__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncClass_asyncVoidThrows__resultLambda$Impl(this.handle);
 
@@ -309,7 +309,7 @@ final _smokeAsyncclassAsyncvoidthrowserrorlambdaCreateProxy = __lib.catchArgumen
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncvoidthrowsErrorlambda_create_proxy'));
 
-class AsyncClass_asyncVoidThrows__errorLambda$Impl {
+class AsyncClass_asyncVoidThrows__errorLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncClass_asyncVoidThrows__errorLambda$Impl(this.handle);
 
@@ -361,7 +361,7 @@ final _smokeAsyncclassAsyncintresultlambdaCreateProxy = __lib.catchArgumentError
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncintResultlambda_create_proxy'));
 
-class AsyncClass_asyncInt__resultLambda$Impl {
+class AsyncClass_asyncInt__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncClass_asyncInt__resultLambda$Impl(this.handle);
 
@@ -413,7 +413,7 @@ final _smokeAsyncclassAsyncintthrowsresultlambdaCreateProxy = __lib.catchArgumen
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncintthrowsResultlambda_create_proxy'));
 
-class AsyncClass_asyncIntThrows__resultLambda$Impl {
+class AsyncClass_asyncIntThrows__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncClass_asyncIntThrows__resultLambda$Impl(this.handle);
 
@@ -465,7 +465,7 @@ final _smokeAsyncclassAsyncintthrowserrorlambdaCreateProxy = __lib.catchArgument
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncintthrowsErrorlambda_create_proxy'));
 
-class AsyncClass_asyncIntThrows__errorLambda$Impl {
+class AsyncClass_asyncIntThrows__errorLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncClass_asyncIntThrows__errorLambda$Impl(this.handle);
 
@@ -517,7 +517,7 @@ final _smokeAsyncclassAsyncstaticresultlambdaCreateProxy = __lib.catchArgumentEr
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncstaticResultlambda_create_proxy'));
 
-class AsyncClass_asyncStatic__resultLambda$Impl {
+class AsyncClass_asyncStatic__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncClass_asyncStatic__resultLambda$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_class.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:async';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
@@ -7,17 +9,28 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/async_error_code.dart';
 import 'package:library/src/smoke/async_exception.dart';
 import 'package:meta/meta.dart';
-abstract class AsyncClass {
+
+abstract class AsyncClass implements Finalizable {
+
+
   Future<void> asyncVoid(bool input);
+
   Future<void> asyncVoidThrows(bool input);
+
   Future<int> asyncInt(bool input);
+
   Future<int> asyncIntThrows(bool input);
+
   static Future<void> asyncStatic(bool input) => $prototype.asyncStatic(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = AsyncClass$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // AsyncClass "private" section, not exported.
+
 final _smokeAsyncclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -30,10 +43,19 @@ final _smokeAsyncclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AsyncClass_release_handle'));
+
+
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
+
   AsyncClass$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   Future<void> asyncVoid(bool input) {
     final $completer = Completer<void>();
@@ -43,6 +65,7 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     );
     return $completer.future;
   }
+
   void _asyncVoid__async(AsyncClass_asyncVoid__resultLambda _resultLambda, bool input) {
     final __asyncVoid__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_AsyncClass_asyncVoid__asyncVoid__resultLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncclassAsyncvoidresultlambdaToFfi(_resultLambda);
@@ -51,7 +74,9 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     __asyncVoid__asyncFfi(_handle, __lib.LibraryContext.isolateId, __resultLambdaHandle, _inputHandle);
     smokeAsyncclassAsyncvoidresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   @override
   Future<void> asyncVoidThrows(bool input) {
     final $completer = Completer<void>();
@@ -62,6 +87,7 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     );
     return $completer.future;
   }
+
   void _asyncVoidThrows__async(AsyncClass_asyncVoidThrows__resultLambda _resultLambda, AsyncClass_asyncVoidThrows__errorLambda _errorLambda, bool input) {
     final __asyncVoidThrows__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>, int)>('library_smoke_AsyncClass_asyncVoidThrows__asyncVoidThrows__resultLambda_asyncVoidThrows__errorLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncclassAsyncvoidthrowsresultlambdaToFfi(_resultLambda);
@@ -72,7 +98,9 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     smokeAsyncclassAsyncvoidthrowsresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     smokeAsyncclassAsyncvoidthrowserrorlambdaReleaseFfiHandle(__errorLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   @override
   Future<int> asyncInt(bool input) {
     final $completer = Completer<int>();
@@ -82,6 +110,7 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     );
     return $completer.future;
   }
+
   void _asyncInt__async(AsyncClass_asyncInt__resultLambda _resultLambda, bool input) {
     final __asyncInt__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_AsyncClass_asyncInt__asyncInt__resultLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncclassAsyncintresultlambdaToFfi(_resultLambda);
@@ -90,7 +119,9 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     __asyncInt__asyncFfi(_handle, __lib.LibraryContext.isolateId, __resultLambdaHandle, _inputHandle);
     smokeAsyncclassAsyncintresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   @override
   Future<int> asyncIntThrows(bool input) {
     final $completer = Completer<int>();
@@ -101,6 +132,7 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     );
     return $completer.future;
   }
+
   void _asyncIntThrows__async(AsyncClass_asyncIntThrows__resultLambda _resultLambda, AsyncClass_asyncIntThrows__errorLambda _errorLambda, bool input) {
     final __asyncIntThrows__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>, int)>('library_smoke_AsyncClass_asyncIntThrows__asyncIntThrows__resultLambda_asyncIntThrows__errorLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncclassAsyncintthrowsresultlambdaToFfi(_resultLambda);
@@ -111,7 +143,9 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     smokeAsyncclassAsyncintthrowsresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     smokeAsyncclassAsyncintthrowserrorlambdaReleaseFfiHandle(__errorLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   Future<void> asyncStatic(bool input) {
     final $completer = Completer<void>();
     _asyncStatic__async(
@@ -120,6 +154,7 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     );
     return $completer.future;
   }
+
   void _asyncStatic__async(AsyncClass_asyncStatic__resultLambda _resultLambda, bool input) {
     final __asyncStatic__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>, Uint8), void Function(int, Pointer<Void>, int)>('library_smoke_AsyncClass_asyncStatic__asyncStatic__resultLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncclassAsyncstaticresultlambdaToFfi(_resultLambda);
@@ -127,31 +162,46 @@ class AsyncClass$Impl extends __lib.NativeBase implements AsyncClass {
     __asyncStatic__asyncFfi(__lib.LibraryContext.isolateId, __resultLambdaHandle, _inputHandle);
     smokeAsyncclassAsyncstaticresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
+
 }
+
 Pointer<Void> smokeAsyncclassToFfi(AsyncClass value) =>
   _smokeAsyncclassCopyHandle((value as __lib.NativeBase).handle);
+
 AsyncClass smokeAsyncclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AsyncClass) return instance;
+
   final _copiedHandle = _smokeAsyncclassCopyHandle(handle);
   final result = AsyncClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeAsyncclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeAsyncclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassReleaseHandle(handle);
+
 Pointer<Void> smokeAsyncclassToFfiNullable(AsyncClass? value) =>
   value != null ? smokeAsyncclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 AsyncClass? smokeAsyncclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeAsyncclassFromFfi(handle) : null;
+
 void smokeAsyncclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAsyncclassReleaseHandle(handle);
+
 // End of AsyncClass "private" section.
+
+
 typedef AsyncClass_asyncVoid__resultLambda = void Function();
+
 // AsyncClass_asyncVoid__resultLambda "private" section, not exported.
+
 final _smokeAsyncclassAsyncvoidresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -160,22 +210,29 @@ final _smokeAsyncclassAsyncvoidresultlambdaCreateProxy = __lib.catchArgumentErro
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncvoidResultlambda_create_proxy'));
+
 class AsyncClass_asyncVoid__resultLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncVoid__resultLambda$Impl(this.handle);
+
   void asyncVoid__resultLambda() {
     final _asyncVoid__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncClass_AsyncvoidResultlambda_call'));
     final _handle = this.handle;
     _asyncVoid__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAsyncclassAsyncvoidresultlambdaasyncVoid__resultLambdaStatic(Object _obj) {
+  
   try {
     (_obj as AsyncClass_asyncVoid__resultLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncclassAsyncvoidresultlambdaToFfi(AsyncClass_asyncVoid__resultLambda value) =>
   _smokeAsyncclassAsyncvoidresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -183,11 +240,17 @@ Pointer<Void> smokeAsyncclassAsyncvoidresultlambdaToFfi(AsyncClass_asyncVoid__re
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncclassAsyncvoidresultlambdaasyncVoid__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncclassAsyncvoidresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncvoidresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncClass_asyncVoid__resultLambda "private" section.
 typedef AsyncClass_asyncVoidThrows__resultLambda = void Function();
+
 // AsyncClass_asyncVoidThrows__resultLambda "private" section, not exported.
+
 final _smokeAsyncclassAsyncvoidthrowsresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -196,22 +259,29 @@ final _smokeAsyncclassAsyncvoidthrowsresultlambdaCreateProxy = __lib.catchArgume
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncvoidthrowsResultlambda_create_proxy'));
+
 class AsyncClass_asyncVoidThrows__resultLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncVoidThrows__resultLambda$Impl(this.handle);
+
   void asyncVoidThrows__resultLambda() {
     final _asyncVoidThrows__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncClass_AsyncvoidthrowsResultlambda_call'));
     final _handle = this.handle;
     _asyncVoidThrows__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAsyncclassAsyncvoidthrowsresultlambdaasyncVoidThrows__resultLambdaStatic(Object _obj) {
+  
   try {
     (_obj as AsyncClass_asyncVoidThrows__resultLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncclassAsyncvoidthrowsresultlambdaToFfi(AsyncClass_asyncVoidThrows__resultLambda value) =>
   _smokeAsyncclassAsyncvoidthrowsresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -219,11 +289,17 @@ Pointer<Void> smokeAsyncclassAsyncvoidthrowsresultlambdaToFfi(AsyncClass_asyncVo
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncclassAsyncvoidthrowsresultlambdaasyncVoidThrows__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncclassAsyncvoidthrowsresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncvoidthrowsresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncClass_asyncVoidThrows__resultLambda "private" section.
 typedef AsyncClass_asyncVoidThrows__errorLambda = void Function(AsyncErrorCode);
+
 // AsyncClass_asyncVoidThrows__errorLambda "private" section, not exported.
+
 final _smokeAsyncclassAsyncvoidthrowserrorlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -232,18 +308,24 @@ final _smokeAsyncclassAsyncvoidthrowserrorlambdaCreateProxy = __lib.catchArgumen
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncvoidthrowsErrorlambda_create_proxy'));
+
 class AsyncClass_asyncVoidThrows__errorLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncVoidThrows__errorLambda$Impl(this.handle);
+
   void asyncVoidThrows__errorLambda(AsyncErrorCode p0) {
     final _asyncVoidThrows__errorLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncClass_AsyncvoidthrowsErrorlambda_call__AsyncErrorCode'));
     final _p0Handle = smokeAsyncerrorcodeToFfi(p0);
     final _handle = this.handle;
     _asyncVoidThrows__errorLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     smokeAsyncerrorcodeReleaseFfiHandle(_p0Handle);
+
   }
+
 }
+
 int _smokeAsyncclassAsyncvoidthrowserrorlambdaasyncVoidThrows__errorLambdaStatic(Object _obj, int p0) {
+  
   try {
     (_obj as AsyncClass_asyncVoidThrows__errorLambda)(smokeAsyncerrorcodeFromFfi(p0));
   } finally {
@@ -251,6 +333,7 @@ int _smokeAsyncclassAsyncvoidthrowserrorlambdaasyncVoidThrows__errorLambdaStatic
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncclassAsyncvoidthrowserrorlambdaToFfi(AsyncClass_asyncVoidThrows__errorLambda value) =>
   _smokeAsyncclassAsyncvoidthrowserrorlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -258,11 +341,17 @@ Pointer<Void> smokeAsyncclassAsyncvoidthrowserrorlambdaToFfi(AsyncClass_asyncVoi
     value,
     Pointer.fromFunction<Int64 Function(Handle, Uint32)>(_smokeAsyncclassAsyncvoidthrowserrorlambdaasyncVoidThrows__errorLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncclassAsyncvoidthrowserrorlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncvoidthrowserrorlambdaReleaseHandle(handle);
+
+
 // End of AsyncClass_asyncVoidThrows__errorLambda "private" section.
 typedef AsyncClass_asyncInt__resultLambda = void Function(int);
+
 // AsyncClass_asyncInt__resultLambda "private" section, not exported.
+
 final _smokeAsyncclassAsyncintresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -271,23 +360,32 @@ final _smokeAsyncclassAsyncintresultlambdaCreateProxy = __lib.catchArgumentError
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncintResultlambda_create_proxy'));
+
 class AsyncClass_asyncInt__resultLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncInt__resultLambda$Impl(this.handle);
+
   void asyncInt__resultLambda(int p0) {
     final _asyncInt__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncClass_AsyncintResultlambda_call__Int'));
     final _p0Handle = (p0);
     final _handle = this.handle;
     _asyncInt__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+
+
   }
+
 }
+
 int _smokeAsyncclassAsyncintresultlambdaasyncInt__resultLambdaStatic(Object _obj, int p0) {
+  
   try {
     (_obj as AsyncClass_asyncInt__resultLambda)((p0));
   } finally {
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncclassAsyncintresultlambdaToFfi(AsyncClass_asyncInt__resultLambda value) =>
   _smokeAsyncclassAsyncintresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -295,11 +393,17 @@ Pointer<Void> smokeAsyncclassAsyncintresultlambdaToFfi(AsyncClass_asyncInt__resu
     value,
     Pointer.fromFunction<Int64 Function(Handle, Int32)>(_smokeAsyncclassAsyncintresultlambdaasyncInt__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncclassAsyncintresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncintresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncClass_asyncInt__resultLambda "private" section.
 typedef AsyncClass_asyncIntThrows__resultLambda = void Function(int);
+
 // AsyncClass_asyncIntThrows__resultLambda "private" section, not exported.
+
 final _smokeAsyncclassAsyncintthrowsresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -308,23 +412,32 @@ final _smokeAsyncclassAsyncintthrowsresultlambdaCreateProxy = __lib.catchArgumen
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncintthrowsResultlambda_create_proxy'));
+
 class AsyncClass_asyncIntThrows__resultLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncIntThrows__resultLambda$Impl(this.handle);
+
   void asyncIntThrows__resultLambda(int p0) {
     final _asyncIntThrows__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncClass_AsyncintthrowsResultlambda_call__Int'));
     final _p0Handle = (p0);
     final _handle = this.handle;
     _asyncIntThrows__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+
+
   }
+
 }
+
 int _smokeAsyncclassAsyncintthrowsresultlambdaasyncIntThrows__resultLambdaStatic(Object _obj, int p0) {
+  
   try {
     (_obj as AsyncClass_asyncIntThrows__resultLambda)((p0));
   } finally {
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncclassAsyncintthrowsresultlambdaToFfi(AsyncClass_asyncIntThrows__resultLambda value) =>
   _smokeAsyncclassAsyncintthrowsresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -332,11 +445,17 @@ Pointer<Void> smokeAsyncclassAsyncintthrowsresultlambdaToFfi(AsyncClass_asyncInt
     value,
     Pointer.fromFunction<Int64 Function(Handle, Int32)>(_smokeAsyncclassAsyncintthrowsresultlambdaasyncIntThrows__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncclassAsyncintthrowsresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncintthrowsresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncClass_asyncIntThrows__resultLambda "private" section.
 typedef AsyncClass_asyncIntThrows__errorLambda = void Function(AsyncErrorCode);
+
 // AsyncClass_asyncIntThrows__errorLambda "private" section, not exported.
+
 final _smokeAsyncclassAsyncintthrowserrorlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -345,18 +464,24 @@ final _smokeAsyncclassAsyncintthrowserrorlambdaCreateProxy = __lib.catchArgument
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncintthrowsErrorlambda_create_proxy'));
+
 class AsyncClass_asyncIntThrows__errorLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncIntThrows__errorLambda$Impl(this.handle);
+
   void asyncIntThrows__errorLambda(AsyncErrorCode p0) {
     final _asyncIntThrows__errorLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncClass_AsyncintthrowsErrorlambda_call__AsyncErrorCode'));
     final _p0Handle = smokeAsyncerrorcodeToFfi(p0);
     final _handle = this.handle;
     _asyncIntThrows__errorLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     smokeAsyncerrorcodeReleaseFfiHandle(_p0Handle);
+
   }
+
 }
+
 int _smokeAsyncclassAsyncintthrowserrorlambdaasyncIntThrows__errorLambdaStatic(Object _obj, int p0) {
+  
   try {
     (_obj as AsyncClass_asyncIntThrows__errorLambda)(smokeAsyncerrorcodeFromFfi(p0));
   } finally {
@@ -364,6 +489,7 @@ int _smokeAsyncclassAsyncintthrowserrorlambdaasyncIntThrows__errorLambdaStatic(O
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncclassAsyncintthrowserrorlambdaToFfi(AsyncClass_asyncIntThrows__errorLambda value) =>
   _smokeAsyncclassAsyncintthrowserrorlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -371,11 +497,17 @@ Pointer<Void> smokeAsyncclassAsyncintthrowserrorlambdaToFfi(AsyncClass_asyncIntT
     value,
     Pointer.fromFunction<Int64 Function(Handle, Uint32)>(_smokeAsyncclassAsyncintthrowserrorlambdaasyncIntThrows__errorLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncclassAsyncintthrowserrorlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncintthrowserrorlambdaReleaseHandle(handle);
+
+
 // End of AsyncClass_asyncIntThrows__errorLambda "private" section.
 typedef AsyncClass_asyncStatic__resultLambda = void Function();
+
 // AsyncClass_asyncStatic__resultLambda "private" section, not exported.
+
 final _smokeAsyncclassAsyncstaticresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -384,22 +516,29 @@ final _smokeAsyncclassAsyncstaticresultlambdaCreateProxy = __lib.catchArgumentEr
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncClass_AsyncstaticResultlambda_create_proxy'));
+
 class AsyncClass_asyncStatic__resultLambda$Impl {
   final Pointer<Void> handle;
   AsyncClass_asyncStatic__resultLambda$Impl(this.handle);
+
   void asyncStatic__resultLambda() {
     final _asyncStatic__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncClass_AsyncstaticResultlambda_call'));
     final _handle = this.handle;
     _asyncStatic__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAsyncclassAsyncstaticresultlambdaasyncStatic__resultLambdaStatic(Object _obj) {
+  
   try {
     (_obj as AsyncClass_asyncStatic__resultLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncclassAsyncstaticresultlambdaToFfi(AsyncClass_asyncStatic__resultLambda value) =>
   _smokeAsyncclassAsyncstaticresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -407,6 +546,10 @@ Pointer<Void> smokeAsyncclassAsyncstaticresultlambdaToFfi(AsyncClass_asyncStatic
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncclassAsyncstaticresultlambdaasyncStatic__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncclassAsyncstaticresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncclassAsyncstaticresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncClass_asyncStatic__resultLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
@@ -98,7 +98,7 @@ final _smokeAsyncrenamedDisposeresultlambdaCreateProxy = __lib.catchArgumentErro
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncRenamed_DisposeResultlambda_create_proxy'));
 
-class AsyncRenamed_dispose__resultLambda$Impl {
+class AsyncRenamed_dispose__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncRenamed_dispose__resultLambda$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_renamed.dart
@@ -1,12 +1,20 @@
+
+
 import 'dart:async';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class AsyncRenamed {
+
+abstract class AsyncRenamed implements Finalizable {
+
+
   Future<void> dispose();
 }
+
+
 // AsyncRenamed "private" section, not exported.
+
 final _smokeAsyncrenamedRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -19,8 +27,13 @@ final _smokeAsyncrenamedReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AsyncRenamed_release_handle'));
+
+
+
 class AsyncRenamed$Impl extends __lib.NativeBase implements AsyncRenamed {
+
   AsyncRenamed$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   Future<void> dispose() {
     final $completer = Completer<void>();
@@ -29,37 +42,53 @@ class AsyncRenamed$Impl extends __lib.NativeBase implements AsyncRenamed {
     );
     return $completer.future;
   }
+
   void _dispose__async(AsyncRenamed_dispose__resultLambda _resultLambda) {
     final __dispose__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AsyncRenamed_dispose__dispose__resultLambda'));
     final __resultLambdaHandle = smokeAsyncrenamedDisposeresultlambdaToFfi(_resultLambda);
     final _handle = this.handle;
     __dispose__asyncFfi(_handle, __lib.LibraryContext.isolateId, __resultLambdaHandle);
     smokeAsyncrenamedDisposeresultlambdaReleaseFfiHandle(__resultLambdaHandle);
+
   }
+
+
 }
+
 Pointer<Void> smokeAsyncrenamedToFfi(AsyncRenamed value) =>
   _smokeAsyncrenamedCopyHandle((value as __lib.NativeBase).handle);
+
 AsyncRenamed smokeAsyncrenamedFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AsyncRenamed) return instance;
+
   final _copiedHandle = _smokeAsyncrenamedCopyHandle(handle);
   final result = AsyncRenamed$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeAsyncrenamedRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeAsyncrenamedReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncrenamedReleaseHandle(handle);
+
 Pointer<Void> smokeAsyncrenamedToFfiNullable(AsyncRenamed? value) =>
   value != null ? smokeAsyncrenamedToFfi(value) : Pointer<Void>.fromAddress(0);
+
 AsyncRenamed? smokeAsyncrenamedFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeAsyncrenamedFromFfi(handle) : null;
+
 void smokeAsyncrenamedReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAsyncrenamedReleaseHandle(handle);
+
 // End of AsyncRenamed "private" section.
+
+
 typedef AsyncRenamed_dispose__resultLambda = void Function();
+
 // AsyncRenamed_dispose__resultLambda "private" section, not exported.
+
 final _smokeAsyncrenamedDisposeresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -68,22 +97,29 @@ final _smokeAsyncrenamedDisposeresultlambdaCreateProxy = __lib.catchArgumentErro
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncRenamed_DisposeResultlambda_create_proxy'));
+
 class AsyncRenamed_dispose__resultLambda$Impl {
   final Pointer<Void> handle;
   AsyncRenamed_dispose__resultLambda$Impl(this.handle);
+
   void dispose__resultLambda() {
     final _dispose__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncRenamed_DisposeResultlambda_call'));
     final _handle = this.handle;
     _dispose__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAsyncrenamedDisposeresultlambdadispose__resultLambdaStatic(Object _obj) {
+  
   try {
     (_obj as AsyncRenamed_dispose__resultLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncrenamedDisposeresultlambdaToFfi(AsyncRenamed_dispose__resultLambda value) =>
   _smokeAsyncrenamedDisposeresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -91,6 +127,10 @@ Pointer<Void> smokeAsyncrenamedDisposeresultlambdaToFfi(AsyncRenamed_dispose__re
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncrenamedDisposeresultlambdadispose__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncrenamedDisposeresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncrenamedDisposeresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncRenamed_dispose__resultLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_struct.dart
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/lib/src/smoke/async_struct.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:async';
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
@@ -5,19 +7,36 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/throw_me_exception.dart';
 import 'package:meta/meta.dart';
+
+
+
+
+
+
+
 class AsyncStruct {
   String stringField;
+
   AsyncStruct(this.stringField);
+
   Future<void> asyncVoid(bool input) => $prototype.asyncVoid(this, input);
+
   Future<void> asyncVoidThrows(bool input) => $prototype.asyncVoidThrows(this, input);
+
   Future<int> asyncInt(bool input) => $prototype.asyncInt(this, input);
+
   Future<int> asyncIntThrows(bool input) => $prototype.asyncIntThrows(this, input);
+
   static Future<void> asyncStatic(bool input) => $prototype.asyncStatic(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = AsyncStruct$Impl();
 }
+
+
 // AsyncStruct "private" section, not exported.
+
 final _smokeAsyncstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -30,6 +49,9 @@ final _smokeAsyncstructGetFieldstringField = __lib.catchArgumentError(() => __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AsyncStruct_get_field_stringField'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class AsyncStruct$Impl {
@@ -41,6 +63,7 @@ class AsyncStruct$Impl {
     );
     return $completer.future;
   }
+
   void _asyncVoid__async(AsyncStruct $that, AsyncStruct_asyncVoid__resultLambda _resultLambda, bool input) {
     final __asyncVoid__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_AsyncStruct_asyncVoid__asyncVoid__resultLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncstructAsyncvoidresultlambdaToFfi(_resultLambda);
@@ -50,7 +73,9 @@ class AsyncStruct$Impl {
     smokeAsyncstructReleaseFfiHandle(_handle);
     smokeAsyncstructAsyncvoidresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   Future<void> asyncVoidThrows(AsyncStruct $that, bool input) {
     final $completer = Completer<void>();
     _asyncVoidThrows__async($that,
@@ -60,6 +85,7 @@ class AsyncStruct$Impl {
     );
     return $completer.future;
   }
+
   void _asyncVoidThrows__async(AsyncStruct $that, AsyncStruct_asyncVoidThrows__resultLambda _resultLambda, AsyncStruct_asyncVoidThrows__errorLambda _errorLambda, bool input) {
     final __asyncVoidThrows__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>, int)>('library_smoke_AsyncStruct_asyncVoidThrows__asyncVoidThrows__resultLambda_asyncVoidThrows__errorLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncstructAsyncvoidthrowsresultlambdaToFfi(_resultLambda);
@@ -71,7 +97,9 @@ class AsyncStruct$Impl {
     smokeAsyncstructAsyncvoidthrowsresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     smokeAsyncstructAsyncvoidthrowserrorlambdaReleaseFfiHandle(__errorLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   Future<int> asyncInt(AsyncStruct $that, bool input) {
     final $completer = Completer<int>();
     _asyncInt__async($that,
@@ -80,6 +108,7 @@ class AsyncStruct$Impl {
     );
     return $completer.future;
   }
+
   void _asyncInt__async(AsyncStruct $that, AsyncStruct_asyncInt__resultLambda _resultLambda, bool input) {
     final __asyncInt__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_AsyncStruct_asyncInt__asyncInt__resultLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncstructAsyncintresultlambdaToFfi(_resultLambda);
@@ -89,7 +118,9 @@ class AsyncStruct$Impl {
     smokeAsyncstructReleaseFfiHandle(_handle);
     smokeAsyncstructAsyncintresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   Future<int> asyncIntThrows(AsyncStruct $that, bool input) {
     final $completer = Completer<int>();
     _asyncIntThrows__async($that,
@@ -99,6 +130,7 @@ class AsyncStruct$Impl {
     );
     return $completer.future;
   }
+
   void _asyncIntThrows__async(AsyncStruct $that, AsyncStruct_asyncIntThrows__resultLambda _resultLambda, AsyncStruct_asyncIntThrows__errorLambda _errorLambda, bool input) {
     final __asyncIntThrows__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>, int)>('library_smoke_AsyncStruct_asyncIntThrows__asyncIntThrows__resultLambda_asyncIntThrows__errorLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncstructAsyncintthrowsresultlambdaToFfi(_resultLambda);
@@ -110,7 +142,9 @@ class AsyncStruct$Impl {
     smokeAsyncstructAsyncintthrowsresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     smokeAsyncstructAsyncintthrowserrorlambdaReleaseFfiHandle(__errorLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
   Future<void> asyncStatic(bool input) {
     final $completer = Completer<void>();
     _asyncStatic__async(
@@ -119,6 +153,7 @@ class AsyncStruct$Impl {
     );
     return $completer.future;
   }
+
   void _asyncStatic__async(AsyncStruct_asyncStatic__resultLambda _resultLambda, bool input) {
     final __asyncStatic__asyncFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>, Uint8), void Function(int, Pointer<Void>, int)>('library_smoke_AsyncStruct_asyncStatic__asyncStatic__resultLambda_Boolean'));
     final __resultLambdaHandle = smokeAsyncstructAsyncstaticresultlambdaToFfi(_resultLambda);
@@ -126,14 +161,18 @@ class AsyncStruct$Impl {
     __asyncStatic__asyncFfi(__lib.LibraryContext.isolateId, __resultLambdaHandle, _inputHandle);
     smokeAsyncstructAsyncstaticresultlambdaReleaseFfiHandle(__resultLambdaHandle);
     booleanReleaseFfiHandle(_inputHandle);
+
   }
+
 }
+
 Pointer<Void> smokeAsyncstructToFfi(AsyncStruct value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeAsyncstructCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 AsyncStruct smokeAsyncstructFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeAsyncstructGetFieldstringField(handle);
   try {
@@ -144,8 +183,11 @@ AsyncStruct smokeAsyncstructFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeAsyncstructReleaseFfiHandle(Pointer<Void> handle) => _smokeAsyncstructReleaseHandle(handle);
+
 // Nullable AsyncStruct
+
 final _smokeAsyncstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -158,6 +200,7 @@ final _smokeAsyncstructGetValueNullable = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AsyncStruct_get_value_nullable'));
+
 Pointer<Void> smokeAsyncstructToFfiNullable(AsyncStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeAsyncstructToFfi(value);
@@ -165,6 +208,7 @@ Pointer<Void> smokeAsyncstructToFfiNullable(AsyncStruct? value) {
   smokeAsyncstructReleaseFfiHandle(_handle);
   return result;
 }
+
 AsyncStruct? smokeAsyncstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeAsyncstructGetValueNullable(handle);
@@ -172,11 +216,17 @@ AsyncStruct? smokeAsyncstructFromFfiNullable(Pointer<Void> handle) {
   smokeAsyncstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeAsyncstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAsyncstructReleaseHandleNullable(handle);
+
 // End of AsyncStruct "private" section.
+
+
 typedef AsyncStruct_asyncVoid__resultLambda = void Function();
+
 // AsyncStruct_asyncVoid__resultLambda "private" section, not exported.
+
 final _smokeAsyncstructAsyncvoidresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -185,22 +235,29 @@ final _smokeAsyncstructAsyncvoidresultlambdaCreateProxy = __lib.catchArgumentErr
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncStruct_AsyncvoidResultlambda_create_proxy'));
-class AsyncStruct_asyncVoid__resultLambda$Impl {
+
+class AsyncStruct_asyncVoid__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncStruct_asyncVoid__resultLambda$Impl(this.handle);
+
   void asyncVoid__resultLambda() {
     final _asyncVoid__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncStruct_AsyncvoidResultlambda_call'));
     final _handle = this.handle;
     _asyncVoid__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAsyncstructAsyncvoidresultlambdaasyncVoid__resultLambdaStatic(Object _obj) {
+  
   try {
     (_obj as AsyncStruct_asyncVoid__resultLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncstructAsyncvoidresultlambdaToFfi(AsyncStruct_asyncVoid__resultLambda value) =>
   _smokeAsyncstructAsyncvoidresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -208,11 +265,17 @@ Pointer<Void> smokeAsyncstructAsyncvoidresultlambdaToFfi(AsyncStruct_asyncVoid__
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncstructAsyncvoidresultlambdaasyncVoid__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncstructAsyncvoidresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncvoidresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncStruct_asyncVoid__resultLambda "private" section.
 typedef AsyncStruct_asyncVoidThrows__resultLambda = void Function();
+
 // AsyncStruct_asyncVoidThrows__resultLambda "private" section, not exported.
+
 final _smokeAsyncstructAsyncvoidthrowsresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -221,22 +284,29 @@ final _smokeAsyncstructAsyncvoidthrowsresultlambdaCreateProxy = __lib.catchArgum
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncStruct_AsyncvoidthrowsResultlambda_create_proxy'));
-class AsyncStruct_asyncVoidThrows__resultLambda$Impl {
+
+class AsyncStruct_asyncVoidThrows__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncStruct_asyncVoidThrows__resultLambda$Impl(this.handle);
+
   void asyncVoidThrows__resultLambda() {
     final _asyncVoidThrows__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncStruct_AsyncvoidthrowsResultlambda_call'));
     final _handle = this.handle;
     _asyncVoidThrows__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAsyncstructAsyncvoidthrowsresultlambdaasyncVoidThrows__resultLambdaStatic(Object _obj) {
+  
   try {
     (_obj as AsyncStruct_asyncVoidThrows__resultLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncstructAsyncvoidthrowsresultlambdaToFfi(AsyncStruct_asyncVoidThrows__resultLambda value) =>
   _smokeAsyncstructAsyncvoidthrowsresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -244,11 +314,17 @@ Pointer<Void> smokeAsyncstructAsyncvoidthrowsresultlambdaToFfi(AsyncStruct_async
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncstructAsyncvoidthrowsresultlambdaasyncVoidThrows__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncstructAsyncvoidthrowsresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncvoidthrowsresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncStruct_asyncVoidThrows__resultLambda "private" section.
 typedef AsyncStruct_asyncVoidThrows__errorLambda = void Function(String);
+
 // AsyncStruct_asyncVoidThrows__errorLambda "private" section, not exported.
+
 final _smokeAsyncstructAsyncvoidthrowserrorlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -257,18 +333,24 @@ final _smokeAsyncstructAsyncvoidthrowserrorlambdaCreateProxy = __lib.catchArgume
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncStruct_AsyncvoidthrowsErrorlambda_create_proxy'));
-class AsyncStruct_asyncVoidThrows__errorLambda$Impl {
+
+class AsyncStruct_asyncVoidThrows__errorLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncStruct_asyncVoidThrows__errorLambda$Impl(this.handle);
+
   void asyncVoidThrows__errorLambda(String p0) {
     final _asyncVoidThrows__errorLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AsyncStruct_AsyncvoidthrowsErrorlambda_call__String'));
     final _p0Handle = stringToFfi(p0);
     final _handle = this.handle;
     _asyncVoidThrows__errorLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     stringReleaseFfiHandle(_p0Handle);
+
   }
+
 }
+
 int _smokeAsyncstructAsyncvoidthrowserrorlambdaasyncVoidThrows__errorLambdaStatic(Object _obj, Pointer<Void> p0) {
+  
   try {
     (_obj as AsyncStruct_asyncVoidThrows__errorLambda)(stringFromFfi(p0));
   } finally {
@@ -276,6 +358,7 @@ int _smokeAsyncstructAsyncvoidthrowserrorlambdaasyncVoidThrows__errorLambdaStati
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncstructAsyncvoidthrowserrorlambdaToFfi(AsyncStruct_asyncVoidThrows__errorLambda value) =>
   _smokeAsyncstructAsyncvoidthrowserrorlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -283,11 +366,17 @@ Pointer<Void> smokeAsyncstructAsyncvoidthrowserrorlambdaToFfi(AsyncStruct_asyncV
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>)>(_smokeAsyncstructAsyncvoidthrowserrorlambdaasyncVoidThrows__errorLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncstructAsyncvoidthrowserrorlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncvoidthrowserrorlambdaReleaseHandle(handle);
+
+
 // End of AsyncStruct_asyncVoidThrows__errorLambda "private" section.
 typedef AsyncStruct_asyncInt__resultLambda = void Function(int);
+
 // AsyncStruct_asyncInt__resultLambda "private" section, not exported.
+
 final _smokeAsyncstructAsyncintresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -296,23 +385,32 @@ final _smokeAsyncstructAsyncintresultlambdaCreateProxy = __lib.catchArgumentErro
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncStruct_AsyncintResultlambda_create_proxy'));
-class AsyncStruct_asyncInt__resultLambda$Impl {
+
+class AsyncStruct_asyncInt__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncStruct_asyncInt__resultLambda$Impl(this.handle);
+
   void asyncInt__resultLambda(int p0) {
     final _asyncInt__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncStruct_AsyncintResultlambda_call__Int'));
     final _p0Handle = (p0);
     final _handle = this.handle;
     _asyncInt__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+
+
   }
+
 }
+
 int _smokeAsyncstructAsyncintresultlambdaasyncInt__resultLambdaStatic(Object _obj, int p0) {
+  
   try {
     (_obj as AsyncStruct_asyncInt__resultLambda)((p0));
   } finally {
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncstructAsyncintresultlambdaToFfi(AsyncStruct_asyncInt__resultLambda value) =>
   _smokeAsyncstructAsyncintresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -320,11 +418,17 @@ Pointer<Void> smokeAsyncstructAsyncintresultlambdaToFfi(AsyncStruct_asyncInt__re
     value,
     Pointer.fromFunction<Int64 Function(Handle, Int32)>(_smokeAsyncstructAsyncintresultlambdaasyncInt__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncstructAsyncintresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncintresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncStruct_asyncInt__resultLambda "private" section.
 typedef AsyncStruct_asyncIntThrows__resultLambda = void Function(int);
+
 // AsyncStruct_asyncIntThrows__resultLambda "private" section, not exported.
+
 final _smokeAsyncstructAsyncintthrowsresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -333,23 +437,32 @@ final _smokeAsyncstructAsyncintthrowsresultlambdaCreateProxy = __lib.catchArgume
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncStruct_AsyncintthrowsResultlambda_create_proxy'));
-class AsyncStruct_asyncIntThrows__resultLambda$Impl {
+
+class AsyncStruct_asyncIntThrows__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncStruct_asyncIntThrows__resultLambda$Impl(this.handle);
+
   void asyncIntThrows__resultLambda(int p0) {
     final _asyncIntThrows__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Int32), void Function(Pointer<Void>, int, int)>('library_smoke_AsyncStruct_AsyncintthrowsResultlambda_call__Int'));
     final _p0Handle = (p0);
     final _handle = this.handle;
     _asyncIntThrows__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
+
+
   }
+
 }
+
 int _smokeAsyncstructAsyncintthrowsresultlambdaasyncIntThrows__resultLambdaStatic(Object _obj, int p0) {
+  
   try {
     (_obj as AsyncStruct_asyncIntThrows__resultLambda)((p0));
   } finally {
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncstructAsyncintthrowsresultlambdaToFfi(AsyncStruct_asyncIntThrows__resultLambda value) =>
   _smokeAsyncstructAsyncintthrowsresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -357,11 +470,17 @@ Pointer<Void> smokeAsyncstructAsyncintthrowsresultlambdaToFfi(AsyncStruct_asyncI
     value,
     Pointer.fromFunction<Int64 Function(Handle, Int32)>(_smokeAsyncstructAsyncintthrowsresultlambdaasyncIntThrows__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncstructAsyncintthrowsresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncintthrowsresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncStruct_asyncIntThrows__resultLambda "private" section.
 typedef AsyncStruct_asyncIntThrows__errorLambda = void Function(String);
+
 // AsyncStruct_asyncIntThrows__errorLambda "private" section, not exported.
+
 final _smokeAsyncstructAsyncintthrowserrorlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -370,18 +489,24 @@ final _smokeAsyncstructAsyncintthrowserrorlambdaCreateProxy = __lib.catchArgumen
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncStruct_AsyncintthrowsErrorlambda_create_proxy'));
-class AsyncStruct_asyncIntThrows__errorLambda$Impl {
+
+class AsyncStruct_asyncIntThrows__errorLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncStruct_asyncIntThrows__errorLambda$Impl(this.handle);
+
   void asyncIntThrows__errorLambda(String p0) {
     final _asyncIntThrows__errorLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AsyncStruct_AsyncintthrowsErrorlambda_call__String'));
     final _p0Handle = stringToFfi(p0);
     final _handle = this.handle;
     _asyncIntThrows__errorLambdaFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     stringReleaseFfiHandle(_p0Handle);
+
   }
+
 }
+
 int _smokeAsyncstructAsyncintthrowserrorlambdaasyncIntThrows__errorLambdaStatic(Object _obj, Pointer<Void> p0) {
+  
   try {
     (_obj as AsyncStruct_asyncIntThrows__errorLambda)(stringFromFfi(p0));
   } finally {
@@ -389,6 +514,7 @@ int _smokeAsyncstructAsyncintthrowserrorlambdaasyncIntThrows__errorLambdaStatic(
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncstructAsyncintthrowserrorlambdaToFfi(AsyncStruct_asyncIntThrows__errorLambda value) =>
   _smokeAsyncstructAsyncintthrowserrorlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -396,11 +522,17 @@ Pointer<Void> smokeAsyncstructAsyncintthrowserrorlambdaToFfi(AsyncStruct_asyncIn
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>)>(_smokeAsyncstructAsyncintthrowserrorlambdaasyncIntThrows__errorLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncstructAsyncintthrowserrorlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncintthrowserrorlambdaReleaseHandle(handle);
+
+
 // End of AsyncStruct_asyncIntThrows__errorLambda "private" section.
 typedef AsyncStruct_asyncStatic__resultLambda = void Function();
+
 // AsyncStruct_asyncStatic__resultLambda "private" section, not exported.
+
 final _smokeAsyncstructAsyncstaticresultlambdaReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -409,22 +541,29 @@ final _smokeAsyncstructAsyncstaticresultlambdaCreateProxy = __lib.catchArgumentE
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AsyncStruct_AsyncstaticResultlambda_create_proxy'));
-class AsyncStruct_asyncStatic__resultLambda$Impl {
+
+class AsyncStruct_asyncStatic__resultLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AsyncStruct_asyncStatic__resultLambda$Impl(this.handle);
+
   void asyncStatic__resultLambda() {
     final _asyncStatic__resultLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AsyncStruct_AsyncstaticResultlambda_call'));
     final _handle = this.handle;
     _asyncStatic__resultLambdaFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAsyncstructAsyncstaticresultlambdaasyncStatic__resultLambdaStatic(Object _obj) {
+  
   try {
     (_obj as AsyncStruct_asyncStatic__resultLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAsyncstructAsyncstaticresultlambdaToFfi(AsyncStruct_asyncStatic__resultLambda value) =>
   _smokeAsyncstructAsyncstaticresultlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -432,6 +571,10 @@ Pointer<Void> smokeAsyncstructAsyncstaticresultlambdaToFfi(AsyncStruct_asyncStat
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAsyncstructAsyncstaticresultlambdaasyncStatic__resultLambdaStatic, __lib.unknownError)
   );
+
+
 void smokeAsyncstructAsyncstaticresultlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAsyncstructAsyncstaticresultlambdaReleaseHandle(handle);
+
+
 // End of AsyncStruct_asyncStatic__resultLambda "private" section.

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_class.dart
@@ -1,21 +1,30 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 @OnClass
-abstract class AttributesClass {
+abstract class AttributesClass implements Finalizable {
 
   @OnConstInClass
   static final bool pi = false;
+
+
   @OnFunctionInClass
   void veryFun(@OnParameterInClass String param);
   @OnPropertyInClass
   String get prop;
   @OnPropertyInClass
   set prop(String value);
+
 }
+
+
 // AttributesClass "private" section, not exported.
+
 final _smokeAttributesclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -28,7 +37,11 @@ final _smokeAttributesclassReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesClass_release_handle'));
+
+
+
 class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
+
   AttributesClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -38,7 +51,9 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
     final _handle = this.handle;
     _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
     stringReleaseFfiHandle(_paramHandle);
+
   }
+
   @OnPropertyInClass
   @override
   String get prop {
@@ -49,8 +64,11 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @OnPropertyInClass
   @override
   set prop(String value) {
@@ -59,26 +77,40 @@ class AttributesClass$Impl extends __lib.NativeBase implements AttributesClass {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeAttributesclassToFfi(AttributesClass value) =>
   _smokeAttributesclassCopyHandle((value as __lib.NativeBase).handle);
+
 AttributesClass smokeAttributesclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesClass) return instance;
+
   final _copiedHandle = _smokeAttributesclassCopyHandle(handle);
   final result = AttributesClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeAttributesclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeAttributesclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAttributesclassReleaseHandle(handle);
+
 Pointer<Void> smokeAttributesclassToFfiNullable(AttributesClass? value) =>
   value != null ? smokeAttributesclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 AttributesClass? smokeAttributesclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeAttributesclassFromFfi(handle) : null;
+
 void smokeAttributesclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributesclassReleaseHandle(handle);
+
 // End of AttributesClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_interface.dart
@@ -1,11 +1,15 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 @OnInterface
-abstract class AttributesInterface {
+abstract class AttributesInterface implements Finalizable {
+
   factory AttributesInterface(
     void Function(String) veryFunLambda,
     String Function() propGetLambda,
@@ -18,14 +22,20 @@ abstract class AttributesInterface {
 
   @OnConstInInterface
   static final bool pi = false;
+
+
   @OnFunctionInInterface
   void veryFun(@OnParameterInInterface String param);
   @OnPropertyInInterface
   String get prop;
   @OnPropertyInInterface
   set prop(String value);
+
 }
+
+
 // AttributesInterface "private" section, not exported.
+
 final _smokeAttributesinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -46,10 +56,13 @@ final _smokeAttributesinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesInterface_get_type_id'));
+
+
 class AttributesInterface$Lambdas implements AttributesInterface {
   void Function(String) veryFunLambda;
   String Function() propGetLambda;
   void Function(String) propSetLambda;
+
   AttributesInterface$Lambdas(
     this.veryFunLambda,
     this.propGetLambda,
@@ -64,7 +77,9 @@ class AttributesInterface$Lambdas implements AttributesInterface {
   @override
   set prop(String value) => propSetLambda(value);
 }
+
 class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInterface {
+
   AttributesInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -74,7 +89,9 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
     final _handle = this.handle;
     _veryFunFfi(_handle, __lib.LibraryContext.isolateId, _paramHandle);
     stringReleaseFfiHandle(_paramHandle);
+
   }
+
   @OnPropertyInInterface
   String get prop {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_AttributesInterface_prop_get'));
@@ -84,8 +101,12 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   @OnPropertyInInterface
   set prop(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_AttributesInterface_prop_set__String'));
@@ -93,9 +114,15 @@ class AttributesInterface$Impl extends __lib.NativeBase implements AttributesInt
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeAttributesinterfaceveryFunStatic(Object _obj, Pointer<Void> param) {
+
   try {
     (_obj as AttributesInterface).veryFun(stringFromFfi(param));
   } finally {
@@ -103,10 +130,12 @@ int _smokeAttributesinterfaceveryFunStatic(Object _obj, Pointer<Void> param) {
   }
   return 0;
 }
+
 int _smokeAttributesinterfacepropGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as AttributesInterface).prop);
   return 0;
 }
+
 int _smokeAttributesinterfacepropSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as AttributesInterface).prop =
@@ -116,8 +145,10 @@ int _smokeAttributesinterfacepropSetStatic(Object _obj, Pointer<Void> _value) {
   }
   return 0;
 }
+
 Pointer<Void> smokeAttributesinterfaceToFfi(AttributesInterface value) {
   if (value is __lib.NativeBase) return _smokeAttributesinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeAttributesinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -126,15 +157,19 @@ Pointer<Void> smokeAttributesinterfaceToFfi(AttributesInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeAttributesinterfacepropGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeAttributesinterfacepropSetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 AttributesInterface smokeAttributesinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesInterface) return instance;
+
   final _typeIdHandle = _smokeAttributesinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeAttributesinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -143,12 +178,19 @@ AttributesInterface smokeAttributesinterfaceFromFfi(Pointer<Void> handle) {
   _smokeAttributesinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeAttributesinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAttributesinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeAttributesinterfaceToFfiNullable(AttributesInterface? value) =>
   value != null ? smokeAttributesinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 AttributesInterface? smokeAttributesinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeAttributesinterfaceFromFfi(handle) : null;
+
 void smokeAttributesinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributesinterfaceReleaseHandle(handle);
+
 // End of AttributesInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_lambda.dart
@@ -1,9 +1,14 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+
 @OnLambda
 typedef AttributesLambda = void Function();
+
 // AttributesLambda "private" section, not exported.
+
 final _smokeAttributeslambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -20,22 +25,29 @@ final _smokeAttributeslambdaCreateProxy = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_AttributesLambda_create_proxy'));
-class AttributesLambda$Impl {
+
+class AttributesLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   AttributesLambda$Impl(this.handle);
+
   void call() {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesLambda_call'));
     final _handle = this.handle;
     _callFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeAttributeslambdacallStatic(Object _obj) {
+  
   try {
     (_obj as AttributesLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeAttributeslambdaToFfi(AttributesLambda value) =>
   _smokeAttributeslambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -43,6 +55,7 @@ Pointer<Void> smokeAttributeslambdaToFfi(AttributesLambda value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeAttributeslambdacallStatic, __lib.unknownError)
   );
+
 AttributesLambda smokeAttributeslambdaFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeAttributeslambdaCopyHandle(handle);
   final _impl = AttributesLambda$Impl(_copiedHandle);
@@ -50,9 +63,12 @@ AttributesLambda smokeAttributeslambdaFromFfi(Pointer<Void> handle) {
   _smokeAttributeslambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeAttributeslambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAttributeslambdaReleaseHandle(handle);
+
 // Nullable AttributesLambda
+
 final _smokeAttributeslambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -65,6 +81,7 @@ final _smokeAttributeslambdaGetValueNullable = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesLambda_get_value_nullable'));
+
 Pointer<Void> smokeAttributeslambdaToFfiNullable(AttributesLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeAttributeslambdaToFfi(value);
@@ -72,6 +89,7 @@ Pointer<Void> smokeAttributeslambdaToFfiNullable(AttributesLambda? value) {
   smokeAttributeslambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 AttributesLambda? smokeAttributeslambdaFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeAttributeslambdaGetValueNullable(handle);
@@ -79,6 +97,10 @@ AttributesLambda? smokeAttributeslambdaFromFfiNullable(Pointer<Void> handle) {
   smokeAttributeslambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeAttributeslambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributeslambdaReleaseHandleNullable(handle);
+
 // End of AttributesLambda "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_comments.dart
@@ -8,7 +8,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 
 /// Class comment
 @OnClass
-abstract class AttributesWithComments {
+abstract class AttributesWithComments implements Finalizable {
 
   /// Const comment
   @OnConstInClass

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_with_deprecated.dart
@@ -1,15 +1,22 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 @Deprecated("")
 @OnClass
-abstract class AttributesWithDeprecated {
+abstract class AttributesWithDeprecated implements Finalizable {
+
   @Deprecated("")
   @OnConstInClass
   static final bool pi = false;
+
+
   @Deprecated("")
+
   @OnFunctionInClass
   void veryFun();
   @Deprecated("")
@@ -18,16 +25,23 @@ abstract class AttributesWithDeprecated {
   @Deprecated("")
   @OnPropertyInClass
   set prop(String value);
+
 }
+
+
 class AttributesWithDeprecated_SomeStruct {
   @Deprecated("")
   @OnField
   String field;
+
   AttributesWithDeprecated_SomeStruct._(this.field);
   AttributesWithDeprecated_SomeStruct()
     : field = "";
 }
+
+
 // AttributesWithDeprecated_SomeStruct "private" section, not exported.
+
 final _smokeAttributeswithdeprecatedSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -40,12 +54,16 @@ final _smokeAttributeswithdeprecatedSomestructGetFieldfield = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_get_field_field'));
+
+
+
 Pointer<Void> smokeAttributeswithdeprecatedSomestructToFfi(AttributesWithDeprecated_SomeStruct value) {
   final _fieldHandle = stringToFfi(value.field);
   final _result = _smokeAttributeswithdeprecatedSomestructCreateHandle(_fieldHandle);
   stringReleaseFfiHandle(_fieldHandle);
   return _result;
 }
+
 AttributesWithDeprecated_SomeStruct smokeAttributeswithdeprecatedSomestructFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeAttributeswithdeprecatedSomestructGetFieldfield(handle);
   try {
@@ -56,8 +74,11 @@ AttributesWithDeprecated_SomeStruct smokeAttributeswithdeprecatedSomestructFromF
     stringReleaseFfiHandle(_fieldHandle);
   }
 }
+
 void smokeAttributeswithdeprecatedSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeAttributeswithdeprecatedSomestructReleaseHandle(handle);
+
 // Nullable AttributesWithDeprecated_SomeStruct
+
 final _smokeAttributeswithdeprecatedSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -70,6 +91,7 @@ final _smokeAttributeswithdeprecatedSomestructGetValueNullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeAttributeswithdeprecatedSomestructToFfiNullable(AttributesWithDeprecated_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeAttributeswithdeprecatedSomestructToFfi(value);
@@ -77,6 +99,7 @@ Pointer<Void> smokeAttributeswithdeprecatedSomestructToFfiNullable(AttributesWit
   smokeAttributeswithdeprecatedSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 AttributesWithDeprecated_SomeStruct? smokeAttributeswithdeprecatedSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeAttributeswithdeprecatedSomestructGetValueNullable(handle);
@@ -84,10 +107,14 @@ AttributesWithDeprecated_SomeStruct? smokeAttributeswithdeprecatedSomestructFrom
   smokeAttributeswithdeprecatedSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeAttributeswithdeprecatedSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributeswithdeprecatedSomestructReleaseHandleNullable(handle);
+
 // End of AttributesWithDeprecated_SomeStruct "private" section.
+
 // AttributesWithDeprecated "private" section, not exported.
+
 final _smokeAttributeswithdeprecatedRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -100,14 +127,21 @@ final _smokeAttributeswithdeprecatedReleaseHandle = __lib.catchArgumentError(() 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_AttributesWithDeprecated_release_handle'));
+
+
+
 class AttributesWithDeprecated$Impl extends __lib.NativeBase implements AttributesWithDeprecated {
+
   AttributesWithDeprecated$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void veryFun() {
     final _veryFunFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_AttributesWithDeprecated_veryFun'));
     final _handle = this.handle;
     _veryFunFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @OnPropertyInClass
   @override
   String get prop {
@@ -118,8 +152,11 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @OnPropertyInClass
   @override
   set prop(String value) {
@@ -128,26 +165,40 @@ class AttributesWithDeprecated$Impl extends __lib.NativeBase implements Attribut
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeAttributeswithdeprecatedToFfi(AttributesWithDeprecated value) =>
   _smokeAttributeswithdeprecatedCopyHandle((value as __lib.NativeBase).handle);
+
 AttributesWithDeprecated smokeAttributeswithdeprecatedFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is AttributesWithDeprecated) return instance;
+
   final _copiedHandle = _smokeAttributeswithdeprecatedCopyHandle(handle);
   final result = AttributesWithDeprecated$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeAttributeswithdeprecatedRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeAttributeswithdeprecatedReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeAttributeswithdeprecatedReleaseHandle(handle);
+
 Pointer<Void> smokeAttributeswithdeprecatedToFfiNullable(AttributesWithDeprecated? value) =>
   value != null ? smokeAttributeswithdeprecatedToFfi(value) : Pointer<Void>.fromAddress(0);
+
 AttributesWithDeprecated? smokeAttributeswithdeprecatedFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeAttributeswithdeprecatedFromFfi(handle) : null;
+
 void smokeAttributeswithdeprecatedReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributeswithdeprecatedReleaseHandle(handle);
+
 // End of AttributesWithDeprecated "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/multiple_attributes_dart.dart
@@ -1,31 +1,52 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class MultipleAttributesDart {
+
+abstract class MultipleAttributesDart implements Finalizable {
+
 
   @Foo
+
   @Bar
   void noLists2();
+
   @Foo
+
   @Bar
+
   @Baz
   void noLists3();
+
   @Foo
+
   @Bar
+
   @Baz
   void listFirst();
+
   @Foo
+
   @Bar
+
   @Baz
   void listSecond();
+
   @Foo
+
   @Bar
+
   @Baz
+
   @Fizz
   void twoLists();
 }
+
+
 // MultipleAttributesDart "private" section, not exported.
+
 final _smokeMultipleattributesdartRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -38,7 +59,15 @@ final _smokeMultipleattributesdartReleaseHandle = __lib.catchArgumentError(() =>
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MultipleAttributesDart_release_handle'));
+
+
+
+
+
+
+
 class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAttributesDart {
+
   MultipleAttributesDart$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -46,50 +75,71 @@ class MultipleAttributesDart$Impl extends __lib.NativeBase implements MultipleAt
     final _noLists2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists2'));
     final _handle = this.handle;
     _noLists2Ffi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void noLists3() {
     final _noLists3Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_noLists3'));
     final _handle = this.handle;
     _noLists3Ffi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void listFirst() {
     final _listFirstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listFirst'));
     final _handle = this.handle;
     _listFirstFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void listSecond() {
     final _listSecondFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_listSecond'));
     final _handle = this.handle;
     _listSecondFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void twoLists() {
     final _twoListsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_MultipleAttributesDart_twoLists'));
     final _handle = this.handle;
     _twoListsFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokeMultipleattributesdartToFfi(MultipleAttributesDart value) =>
   _smokeMultipleattributesdartCopyHandle((value as __lib.NativeBase).handle);
+
 MultipleAttributesDart smokeMultipleattributesdartFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MultipleAttributesDart) return instance;
+
   final _copiedHandle = _smokeMultipleattributesdartCopyHandle(handle);
   final result = MultipleAttributesDart$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeMultipleattributesdartRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeMultipleattributesdartReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeMultipleattributesdartReleaseHandle(handle);
+
 Pointer<Void> smokeMultipleattributesdartToFfiNullable(MultipleAttributesDart? value) =>
   value != null ? smokeMultipleattributesdartToFfi(value) : Pointer<Void>.fromAddress(0);
+
 MultipleAttributesDart? smokeMultipleattributesdartFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeMultipleattributesdartFromFfi(handle) : null;
+
 void smokeMultipleattributesdartReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeMultipleattributesdartReleaseHandle(handle);
+
 // End of MultipleAttributesDart "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/special_attributes.dart
@@ -1,15 +1,25 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class SpecialAttributes {
+
+abstract class SpecialAttributes implements Finalizable {
+
 
   @Deprecated("foo\nbar")
+
+
   void withEscaping();
+
   @HackMerm -rf *
   void withLineBreak();
 }
+
+
 // SpecialAttributes "private" section, not exported.
+
 final _smokeSpecialattributesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -22,7 +32,12 @@ final _smokeSpecialattributesReleaseHandle = __lib.catchArgumentError(() => __li
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialAttributes_release_handle'));
+
+
+
+
 class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttributes {
+
   SpecialAttributes$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -30,32 +45,47 @@ class SpecialAttributes$Impl extends __lib.NativeBase implements SpecialAttribut
     final _withEscapingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withEscaping'));
     final _handle = this.handle;
     _withEscapingFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void withLineBreak() {
     final _withLineBreakFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialAttributes_withLineBreak'));
     final _handle = this.handle;
     _withLineBreakFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokeSpecialattributesToFfi(SpecialAttributes value) =>
   _smokeSpecialattributesCopyHandle((value as __lib.NativeBase).handle);
+
 SpecialAttributes smokeSpecialattributesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SpecialAttributes) return instance;
+
   final _copiedHandle = _smokeSpecialattributesCopyHandle(handle);
   final result = SpecialAttributes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSpecialattributesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSpecialattributesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSpecialattributesReleaseHandle(handle);
+
 Pointer<Void> smokeSpecialattributesToFfiNullable(SpecialAttributes? value) =>
   value != null ? smokeSpecialattributesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SpecialAttributes? smokeSpecialattributesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSpecialattributesFromFfi(handle) : null;
+
 void smokeSpecialattributesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSpecialattributesReleaseHandle(handle);
+
 // End of SpecialAttributes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/dart/lib/src/smoke/basic_types.dart
@@ -1,28 +1,47 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class BasicTypes {
+
+abstract class BasicTypes implements Finalizable {
+
 
   static String stringFunction(String input) => $prototype.stringFunction(input);
+
   static bool boolFunction(bool input) => $prototype.boolFunction(input);
+
   static double floatFunction(double input) => $prototype.floatFunction(input);
+
   static double doubleFunction(double input) => $prototype.doubleFunction(input);
+
   static int byteFunction(int input) => $prototype.byteFunction(input);
+
   static int shortFunction(int input) => $prototype.shortFunction(input);
+
   static int intFunction(int input) => $prototype.intFunction(input);
+
   static int longFunction(int input) => $prototype.longFunction(input);
+
   static int ubyteFunction(int input) => $prototype.ubyteFunction(input);
+
   static int ushortFunction(int input) => $prototype.ushortFunction(input);
+
   static int uintFunction(int input) => $prototype.uintFunction(input);
+
   static int ulongFunction(int input) => $prototype.ulongFunction(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = BasicTypes$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // BasicTypes "private" section, not exported.
+
 final _smokeBasictypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -35,9 +54,24 @@ final _smokeBasictypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_BasicTypes_release_handle'));
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
+
   BasicTypes$Impl(Pointer<Void> handle) : super(handle);
 
   String stringFunction(String input) {
@@ -49,8 +83,11 @@ class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   bool boolFunction(bool input) {
     final _boolFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_boolFunction__Boolean'));
     final _inputHandle = booleanToFfi(input);
@@ -60,117 +97,181 @@ class BasicTypes$Impl extends __lib.NativeBase implements BasicTypes {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   double floatFunction(double input) {
     final _floatFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Int32, Float), double Function(int, double)>('library_smoke_BasicTypes_floatFunction__Float'));
     final _inputHandle = (input);
     final __resultHandle = _floatFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   double doubleFunction(double input) {
     final _doubleFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_BasicTypes_doubleFunction__Double'));
     final _inputHandle = (input);
     final __resultHandle = _doubleFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int byteFunction(int input) {
     final _byteFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int8 Function(Int32, Int8), int Function(int, int)>('library_smoke_BasicTypes_byteFunction__Byte'));
     final _inputHandle = (input);
     final __resultHandle = _byteFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int shortFunction(int input) {
     final _shortFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int16 Function(Int32, Int16), int Function(int, int)>('library_smoke_BasicTypes_shortFunction__Short'));
     final _inputHandle = (input);
     final __resultHandle = _shortFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int intFunction(int input) {
     final _intFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Int32, Int32), int Function(int, int)>('library_smoke_BasicTypes_intFunction__Int'));
     final _inputHandle = (input);
     final __resultHandle = _intFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int longFunction(int input) {
     final _longFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int64 Function(Int32, Int64), int Function(int, int)>('library_smoke_BasicTypes_longFunction__Long'));
     final _inputHandle = (input);
     final __resultHandle = _longFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int ubyteFunction(int input) {
     final _ubyteFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_BasicTypes_ubyteFunction__UByte'));
     final _inputHandle = (input);
     final __resultHandle = _ubyteFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int ushortFunction(int input) {
     final _ushortFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint16 Function(Int32, Uint16), int Function(int, int)>('library_smoke_BasicTypes_ushortFunction__UShort'));
     final _inputHandle = (input);
     final __resultHandle = _ushortFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int uintFunction(int input) {
     final _uintFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_BasicTypes_uintFunction__UInt'));
     final _inputHandle = (input);
     final __resultHandle = _uintFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   int ulongFunction(int input) {
     final _ulongFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Int32, Uint64), int Function(int, int)>('library_smoke_BasicTypes_ulongFunction__ULong'));
     final _inputHandle = (input);
     final __resultHandle = _ulongFunctionFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeBasictypesToFfi(BasicTypes value) =>
   _smokeBasictypesCopyHandle((value as __lib.NativeBase).handle);
+
 BasicTypes smokeBasictypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is BasicTypes) return instance;
+
   final _copiedHandle = _smokeBasictypesCopyHandle(handle);
   final result = BasicTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeBasictypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeBasictypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeBasictypesReleaseHandle(handle);
+
 Pointer<Void> smokeBasictypesToFfiNullable(BasicTypes? value) =>
   value != null ? smokeBasictypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 BasicTypes? smokeBasictypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeBasictypesFromFfi(handle) : null;
+
 void smokeBasictypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeBasictypesReleaseHandle(handle);
+
 // End of BasicTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -8,7 +8,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 
 /// This is some very useful interface.
-abstract class Comments {
+abstract class Comments implements Finalizable {
 
   /// This is some very useful constant.
   static final bool veryUseful = true;

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -341,7 +341,7 @@ final _smokeCommentsSomelambdaCreateProxy = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Comments_SomeLambda_create_proxy'));
 
-class Comments_SomeLambda$Impl {
+class Comments_SomeLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   Comments_SomeLambda$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -8,7 +8,7 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 
 /// This is some very useful interface.
-abstract class CommentsInterface {
+abstract class CommentsInterface implements Finalizable {
   /// This is some very useful interface.
 
   factory CommentsInterface(

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_links.dart
@@ -1,9 +1,12 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
+
 /// The nested types like [CommentsLinks.randomMethod2] don't need full name prefix, but it's
 /// possible to references other interfaces like [CommentsInterface] or other members
 /// [Comments.someMethodWithAllComments].
@@ -11,7 +14,8 @@ import 'package:library/src/smoke/comments.dart';
 /// Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
 ///
 /// [example1]: http://example.com/1
-abstract class CommentsLinks {
+abstract class CommentsLinks implements Finalizable {
+
   /// Link types:
   /// * constant: [Comments.veryUseful]
   /// * struct: [Comments_SomeStruct]
@@ -58,15 +62,23 @@ abstract class CommentsLinks {
   ///
   void randomMethod2(String text, bool flag);
 }
+
 /// Links also work in:
+
 class CommentsLinks_RandomStruct {
   /// Some random field [Comments_SomeStruct]
   Comments_SomeStruct randomField;
+
   /// constructor comments [Comments_SomeStruct]
+
   /// [randomField] Some random field [Comments_SomeStruct]
+
   CommentsLinks_RandomStruct(this.randomField);
 }
+
+
 // CommentsLinks_RandomStruct "private" section, not exported.
+
 final _smokeCommentslinksRandomstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -79,12 +91,16 @@ final _smokeCommentslinksRandomstructGetFieldrandomField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_get_field_randomField'));
+
+
+
 Pointer<Void> smokeCommentslinksRandomstructToFfi(CommentsLinks_RandomStruct value) {
   final _randomFieldHandle = smokeCommentsSomestructToFfi(value.randomField);
   final _result = _smokeCommentslinksRandomstructCreateHandle(_randomFieldHandle);
   smokeCommentsSomestructReleaseFfiHandle(_randomFieldHandle);
   return _result;
 }
+
 CommentsLinks_RandomStruct smokeCommentslinksRandomstructFromFfi(Pointer<Void> handle) {
   final _randomFieldHandle = _smokeCommentslinksRandomstructGetFieldrandomField(handle);
   try {
@@ -95,8 +111,11 @@ CommentsLinks_RandomStruct smokeCommentslinksRandomstructFromFfi(Pointer<Void> h
     smokeCommentsSomestructReleaseFfiHandle(_randomFieldHandle);
   }
 }
+
 void smokeCommentslinksRandomstructReleaseFfiHandle(Pointer<Void> handle) => _smokeCommentslinksRandomstructReleaseHandle(handle);
+
 // Nullable CommentsLinks_RandomStruct
+
 final _smokeCommentslinksRandomstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -109,6 +128,7 @@ final _smokeCommentslinksRandomstructGetValueNullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_RandomStruct_get_value_nullable'));
+
 Pointer<Void> smokeCommentslinksRandomstructToFfiNullable(CommentsLinks_RandomStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCommentslinksRandomstructToFfi(value);
@@ -116,6 +136,7 @@ Pointer<Void> smokeCommentslinksRandomstructToFfiNullable(CommentsLinks_RandomSt
   smokeCommentslinksRandomstructReleaseFfiHandle(_handle);
   return result;
 }
+
 CommentsLinks_RandomStruct? smokeCommentslinksRandomstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCommentslinksRandomstructGetValueNullable(handle);
@@ -123,10 +144,14 @@ CommentsLinks_RandomStruct? smokeCommentslinksRandomstructFromFfiNullable(Pointe
   smokeCommentslinksRandomstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCommentslinksRandomstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentslinksRandomstructReleaseHandleNullable(handle);
+
 // End of CommentsLinks_RandomStruct "private" section.
+
 // CommentsLinks "private" section, not exported.
+
 final _smokeCommentslinksRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -139,6 +164,8 @@ final _smokeCommentslinksReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_release_handle'));
+
+
 final _randomMethodsmokeCommentslinksRandommethodSomeenumReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -155,8 +182,13 @@ final _randomMethodsmokeCommentslinksRandommethodSomeenumReturnHasError = __lib.
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CommentsLinks_randomMethod__SomeEnum_return_has_error'));
+
+
+
 class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
+
   CommentsLinks$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   Comments_SomeEnum randomMethod(Comments_SomeEnum inputParameter) {
     final _randomMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Uint32), Pointer<Void> Function(Pointer<Void>, int, int)>('library_smoke_CommentsLinks_randomMethod__SomeEnum'));
@@ -179,8 +211,11 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
       return smokeCommentsSomeenumFromFfi(__resultHandle);
     } finally {
       smokeCommentsSomeenumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void randomMethod2(String text, bool flag) {
     final _randomMethod2Ffi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Uint8), void Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_CommentsLinks_randomMethod__String_Boolean'));
@@ -190,26 +225,39 @@ class CommentsLinks$Impl extends __lib.NativeBase implements CommentsLinks {
     _randomMethod2Ffi(_handle, __lib.LibraryContext.isolateId, _textHandle, _flagHandle);
     stringReleaseFfiHandle(_textHandle);
     booleanReleaseFfiHandle(_flagHandle);
+
   }
+
+
 }
+
 Pointer<Void> smokeCommentslinksToFfi(CommentsLinks value) =>
   _smokeCommentslinksCopyHandle((value as __lib.NativeBase).handle);
+
 CommentsLinks smokeCommentslinksFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsLinks) return instance;
+
   final _copiedHandle = _smokeCommentslinksCopyHandle(handle);
   final result = CommentsLinks$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCommentslinksRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCommentslinksReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCommentslinksReleaseHandle(handle);
+
 Pointer<Void> smokeCommentslinksToFfiNullable(CommentsLinks? value) =>
   value != null ? smokeCommentslinksToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CommentsLinks? smokeCommentslinksFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCommentslinksFromFfi(handle) : null;
+
 void smokeCommentslinksReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentslinksReleaseHandle(handle);
+
 // End of CommentsLinks "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_markdown.dart
@@ -1,7 +1,10 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+
 /// First line.
 ///
 /// Second line.
@@ -27,10 +30,13 @@ import 'package:library/src/_token_cache.dart' as __lib;
 /// ---
 ///
 /// [title](https://www.markdownguide.org/cheat-sheet/)
-abstract class CommentsMarkdown {
+abstract class CommentsMarkdown implements Finalizable {
 
 }
+
+
 // CommentsMarkdown "private" section, not exported.
+
 final _smokeCommentsmarkdownRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -43,28 +49,42 @@ final _smokeCommentsmarkdownReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsMarkdown_release_handle'));
+
+
 class CommentsMarkdown$Impl extends __lib.NativeBase implements CommentsMarkdown {
+
   CommentsMarkdown$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeCommentsmarkdownToFfi(CommentsMarkdown value) =>
   _smokeCommentsmarkdownCopyHandle((value as __lib.NativeBase).handle);
+
 CommentsMarkdown smokeCommentsmarkdownFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsMarkdown) return instance;
+
   final _copiedHandle = _smokeCommentsmarkdownCopyHandle(handle);
   final result = CommentsMarkdown$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCommentsmarkdownRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCommentsmarkdownReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCommentsmarkdownReleaseHandle(handle);
+
 Pointer<Void> smokeCommentsmarkdownToFfiNullable(CommentsMarkdown? value) =>
   value != null ? smokeCommentsmarkdownToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CommentsMarkdown? smokeCommentsmarkdownFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCommentsmarkdownFromFfi(handle) : null;
+
 void smokeCommentsmarkdownReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentsmarkdownReleaseHandle(handle);
+
 // End of CommentsMarkdown "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table.dart
@@ -1,7 +1,10 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+
 /// Something lorem something ipsum.
 ///
 /// | Tables | Are | Cool |
@@ -9,9 +12,13 @@ import 'package:library/src/_token_cache.dart' as __lib;
 /// | col 1 is |  left-aligned | $1600 |
 /// | col 2 is |    centered   |   $12 |
 /// | col 3 is | right-aligned |    $1 |
-abstract class CommentsTable {
+abstract class CommentsTable implements Finalizable {
+
 }
+
+
 // CommentsTable "private" section, not exported.
+
 final _smokeCommentstableRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -24,27 +31,42 @@ final _smokeCommentstableReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsTable_release_handle'));
+
+
 class CommentsTable$Impl extends __lib.NativeBase implements CommentsTable {
+
   CommentsTable$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokeCommentstableToFfi(CommentsTable value) =>
   _smokeCommentstableCopyHandle((value as __lib.NativeBase).handle);
+
 CommentsTable smokeCommentstableFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsTable) return instance;
+
   final _copiedHandle = _smokeCommentstableCopyHandle(handle);
   final result = CommentsTable$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCommentstableRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCommentstableReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCommentstableReleaseHandle(handle);
+
 Pointer<Void> smokeCommentstableToFfiNullable(CommentsTable? value) =>
   value != null ? smokeCommentstableToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CommentsTable? smokeCommentstableFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCommentstableFromFfi(handle) : null;
+
 void smokeCommentstableReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentstableReleaseHandle(handle);
+
 // End of CommentsTable "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_table_links.dart
@@ -1,7 +1,10 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+
 /// Something lorem something ipsum.
 ///
 /// | Tables | Are | Cool |
@@ -9,9 +12,13 @@ import 'package:library/src/_token_cache.dart' as __lib;
 /// | col 1 is |  [CommentsTable] | $1600 |
 /// | col 2 is |[Comments_SomeEnum]|   $12 |
 /// | col 3 is |[Comments_SomeEnum.useful]|    $1 |
-abstract class CommentsTableLinks {
+abstract class CommentsTableLinks implements Finalizable {
+
 }
+
+
 // CommentsTableLinks "private" section, not exported.
+
 final _smokeCommentstablelinksRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -24,27 +31,42 @@ final _smokeCommentstablelinksReleaseHandle = __lib.catchArgumentError(() => __l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CommentsTableLinks_release_handle'));
+
+
 class CommentsTableLinks$Impl extends __lib.NativeBase implements CommentsTableLinks {
+
   CommentsTableLinks$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokeCommentstablelinksToFfi(CommentsTableLinks value) =>
   _smokeCommentstablelinksCopyHandle((value as __lib.NativeBase).handle);
+
 CommentsTableLinks smokeCommentstablelinksFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CommentsTableLinks) return instance;
+
   final _copiedHandle = _smokeCommentstablelinksCopyHandle(handle);
   final result = CommentsTableLinks$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCommentstablelinksRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCommentstablelinksReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCommentstablelinksReleaseHandle(handle);
+
 Pointer<Void> smokeCommentstablelinksToFfiNullable(CommentsTableLinks? value) =>
   value != null ? smokeCommentstablelinksToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CommentsTableLinks? smokeCommentstablelinksFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCommentstablelinksFromFfi(handle) : null;
+
 void smokeCommentstablelinksReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCommentstablelinksReleaseHandle(handle);
+
 // End of CommentsTableLinks "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/ctor_links.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/ctor_links.dart
@@ -1,19 +1,30 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class CtorLinks {
+
+abstract class CtorLinks implements Finalizable {
+
 }
+
 /// This class has just one constructor [CtorLinks_SingleCtor.CtorLinks_SingleCtor()].
-abstract class CtorLinks_SingleCtor {
+abstract class CtorLinks_SingleCtor implements Finalizable {
+
   factory CtorLinks_SingleCtor() => $prototype.create();
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = CtorLinks_SingleCtor$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // CtorLinks_SingleCtor "private" section, not exported.
+
 final _smokeCtorlinksSinglectorRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -26,54 +37,77 @@ final _smokeCtorlinksSinglectorReleaseHandle = __lib.catchArgumentError(() => __
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CtorLinks_SingleCtor_release_handle'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class CtorLinks_SingleCtor$Impl extends __lib.NativeBase implements CtorLinks_SingleCtor {
+
   CtorLinks_SingleCtor$Impl(Pointer<Void> handle) : super(handle);
+
+
   CtorLinks_SingleCtor create() {
     final _result_handle = _create();
     final _result = CtorLinks_SingleCtor$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeCtorlinksSinglectorRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _create() {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_CtorLinks_SingleCtor_create'));
     final __resultHandle = _createFfi(__lib.LibraryContext.isolateId);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeCtorlinksSinglectorToFfi(CtorLinks_SingleCtor value) =>
   _smokeCtorlinksSinglectorCopyHandle((value as __lib.NativeBase).handle);
+
 CtorLinks_SingleCtor smokeCtorlinksSinglectorFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CtorLinks_SingleCtor) return instance;
+
   final _copiedHandle = _smokeCtorlinksSinglectorCopyHandle(handle);
   final result = CtorLinks_SingleCtor$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCtorlinksSinglectorRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCtorlinksSinglectorReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCtorlinksSinglectorReleaseHandle(handle);
+
 Pointer<Void> smokeCtorlinksSinglectorToFfiNullable(CtorLinks_SingleCtor? value) =>
   value != null ? smokeCtorlinksSinglectorToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CtorLinks_SingleCtor? smokeCtorlinksSinglectorFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCtorlinksSinglectorFromFfi(handle) : null;
+
 void smokeCtorlinksSinglectorReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCtorlinksSinglectorReleaseHandle(handle);
+
 // End of CtorLinks_SingleCtor "private" section.
 /// This class has just one constructor with one argument [CtorLinks_SingleCtorWithOneArgument.CtorLinks_SingleCtorWithOneArgument()].
-abstract class CtorLinks_SingleCtorWithOneArgument {
+abstract class CtorLinks_SingleCtorWithOneArgument implements Finalizable {
+
   factory CtorLinks_SingleCtorWithOneArgument(int arg) => $prototype.create(arg);
+
 
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = CtorLinks_SingleCtorWithOneArgument$Impl(Pointer<Void>.fromAddress(0));
 }
 
+
 // CtorLinks_SingleCtorWithOneArgument "private" section, not exported.
+
 final _smokeCtorlinksSinglectorwithoneargumentRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -87,11 +121,14 @@ final _smokeCtorlinksSinglectorwithoneargumentReleaseHandle = __lib.catchArgumen
     void Function(Pointer<Void>)
   >('library_smoke_CtorLinks_SingleCtorWithOneArgument_release_handle'));
 
+
+
 /// @nodoc
 @visibleForTesting
 class CtorLinks_SingleCtorWithOneArgument$Impl extends __lib.NativeBase implements CtorLinks_SingleCtorWithOneArgument {
 
   CtorLinks_SingleCtorWithOneArgument$Impl(Pointer<Void> handle) : super(handle);
+
 
   CtorLinks_SingleCtorWithOneArgument create(int arg) {
     final _result_handle = _create(arg);
@@ -110,6 +147,8 @@ class CtorLinks_SingleCtorWithOneArgument$Impl extends __lib.NativeBase implemen
 
     return __resultHandle;
   }
+
+
 }
 
 Pointer<Void> smokeCtorlinksSinglectorwithoneargumentToFfi(CtorLinks_SingleCtorWithOneArgument value) =>
@@ -141,15 +180,19 @@ void smokeCtorlinksSinglectorwithoneargumentReleaseFfiHandleNullable(Pointer<Voi
 
 // End of CtorLinks_SingleCtorWithOneArgument "private" section.
 /// This class has just one constructor with two argument [CtorLinks_SingleCtorWithTwoArgument.CtorLinks_SingleCtorWithTwoArgument()].
-abstract class CtorLinks_SingleCtorWithTwoArgument {
+abstract class CtorLinks_SingleCtorWithTwoArgument implements Finalizable {
+
   factory CtorLinks_SingleCtorWithTwoArgument(int arg, String arg2) => $prototype.create(arg, arg2);
+
 
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = CtorLinks_SingleCtorWithTwoArgument$Impl(Pointer<Void>.fromAddress(0));
 }
 
+
 // CtorLinks_SingleCtorWithTwoArgument "private" section, not exported.
+
 final _smokeCtorlinksSinglectorwithtwoargumentRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -163,11 +206,14 @@ final _smokeCtorlinksSinglectorwithtwoargumentReleaseHandle = __lib.catchArgumen
     void Function(Pointer<Void>)
   >('library_smoke_CtorLinks_SingleCtorWithTwoArgument_release_handle'));
 
+
+
 /// @nodoc
 @visibleForTesting
 class CtorLinks_SingleCtorWithTwoArgument$Impl extends __lib.NativeBase implements CtorLinks_SingleCtorWithTwoArgument {
 
   CtorLinks_SingleCtorWithTwoArgument$Impl(Pointer<Void> handle) : super(handle);
+
 
   CtorLinks_SingleCtorWithTwoArgument create(int arg, String arg2) {
     final _result_handle = _create(arg, arg2);
@@ -188,6 +234,8 @@ class CtorLinks_SingleCtorWithTwoArgument$Impl extends __lib.NativeBase implemen
     stringReleaseFfiHandle(_arg2Handle);
     return __resultHandle;
   }
+
+
 }
 
 Pointer<Void> smokeCtorlinksSinglectorwithtwoargumentToFfi(CtorLinks_SingleCtorWithTwoArgument value) =>
@@ -218,15 +266,23 @@ void smokeCtorlinksSinglectorwithtwoargumentReleaseFfiHandleNullable(Pointer<Voi
   _smokeCtorlinksSinglectorwithtwoargumentReleaseHandle(handle);
 
 // End of CtorLinks_SingleCtorWithTwoArgument "private" section.
-abstract class CtorLinks_OverloadedCtors {
+abstract class CtorLinks_OverloadedCtors implements Finalizable {
+
   factory CtorLinks_OverloadedCtors.withString(String input) => $prototype.withString(input);
+
   @Deprecated("Use [CtorLinks_OverloadedCtors.withString] instead.")
+
   factory CtorLinks_OverloadedCtors(String input, bool flag) => $prototype.$init(input, flag);
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = CtorLinks_OverloadedCtors$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // CtorLinks_OverloadedCtors "private" section, not exported.
+
 final _smokeCtorlinksOverloadedctorsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -239,24 +295,38 @@ final _smokeCtorlinksOverloadedctorsReleaseHandle = __lib.catchArgumentError(() 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CtorLinks_OverloadedCtors_release_handle'));
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class CtorLinks_OverloadedCtors$Impl extends __lib.NativeBase implements CtorLinks_OverloadedCtors {
+
   CtorLinks_OverloadedCtors$Impl(Pointer<Void> handle) : super(handle);
+
+
   CtorLinks_OverloadedCtors withString(String input) {
     final _result_handle = _withString(input);
     final _result = CtorLinks_OverloadedCtors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeCtorlinksOverloadedctorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   CtorLinks_OverloadedCtors $init(String input, bool flag) {
     final _result_handle = _$init(input, flag);
     final _result = CtorLinks_OverloadedCtors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeCtorlinksOverloadedctorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _withString(String input) {
     final _withStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_CtorLinks_OverloadedCtors_create__String'));
     final _inputHandle = stringToFfi(input);
@@ -264,6 +334,7 @@ class CtorLinks_OverloadedCtors$Impl extends __lib.NativeBase implements CtorLin
     stringReleaseFfiHandle(_inputHandle);
     return __resultHandle;
   }
+
   static Pointer<Void> _$init(String input, bool flag) {
     final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Uint8), Pointer<Void> Function(int, Pointer<Void>, int)>('library_smoke_CtorLinks_OverloadedCtors_create__String_Boolean'));
     final _inputHandle = stringToFfi(input);
@@ -273,29 +344,41 @@ class CtorLinks_OverloadedCtors$Impl extends __lib.NativeBase implements CtorLin
     booleanReleaseFfiHandle(_flagHandle);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeCtorlinksOverloadedctorsToFfi(CtorLinks_OverloadedCtors value) =>
   _smokeCtorlinksOverloadedctorsCopyHandle((value as __lib.NativeBase).handle);
+
 CtorLinks_OverloadedCtors smokeCtorlinksOverloadedctorsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CtorLinks_OverloadedCtors) return instance;
+
   final _copiedHandle = _smokeCtorlinksOverloadedctorsCopyHandle(handle);
   final result = CtorLinks_OverloadedCtors$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCtorlinksOverloadedctorsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCtorlinksOverloadedctorsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCtorlinksOverloadedctorsReleaseHandle(handle);
+
 Pointer<Void> smokeCtorlinksOverloadedctorsToFfiNullable(CtorLinks_OverloadedCtors? value) =>
   value != null ? smokeCtorlinksOverloadedctorsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CtorLinks_OverloadedCtors? smokeCtorlinksOverloadedctorsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCtorlinksOverloadedctorsFromFfi(handle) : null;
+
 void smokeCtorlinksOverloadedctorsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCtorlinksOverloadedctorsReleaseHandle(handle);
+
 // End of CtorLinks_OverloadedCtors "private" section.
+
 // CtorLinks "private" section, not exported.
+
 final _smokeCtorlinksRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -308,27 +391,42 @@ final _smokeCtorlinksReleaseHandle = __lib.catchArgumentError(() => __lib.native
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CtorLinks_release_handle'));
+
+
 class CtorLinks$Impl extends __lib.NativeBase implements CtorLinks {
+
   CtorLinks$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokeCtorlinksToFfi(CtorLinks value) =>
   _smokeCtorlinksCopyHandle((value as __lib.NativeBase).handle);
+
 CtorLinks smokeCtorlinksFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CtorLinks) return instance;
+
   final _copiedHandle = _smokeCtorlinksCopyHandle(handle);
   final result = CtorLinks$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCtorlinksRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCtorlinksReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCtorlinksReleaseHandle(handle);
+
 Pointer<Void> smokeCtorlinksToFfiNullable(CtorLinks? value) =>
   value != null ? smokeCtorlinksToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CtorLinks? smokeCtorlinksFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCtorlinksFromFfi(handle) : null;
+
 void smokeCtorlinksReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCtorlinksReleaseHandle(handle);
+
 // End of CtorLinks "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -9,7 +9,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 
 /// This is some very useful interface.
 @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
-abstract class DeprecationComments {
+abstract class DeprecationComments implements Finalizable {
   /// This is some very useful interface.
   @Deprecated("Unfortunately, this interface is deprecated. Use [Comments] instead.")
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -1,12 +1,16 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 @Deprecated("Unfortunately, this interface is deprecated.")
-abstract class DeprecationCommentsOnly {
+abstract class DeprecationCommentsOnly implements Finalizable {
   @Deprecated("Unfortunately, this interface is deprecated.")
+
   factory DeprecationCommentsOnly(
     bool Function(String) someMethodWithAllCommentsLambda,
     bool Function() isSomePropertyGetLambda,
@@ -16,25 +20,33 @@ abstract class DeprecationCommentsOnly {
     isSomePropertyGetLambda,
     isSomePropertySetLambda
   );
+
   @Deprecated("Unfortunately, this constant is deprecated.")
   static final bool veryUseful = true;
+
+
   /// [input] Very useful input parameter
   ///
   /// Returns [bool]. Usefulness of the input
   ///
   @Deprecated("Unfortunately, this method is deprecated.")
+
   bool someMethodWithAllComments(String input);
   @Deprecated("Unfortunately, this property's getter is deprecated.")
   bool get isSomeProperty;
   @Deprecated("Unfortunately, this property's setter is deprecated.")
   set isSomeProperty(bool value);
+
 }
+
 @Deprecated("Unfortunately, this enum is deprecated.")
 enum DeprecationCommentsOnly_SomeEnum {
     @Deprecated("Unfortunately, this item is deprecated.")
     useless
 }
+
 // DeprecationCommentsOnly_SomeEnum "private" section, not exported.
+
 int smokeDeprecationcommentsonlySomeenumToFfi(DeprecationCommentsOnly_SomeEnum value) {
   switch (value) {
   case DeprecationCommentsOnly_SomeEnum.useless:
@@ -43,6 +55,7 @@ int smokeDeprecationcommentsonlySomeenumToFfi(DeprecationCommentsOnly_SomeEnum v
     throw StateError("Invalid enum value $value for DeprecationCommentsOnly_SomeEnum enum.");
   }
 }
+
 DeprecationCommentsOnly_SomeEnum smokeDeprecationcommentsonlySomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -51,7 +64,9 @@ DeprecationCommentsOnly_SomeEnum smokeDeprecationcommentsonlySomeenumFromFfi(int
     throw StateError("Invalid numeric value $handle for DeprecationCommentsOnly_SomeEnum enum.");
   }
 }
+
 void smokeDeprecationcommentsonlySomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeDeprecationcommentsonlySomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -64,6 +79,7 @@ final _smokeDeprecationcommentsonlySomeenumGetValueNullable = __lib.catchArgumen
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeDeprecationcommentsonlySomeenumToFfiNullable(DeprecationCommentsOnly_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsonlySomeenumToFfi(value);
@@ -71,6 +87,7 @@ Pointer<Void> smokeDeprecationcommentsonlySomeenumToFfiNullable(DeprecationComme
   smokeDeprecationcommentsonlySomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 DeprecationCommentsOnly_SomeEnum? smokeDeprecationcommentsonlySomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsonlySomeenumGetValueNullable(handle);
@@ -78,18 +95,25 @@ DeprecationCommentsOnly_SomeEnum? smokeDeprecationcommentsonlySomeenumFromFfiNul
   smokeDeprecationcommentsonlySomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDeprecationcommentsonlySomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDeprecationcommentsonlySomeenumReleaseHandleNullable(handle);
+
 // End of DeprecationCommentsOnly_SomeEnum "private" section.
 @Deprecated("Unfortunately, this struct is deprecated.")
+
 class DeprecationCommentsOnly_SomeStruct {
   @Deprecated("Unfortunately, this field is deprecated.")
   bool someField;
+
   DeprecationCommentsOnly_SomeStruct._(this.someField);
   DeprecationCommentsOnly_SomeStruct()
     : someField = false;
 }
+
+
 // DeprecationCommentsOnly_SomeStruct "private" section, not exported.
+
 final _smokeDeprecationcommentsonlySomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
@@ -102,12 +126,16 @@ final _smokeDeprecationcommentsonlySomestructGetFieldsomeField = __lib.catchArgu
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeDeprecationcommentsonlySomestructToFfi(DeprecationCommentsOnly_SomeStruct value) {
   final _someFieldHandle = booleanToFfi(value.someField);
   final _result = _smokeDeprecationcommentsonlySomestructCreateHandle(_someFieldHandle);
   booleanReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 DeprecationCommentsOnly_SomeStruct smokeDeprecationcommentsonlySomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeDeprecationcommentsonlySomestructGetFieldsomeField(handle);
   try {
@@ -118,8 +146,11 @@ DeprecationCommentsOnly_SomeStruct smokeDeprecationcommentsonlySomestructFromFfi
     booleanReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeDeprecationcommentsonlySomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeDeprecationcommentsonlySomestructReleaseHandle(handle);
+
 // Nullable DeprecationCommentsOnly_SomeStruct
+
 final _smokeDeprecationcommentsonlySomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -132,6 +163,7 @@ final _smokeDeprecationcommentsonlySomestructGetValueNullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeDeprecationcommentsonlySomestructToFfiNullable(DeprecationCommentsOnly_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDeprecationcommentsonlySomestructToFfi(value);
@@ -139,6 +171,7 @@ Pointer<Void> smokeDeprecationcommentsonlySomestructToFfiNullable(DeprecationCom
   smokeDeprecationcommentsonlySomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 DeprecationCommentsOnly_SomeStruct? smokeDeprecationcommentsonlySomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDeprecationcommentsonlySomestructGetValueNullable(handle);
@@ -146,10 +179,14 @@ DeprecationCommentsOnly_SomeStruct? smokeDeprecationcommentsonlySomestructFromFf
   smokeDeprecationcommentsonlySomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDeprecationcommentsonlySomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDeprecationcommentsonlySomestructReleaseHandleNullable(handle);
+
 // End of DeprecationCommentsOnly_SomeStruct "private" section.
+
 // DeprecationCommentsOnly "private" section, not exported.
+
 final _smokeDeprecationcommentsonlyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -170,15 +207,19 @@ final _smokeDeprecationcommentsonlyGetTypeId = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DeprecationCommentsOnly_get_type_id'));
+
+
 class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
   bool Function(String) someMethodWithAllCommentsLambda;
   bool Function() isSomePropertyGetLambda;
   void Function(bool) isSomePropertySetLambda;
+
   DeprecationCommentsOnly$Lambdas(
     this.someMethodWithAllCommentsLambda,
     this.isSomePropertyGetLambda,
     this.isSomePropertySetLambda
   );
+
   @override
   bool someMethodWithAllComments(String input) =>
     someMethodWithAllCommentsLambda(input);
@@ -187,8 +228,11 @@ class DeprecationCommentsOnly$Lambdas implements DeprecationCommentsOnly {
   @override
   set isSomeProperty(bool value) => isSomePropertySetLambda(value);
 }
+
 class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements DeprecationCommentsOnly {
+
   DeprecationCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DeprecationCommentsOnly_someMethodWithAllComments__String'));
@@ -200,8 +244,11 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @Deprecated("Unfortunately, this property's getter is deprecated.")
   bool get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_get'));
@@ -211,17 +258,27 @@ class DeprecationCommentsOnly$Impl extends __lib.NativeBase implements Deprecati
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   @Deprecated("Unfortunately, this property's setter is deprecated.")
+
   set isSomeProperty(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_DeprecationCommentsOnly_isSomeProperty_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(Object _obj, Pointer<Void> input, Pointer<Uint8> _result) {
   bool? _resultObject;
   try {
@@ -232,10 +289,12 @@ int _smokeDeprecationcommentsonlysomeMethodWithAllCommentsStatic(Object _obj, Po
   }
   return 0;
 }
+
 int _smokeDeprecationcommentsonlyisSomePropertyGetStatic(Object _obj, Pointer<Uint8> _result) {
   _result.value = booleanToFfi((_obj as DeprecationCommentsOnly).isSomeProperty);
   return 0;
 }
+
 int _smokeDeprecationcommentsonlyisSomePropertySetStatic(Object _obj, int _value) {
   try {
     (_obj as DeprecationCommentsOnly).isSomeProperty =
@@ -245,8 +304,10 @@ int _smokeDeprecationcommentsonlyisSomePropertySetStatic(Object _obj, int _value
   }
   return 0;
 }
+
 Pointer<Void> smokeDeprecationcommentsonlyToFfi(DeprecationCommentsOnly value) {
   if (value is __lib.NativeBase) return _smokeDeprecationcommentsonlyCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeDeprecationcommentsonlyCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -255,15 +316,19 @@ Pointer<Void> smokeDeprecationcommentsonlyToFfi(DeprecationCommentsOnly value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Uint8>)>(_smokeDeprecationcommentsonlyisSomePropertyGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeDeprecationcommentsonlyisSomePropertySetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 DeprecationCommentsOnly smokeDeprecationcommentsonlyFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DeprecationCommentsOnly) return instance;
+
   final _typeIdHandle = _smokeDeprecationcommentsonlyGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeDeprecationcommentsonlyCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -272,12 +337,19 @@ DeprecationCommentsOnly smokeDeprecationcommentsonlyFromFfi(Pointer<Void> handle
   _smokeDeprecationcommentsonlyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeDeprecationcommentsonlyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDeprecationcommentsonlyReleaseHandle(handle);
+
 Pointer<Void> smokeDeprecationcommentsonlyToFfiNullable(DeprecationCommentsOnly? value) =>
   value != null ? smokeDeprecationcommentsonlyToFfi(value) : Pointer<Void>.fromAddress(0);
+
 DeprecationCommentsOnly? smokeDeprecationcommentsonlyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDeprecationcommentsonlyFromFfi(handle) : null;
+
 void smokeDeprecationcommentsonlyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDeprecationcommentsonlyReleaseHandle(handle);
+
 // End of DeprecationCommentsOnly "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -227,7 +227,7 @@ final _smokeExcludedcommentsSomelambdaCreateProxy = __lib.catchArgumentError(() 
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_ExcludedComments_SomeLambda_create_proxy'));
 
-class ExcludedComments_SomeLambda$Impl {
+class ExcludedComments_SomeLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   ExcludedComments_SomeLambda$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -8,7 +8,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 
 /// This is some very useful class.
 /// @nodoc
-abstract class ExcludedComments {
+abstract class ExcludedComments implements Finalizable {
 
   /// This is some very useful constant.
   /// @nodoc

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_interface.dart
@@ -1,15 +1,21 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// This is some very useful interface.
 /// @nodoc
-abstract class ExcludedCommentsInterface {
+abstract class ExcludedCommentsInterface implements Finalizable {
 
 }
+
+
 // ExcludedCommentsInterface "private" section, not exported.
+
 final _smokeExcludedcommentsinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -30,26 +36,38 @@ final _smokeExcludedcommentsinterfaceGetTypeId = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsInterface_get_type_id'));
+
+
 class ExcludedCommentsInterface$Impl extends __lib.NativeBase implements ExcludedCommentsInterface {
+
   ExcludedCommentsInterface$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
+
+
 Pointer<Void> smokeExcludedcommentsinterfaceToFfi(ExcludedCommentsInterface value) {
   if (value is __lib.NativeBase) return _smokeExcludedcommentsinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeExcludedcommentsinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value
   );
+
   return result;
 }
+
 ExcludedCommentsInterface smokeExcludedcommentsinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExcludedCommentsInterface) return instance;
+
   final _typeIdHandle = _smokeExcludedcommentsinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeExcludedcommentsinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -58,12 +76,19 @@ ExcludedCommentsInterface smokeExcludedcommentsinterfaceFromFfi(Pointer<Void> ha
   _smokeExcludedcommentsinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExcludedcommentsinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExcludedcommentsinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeExcludedcommentsinterfaceToFfiNullable(ExcludedCommentsInterface? value) =>
   value != null ? smokeExcludedcommentsinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExcludedCommentsInterface? smokeExcludedcommentsinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExcludedcommentsinterfaceFromFfi(handle) : null;
+
 void smokeExcludedcommentsinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsinterfaceReleaseHandle(handle);
+
 // End of ExcludedCommentsInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -195,7 +195,7 @@ final _smokeExcludedcommentsonlySomelambdaCreateProxy = __lib.catchArgumentError
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_create_proxy'));
 
-class ExcludedCommentsOnly_SomeLambda$Impl {
+class ExcludedCommentsOnly_SomeLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   ExcludedCommentsOnly_SomeLambda$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -1,27 +1,38 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// @nodoc
-abstract class ExcludedCommentsOnly {
+abstract class ExcludedCommentsOnly implements Finalizable {
+
   /// @nodoc
   static final bool veryUseful = true;
+
+
   /// @nodoc
   bool someMethodWithAllComments(String inputParameter);
+
   /// @nodoc
   void someMethodWithoutReturnTypeOrInputParameters();
   /// @nodoc
   bool get isSomeProperty;
   /// @nodoc
   set isSomeProperty(bool value);
+
 }
+
 /// @nodoc
 enum ExcludedCommentsOnly_SomeEnum {
     /// @nodoc
     useless
 }
+
 // ExcludedCommentsOnly_SomeEnum "private" section, not exported.
+
 int smokeExcludedcommentsonlySomeenumToFfi(ExcludedCommentsOnly_SomeEnum value) {
   switch (value) {
   case ExcludedCommentsOnly_SomeEnum.useless:
@@ -30,6 +41,7 @@ int smokeExcludedcommentsonlySomeenumToFfi(ExcludedCommentsOnly_SomeEnum value) 
     throw StateError("Invalid enum value $value for ExcludedCommentsOnly_SomeEnum enum.");
   }
 }
+
 ExcludedCommentsOnly_SomeEnum smokeExcludedcommentsonlySomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -38,7 +50,9 @@ ExcludedCommentsOnly_SomeEnum smokeExcludedcommentsonlySomeenumFromFfi(int handl
     throw StateError("Invalid numeric value $handle for ExcludedCommentsOnly_SomeEnum enum.");
   }
 }
+
 void smokeExcludedcommentsonlySomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeExcludedcommentsonlySomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -51,6 +65,7 @@ final _smokeExcludedcommentsonlySomeenumGetValueNullable = __lib.catchArgumentEr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeExcludedcommentsonlySomeenumToFfiNullable(ExcludedCommentsOnly_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExcludedcommentsonlySomeenumToFfi(value);
@@ -58,6 +73,7 @@ Pointer<Void> smokeExcludedcommentsonlySomeenumToFfiNullable(ExcludedCommentsOnl
   smokeExcludedcommentsonlySomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ExcludedCommentsOnly_SomeEnum? smokeExcludedcommentsonlySomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExcludedcommentsonlySomeenumGetValueNullable(handle);
@@ -65,8 +81,10 @@ ExcludedCommentsOnly_SomeEnum? smokeExcludedcommentsonlySomeenumFromFfiNullable(
   smokeExcludedcommentsonlySomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExcludedcommentsonlySomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsonlySomeenumReleaseHandleNullable(handle);
+
 // End of ExcludedCommentsOnly_SomeEnum "private" section.
 /// @nodoc
 class ExcludedCommentsOnly_SomethingWrongException implements Exception {
@@ -74,12 +92,17 @@ class ExcludedCommentsOnly_SomethingWrongException implements Exception {
   ExcludedCommentsOnly_SomethingWrongException(this.error);
 }
 /// @nodoc
+
 class ExcludedCommentsOnly_SomeStruct {
   /// @nodoc
   bool someField;
+
   ExcludedCommentsOnly_SomeStruct(this.someField);
 }
+
+
 // ExcludedCommentsOnly_SomeStruct "private" section, not exported.
+
 final _smokeExcludedcommentsonlySomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8),
     Pointer<Void> Function(int)
@@ -92,12 +115,16 @@ final _smokeExcludedcommentsonlySomestructGetFieldsomeField = __lib.catchArgumen
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeExcludedcommentsonlySomestructToFfi(ExcludedCommentsOnly_SomeStruct value) {
   final _someFieldHandle = booleanToFfi(value.someField);
   final _result = _smokeExcludedcommentsonlySomestructCreateHandle(_someFieldHandle);
   booleanReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 ExcludedCommentsOnly_SomeStruct smokeExcludedcommentsonlySomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeExcludedcommentsonlySomestructGetFieldsomeField(handle);
   try {
@@ -108,8 +135,11 @@ ExcludedCommentsOnly_SomeStruct smokeExcludedcommentsonlySomestructFromFfi(Point
     booleanReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeExcludedcommentsonlySomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeExcludedcommentsonlySomestructReleaseHandle(handle);
+
 // Nullable ExcludedCommentsOnly_SomeStruct
+
 final _smokeExcludedcommentsonlySomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -122,6 +152,7 @@ final _smokeExcludedcommentsonlySomestructGetValueNullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeExcludedcommentsonlySomestructToFfiNullable(ExcludedCommentsOnly_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExcludedcommentsonlySomestructToFfi(value);
@@ -129,6 +160,7 @@ Pointer<Void> smokeExcludedcommentsonlySomestructToFfiNullable(ExcludedCommentsO
   smokeExcludedcommentsonlySomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 ExcludedCommentsOnly_SomeStruct? smokeExcludedcommentsonlySomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExcludedcommentsonlySomestructGetValueNullable(handle);
@@ -136,12 +168,16 @@ ExcludedCommentsOnly_SomeStruct? smokeExcludedcommentsonlySomestructFromFfiNulla
   smokeExcludedcommentsonlySomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExcludedcommentsonlySomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsonlySomestructReleaseHandleNullable(handle);
+
 // End of ExcludedCommentsOnly_SomeStruct "private" section.
 /// @nodoc
 typedef ExcludedCommentsOnly_SomeLambda = double Function(String, int);
+
 // ExcludedCommentsOnly_SomeLambda "private" section, not exported.
+
 final _smokeExcludedcommentsonlySomelambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -158,9 +194,11 @@ final _smokeExcludedcommentsonlySomelambdaCreateProxy = __lib.catchArgumentError
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_create_proxy'));
+
 class ExcludedCommentsOnly_SomeLambda$Impl {
   final Pointer<Void> handle;
   ExcludedCommentsOnly_SomeLambda$Impl(this.handle);
+
   double call(String p0, int p1) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32, Pointer<Void>, Int32), double Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_SomeLambda_call__String_Int'));
     final _p0Handle = stringToFfi(p0);
@@ -168,12 +206,18 @@ class ExcludedCommentsOnly_SomeLambda$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
 }
+
 int _smokeExcludedcommentsonlySomelambdacallStatic(Object _obj, Pointer<Void> p0, int p1, Pointer<Double> _result) {
   double? _resultObject;
   try {
@@ -181,9 +225,11 @@ int _smokeExcludedcommentsonlySomelambdacallStatic(Object _obj, Pointer<Void> p0
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeExcludedcommentsonlySomelambdaToFfi(ExcludedCommentsOnly_SomeLambda value) =>
   _smokeExcludedcommentsonlySomelambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -191,6 +237,7 @@ Pointer<Void> smokeExcludedcommentsonlySomelambdaToFfi(ExcludedCommentsOnly_Some
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Int32, Pointer<Double>)>(_smokeExcludedcommentsonlySomelambdacallStatic, __lib.unknownError)
   );
+
 ExcludedCommentsOnly_SomeLambda smokeExcludedcommentsonlySomelambdaFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeExcludedcommentsonlySomelambdaCopyHandle(handle);
   final _impl = ExcludedCommentsOnly_SomeLambda$Impl(_copiedHandle);
@@ -198,9 +245,12 @@ ExcludedCommentsOnly_SomeLambda smokeExcludedcommentsonlySomelambdaFromFfi(Point
   _smokeExcludedcommentsonlySomelambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExcludedcommentsonlySomelambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExcludedcommentsonlySomelambdaReleaseHandle(handle);
+
 // Nullable ExcludedCommentsOnly_SomeLambda
+
 final _smokeExcludedcommentsonlySomelambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -213,6 +263,7 @@ final _smokeExcludedcommentsonlySomelambdaGetValueNullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_SomeLambda_get_value_nullable'));
+
 Pointer<Void> smokeExcludedcommentsonlySomelambdaToFfiNullable(ExcludedCommentsOnly_SomeLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExcludedcommentsonlySomelambdaToFfi(value);
@@ -220,6 +271,7 @@ Pointer<Void> smokeExcludedcommentsonlySomelambdaToFfiNullable(ExcludedCommentsO
   smokeExcludedcommentsonlySomelambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 ExcludedCommentsOnly_SomeLambda? smokeExcludedcommentsonlySomelambdaFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExcludedcommentsonlySomelambdaGetValueNullable(handle);
@@ -227,10 +279,14 @@ ExcludedCommentsOnly_SomeLambda? smokeExcludedcommentsonlySomelambdaFromFfiNulla
   smokeExcludedcommentsonlySomelambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExcludedcommentsonlySomelambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsonlySomelambdaReleaseHandleNullable(handle);
+
 // End of ExcludedCommentsOnly_SomeLambda "private" section.
+
 // ExcludedCommentsOnly "private" section, not exported.
+
 final _smokeExcludedcommentsonlyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -243,6 +299,8 @@ final _smokeExcludedcommentsonlyReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_release_handle'));
+
+
 final _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -259,8 +317,13 @@ final _someMethodWithAllCommentssmokeExcludedcommentsonlySomemethodwithallcommen
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String_return_has_error'));
+
+
+
 class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedCommentsOnly {
+
   ExcludedCommentsOnly$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   bool someMethodWithAllComments(String inputParameter) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ExcludedCommentsOnly_someMethodWithAllComments__String'));
@@ -283,14 +346,19 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void someMethodWithoutReturnTypeOrInputParameters() {
     final _someMethodWithoutReturnTypeOrInputParametersFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_someMethodWithoutReturnTypeOrInputParameters'));
     final _handle = this.handle;
     _someMethodWithoutReturnTypeOrInputParametersFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   bool get isSomeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_get'));
@@ -300,8 +368,11 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set isSomeProperty(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_ExcludedCommentsOnly_isSomeProperty_set__Boolean'));
@@ -309,26 +380,40 @@ class ExcludedCommentsOnly$Impl extends __lib.NativeBase implements ExcludedComm
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeExcludedcommentsonlyToFfi(ExcludedCommentsOnly value) =>
   _smokeExcludedcommentsonlyCopyHandle((value as __lib.NativeBase).handle);
+
 ExcludedCommentsOnly smokeExcludedcommentsonlyFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExcludedCommentsOnly) return instance;
+
   final _copiedHandle = _smokeExcludedcommentsonlyCopyHandle(handle);
   final result = ExcludedCommentsOnly$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeExcludedcommentsonlyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExcludedcommentsonlyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExcludedcommentsonlyReleaseHandle(handle);
+
 Pointer<Void> smokeExcludedcommentsonlyToFfiNullable(ExcludedCommentsOnly? value) =>
   value != null ? smokeExcludedcommentsonlyToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExcludedCommentsOnly? smokeExcludedcommentsonlyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExcludedcommentsonlyFromFfi(handle) : null;
+
 void smokeExcludedcommentsonlyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExcludedcommentsonlyReleaseHandle(handle);
+
 // End of ExcludedCommentsOnly "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/internal_class_with_comments.dart
@@ -1,15 +1,22 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+
 /// This looks internal
 /// @nodoc
-abstract class InternalClassWithComments {
+abstract class InternalClassWithComments implements Finalizable {
+
   /// This is definitely internal
   ///
   void doNothing();
 }
+
+
 // InternalClassWithComments "private" section, not exported.
+
 final _smokeInternalclasswithcommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -22,33 +29,51 @@ final _smokeInternalclasswithcommentsReleaseHandle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithComments_release_handle'));
+
+
+
 class InternalClassWithComments$Impl extends __lib.NativeBase implements InternalClassWithComments {
+
   InternalClassWithComments$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithComments_doNothing'));
     final _handle = this.handle;
     _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokeInternalclasswithcommentsToFfi(InternalClassWithComments value) =>
   _smokeInternalclasswithcommentsCopyHandle((value as __lib.NativeBase).handle);
+
 InternalClassWithComments smokeInternalclasswithcommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClassWithComments) return instance;
+
   final _copiedHandle = _smokeInternalclasswithcommentsCopyHandle(handle);
   final result = InternalClassWithComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeInternalclasswithcommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInternalclasswithcommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInternalclasswithcommentsReleaseHandle(handle);
+
 Pointer<Void> smokeInternalclasswithcommentsToFfiNullable(InternalClassWithComments? value) =>
   value != null ? smokeInternalclasswithcommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InternalClassWithComments? smokeInternalclasswithcommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInternalclasswithcommentsFromFfi(handle) : null;
+
 void smokeInternalclasswithcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInternalclasswithcommentsReleaseHandle(handle);
+
 // End of InternalClassWithComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/lambda_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/lambda_comments.dart
@@ -34,7 +34,7 @@ final _smokeLambdacommentsWithnonamedparametersCreateProxy = __lib.catchArgument
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_WithNoNamedParameters_create_proxy'));
 
-class LambdaComments_WithNoNamedParameters$Impl {
+class LambdaComments_WithNoNamedParameters$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdaComments_WithNoNamedParameters$Impl(this.handle);
 
@@ -142,7 +142,7 @@ final _smokeLambdacommentsWithnodocsforparametersCreateProxy = __lib.catchArgume
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_WithNoDocsForParameters_create_proxy'));
 
-class LambdaComments_WithNoDocsForParameters$Impl {
+class LambdaComments_WithNoDocsForParameters$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdaComments_WithNoDocsForParameters$Impl(this.handle);
 
@@ -254,7 +254,7 @@ final _smokeLambdacommentsWithnamedparametersCreateProxy = __lib.catchArgumentEr
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_WithNamedParameters_create_proxy'));
 
-class LambdaComments_WithNamedParameters$Impl {
+class LambdaComments_WithNamedParameters$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdaComments_WithNamedParameters$Impl(this.handle);
 
@@ -364,7 +364,7 @@ final _smokeLambdacommentsMixeddocnameparametersCreateProxy = __lib.catchArgumen
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_MixedDocNameParameters_create_proxy'));
 
-class LambdaComments_MixedDocNameParameters$Impl {
+class LambdaComments_MixedDocNameParameters$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdaComments_MixedDocNameParameters$Impl(this.handle);
 
@@ -474,7 +474,7 @@ final _smokeLambdacommentsNocommentsnonamedparamsCreateProxy = __lib.catchArgume
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_NoCommentsNoNamedParams_create_proxy'));
 
-class LambdaComments_NoCommentsNoNamedParams$Impl {
+class LambdaComments_NoCommentsNoNamedParams$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdaComments_NoCommentsNoNamedParams$Impl(this.handle);
 
@@ -584,7 +584,7 @@ final _smokeLambdacommentsNocommentswithnamedparamsCreateProxy = __lib.catchArgu
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_NoCommentsWithNamedParams_create_proxy'));
 
-class LambdaComments_NoCommentsWithNamedParams$Impl {
+class LambdaComments_NoCommentsWithNamedParams$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdaComments_NoCommentsWithNamedParams$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/lambda_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/lambda_comments.dart
@@ -1,15 +1,22 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class LambdaComments {
+
+abstract class LambdaComments implements Finalizable {
+
 }
+
 /// The first line of the doc.
 ///
 /// [p0] The first input parameter
 typedef LambdaComments_WithNoNamedParameters = String Function(String);
+
 // LambdaComments_WithNoNamedParameters "private" section, not exported.
+
 final _smokeLambdacommentsWithnonamedparametersRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -26,9 +33,11 @@ final _smokeLambdacommentsWithnonamedparametersCreateProxy = __lib.catchArgument
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_WithNoNamedParameters_create_proxy'));
+
 class LambdaComments_WithNoNamedParameters$Impl {
   final Pointer<Void> handle;
   LambdaComments_WithNoNamedParameters$Impl(this.handle);
+
   String call(String p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdaComments_WithNoNamedParameters_call__String'));
     final _p0Handle = stringToFfi(p0);
@@ -39,9 +48,13 @@ class LambdaComments_WithNoNamedParameters$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdacommentsWithnonamedparameterscallStatic(Object _obj, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -52,6 +65,7 @@ int _smokeLambdacommentsWithnonamedparameterscallStatic(Object _obj, Pointer<Voi
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdacommentsWithnonamedparametersToFfi(LambdaComments_WithNoNamedParameters value) =>
   _smokeLambdacommentsWithnonamedparametersCreateProxy(
     __lib.getObjectToken(value),
@@ -59,6 +73,7 @@ Pointer<Void> smokeLambdacommentsWithnonamedparametersToFfi(LambdaComments_WithN
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdacommentsWithnonamedparameterscallStatic, __lib.unknownError)
   );
+
 LambdaComments_WithNoNamedParameters smokeLambdacommentsWithnonamedparametersFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdacommentsWithnonamedparametersCopyHandle(handle);
   final _impl = LambdaComments_WithNoNamedParameters$Impl(_copiedHandle);
@@ -66,9 +81,12 @@ LambdaComments_WithNoNamedParameters smokeLambdacommentsWithnonamedparametersFro
   _smokeLambdacommentsWithnonamedparametersRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdacommentsWithnonamedparametersReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdacommentsWithnonamedparametersReleaseHandle(handle);
+
 // Nullable LambdaComments_WithNoNamedParameters
+
 final _smokeLambdacommentsWithnonamedparametersCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -81,6 +99,7 @@ final _smokeLambdacommentsWithnonamedparametersGetValueNullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdaComments_WithNoNamedParameters_get_value_nullable'));
+
 Pointer<Void> smokeLambdacommentsWithnonamedparametersToFfiNullable(LambdaComments_WithNoNamedParameters? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdacommentsWithnonamedparametersToFfi(value);
@@ -88,6 +107,7 @@ Pointer<Void> smokeLambdacommentsWithnonamedparametersToFfiNullable(LambdaCommen
   smokeLambdacommentsWithnonamedparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdaComments_WithNoNamedParameters? smokeLambdacommentsWithnonamedparametersFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdacommentsWithnonamedparametersGetValueNullable(handle);
@@ -95,12 +115,16 @@ LambdaComments_WithNoNamedParameters? smokeLambdacommentsWithnonamedparametersFr
   smokeLambdacommentsWithnonamedparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdacommentsWithnonamedparametersReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdacommentsWithnonamedparametersReleaseHandleNullable(handle);
+
 // End of LambdaComments_WithNoNamedParameters "private" section.
 /// The first line of the doc.
 typedef LambdaComments_WithNoDocsForParameters = String Function(String);
+
 // LambdaComments_WithNoDocsForParameters "private" section, not exported.
+
 final _smokeLambdacommentsWithnodocsforparametersRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -117,9 +141,11 @@ final _smokeLambdacommentsWithnodocsforparametersCreateProxy = __lib.catchArgume
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_WithNoDocsForParameters_create_proxy'));
+
 class LambdaComments_WithNoDocsForParameters$Impl {
   final Pointer<Void> handle;
   LambdaComments_WithNoDocsForParameters$Impl(this.handle);
+
   String call(String p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdaComments_WithNoDocsForParameters_call__String'));
     final _p0Handle = stringToFfi(p0);
@@ -130,9 +156,13 @@ class LambdaComments_WithNoDocsForParameters$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdacommentsWithnodocsforparameterscallStatic(Object _obj, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -143,6 +173,7 @@ int _smokeLambdacommentsWithnodocsforparameterscallStatic(Object _obj, Pointer<V
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdacommentsWithnodocsforparametersToFfi(LambdaComments_WithNoDocsForParameters value) =>
   _smokeLambdacommentsWithnodocsforparametersCreateProxy(
     __lib.getObjectToken(value),
@@ -150,6 +181,7 @@ Pointer<Void> smokeLambdacommentsWithnodocsforparametersToFfi(LambdaComments_Wit
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdacommentsWithnodocsforparameterscallStatic, __lib.unknownError)
   );
+
 LambdaComments_WithNoDocsForParameters smokeLambdacommentsWithnodocsforparametersFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdacommentsWithnodocsforparametersCopyHandle(handle);
   final _impl = LambdaComments_WithNoDocsForParameters$Impl(_copiedHandle);
@@ -157,9 +189,12 @@ LambdaComments_WithNoDocsForParameters smokeLambdacommentsWithnodocsforparameter
   _smokeLambdacommentsWithnodocsforparametersRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdacommentsWithnodocsforparametersReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdacommentsWithnodocsforparametersReleaseHandle(handle);
+
 // Nullable LambdaComments_WithNoDocsForParameters
+
 final _smokeLambdacommentsWithnodocsforparametersCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -172,6 +207,7 @@ final _smokeLambdacommentsWithnodocsforparametersGetValueNullable = __lib.catchA
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdaComments_WithNoDocsForParameters_get_value_nullable'));
+
 Pointer<Void> smokeLambdacommentsWithnodocsforparametersToFfiNullable(LambdaComments_WithNoDocsForParameters? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdacommentsWithnodocsforparametersToFfi(value);
@@ -179,6 +215,7 @@ Pointer<Void> smokeLambdacommentsWithnodocsforparametersToFfiNullable(LambdaComm
   smokeLambdacommentsWithnodocsforparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdaComments_WithNoDocsForParameters? smokeLambdacommentsWithnodocsforparametersFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdacommentsWithnodocsforparametersGetValueNullable(handle);
@@ -186,8 +223,10 @@ LambdaComments_WithNoDocsForParameters? smokeLambdacommentsWithnodocsforparamete
   smokeLambdacommentsWithnodocsforparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdacommentsWithnodocsforparametersReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdacommentsWithnodocsforparametersReleaseHandleNullable(handle);
+
 // End of LambdaComments_WithNoDocsForParameters "private" section.
 /// The first line of the doc.
 ///
@@ -195,7 +234,9 @@ void smokeLambdacommentsWithnodocsforparametersReleaseFfiHandleNullable(Pointer<
 ///
 /// Returns The string.
 typedef LambdaComments_WithNamedParameters = String Function(String inputParameter);
+
 // LambdaComments_WithNamedParameters "private" section, not exported.
+
 final _smokeLambdacommentsWithnamedparametersRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -212,9 +253,11 @@ final _smokeLambdacommentsWithnamedparametersCreateProxy = __lib.catchArgumentEr
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_WithNamedParameters_create_proxy'));
+
 class LambdaComments_WithNamedParameters$Impl {
   final Pointer<Void> handle;
   LambdaComments_WithNamedParameters$Impl(this.handle);
+
   String call(String inputParameter) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdaComments_WithNamedParameters_call__String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
@@ -225,9 +268,13 @@ class LambdaComments_WithNamedParameters$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdacommentsWithnamedparameterscallStatic(Object _obj, Pointer<Void> inputParameter, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -238,6 +285,7 @@ int _smokeLambdacommentsWithnamedparameterscallStatic(Object _obj, Pointer<Void>
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdacommentsWithnamedparametersToFfi(LambdaComments_WithNamedParameters value) =>
   _smokeLambdacommentsWithnamedparametersCreateProxy(
     __lib.getObjectToken(value),
@@ -245,6 +293,7 @@ Pointer<Void> smokeLambdacommentsWithnamedparametersToFfi(LambdaComments_WithNam
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdacommentsWithnamedparameterscallStatic, __lib.unknownError)
   );
+
 LambdaComments_WithNamedParameters smokeLambdacommentsWithnamedparametersFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdacommentsWithnamedparametersCopyHandle(handle);
   final _impl = LambdaComments_WithNamedParameters$Impl(_copiedHandle);
@@ -252,9 +301,12 @@ LambdaComments_WithNamedParameters smokeLambdacommentsWithnamedparametersFromFfi
   _smokeLambdacommentsWithnamedparametersRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdacommentsWithnamedparametersReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdacommentsWithnamedparametersReleaseHandle(handle);
+
 // Nullable LambdaComments_WithNamedParameters
+
 final _smokeLambdacommentsWithnamedparametersCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -267,6 +319,7 @@ final _smokeLambdacommentsWithnamedparametersGetValueNullable = __lib.catchArgum
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdaComments_WithNamedParameters_get_value_nullable'));
+
 Pointer<Void> smokeLambdacommentsWithnamedparametersToFfiNullable(LambdaComments_WithNamedParameters? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdacommentsWithnamedparametersToFfi(value);
@@ -274,6 +327,7 @@ Pointer<Void> smokeLambdacommentsWithnamedparametersToFfiNullable(LambdaComments
   smokeLambdacommentsWithnamedparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdaComments_WithNamedParameters? smokeLambdacommentsWithnamedparametersFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdacommentsWithnamedparametersGetValueNullable(handle);
@@ -281,14 +335,18 @@ LambdaComments_WithNamedParameters? smokeLambdacommentsWithnamedparametersFromFf
   smokeLambdacommentsWithnamedparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdacommentsWithnamedparametersReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdacommentsWithnamedparametersReleaseHandleNullable(handle);
+
 // End of LambdaComments_WithNamedParameters "private" section.
 /// The first line of the doc.
 ///
 /// Returns The string.
 typedef LambdaComments_MixedDocNameParameters = String Function(String inputParameter, String secondInputParameter);
+
 // LambdaComments_MixedDocNameParameters "private" section, not exported.
+
 final _smokeLambdacommentsMixeddocnameparametersRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -305,9 +363,11 @@ final _smokeLambdacommentsMixeddocnameparametersCreateProxy = __lib.catchArgumen
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_MixedDocNameParameters_create_proxy'));
+
 class LambdaComments_MixedDocNameParameters$Impl {
   final Pointer<Void> handle;
   LambdaComments_MixedDocNameParameters$Impl(this.handle);
+
   String call(String inputParameter, String secondInputParameter) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_LambdaComments_MixedDocNameParameters_call__String_String'));
     final _inputParameterHandle = stringToFfi(inputParameter);
@@ -320,9 +380,13 @@ class LambdaComments_MixedDocNameParameters$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdacommentsMixeddocnameparameterscallStatic(Object _obj, Pointer<Void> inputParameter, Pointer<Void> secondInputParameter, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -334,6 +398,7 @@ int _smokeLambdacommentsMixeddocnameparameterscallStatic(Object _obj, Pointer<Vo
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdacommentsMixeddocnameparametersToFfi(LambdaComments_MixedDocNameParameters value) =>
   _smokeLambdacommentsMixeddocnameparametersCreateProxy(
     __lib.getObjectToken(value),
@@ -341,6 +406,7 @@ Pointer<Void> smokeLambdacommentsMixeddocnameparametersToFfi(LambdaComments_Mixe
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdacommentsMixeddocnameparameterscallStatic, __lib.unknownError)
   );
+
 LambdaComments_MixedDocNameParameters smokeLambdacommentsMixeddocnameparametersFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdacommentsMixeddocnameparametersCopyHandle(handle);
   final _impl = LambdaComments_MixedDocNameParameters$Impl(_copiedHandle);
@@ -348,9 +414,12 @@ LambdaComments_MixedDocNameParameters smokeLambdacommentsMixeddocnameparametersF
   _smokeLambdacommentsMixeddocnameparametersRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdacommentsMixeddocnameparametersReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdacommentsMixeddocnameparametersReleaseHandle(handle);
+
 // Nullable LambdaComments_MixedDocNameParameters
+
 final _smokeLambdacommentsMixeddocnameparametersCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -363,6 +432,7 @@ final _smokeLambdacommentsMixeddocnameparametersGetValueNullable = __lib.catchAr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdaComments_MixedDocNameParameters_get_value_nullable'));
+
 Pointer<Void> smokeLambdacommentsMixeddocnameparametersToFfiNullable(LambdaComments_MixedDocNameParameters? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdacommentsMixeddocnameparametersToFfi(value);
@@ -370,6 +440,7 @@ Pointer<Void> smokeLambdacommentsMixeddocnameparametersToFfiNullable(LambdaComme
   smokeLambdacommentsMixeddocnameparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdaComments_MixedDocNameParameters? smokeLambdacommentsMixeddocnameparametersFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdacommentsMixeddocnameparametersGetValueNullable(handle);
@@ -377,11 +448,15 @@ LambdaComments_MixedDocNameParameters? smokeLambdacommentsMixeddocnameparameters
   smokeLambdacommentsMixeddocnameparametersReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdacommentsMixeddocnameparametersReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdacommentsMixeddocnameparametersReleaseHandleNullable(handle);
+
 // End of LambdaComments_MixedDocNameParameters "private" section.
 typedef LambdaComments_NoCommentsNoNamedParams = String Function(String, String);
+
 // LambdaComments_NoCommentsNoNamedParams "private" section, not exported.
+
 final _smokeLambdacommentsNocommentsnonamedparamsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -398,9 +473,11 @@ final _smokeLambdacommentsNocommentsnonamedparamsCreateProxy = __lib.catchArgume
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_NoCommentsNoNamedParams_create_proxy'));
+
 class LambdaComments_NoCommentsNoNamedParams$Impl {
   final Pointer<Void> handle;
   LambdaComments_NoCommentsNoNamedParams$Impl(this.handle);
+
   String call(String p0, String p1) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_LambdaComments_NoCommentsNoNamedParams_call__String_String'));
     final _p0Handle = stringToFfi(p0);
@@ -413,9 +490,13 @@ class LambdaComments_NoCommentsNoNamedParams$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdacommentsNocommentsnonamedparamscallStatic(Object _obj, Pointer<Void> p0, Pointer<Void> p1, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -427,6 +508,7 @@ int _smokeLambdacommentsNocommentsnonamedparamscallStatic(Object _obj, Pointer<V
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdacommentsNocommentsnonamedparamsToFfi(LambdaComments_NoCommentsNoNamedParams value) =>
   _smokeLambdacommentsNocommentsnonamedparamsCreateProxy(
     __lib.getObjectToken(value),
@@ -434,6 +516,7 @@ Pointer<Void> smokeLambdacommentsNocommentsnonamedparamsToFfi(LambdaComments_NoC
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdacommentsNocommentsnonamedparamscallStatic, __lib.unknownError)
   );
+
 LambdaComments_NoCommentsNoNamedParams smokeLambdacommentsNocommentsnonamedparamsFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdacommentsNocommentsnonamedparamsCopyHandle(handle);
   final _impl = LambdaComments_NoCommentsNoNamedParams$Impl(_copiedHandle);
@@ -441,9 +524,12 @@ LambdaComments_NoCommentsNoNamedParams smokeLambdacommentsNocommentsnonamedparam
   _smokeLambdacommentsNocommentsnonamedparamsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdacommentsNocommentsnonamedparamsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdacommentsNocommentsnonamedparamsReleaseHandle(handle);
+
 // Nullable LambdaComments_NoCommentsNoNamedParams
+
 final _smokeLambdacommentsNocommentsnonamedparamsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -456,6 +542,7 @@ final _smokeLambdacommentsNocommentsnonamedparamsGetValueNullable = __lib.catchA
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdaComments_NoCommentsNoNamedParams_get_value_nullable'));
+
 Pointer<Void> smokeLambdacommentsNocommentsnonamedparamsToFfiNullable(LambdaComments_NoCommentsNoNamedParams? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdacommentsNocommentsnonamedparamsToFfi(value);
@@ -463,6 +550,7 @@ Pointer<Void> smokeLambdacommentsNocommentsnonamedparamsToFfiNullable(LambdaComm
   smokeLambdacommentsNocommentsnonamedparamsReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdaComments_NoCommentsNoNamedParams? smokeLambdacommentsNocommentsnonamedparamsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdacommentsNocommentsnonamedparamsGetValueNullable(handle);
@@ -470,11 +558,15 @@ LambdaComments_NoCommentsNoNamedParams? smokeLambdacommentsNocommentsnonamedpara
   smokeLambdacommentsNocommentsnonamedparamsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdacommentsNocommentsnonamedparamsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdacommentsNocommentsnonamedparamsReleaseHandleNullable(handle);
+
 // End of LambdaComments_NoCommentsNoNamedParams "private" section.
 typedef LambdaComments_NoCommentsWithNamedParams = String Function(String first, String second);
+
 // LambdaComments_NoCommentsWithNamedParams "private" section, not exported.
+
 final _smokeLambdacommentsNocommentswithnamedparamsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -491,9 +583,11 @@ final _smokeLambdacommentsNocommentswithnamedparamsCreateProxy = __lib.catchArgu
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdaComments_NoCommentsWithNamedParams_create_proxy'));
+
 class LambdaComments_NoCommentsWithNamedParams$Impl {
   final Pointer<Void> handle;
   LambdaComments_NoCommentsWithNamedParams$Impl(this.handle);
+
   String call(String first, String second) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_LambdaComments_NoCommentsWithNamedParams_call__String_String'));
     final _firstHandle = stringToFfi(first);
@@ -506,9 +600,13 @@ class LambdaComments_NoCommentsWithNamedParams$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdacommentsNocommentswithnamedparamscallStatic(Object _obj, Pointer<Void> first, Pointer<Void> second, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -520,6 +618,7 @@ int _smokeLambdacommentsNocommentswithnamedparamscallStatic(Object _obj, Pointer
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdacommentsNocommentswithnamedparamsToFfi(LambdaComments_NoCommentsWithNamedParams value) =>
   _smokeLambdacommentsNocommentswithnamedparamsCreateProxy(
     __lib.getObjectToken(value),
@@ -527,6 +626,7 @@ Pointer<Void> smokeLambdacommentsNocommentswithnamedparamsToFfi(LambdaComments_N
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdacommentsNocommentswithnamedparamscallStatic, __lib.unknownError)
   );
+
 LambdaComments_NoCommentsWithNamedParams smokeLambdacommentsNocommentswithnamedparamsFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdacommentsNocommentswithnamedparamsCopyHandle(handle);
   final _impl = LambdaComments_NoCommentsWithNamedParams$Impl(_copiedHandle);
@@ -534,9 +634,12 @@ LambdaComments_NoCommentsWithNamedParams smokeLambdacommentsNocommentswithnamedp
   _smokeLambdacommentsNocommentswithnamedparamsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdacommentsNocommentswithnamedparamsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdacommentsNocommentswithnamedparamsReleaseHandle(handle);
+
 // Nullable LambdaComments_NoCommentsWithNamedParams
+
 final _smokeLambdacommentsNocommentswithnamedparamsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -549,6 +652,7 @@ final _smokeLambdacommentsNocommentswithnamedparamsGetValueNullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdaComments_NoCommentsWithNamedParams_get_value_nullable'));
+
 Pointer<Void> smokeLambdacommentsNocommentswithnamedparamsToFfiNullable(LambdaComments_NoCommentsWithNamedParams? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdacommentsNocommentswithnamedparamsToFfi(value);
@@ -556,6 +660,7 @@ Pointer<Void> smokeLambdacommentsNocommentswithnamedparamsToFfiNullable(LambdaCo
   smokeLambdacommentsNocommentswithnamedparamsReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdaComments_NoCommentsWithNamedParams? smokeLambdacommentsNocommentswithnamedparamsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdacommentsNocommentswithnamedparamsGetValueNullable(handle);
@@ -563,10 +668,14 @@ LambdaComments_NoCommentsWithNamedParams? smokeLambdacommentsNocommentswithnamed
   smokeLambdacommentsNocommentswithnamedparamsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdacommentsNocommentswithnamedparamsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdacommentsNocommentswithnamedparamsReleaseHandleNullable(handle);
+
 // End of LambdaComments_NoCommentsWithNamedParams "private" section.
+
 // LambdaComments "private" section, not exported.
+
 final _smokeLambdacommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -579,27 +688,42 @@ final _smokeLambdacommentsReleaseHandle = __lib.catchArgumentError(() => __lib.n
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdaComments_release_handle'));
+
+
 class LambdaComments$Impl extends __lib.NativeBase implements LambdaComments {
+
   LambdaComments$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokeLambdacommentsToFfi(LambdaComments value) =>
   _smokeLambdacommentsCopyHandle((value as __lib.NativeBase).handle);
+
 LambdaComments smokeLambdacommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LambdaComments) return instance;
+
   final _copiedHandle = _smokeLambdacommentsCopyHandle(handle);
   final result = LambdaComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeLambdacommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdacommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdacommentsReleaseHandle(handle);
+
 Pointer<Void> smokeLambdacommentsToFfiNullable(LambdaComments? value) =>
   value != null ? smokeLambdacommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 LambdaComments? smokeLambdacommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeLambdacommentsFromFfi(handle) : null;
+
 void smokeLambdacommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdacommentsReleaseHandle(handle);
+
 // End of LambdaComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -36,7 +36,7 @@ final _smokeMapsceneLoadscenecallbackCreateProxy = __lib.catchArgumentError(() =
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_MapScene_LoadSceneCallback_create_proxy'));
 
-class MapScene_LoadSceneCallback$Impl {
+class MapScene_LoadSceneCallback$Impl implements Finalizable {
   final Pointer<Void> handle;
   MapScene_LoadSceneCallback$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/map_scene.dart
@@ -1,16 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// Referencing some type [MapScene.loadSceneWithInt].
-abstract class MapScene {
+abstract class MapScene implements Finalizable {
+
 
   void loadSceneWithInt(int mapScheme, MapScene_LoadSceneCallback? callback);
+
   void loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback);
 }
+
 typedef MapScene_LoadSceneCallback = void Function(String?);
+
 // MapScene_LoadSceneCallback "private" section, not exported.
+
 final _smokeMapsceneLoadscenecallbackRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -27,18 +35,24 @@ final _smokeMapsceneLoadscenecallbackCreateProxy = __lib.catchArgumentError(() =
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_MapScene_LoadSceneCallback_create_proxy'));
+
 class MapScene_LoadSceneCallback$Impl {
   final Pointer<Void> handle;
   MapScene_LoadSceneCallback$Impl(this.handle);
+
   void call(String? p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MapScene_LoadSceneCallback_call__String_'));
     final _p0Handle = stringToFfiNullable(p0);
     final _handle = this.handle;
     _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     stringReleaseFfiHandleNullable(_p0Handle);
+
   }
+
 }
+
 int _smokeMapsceneLoadscenecallbackcallStatic(Object _obj, Pointer<Void> p0) {
+  
   try {
     (_obj as MapScene_LoadSceneCallback)(stringFromFfiNullable(p0));
   } finally {
@@ -46,6 +60,7 @@ int _smokeMapsceneLoadscenecallbackcallStatic(Object _obj, Pointer<Void> p0) {
   }
   return 0;
 }
+
 Pointer<Void> smokeMapsceneLoadscenecallbackToFfi(MapScene_LoadSceneCallback value) =>
   _smokeMapsceneLoadscenecallbackCreateProxy(
     __lib.getObjectToken(value),
@@ -53,6 +68,7 @@ Pointer<Void> smokeMapsceneLoadscenecallbackToFfi(MapScene_LoadSceneCallback val
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>)>(_smokeMapsceneLoadscenecallbackcallStatic, __lib.unknownError)
   );
+
 MapScene_LoadSceneCallback smokeMapsceneLoadscenecallbackFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeMapsceneLoadscenecallbackCopyHandle(handle);
   final _impl = MapScene_LoadSceneCallback$Impl(_copiedHandle);
@@ -60,9 +76,12 @@ MapScene_LoadSceneCallback smokeMapsceneLoadscenecallbackFromFfi(Pointer<Void> h
   _smokeMapsceneLoadscenecallbackRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeMapsceneLoadscenecallbackReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeMapsceneLoadscenecallbackReleaseHandle(handle);
+
 // Nullable MapScene_LoadSceneCallback
+
 final _smokeMapsceneLoadscenecallbackCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -75,6 +94,7 @@ final _smokeMapsceneLoadscenecallbackGetValueNullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MapScene_LoadSceneCallback_get_value_nullable'));
+
 Pointer<Void> smokeMapsceneLoadscenecallbackToFfiNullable(MapScene_LoadSceneCallback? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeMapsceneLoadscenecallbackToFfi(value);
@@ -82,6 +102,7 @@ Pointer<Void> smokeMapsceneLoadscenecallbackToFfiNullable(MapScene_LoadSceneCall
   smokeMapsceneLoadscenecallbackReleaseFfiHandle(_handle);
   return result;
 }
+
 MapScene_LoadSceneCallback? smokeMapsceneLoadscenecallbackFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeMapsceneLoadscenecallbackGetValueNullable(handle);
@@ -89,10 +110,14 @@ MapScene_LoadSceneCallback? smokeMapsceneLoadscenecallbackFromFfiNullable(Pointe
   smokeMapsceneLoadscenecallbackReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeMapsceneLoadscenecallbackReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeMapsceneLoadscenecallbackReleaseHandleNullable(handle);
+
 // End of MapScene_LoadSceneCallback "private" section.
+
 // MapScene "private" section, not exported.
+
 final _smokeMapsceneRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -105,7 +130,12 @@ final _smokeMapsceneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MapScene_release_handle'));
+
+
+
+
 class MapScene$Impl extends __lib.NativeBase implements MapScene {
+
   MapScene$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -115,8 +145,11 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     final _callbackHandle = smokeMapsceneLoadscenecallbackToFfiNullable(callback);
     final _handle = this.handle;
     _loadSceneWithIntFfi(_handle, __lib.LibraryContext.isolateId, _mapSchemeHandle, _callbackHandle);
+
     smokeMapsceneLoadscenecallbackReleaseFfiHandleNullable(_callbackHandle);
+
   }
+
   @override
   void loadSceneWithString(String configurationFile, MapScene_LoadSceneCallback? callback) {
     final _loadSceneWithStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MapScene_loadScene__String_LoadSceneCallback_'));
@@ -126,26 +159,39 @@ class MapScene$Impl extends __lib.NativeBase implements MapScene {
     _loadSceneWithStringFfi(_handle, __lib.LibraryContext.isolateId, _configurationFileHandle, _callbackHandle);
     stringReleaseFfiHandle(_configurationFileHandle);
     smokeMapsceneLoadscenecallbackReleaseFfiHandleNullable(_callbackHandle);
+
   }
+
+
 }
+
 Pointer<Void> smokeMapsceneToFfi(MapScene value) =>
   _smokeMapsceneCopyHandle((value as __lib.NativeBase).handle);
+
 MapScene smokeMapsceneFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MapScene) return instance;
+
   final _copiedHandle = _smokeMapsceneCopyHandle(handle);
   final result = MapScene$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeMapsceneRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeMapsceneReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeMapsceneReleaseHandle(handle);
+
 Pointer<Void> smokeMapsceneToFfiNullable(MapScene? value) =>
   value != null ? smokeMapsceneToFfi(value) : Pointer<Void>.fromAddress(0);
+
 MapScene? smokeMapsceneFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeMapsceneFromFfi(handle) : null;
+
 void smokeMapsceneReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeMapsceneReleaseHandle(handle);
+
 // End of MapScene "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/multi_line_comments.dart
@@ -1,8 +1,11 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// This is some very useful interface.
 ///
 /// There is a lot to say about this interface.
@@ -17,7 +20,7 @@ import 'package:library/src/builtin_types__conversion.dart';
 /// * escaping
 ///
 /// ```Some example code;```
-abstract class MultiLineComments {
+abstract class MultiLineComments implements Finalizable {
 
   /// This is very important method.
   ///
@@ -39,7 +42,10 @@ abstract class MultiLineComments {
   ///
   double someMethodWithLongComment(String input, double ratio);
 }
+
+
 // MultiLineComments "private" section, not exported.
+
 final _smokeMultilinecommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -52,7 +58,11 @@ final _smokeMultilinecommentsReleaseHandle = __lib.catchArgumentError(() => __li
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MultiLineComments_release_handle'));
+
+
+
 class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineComments {
+
   MultiLineComments$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -63,30 +73,46 @@ class MultiLineComments$Impl extends __lib.NativeBase implements MultiLineCommen
     final _handle = this.handle;
     final __resultHandle = _someMethodWithLongCommentFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle, _ratioHandle);
     stringReleaseFfiHandle(_inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeMultilinecommentsToFfi(MultiLineComments value) =>
   _smokeMultilinecommentsCopyHandle((value as __lib.NativeBase).handle);
+
 MultiLineComments smokeMultilinecommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MultiLineComments) return instance;
+
   final _copiedHandle = _smokeMultilinecommentsCopyHandle(handle);
   final result = MultiLineComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeMultilinecommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeMultilinecommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeMultilinecommentsReleaseHandle(handle);
+
 Pointer<Void> smokeMultilinecommentsToFfiNullable(MultiLineComments? value) =>
   value != null ? smokeMultilinecommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 MultiLineComments? smokeMultilinecommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeMultilinecommentsFromFfi(handle) : null;
+
 void smokeMultilinecommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeMultilinecommentsReleaseHandle(handle);
+
 // End of MultiLineComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -1,9 +1,13 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class PlatformComments {
+
+abstract class PlatformComments implements Finalizable {
+
   /// This is some very useless method that cannot have overloads.
   ///
   void doNothing();
@@ -19,14 +23,19 @@ abstract class PlatformComments {
   /// Throws [PlatformComments_SomethingWrongException]. Sometimes it happens.
   ///
   bool someMethodWithAllComments(String input);
+
   @Deprecated("A very useless method that is deprecated.")
+
   void someDeprecatedMethod();
 }
+
 enum PlatformComments_SomeEnum {
     useless,
     useful
 }
+
 // PlatformComments_SomeEnum "private" section, not exported.
+
 int smokePlatformcommentsSomeenumToFfi(PlatformComments_SomeEnum value) {
   switch (value) {
   case PlatformComments_SomeEnum.useless:
@@ -37,6 +46,7 @@ int smokePlatformcommentsSomeenumToFfi(PlatformComments_SomeEnum value) {
     throw StateError("Invalid enum value $value for PlatformComments_SomeEnum enum.");
   }
 }
+
 PlatformComments_SomeEnum smokePlatformcommentsSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -47,7 +57,9 @@ PlatformComments_SomeEnum smokePlatformcommentsSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for PlatformComments_SomeEnum enum.");
   }
 }
+
 void smokePlatformcommentsSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokePlatformcommentsSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -60,6 +72,7 @@ final _smokePlatformcommentsSomeenumGetValueNullable = __lib.catchArgumentError(
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokePlatformcommentsSomeenumToFfiNullable(PlatformComments_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePlatformcommentsSomeenumToFfi(value);
@@ -67,6 +80,7 @@ Pointer<Void> smokePlatformcommentsSomeenumToFfiNullable(PlatformComments_SomeEn
   smokePlatformcommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 PlatformComments_SomeEnum? smokePlatformcommentsSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePlatformcommentsSomeenumGetValueNullable(handle);
@@ -74,8 +88,10 @@ PlatformComments_SomeEnum? smokePlatformcommentsSomeenumFromFfiNullable(Pointer<
   smokePlatformcommentsSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePlatformcommentsSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformcommentsSomeenumReleaseHandleNullable(handle);
+
 // End of PlatformComments_SomeEnum "private" section.
 /// An exception when something goes wrong.
 class PlatformComments_SomethingWrongException implements Exception {
@@ -83,11 +99,16 @@ class PlatformComments_SomethingWrongException implements Exception {
   PlatformComments_SomethingWrongException(this.error);
 }
 /// This is a.
+
 class PlatformComments_Something {
   String nothing;
+
   PlatformComments_Something(this.nothing);
 }
+
+
 // PlatformComments_Something "private" section, not exported.
+
 final _smokePlatformcommentsSomethingCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -100,12 +121,16 @@ final _smokePlatformcommentsSomethingGetFieldnothing = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_get_field_nothing'));
+
+
+
 Pointer<Void> smokePlatformcommentsSomethingToFfi(PlatformComments_Something value) {
   final _nothingHandle = stringToFfi(value.nothing);
   final _result = _smokePlatformcommentsSomethingCreateHandle(_nothingHandle);
   stringReleaseFfiHandle(_nothingHandle);
   return _result;
 }
+
 PlatformComments_Something smokePlatformcommentsSomethingFromFfi(Pointer<Void> handle) {
   final _nothingHandle = _smokePlatformcommentsSomethingGetFieldnothing(handle);
   try {
@@ -116,8 +141,11 @@ PlatformComments_Something smokePlatformcommentsSomethingFromFfi(Pointer<Void> h
     stringReleaseFfiHandle(_nothingHandle);
   }
 }
+
 void smokePlatformcommentsSomethingReleaseFfiHandle(Pointer<Void> handle) => _smokePlatformcommentsSomethingReleaseHandle(handle);
+
 // Nullable PlatformComments_Something
+
 final _smokePlatformcommentsSomethingCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -130,6 +158,7 @@ final _smokePlatformcommentsSomethingGetValueNullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformComments_Something_get_value_nullable'));
+
 Pointer<Void> smokePlatformcommentsSomethingToFfiNullable(PlatformComments_Something? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePlatformcommentsSomethingToFfi(value);
@@ -137,6 +166,7 @@ Pointer<Void> smokePlatformcommentsSomethingToFfiNullable(PlatformComments_Somet
   smokePlatformcommentsSomethingReleaseFfiHandle(_handle);
   return result;
 }
+
 PlatformComments_Something? smokePlatformcommentsSomethingFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePlatformcommentsSomethingGetValueNullable(handle);
@@ -144,10 +174,14 @@ PlatformComments_Something? smokePlatformcommentsSomethingFromFfiNullable(Pointe
   smokePlatformcommentsSomethingReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePlatformcommentsSomethingReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformcommentsSomethingReleaseHandleNullable(handle);
+
 // End of PlatformComments_Something "private" section.
+
 // PlatformComments "private" section, not exported.
+
 final _smokePlatformcommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -160,6 +194,10 @@ final _smokePlatformcommentsReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformComments_release_handle'));
+
+
+
+
 final _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -176,20 +214,29 @@ final _someMethodWithAllCommentssmokePlatformcommentsSomemethodwithallcommentsSt
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformComments_someMethodWithAllComments__String_return_has_error'));
+
+
+
 class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments {
+
   PlatformComments$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void doNothing() {
     final _doNothingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doNothing'));
     final _handle = this.handle;
     _doNothingFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void doMagic() {
     final _doMagicFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_doMagic'));
     final _handle = this.handle;
     _doMagicFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformComments_someMethodWithAllComments__String'));
@@ -212,33 +259,49 @@ class PlatformComments$Impl extends __lib.NativeBase implements PlatformComments
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   void someDeprecatedMethod() {
     final _someDeprecatedMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_PlatformComments_someDeprecatedMethod'));
     final _handle = this.handle;
     _someDeprecatedMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokePlatformcommentsToFfi(PlatformComments value) =>
   _smokePlatformcommentsCopyHandle((value as __lib.NativeBase).handle);
+
 PlatformComments smokePlatformcommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PlatformComments) return instance;
+
   final _copiedHandle = _smokePlatformcommentsCopyHandle(handle);
   final result = PlatformComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokePlatformcommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePlatformcommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePlatformcommentsReleaseHandle(handle);
+
 Pointer<Void> smokePlatformcommentsToFfiNullable(PlatformComments? value) =>
   value != null ? smokePlatformcommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 PlatformComments? smokePlatformcommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePlatformcommentsFromFfi(handle) : null;
+
 void smokePlatformcommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformcommentsReleaseHandle(handle);
+
 // End of PlatformComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments_line_breaks.dart
@@ -1,11 +1,18 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+
 /// Text leading line break
-abstract class PlatformCommentsLineBreaks {
+abstract class PlatformCommentsLineBreaks implements Finalizable {
+
 }
+
+
 // PlatformCommentsLineBreaks "private" section, not exported.
+
 final _smokePlatformcommentslinebreaksRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -18,27 +25,42 @@ final _smokePlatformcommentslinebreaksReleaseHandle = __lib.catchArgumentError((
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformCommentsLineBreaks_release_handle'));
+
+
 class PlatformCommentsLineBreaks$Impl extends __lib.NativeBase implements PlatformCommentsLineBreaks {
+
   PlatformCommentsLineBreaks$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokePlatformcommentslinebreaksToFfi(PlatformCommentsLineBreaks value) =>
   _smokePlatformcommentslinebreaksCopyHandle((value as __lib.NativeBase).handle);
+
 PlatformCommentsLineBreaks smokePlatformcommentslinebreaksFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PlatformCommentsLineBreaks) return instance;
+
   final _copiedHandle = _smokePlatformcommentslinebreaksCopyHandle(handle);
   final result = PlatformCommentsLineBreaks$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokePlatformcommentslinebreaksRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePlatformcommentslinebreaksReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePlatformcommentslinebreaksReleaseHandle(handle);
+
 Pointer<Void> smokePlatformcommentslinebreaksToFfiNullable(PlatformCommentsLineBreaks? value) =>
   value != null ? smokePlatformcommentslinebreaksToFfi(value) : Pointer<Void>.fromAddress(0);
+
 PlatformCommentsLineBreaks? smokePlatformcommentslinebreaksFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePlatformcommentslinebreaksFromFfi(handle) : null;
+
 void smokePlatformcommentslinebreaksReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformcommentslinebreaksReleaseHandle(handle);
+
 // End of PlatformCommentsLineBreaks "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/unicode_comments.dart
@@ -1,10 +1,14 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/comments.dart';
-abstract class UnicodeComments {
+
+abstract class UnicodeComments implements Finalizable {
+
   /// Süßölgefäß
   ///
   /// [input] שלום
@@ -15,7 +19,10 @@ abstract class UnicodeComments {
   ///
   bool someMethodWithAllComments(String input);
 }
+
+
 // UnicodeComments "private" section, not exported.
+
 final _smokeUnicodecommentsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -28,6 +35,8 @@ final _smokeUnicodecommentsReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_release_handle'));
+
+
 final _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -44,8 +53,12 @@ final _someMethodWithAllCommentssmokeUnicodecommentsSomemethodwithallcommentsStr
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UnicodeComments_someMethodWithAllComments__String_return_has_error'));
+
+
 class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
+
   UnicodeComments$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   bool someMethodWithAllComments(String input) {
     final _someMethodWithAllCommentsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_UnicodeComments_someMethodWithAllComments__String'));
@@ -68,27 +81,41 @@ class UnicodeComments$Impl extends __lib.NativeBase implements UnicodeComments {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeUnicodecommentsToFfi(UnicodeComments value) =>
   _smokeUnicodecommentsCopyHandle((value as __lib.NativeBase).handle);
+
 UnicodeComments smokeUnicodecommentsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UnicodeComments) return instance;
+
   final _copiedHandle = _smokeUnicodecommentsCopyHandle(handle);
   final result = UnicodeComments$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeUnicodecommentsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeUnicodecommentsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeUnicodecommentsReleaseHandle(handle);
+
 Pointer<Void> smokeUnicodecommentsToFfiNullable(UnicodeComments? value) =>
   value != null ? smokeUnicodecommentsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 UnicodeComments? smokeUnicodecommentsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeUnicodecommentsFromFfi(handle) : null;
+
 void smokeUnicodecommentsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeUnicodecommentsReleaseHandle(handle);
+
 // End of UnicodeComments "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/collection_constants.dart
@@ -1,15 +1,25 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class CollectionConstants {
+
+abstract class CollectionConstants implements Finalizable {
 
   static final List<String> listConstant = ["foo", "bar"];
+
   static final Set<String> setConstant = {"foo", "bar"};
+
   static final Map<String, String> mapConstant = {"foo": "bar"};
+
   static final Map<List<String>, Set<String>> mixedConstant = {["foo"]: {"bar"}};
+
 }
+
+
 // CollectionConstants "private" section, not exported.
+
 final _smokeCollectionconstantsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -22,28 +32,42 @@ final _smokeCollectionconstantsReleaseHandle = __lib.catchArgumentError(() => __
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CollectionConstants_release_handle'));
+
+
 class CollectionConstants$Impl extends __lib.NativeBase implements CollectionConstants {
+
   CollectionConstants$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeCollectionconstantsToFfi(CollectionConstants value) =>
   _smokeCollectionconstantsCopyHandle((value as __lib.NativeBase).handle);
+
 CollectionConstants smokeCollectionconstantsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CollectionConstants) return instance;
+
   final _copiedHandle = _smokeCollectionconstantsCopyHandle(handle);
   final result = CollectionConstants$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCollectionconstantsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCollectionconstantsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCollectionconstantsReleaseHandle(handle);
+
 Pointer<Void> smokeCollectionconstantsToFfiNullable(CollectionConstants? value) =>
   value != null ? smokeCollectionconstantsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CollectionConstants? smokeCollectionconstantsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCollectionconstantsFromFfi(handle) : null;
+
 void smokeCollectionconstantsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCollectionconstantsReleaseHandle(handle);
+
 // End of CollectionConstants "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -1,22 +1,35 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class ConstantsInterface {
+
+abstract class ConstantsInterface implements Finalizable {
 
   static final bool boolConstant = true;
+
   static final int intConstant = -11;
+
   static final int uintConstant = 4294967295;
+
   static final double floatConstant = 2.71;
+
   static final double doubleConstant = -3.14;
+
   static final String stringConstant = "Foo bar";
+
   static final ConstantsInterface_StateEnum enumConstant = ConstantsInterface_StateEnum.on;
+
 }
+
 enum ConstantsInterface_StateEnum {
     off,
     on
 }
+
 // ConstantsInterface_StateEnum "private" section, not exported.
+
 int smokeConstantsinterfaceStateenumToFfi(ConstantsInterface_StateEnum value) {
   switch (value) {
   case ConstantsInterface_StateEnum.off:
@@ -27,6 +40,7 @@ int smokeConstantsinterfaceStateenumToFfi(ConstantsInterface_StateEnum value) {
     throw StateError("Invalid enum value $value for ConstantsInterface_StateEnum enum.");
   }
 }
+
 ConstantsInterface_StateEnum smokeConstantsinterfaceStateenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -37,7 +51,9 @@ ConstantsInterface_StateEnum smokeConstantsinterfaceStateenumFromFfi(int handle)
     throw StateError("Invalid numeric value $handle for ConstantsInterface_StateEnum enum.");
   }
 }
+
 void smokeConstantsinterfaceStateenumReleaseFfiHandle(int handle) {}
+
 final _smokeConstantsinterfaceStateenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -50,6 +66,7 @@ final _smokeConstantsinterfaceStateenumGetValueNullable = __lib.catchArgumentErr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_StateEnum_get_value_nullable'));
+
 Pointer<Void> smokeConstantsinterfaceStateenumToFfiNullable(ConstantsInterface_StateEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeConstantsinterfaceStateenumToFfi(value);
@@ -57,6 +74,7 @@ Pointer<Void> smokeConstantsinterfaceStateenumToFfiNullable(ConstantsInterface_S
   smokeConstantsinterfaceStateenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ConstantsInterface_StateEnum? smokeConstantsinterfaceStateenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeConstantsinterfaceStateenumGetValueNullable(handle);
@@ -64,10 +82,14 @@ ConstantsInterface_StateEnum? smokeConstantsinterfaceStateenumFromFfiNullable(Po
   smokeConstantsinterfaceStateenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeConstantsinterfaceStateenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeConstantsinterfaceStateenumReleaseHandleNullable(handle);
+
 // End of ConstantsInterface_StateEnum "private" section.
+
 // ConstantsInterface "private" section, not exported.
+
 final _smokeConstantsinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -80,28 +102,42 @@ final _smokeConstantsinterfaceReleaseHandle = __lib.catchArgumentError(() => __l
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ConstantsInterface_release_handle'));
+
+
 class ConstantsInterface$Impl extends __lib.NativeBase implements ConstantsInterface {
+
   ConstantsInterface$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeConstantsinterfaceToFfi(ConstantsInterface value) =>
   _smokeConstantsinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
 ConstantsInterface smokeConstantsinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ConstantsInterface) return instance;
+
   final _copiedHandle = _smokeConstantsinterfaceCopyHandle(handle);
   final result = ConstantsInterface$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeConstantsinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeConstantsinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeConstantsinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeConstantsinterfaceToFfiNullable(ConstantsInterface? value) =>
   value != null ? smokeConstantsinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ConstantsInterface? smokeConstantsinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeConstantsinterfaceFromFfi(handle) : null;
+
 void smokeConstantsinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeConstantsinterfaceReleaseHandle(handle);
+
 // End of ConstantsInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/struct_constants.dart
@@ -1,19 +1,31 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class StructConstants {
+
+abstract class StructConstants implements Finalizable {
 
   static final StructConstants_SomeStruct structConstant = StructConstants_SomeStruct("bar Buzz", 1.41);
+
   static final StructConstants_NestingStruct nestingStructConstant = StructConstants_NestingStruct(StructConstants_SomeStruct("nonsense", -2.82));
+
 }
+
+
 class StructConstants_SomeStruct {
   String stringField;
+
   double floatField;
+
   StructConstants_SomeStruct(this.stringField, this.floatField);
 }
+
+
 // StructConstants_SomeStruct "private" section, not exported.
+
 final _smokeStructconstantsSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Float),
     Pointer<Void> Function(Pointer<Void>, double)
@@ -30,27 +42,36 @@ final _smokeStructconstantsSomestructGetFieldfloatField = __lib.catchArgumentErr
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_get_field_floatField'));
+
+
+
 Pointer<Void> smokeStructconstantsSomestructToFfi(StructConstants_SomeStruct value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _floatFieldHandle = (value.floatField);
   final _result = _smokeStructconstantsSomestructCreateHandle(_stringFieldHandle, _floatFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
+  
   return _result;
 }
+
 StructConstants_SomeStruct smokeStructconstantsSomestructFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeStructconstantsSomestructGetFieldstringField(handle);
   final _floatFieldHandle = _smokeStructconstantsSomestructGetFieldfloatField(handle);
   try {
     return StructConstants_SomeStruct(
-      stringFromFfi(_stringFieldHandle),
+      stringFromFfi(_stringFieldHandle), 
       (_floatFieldHandle)
     );
   } finally {
     stringReleaseFfiHandle(_stringFieldHandle);
+    
   }
 }
+
 void smokeStructconstantsSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeStructconstantsSomestructReleaseHandle(handle);
+
 // Nullable StructConstants_SomeStruct
+
 final _smokeStructconstantsSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -63,6 +84,7 @@ final _smokeStructconstantsSomestructGetValueNullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeStructconstantsSomestructToFfiNullable(StructConstants_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeStructconstantsSomestructToFfi(value);
@@ -70,6 +92,7 @@ Pointer<Void> smokeStructconstantsSomestructToFfiNullable(StructConstants_SomeSt
   smokeStructconstantsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 StructConstants_SomeStruct? smokeStructconstantsSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeStructconstantsSomestructGetValueNullable(handle);
@@ -77,14 +100,21 @@ StructConstants_SomeStruct? smokeStructconstantsSomestructFromFfiNullable(Pointe
   smokeStructconstantsSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeStructconstantsSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStructconstantsSomestructReleaseHandleNullable(handle);
+
 // End of StructConstants_SomeStruct "private" section.
+
 class StructConstants_NestingStruct {
   StructConstants_SomeStruct structField;
+
   StructConstants_NestingStruct(this.structField);
 }
+
+
 // StructConstants_NestingStruct "private" section, not exported.
+
 final _smokeStructconstantsNestingstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -97,12 +127,16 @@ final _smokeStructconstantsNestingstructGetFieldstructField = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_get_field_structField'));
+
+
+
 Pointer<Void> smokeStructconstantsNestingstructToFfi(StructConstants_NestingStruct value) {
   final _structFieldHandle = smokeStructconstantsSomestructToFfi(value.structField);
   final _result = _smokeStructconstantsNestingstructCreateHandle(_structFieldHandle);
   smokeStructconstantsSomestructReleaseFfiHandle(_structFieldHandle);
   return _result;
 }
+
 StructConstants_NestingStruct smokeStructconstantsNestingstructFromFfi(Pointer<Void> handle) {
   final _structFieldHandle = _smokeStructconstantsNestingstructGetFieldstructField(handle);
   try {
@@ -113,8 +147,11 @@ StructConstants_NestingStruct smokeStructconstantsNestingstructFromFfi(Pointer<V
     smokeStructconstantsSomestructReleaseFfiHandle(_structFieldHandle);
   }
 }
+
 void smokeStructconstantsNestingstructReleaseFfiHandle(Pointer<Void> handle) => _smokeStructconstantsNestingstructReleaseHandle(handle);
+
 // Nullable StructConstants_NestingStruct
+
 final _smokeStructconstantsNestingstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -127,6 +164,7 @@ final _smokeStructconstantsNestingstructGetValueNullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StructConstants_NestingStruct_get_value_nullable'));
+
 Pointer<Void> smokeStructconstantsNestingstructToFfiNullable(StructConstants_NestingStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeStructconstantsNestingstructToFfi(value);
@@ -134,6 +172,7 @@ Pointer<Void> smokeStructconstantsNestingstructToFfiNullable(StructConstants_Nes
   smokeStructconstantsNestingstructReleaseFfiHandle(_handle);
   return result;
 }
+
 StructConstants_NestingStruct? smokeStructconstantsNestingstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeStructconstantsNestingstructGetValueNullable(handle);
@@ -141,10 +180,14 @@ StructConstants_NestingStruct? smokeStructconstantsNestingstructFromFfiNullable(
   smokeStructconstantsNestingstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeStructconstantsNestingstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStructconstantsNestingstructReleaseHandleNullable(handle);
+
 // End of StructConstants_NestingStruct "private" section.
+
 // StructConstants "private" section, not exported.
+
 final _smokeStructconstantsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -157,28 +200,42 @@ final _smokeStructconstantsReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_StructConstants_release_handle'));
+
+
 class StructConstants$Impl extends __lib.NativeBase implements StructConstants {
+
   StructConstants$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeStructconstantsToFfi(StructConstants value) =>
   _smokeStructconstantsCopyHandle((value as __lib.NativeBase).handle);
+
 StructConstants smokeStructconstantsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is StructConstants) return instance;
+
   final _copiedHandle = _smokeStructconstantsCopyHandle(handle);
   final result = StructConstants$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeStructconstantsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeStructconstantsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeStructconstantsReleaseHandle(handle);
+
 Pointer<Void> smokeStructconstantsToFfiNullable(StructConstants? value) =>
   value != null ? smokeStructconstantsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 StructConstants? smokeStructconstantsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeStructconstantsFromFfi(handle) : null;
+
 void smokeStructconstantsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStructconstantsReleaseHandle(handle);
+
 // End of StructConstants "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,22 +8,34 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class Constructors {
+
+abstract class Constructors implements Finalizable {
+
   factory Constructors() => $prototype.$init();
+
   factory Constructors.fromOther(Constructors other) => $prototype.fromOther(other);
+
   factory Constructors.fromMulti(String foo, int bar) => $prototype.fromMulti(foo, bar);
+
   factory Constructors.fromString(String input) => $prototype.fromString(input);
+
   factory Constructors.fromList(List<double> input) => $prototype.fromList(input);
+
   factory Constructors.create(int input) => $prototype.create(input);
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Constructors$Impl(Pointer<Void>.fromAddress(0));
 }
+
 enum Constructors_ErrorEnum {
     none,
     crashed
 }
+
 // Constructors_ErrorEnum "private" section, not exported.
+
 int smokeConstructorsErrorenumToFfi(Constructors_ErrorEnum value) {
   switch (value) {
   case Constructors_ErrorEnum.none:
@@ -32,6 +46,7 @@ int smokeConstructorsErrorenumToFfi(Constructors_ErrorEnum value) {
     throw StateError("Invalid enum value $value for Constructors_ErrorEnum enum.");
   }
 }
+
 Constructors_ErrorEnum smokeConstructorsErrorenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -42,7 +57,9 @@ Constructors_ErrorEnum smokeConstructorsErrorenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Constructors_ErrorEnum enum.");
   }
 }
+
 void smokeConstructorsErrorenumReleaseFfiHandle(int handle) {}
+
 final _smokeConstructorsErrorenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -55,6 +72,7 @@ final _smokeConstructorsErrorenumGetValueNullable = __lib.catchArgumentError(() 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_ErrorEnum_get_value_nullable'));
+
 Pointer<Void> smokeConstructorsErrorenumToFfiNullable(Constructors_ErrorEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeConstructorsErrorenumToFfi(value);
@@ -62,6 +80,7 @@ Pointer<Void> smokeConstructorsErrorenumToFfiNullable(Constructors_ErrorEnum? va
   smokeConstructorsErrorenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Constructors_ErrorEnum? smokeConstructorsErrorenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeConstructorsErrorenumGetValueNullable(handle);
@@ -69,14 +88,18 @@ Constructors_ErrorEnum? smokeConstructorsErrorenumFromFfiNullable(Pointer<Void> 
   smokeConstructorsErrorenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeConstructorsErrorenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeConstructorsErrorenumReleaseHandleNullable(handle);
+
 // End of Constructors_ErrorEnum "private" section.
 class Constructors_ConstructorExplodedException implements Exception {
   final Constructors_ErrorEnum error;
   Constructors_ConstructorExplodedException(this.error);
 }
+
 // Constructors "private" section, not exported.
+
 final _smokeConstructorsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -93,6 +116,11 @@ final _smokeConstructorsGetTypeId = __lib.catchArgumentError(() => __lib.nativeL
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constructors_get_type_id'));
+
+
+
+
+
 final _fromStringsmokeConstructorsCreateStringReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -109,57 +137,88 @@ final _fromStringsmokeConstructorsCreateStringReturnHasError = __lib.catchArgume
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constructors_create__String_return_has_error'));
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class Constructors$Impl extends __lib.NativeBase implements Constructors {
+
   Constructors$Impl(Pointer<Void> handle) : super(handle);
+
+
   Constructors $init() {
     final _result_handle = _$init();
     final _result = Constructors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeConstructorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   Constructors fromOther(Constructors other) {
     final _result_handle = _fromOther(other);
     final _result = Constructors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeConstructorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   Constructors fromMulti(String foo, int bar) {
     final _result_handle = _fromMulti(foo, bar);
     final _result = Constructors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeConstructorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   Constructors fromString(String input) {
     final _result_handle = _fromString(input);
     final _result = Constructors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeConstructorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   Constructors fromList(List<double> input) {
     final _result_handle = _fromList(input);
     final _result = Constructors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeConstructorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   Constructors create(int input) {
     final _result_handle = _create(input);
     final _result = Constructors$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeConstructorsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _$init() {
     final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Constructors_create'));
     final __resultHandle = _$initFfi(__lib.LibraryContext.isolateId);
     return __resultHandle;
   }
+
   static Pointer<Void> _fromOther(Constructors other) {
     final _fromOtherFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__Constructors'));
     final _otherHandle = smokeConstructorsToFfi(other);
@@ -167,14 +226,17 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
     smokeConstructorsReleaseFfiHandle(_otherHandle);
     return __resultHandle;
   }
+
   static Pointer<Void> _fromMulti(String foo, int bar) {
     final _fromMultiFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Uint64), Pointer<Void> Function(int, Pointer<Void>, int)>('library_smoke_Constructors_create__String_ULong'));
     final _fooHandle = stringToFfi(foo);
     final _barHandle = (bar);
     final __resultHandle = _fromMultiFfi(__lib.LibraryContext.isolateId, _fooHandle, _barHandle);
     stringReleaseFfiHandle(_fooHandle);
+
     return __resultHandle;
   }
+
   static Pointer<Void> _fromString(String input) {
     final _fromStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__String'));
     final _inputHandle = stringToFfi(input);
@@ -193,6 +255,7 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
     _fromStringsmokeConstructorsCreateStringReturnReleaseHandle(__callResultHandle);
     return __resultHandle;
   }
+
   static Pointer<Void> _fromList(List<double> input) {
     final _fromListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Constructors_create__ListOf_Double'));
     final _inputHandle = foobarListofDoubleToFfi(input);
@@ -200,22 +263,30 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
     foobarListofDoubleReleaseFfiHandle(_inputHandle);
     return __resultHandle;
   }
+
   static Pointer<Void> _create(int input) {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_Constructors_create__ULong'));
     final _inputHandle = (input);
     final __resultHandle = _createFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeConstructorsToFfi(Constructors value) =>
   _smokeConstructorsCopyHandle((value as __lib.NativeBase).handle);
+
 Constructors smokeConstructorsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Constructors) return instance;
+
   final _typeIdHandle = _smokeConstructorsGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeConstructorsCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -224,12 +295,19 @@ Constructors smokeConstructorsFromFfi(Pointer<Void> handle) {
   _smokeConstructorsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeConstructorsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeConstructorsReleaseHandle(handle);
+
 Pointer<Void> smokeConstructorsToFfiNullable(Constructors? value) =>
   value != null ? smokeConstructorsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Constructors? smokeConstructorsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeConstructorsFromFfi(handle) : null;
+
 void smokeConstructorsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeConstructorsReleaseHandle(handle);
+
 // End of Constructors "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_named_constructor.dart
@@ -1,16 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
-abstract class SingleNamedConstructor {
+
+abstract class SingleNamedConstructor implements Finalizable {
+
   factory SingleNamedConstructor.fooBar() => $prototype.fooBar();
+
 
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = SingleNamedConstructor$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // SingleNamedConstructor "private" section, not exported.
+
 final _smokeSinglenamedconstructorRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -23,42 +31,62 @@ final _smokeSinglenamedconstructorReleaseHandle = __lib.catchArgumentError(() =>
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SingleNamedConstructor_release_handle'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class SingleNamedConstructor$Impl extends __lib.NativeBase implements SingleNamedConstructor {
+
   SingleNamedConstructor$Impl(Pointer<Void> handle) : super(handle);
+
 
   SingleNamedConstructor fooBar() {
     final _result_handle = _fooBar();
     final _result = SingleNamedConstructor$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeSinglenamedconstructorRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamedConstructor_create'));
     final __resultHandle = _fooBarFfi(__lib.LibraryContext.isolateId);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeSinglenamedconstructorToFfi(SingleNamedConstructor value) =>
   _smokeSinglenamedconstructorCopyHandle((value as __lib.NativeBase).handle);
+
 SingleNamedConstructor smokeSinglenamedconstructorFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SingleNamedConstructor) return instance;
+
   final _copiedHandle = _smokeSinglenamedconstructorCopyHandle(handle);
   final result = SingleNamedConstructor$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSinglenamedconstructorRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSinglenamedconstructorReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSinglenamedconstructorReleaseHandle(handle);
+
 Pointer<Void> smokeSinglenamedconstructorToFfiNullable(SingleNamedConstructor? value) =>
   value != null ? smokeSinglenamedconstructorToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SingleNamedConstructor? smokeSinglenamedconstructorFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSinglenamedconstructorFromFfi(handle) : null;
+
 void smokeSinglenamedconstructorReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSinglenamedconstructorReleaseHandle(handle);
+
 // End of SingleNamedConstructor "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/single_nameless_constructor.dart
@@ -1,16 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
-abstract class SingleNamelessConstructor {
+
+abstract class SingleNamelessConstructor implements Finalizable {
+
   factory SingleNamelessConstructor() => $prototype.create();
+
 
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = SingleNamelessConstructor$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // SingleNamelessConstructor "private" section, not exported.
+
 final _smokeSinglenamelessconstructorRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -23,42 +31,62 @@ final _smokeSinglenamelessconstructorReleaseHandle = __lib.catchArgumentError(()
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SingleNamelessConstructor_release_handle'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class SingleNamelessConstructor$Impl extends __lib.NativeBase implements SingleNamelessConstructor {
+
   SingleNamelessConstructor$Impl(Pointer<Void> handle) : super(handle);
+
 
   SingleNamelessConstructor create() {
     final _result_handle = _create();
     final _result = SingleNamelessConstructor$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeSinglenamelessconstructorRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _create() {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_SingleNamelessConstructor_create'));
     final __resultHandle = _createFfi(__lib.LibraryContext.isolateId);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeSinglenamelessconstructorToFfi(SingleNamelessConstructor value) =>
   _smokeSinglenamelessconstructorCopyHandle((value as __lib.NativeBase).handle);
+
 SingleNamelessConstructor smokeSinglenamelessconstructorFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SingleNamelessConstructor) return instance;
+
   final _copiedHandle = _smokeSinglenamelessconstructorCopyHandle(handle);
   final result = SingleNamelessConstructor$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSinglenamelessconstructorRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSinglenamelessconstructorReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSinglenamelessconstructorReleaseHandle(handle);
+
 Pointer<Void> smokeSinglenamelessconstructorToFfiNullable(SingleNamelessConstructor? value) =>
   value != null ? smokeSinglenamelessconstructorToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SingleNamelessConstructor? smokeSinglenamelessconstructorFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSinglenamelessconstructorFromFfi(handle) : null;
+
 void smokeSinglenamelessconstructorReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSinglenamelessconstructorReleaseHandle(handle);
+
 // End of SingleNamelessConstructor "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates.dart
@@ -1,25 +1,40 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-abstract class Dates {
+
+abstract class Dates implements Finalizable {
+
+
   DateTime dateMethod(DateTime input);
+
   DateTime? nullableDateMethod(DateTime? input);
   DateTime get dateProperty;
   set dateProperty(DateTime value);
+
   Set<DateTime> get dateSet;
   set dateSet(Set<DateTime> value);
+
 }
+
+
 class Dates_DateStruct {
   DateTime dateField;
+
   DateTime? nullableDateField;
+
   Dates_DateStruct._(this.dateField, this.nullableDateField);
   Dates_DateStruct(DateTime dateField)
     : dateField = dateField, nullableDateField = null;
 }
+
+
 // Dates_DateStruct "private" section, not exported.
+
 final _smokeDatesDatestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
@@ -36,6 +51,9 @@ final _smokeDatesDatestructGetFieldnullableDateField = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_get_field_nullableDateField'));
+
+
+
 Pointer<Void> smokeDatesDatestructToFfi(Dates_DateStruct value) {
   final _dateFieldHandle = dateToFfi(value.dateField);
   final _nullableDateFieldHandle = dateToFfiNullable(value.nullableDateField);
@@ -44,12 +62,13 @@ Pointer<Void> smokeDatesDatestructToFfi(Dates_DateStruct value) {
   dateReleaseFfiHandleNullable(_nullableDateFieldHandle);
   return _result;
 }
+
 Dates_DateStruct smokeDatesDatestructFromFfi(Pointer<Void> handle) {
   final _dateFieldHandle = _smokeDatesDatestructGetFielddateField(handle);
   final _nullableDateFieldHandle = _smokeDatesDatestructGetFieldnullableDateField(handle);
   try {
     return Dates_DateStruct._(
-      dateFromFfi(_dateFieldHandle),
+      dateFromFfi(_dateFieldHandle), 
       dateFromFfiNullable(_nullableDateFieldHandle)
     );
   } finally {
@@ -57,8 +76,11 @@ Dates_DateStruct smokeDatesDatestructFromFfi(Pointer<Void> handle) {
     dateReleaseFfiHandleNullable(_nullableDateFieldHandle);
   }
 }
+
 void smokeDatesDatestructReleaseFfiHandle(Pointer<Void> handle) => _smokeDatesDatestructReleaseHandle(handle);
+
 // Nullable Dates_DateStruct
+
 final _smokeDatesDatestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -71,6 +93,7 @@ final _smokeDatesDatestructGetValueNullable = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Dates_DateStruct_get_value_nullable'));
+
 Pointer<Void> smokeDatesDatestructToFfiNullable(Dates_DateStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDatesDatestructToFfi(value);
@@ -78,6 +101,7 @@ Pointer<Void> smokeDatesDatestructToFfiNullable(Dates_DateStruct? value) {
   smokeDatesDatestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Dates_DateStruct? smokeDatesDatestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDatesDatestructGetValueNullable(handle);
@@ -85,10 +109,14 @@ Dates_DateStruct? smokeDatesDatestructFromFfiNullable(Pointer<Void> handle) {
   smokeDatesDatestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDatesDatestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDatesDatestructReleaseHandleNullable(handle);
+
 // End of Dates_DateStruct "private" section.
+
 // Dates "private" section, not exported.
+
 final _smokeDatesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -101,8 +129,14 @@ final _smokeDatesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Dates_release_handle'));
+
+
+
+
 class Dates$Impl extends __lib.NativeBase implements Dates {
+
   Dates$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   DateTime dateMethod(DateTime input) {
     final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateMethod__Date'));
@@ -114,8 +148,11 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
       return dateFromFfi(__resultHandle);
     } finally {
       dateReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   DateTime? nullableDateMethod(DateTime? input) {
     final _nullableDateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Dates_nullableDateMethod__Date_'));
@@ -127,8 +164,11 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
       return dateFromFfiNullable(__resultHandle);
     } finally {
       dateReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   DateTime get dateProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Dates_dateProperty_get'));
@@ -138,8 +178,11 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
       return dateFromFfi(__resultHandle);
     } finally {
       dateReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set dateProperty(DateTime value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_Dates_dateProperty_set__Date'));
@@ -147,7 +190,10 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     dateReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   Set<DateTime> get dateSet {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Dates_dateSet_get'));
@@ -157,8 +203,11 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
       return foobarSetofDateFromFfi(__resultHandle);
     } finally {
       foobarSetofDateReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set dateSet(Set<DateTime> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Dates_dateSet_set__SetOf_Date'));
@@ -166,26 +215,40 @@ class Dates$Impl extends __lib.NativeBase implements Dates {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarSetofDateReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeDatesToFfi(Dates value) =>
   _smokeDatesCopyHandle((value as __lib.NativeBase).handle);
+
 Dates smokeDatesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Dates) return instance;
+
   final _copiedHandle = _smokeDatesCopyHandle(handle);
   final result = Dates$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeDatesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeDatesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDatesReleaseHandle(handle);
+
 Pointer<Void> smokeDatesToFfiNullable(Dates? value) =>
   value != null ? smokeDatesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Dates? smokeDatesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDatesFromFfi(handle) : null;
+
 void smokeDatesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDatesReleaseHandle(handle);
+
 // End of Dates "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
+++ b/gluecodium/src/test/resources/smoke/dates/output/dart/lib/src/smoke/dates_steady.dart
@@ -1,22 +1,36 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-abstract class DatesSteady {
+
+abstract class DatesSteady implements Finalizable {
+
+
   DateTime dateMethod(DateTime input);
+
   DateTime? nullableDateMethod(DateTime? input);
+
   List<DateTime> dateListMethod(List<DateTime> input);
 }
+
+
 class DatesSteady_DateStruct {
   DateTime dateField;
+
   DateTime? nullableDateField;
+
   DatesSteady_DateStruct._(this.dateField, this.nullableDateField);
   DatesSteady_DateStruct(DateTime dateField)
     : dateField = dateField, nullableDateField = null;
 }
+
+
 // DatesSteady_DateStruct "private" section, not exported.
+
 final _smokeDatessteadyDatestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
@@ -33,6 +47,9 @@ final _smokeDatessteadyDatestructGetFieldnullableDateField = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DatesSteady_DateStruct_get_field_nullableDateField'));
+
+
+
 Pointer<Void> smokeDatessteadyDatestructToFfi(DatesSteady_DateStruct value) {
   final _dateFieldHandle = dateToFfi(value.dateField);
   final _nullableDateFieldHandle = dateToFfiNullable(value.nullableDateField);
@@ -41,12 +58,13 @@ Pointer<Void> smokeDatessteadyDatestructToFfi(DatesSteady_DateStruct value) {
   dateReleaseFfiHandleNullable(_nullableDateFieldHandle);
   return _result;
 }
+
 DatesSteady_DateStruct smokeDatessteadyDatestructFromFfi(Pointer<Void> handle) {
   final _dateFieldHandle = _smokeDatessteadyDatestructGetFielddateField(handle);
   final _nullableDateFieldHandle = _smokeDatessteadyDatestructGetFieldnullableDateField(handle);
   try {
     return DatesSteady_DateStruct._(
-      dateFromFfi(_dateFieldHandle),
+      dateFromFfi(_dateFieldHandle), 
       dateFromFfiNullable(_nullableDateFieldHandle)
     );
   } finally {
@@ -54,8 +72,11 @@ DatesSteady_DateStruct smokeDatessteadyDatestructFromFfi(Pointer<Void> handle) {
     dateReleaseFfiHandleNullable(_nullableDateFieldHandle);
   }
 }
+
 void smokeDatessteadyDatestructReleaseFfiHandle(Pointer<Void> handle) => _smokeDatessteadyDatestructReleaseHandle(handle);
+
 // Nullable DatesSteady_DateStruct
+
 final _smokeDatessteadyDatestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -68,6 +89,7 @@ final _smokeDatessteadyDatestructGetValueNullable = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DatesSteady_DateStruct_get_value_nullable'));
+
 Pointer<Void> smokeDatessteadyDatestructToFfiNullable(DatesSteady_DateStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDatessteadyDatestructToFfi(value);
@@ -75,6 +97,7 @@ Pointer<Void> smokeDatessteadyDatestructToFfiNullable(DatesSteady_DateStruct? va
   smokeDatessteadyDatestructReleaseFfiHandle(_handle);
   return result;
 }
+
 DatesSteady_DateStruct? smokeDatessteadyDatestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDatessteadyDatestructGetValueNullable(handle);
@@ -82,10 +105,14 @@ DatesSteady_DateStruct? smokeDatessteadyDatestructFromFfiNullable(Pointer<Void> 
   smokeDatessteadyDatestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDatessteadyDatestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDatessteadyDatestructReleaseHandleNullable(handle);
+
 // End of DatesSteady_DateStruct "private" section.
+
 // DatesSteady "private" section, not exported.
+
 final _smokeDatessteadyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -98,8 +125,15 @@ final _smokeDatessteadyReleaseHandle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DatesSteady_release_handle'));
+
+
+
+
+
 class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
+
   DatesSteady$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   DateTime dateMethod(DateTime input) {
     final _dateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32, Uint64), int Function(Pointer<Void>, int, int)>('library_smoke_DatesSteady_dateMethod__Date'));
@@ -111,8 +145,11 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
       return dateFromFfi(__resultHandle);
     } finally {
       dateReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   DateTime? nullableDateMethod(DateTime? input) {
     final _nullableDateMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_nullableDateMethod__Date_'));
@@ -124,8 +161,11 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
       return dateFromFfiNullable(__resultHandle);
     } finally {
       dateReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   List<DateTime> dateListMethod(List<DateTime> input) {
     final _dateListMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DatesSteady_dateListMethod__ListOf_Date_std_2chrono_2steady_1clock_2time_1point'));
@@ -137,27 +177,41 @@ class DatesSteady$Impl extends __lib.NativeBase implements DatesSteady {
       return foobarListofDateStd2chrono2steady1clock2time1pointFromFfi(__resultHandle);
     } finally {
       foobarListofDateStd2chrono2steady1clock2time1pointReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeDatessteadyToFfi(DatesSteady value) =>
   _smokeDatessteadyCopyHandle((value as __lib.NativeBase).handle);
+
 DatesSteady smokeDatessteadyFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DatesSteady) return instance;
+
   final _copiedHandle = _smokeDatessteadyCopyHandle(handle);
   final result = DatesSteady$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeDatessteadyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeDatessteadyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDatessteadyReleaseHandle(handle);
+
 Pointer<Void> smokeDatessteadyToFfiNullable(DatesSteady? value) =>
   value != null ? smokeDatessteadyToFfi(value) : Pointer<Void>.fromAddress(0);
+
 DatesSteady? smokeDatessteadyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDatessteadyFromFfi(handle) : null;
+
 void smokeDatessteadyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDatessteadyReleaseHandle(handle);
+
 // End of DatesSteady "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
+++ b/gluecodium/src/test/resources/smoke/defaults/output/dart/lib/src/smoke/default_values.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,24 +7,39 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class DefaultValues {
+
+abstract class DefaultValues implements Finalizable {
+
+
   static DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) => $prototype.processStructWithDefaults(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = DefaultValues$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 class DefaultValues_StructWithDefaults {
   int intField;
+
   int uintField;
+
   double floatField;
+
   double doubleField;
+
   bool boolField;
+
   String stringField;
+
   DefaultValues_StructWithDefaults._(this.intField, this.uintField, this.floatField, this.doubleField, this.boolField, this.stringField);
   DefaultValues_StructWithDefaults()
     : intField = 42, uintField = 4294967295, floatField = 3.14, doubleField = -1.4142, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n";
 }
+
+
 // DefaultValues_StructWithDefaults "private" section, not exported.
+
 final _smokeDefaultvaluesStructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int32, Uint32, Float, Double, Uint8, Pointer<Void>),
     Pointer<Void> Function(int, int, double, double, int, Pointer<Void>)
@@ -55,6 +72,9 @@ final _smokeDefaultvaluesStructwithdefaultsGetFieldstringField = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_field_stringField'));
+
+
+
 Pointer<Void> smokeDefaultvaluesStructwithdefaultsToFfi(DefaultValues_StructWithDefaults value) {
   final _intFieldHandle = (value.intField);
   final _uintFieldHandle = (value.uintField);
@@ -63,10 +83,15 @@ Pointer<Void> smokeDefaultvaluesStructwithdefaultsToFfi(DefaultValues_StructWith
   final _boolFieldHandle = booleanToFfi(value.boolField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeDefaultvaluesStructwithdefaultsCreateHandle(_intFieldHandle, _uintFieldHandle, _floatFieldHandle, _doubleFieldHandle, _boolFieldHandle, _stringFieldHandle);
+  
+  
+  
+  
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 DefaultValues_StructWithDefaults smokeDefaultvaluesStructwithdefaultsFromFfi(Pointer<Void> handle) {
   final _intFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldintField(handle);
   final _uintFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFielduintField(handle);
@@ -76,20 +101,27 @@ DefaultValues_StructWithDefaults smokeDefaultvaluesStructwithdefaultsFromFfi(Poi
   final _stringFieldHandle = _smokeDefaultvaluesStructwithdefaultsGetFieldstringField(handle);
   try {
     return DefaultValues_StructWithDefaults._(
-      (_intFieldHandle),
-      (_uintFieldHandle),
-      (_floatFieldHandle),
-      (_doubleFieldHandle),
-      booleanFromFfi(_boolFieldHandle),
+      (_intFieldHandle), 
+      (_uintFieldHandle), 
+      (_floatFieldHandle), 
+      (_doubleFieldHandle), 
+      booleanFromFfi(_boolFieldHandle), 
       stringFromFfi(_stringFieldHandle)
     );
   } finally {
+    
+    
+    
+    
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeDefaultvaluesStructwithdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithdefaultsReleaseHandle(handle);
+
 // Nullable DefaultValues_StructWithDefaults
+
 final _smokeDefaultvaluesStructwithdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -102,6 +134,7 @@ final _smokeDefaultvaluesStructwithdefaultsGetValueNullable = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithDefaults_get_value_nullable'));
+
 Pointer<Void> smokeDefaultvaluesStructwithdefaultsToFfiNullable(DefaultValues_StructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDefaultvaluesStructwithdefaultsToFfi(value);
@@ -109,6 +142,7 @@ Pointer<Void> smokeDefaultvaluesStructwithdefaultsToFfiNullable(DefaultValues_St
   smokeDefaultvaluesStructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 DefaultValues_StructWithDefaults? smokeDefaultvaluesStructwithdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDefaultvaluesStructwithdefaultsGetValueNullable(handle);
@@ -116,20 +150,31 @@ DefaultValues_StructWithDefaults? smokeDefaultvaluesStructwithdefaultsFromFfiNul
   smokeDefaultvaluesStructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDefaultvaluesStructwithdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDefaultvaluesStructwithdefaultsReleaseHandleNullable(handle);
+
 // End of DefaultValues_StructWithDefaults "private" section.
+
 class DefaultValues_NullableStructWithDefaults {
   int? intField;
+
   int? uintField;
+
   double? floatField;
+
   bool? boolField;
+
   String? stringField;
+
   DefaultValues_NullableStructWithDefaults._(this.intField, this.uintField, this.floatField, this.boolField, this.stringField);
   DefaultValues_NullableStructWithDefaults()
     : intField = null, uintField = null, floatField = null, boolField = null, stringField = null;
 }
+
+
 // DefaultValues_NullableStructWithDefaults "private" section, not exported.
+
 final _smokeDefaultvaluesNullablestructwithdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -158,6 +203,9 @@ final _smokeDefaultvaluesNullablestructwithdefaultsGetFieldstringField = __lib.c
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_field_stringField'));
+
+
+
 Pointer<Void> smokeDefaultvaluesNullablestructwithdefaultsToFfi(DefaultValues_NullableStructWithDefaults value) {
   final _intFieldHandle = intToFfiNullable(value.intField);
   final _uintFieldHandle = uIntToFfiNullable(value.uintField);
@@ -172,6 +220,7 @@ Pointer<Void> smokeDefaultvaluesNullablestructwithdefaultsToFfi(DefaultValues_Nu
   stringReleaseFfiHandleNullable(_stringFieldHandle);
   return _result;
 }
+
 DefaultValues_NullableStructWithDefaults smokeDefaultvaluesNullablestructwithdefaultsFromFfi(Pointer<Void> handle) {
   final _intFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldintField(handle);
   final _uintFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFielduintField(handle);
@@ -180,10 +229,10 @@ DefaultValues_NullableStructWithDefaults smokeDefaultvaluesNullablestructwithdef
   final _stringFieldHandle = _smokeDefaultvaluesNullablestructwithdefaultsGetFieldstringField(handle);
   try {
     return DefaultValues_NullableStructWithDefaults._(
-      intFromFfiNullable(_intFieldHandle),
-      uIntFromFfiNullable(_uintFieldHandle),
-      floatFromFfiNullable(_floatFieldHandle),
-      booleanFromFfiNullable(_boolFieldHandle),
+      intFromFfiNullable(_intFieldHandle), 
+      uIntFromFfiNullable(_uintFieldHandle), 
+      floatFromFfiNullable(_floatFieldHandle), 
+      booleanFromFfiNullable(_boolFieldHandle), 
       stringFromFfiNullable(_stringFieldHandle)
     );
   } finally {
@@ -194,8 +243,11 @@ DefaultValues_NullableStructWithDefaults smokeDefaultvaluesNullablestructwithdef
     stringReleaseFfiHandleNullable(_stringFieldHandle);
   }
 }
+
 void smokeDefaultvaluesNullablestructwithdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesNullablestructwithdefaultsReleaseHandle(handle);
+
 // Nullable DefaultValues_NullableStructWithDefaults
+
 final _smokeDefaultvaluesNullablestructwithdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -208,6 +260,7 @@ final _smokeDefaultvaluesNullablestructwithdefaultsGetValueNullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_NullableStructWithDefaults_get_value_nullable'));
+
 Pointer<Void> smokeDefaultvaluesNullablestructwithdefaultsToFfiNullable(DefaultValues_NullableStructWithDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDefaultvaluesNullablestructwithdefaultsToFfi(value);
@@ -215,6 +268,7 @@ Pointer<Void> smokeDefaultvaluesNullablestructwithdefaultsToFfiNullable(DefaultV
   smokeDefaultvaluesNullablestructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 DefaultValues_NullableStructWithDefaults? smokeDefaultvaluesNullablestructwithdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDefaultvaluesNullablestructwithdefaultsGetValueNullable(handle);
@@ -222,21 +276,33 @@ DefaultValues_NullableStructWithDefaults? smokeDefaultvaluesNullablestructwithde
   smokeDefaultvaluesNullablestructwithdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDefaultvaluesNullablestructwithdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDefaultvaluesNullablestructwithdefaultsReleaseHandleNullable(handle);
+
 // End of DefaultValues_NullableStructWithDefaults "private" section.
+
 class DefaultValues_StructWithSpecialDefaults {
   double floatNanField;
+
   double floatInfinityField;
+
   double floatNegativeInfinityField;
+
   double doubleNanField;
+
   double doubleInfinityField;
+
   double doubleNegativeInfinityField;
+
   DefaultValues_StructWithSpecialDefaults._(this.floatNanField, this.floatInfinityField, this.floatNegativeInfinityField, this.doubleNanField, this.doubleInfinityField, this.doubleNegativeInfinityField);
   DefaultValues_StructWithSpecialDefaults()
     : floatNanField = double.nan, floatInfinityField = double.infinity, floatNegativeInfinityField = double.negativeInfinity, doubleNanField = double.nan, doubleInfinityField = double.infinity, doubleNegativeInfinityField = double.negativeInfinity;
 }
+
+
 // DefaultValues_StructWithSpecialDefaults "private" section, not exported.
+
 final _smokeDefaultvaluesStructwithspecialdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Float, Float, Float, Double, Double, Double),
     Pointer<Void> Function(double, double, double, double, double, double)
@@ -269,6 +335,9 @@ final _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleNegativeInfinity
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_field_doubleNegativeInfinityField'));
+
+
+
 Pointer<Void> smokeDefaultvaluesStructwithspecialdefaultsToFfi(DefaultValues_StructWithSpecialDefaults value) {
   final _floatNanFieldHandle = (value.floatNanField);
   final _floatInfinityFieldHandle = (value.floatInfinityField);
@@ -277,8 +346,15 @@ Pointer<Void> smokeDefaultvaluesStructwithspecialdefaultsToFfi(DefaultValues_Str
   final _doubleInfinityFieldHandle = (value.doubleInfinityField);
   final _doubleNegativeInfinityFieldHandle = (value.doubleNegativeInfinityField);
   final _result = _smokeDefaultvaluesStructwithspecialdefaultsCreateHandle(_floatNanFieldHandle, _floatInfinityFieldHandle, _floatNegativeInfinityFieldHandle, _doubleNanFieldHandle, _doubleInfinityFieldHandle, _doubleNegativeInfinityFieldHandle);
+  
+  
+  
+  
+  
+  
   return _result;
 }
+
 DefaultValues_StructWithSpecialDefaults smokeDefaultvaluesStructwithspecialdefaultsFromFfi(Pointer<Void> handle) {
   final _floatNanFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatNanField(handle);
   final _floatInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFieldfloatInfinityField(handle);
@@ -288,18 +364,27 @@ DefaultValues_StructWithSpecialDefaults smokeDefaultvaluesStructwithspecialdefau
   final _doubleNegativeInfinityFieldHandle = _smokeDefaultvaluesStructwithspecialdefaultsGetFielddoubleNegativeInfinityField(handle);
   try {
     return DefaultValues_StructWithSpecialDefaults._(
-      (_floatNanFieldHandle),
-      (_floatInfinityFieldHandle),
-      (_floatNegativeInfinityFieldHandle),
-      (_doubleNanFieldHandle),
-      (_doubleInfinityFieldHandle),
+      (_floatNanFieldHandle), 
+      (_floatInfinityFieldHandle), 
+      (_floatNegativeInfinityFieldHandle), 
+      (_doubleNanFieldHandle), 
+      (_doubleInfinityFieldHandle), 
       (_doubleNegativeInfinityFieldHandle)
     );
   } finally {
+    
+    
+    
+    
+    
+    
   }
 }
+
 void smokeDefaultvaluesStructwithspecialdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithspecialdefaultsReleaseHandle(handle);
+
 // Nullable DefaultValues_StructWithSpecialDefaults
+
 final _smokeDefaultvaluesStructwithspecialdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -312,6 +397,7 @@ final _smokeDefaultvaluesStructwithspecialdefaultsGetValueNullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithSpecialDefaults_get_value_nullable'));
+
 Pointer<Void> smokeDefaultvaluesStructwithspecialdefaultsToFfiNullable(DefaultValues_StructWithSpecialDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDefaultvaluesStructwithspecialdefaultsToFfi(value);
@@ -319,6 +405,7 @@ Pointer<Void> smokeDefaultvaluesStructwithspecialdefaultsToFfiNullable(DefaultVa
   smokeDefaultvaluesStructwithspecialdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 DefaultValues_StructWithSpecialDefaults? smokeDefaultvaluesStructwithspecialdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDefaultvaluesStructwithspecialdefaultsGetValueNullable(handle);
@@ -326,20 +413,31 @@ DefaultValues_StructWithSpecialDefaults? smokeDefaultvaluesStructwithspecialdefa
   smokeDefaultvaluesStructwithspecialdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDefaultvaluesStructwithspecialdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDefaultvaluesStructwithspecialdefaultsReleaseHandleNullable(handle);
+
 // End of DefaultValues_StructWithSpecialDefaults "private" section.
+
 class DefaultValues_StructWithEmptyDefaults {
   List<int> intsField;
+
   List<double> floatsField;
+
   Map<int, String> mapField;
+
   DefaultValues_StructWithDefaults structField;
+
   Set<String> setTypeField;
+
   DefaultValues_StructWithEmptyDefaults._(this.intsField, this.floatsField, this.mapField, this.structField, this.setTypeField);
   DefaultValues_StructWithEmptyDefaults()
     : intsField = [], floatsField = [], mapField = {}, structField = DefaultValues_StructWithDefaults(), setTypeField = {};
 }
+
+
 // DefaultValues_StructWithEmptyDefaults "private" section, not exported.
+
 final _smokeDefaultvaluesStructwithemptydefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -368,6 +466,9 @@ final _smokeDefaultvaluesStructwithemptydefaultsGetFieldsetTypeField = __lib.cat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_field_setTypeField'));
+
+
+
 Pointer<Void> smokeDefaultvaluesStructwithemptydefaultsToFfi(DefaultValues_StructWithEmptyDefaults value) {
   final _intsFieldHandle = foobarListofIntToFfi(value.intsField);
   final _floatsFieldHandle = foobarListofFloatToFfi(value.floatsField);
@@ -382,6 +483,7 @@ Pointer<Void> smokeDefaultvaluesStructwithemptydefaultsToFfi(DefaultValues_Struc
   foobarSetofStringReleaseFfiHandle(_setTypeFieldHandle);
   return _result;
 }
+
 DefaultValues_StructWithEmptyDefaults smokeDefaultvaluesStructwithemptydefaultsFromFfi(Pointer<Void> handle) {
   final _intsFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldintsField(handle);
   final _floatsFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldfloatsField(handle);
@@ -390,10 +492,10 @@ DefaultValues_StructWithEmptyDefaults smokeDefaultvaluesStructwithemptydefaultsF
   final _setTypeFieldHandle = _smokeDefaultvaluesStructwithemptydefaultsGetFieldsetTypeField(handle);
   try {
     return DefaultValues_StructWithEmptyDefaults._(
-      foobarListofIntFromFfi(_intsFieldHandle),
-      foobarListofFloatFromFfi(_floatsFieldHandle),
-      foobarMapofUintToStringFromFfi(_mapFieldHandle),
-      smokeDefaultvaluesStructwithdefaultsFromFfi(_structFieldHandle),
+      foobarListofIntFromFfi(_intsFieldHandle), 
+      foobarListofFloatFromFfi(_floatsFieldHandle), 
+      foobarMapofUintToStringFromFfi(_mapFieldHandle), 
+      smokeDefaultvaluesStructwithdefaultsFromFfi(_structFieldHandle), 
       foobarSetofStringFromFfi(_setTypeFieldHandle)
     );
   } finally {
@@ -404,8 +506,11 @@ DefaultValues_StructWithEmptyDefaults smokeDefaultvaluesStructwithemptydefaultsF
     foobarSetofStringReleaseFfiHandle(_setTypeFieldHandle);
   }
 }
+
 void smokeDefaultvaluesStructwithemptydefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithemptydefaultsReleaseHandle(handle);
+
 // Nullable DefaultValues_StructWithEmptyDefaults
+
 final _smokeDefaultvaluesStructwithemptydefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -418,6 +523,7 @@ final _smokeDefaultvaluesStructwithemptydefaultsGetValueNullable = __lib.catchAr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithEmptyDefaults_get_value_nullable'));
+
 Pointer<Void> smokeDefaultvaluesStructwithemptydefaultsToFfiNullable(DefaultValues_StructWithEmptyDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDefaultvaluesStructwithemptydefaultsToFfi(value);
@@ -425,6 +531,7 @@ Pointer<Void> smokeDefaultvaluesStructwithemptydefaultsToFfiNullable(DefaultValu
   smokeDefaultvaluesStructwithemptydefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 DefaultValues_StructWithEmptyDefaults? smokeDefaultvaluesStructwithemptydefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDefaultvaluesStructwithemptydefaultsGetValueNullable(handle);
@@ -432,18 +539,27 @@ DefaultValues_StructWithEmptyDefaults? smokeDefaultvaluesStructwithemptydefaults
   smokeDefaultvaluesStructwithemptydefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDefaultvaluesStructwithemptydefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDefaultvaluesStructwithemptydefaultsReleaseHandleNullable(handle);
+
 // End of DefaultValues_StructWithEmptyDefaults "private" section.
+
 class DefaultValues_StructWithTypedefDefaults {
   int longField;
+
   bool boolField;
+
   String stringField;
+
   DefaultValues_StructWithTypedefDefaults._(this.longField, this.boolField, this.stringField);
   DefaultValues_StructWithTypedefDefaults()
     : longField = 42, boolField = true, stringField = "\\Jonny \"Magic\" Smith\n";
 }
+
+
 // DefaultValues_StructWithTypedefDefaults "private" section, not exported.
+
 final _smokeDefaultvaluesStructwithtypedefdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int64, Uint8, Pointer<Void>),
     Pointer<Void> Function(int, int, Pointer<Void>)
@@ -464,32 +580,41 @@ final _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldstringField = __lib.ca
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_field_stringField'));
+
+
+
 Pointer<Void> smokeDefaultvaluesStructwithtypedefdefaultsToFfi(DefaultValues_StructWithTypedefDefaults value) {
   final _longFieldHandle = (value.longField);
   final _boolFieldHandle = booleanToFfi(value.boolField);
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeDefaultvaluesStructwithtypedefdefaultsCreateHandle(_longFieldHandle, _boolFieldHandle, _stringFieldHandle);
+  
   booleanReleaseFfiHandle(_boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 DefaultValues_StructWithTypedefDefaults smokeDefaultvaluesStructwithtypedefdefaultsFromFfi(Pointer<Void> handle) {
   final _longFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldlongField(handle);
   final _boolFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldboolField(handle);
   final _stringFieldHandle = _smokeDefaultvaluesStructwithtypedefdefaultsGetFieldstringField(handle);
   try {
     return DefaultValues_StructWithTypedefDefaults._(
-      (_longFieldHandle),
-      booleanFromFfi(_boolFieldHandle),
+      (_longFieldHandle), 
+      booleanFromFfi(_boolFieldHandle), 
       stringFromFfi(_stringFieldHandle)
     );
   } finally {
+    
     booleanReleaseFfiHandle(_boolFieldHandle);
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeDefaultvaluesStructwithtypedefdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeDefaultvaluesStructwithtypedefdefaultsReleaseHandle(handle);
+
 // Nullable DefaultValues_StructWithTypedefDefaults
+
 final _smokeDefaultvaluesStructwithtypedefdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -502,6 +627,7 @@ final _smokeDefaultvaluesStructwithtypedefdefaultsGetValueNullable = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DefaultValues_StructWithTypedefDefaults_get_value_nullable'));
+
 Pointer<Void> smokeDefaultvaluesStructwithtypedefdefaultsToFfiNullable(DefaultValues_StructWithTypedefDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDefaultvaluesStructwithtypedefdefaultsToFfi(value);
@@ -509,6 +635,7 @@ Pointer<Void> smokeDefaultvaluesStructwithtypedefdefaultsToFfiNullable(DefaultVa
   smokeDefaultvaluesStructwithtypedefdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 DefaultValues_StructWithTypedefDefaults? smokeDefaultvaluesStructwithtypedefdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDefaultvaluesStructwithtypedefdefaultsGetValueNullable(handle);
@@ -516,10 +643,14 @@ DefaultValues_StructWithTypedefDefaults? smokeDefaultvaluesStructwithtypedefdefa
   smokeDefaultvaluesStructwithtypedefdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDefaultvaluesStructwithtypedefdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDefaultvaluesStructwithtypedefdefaultsReleaseHandleNullable(handle);
+
 // End of DefaultValues_StructWithTypedefDefaults "private" section.
+
 // DefaultValues "private" section, not exported.
+
 final _smokeDefaultvaluesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -532,10 +663,15 @@ final _smokeDefaultvaluesReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DefaultValues_release_handle'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
+
   DefaultValues$Impl(Pointer<Void> handle) : super(handle);
+
   DefaultValues_StructWithDefaults processStructWithDefaults(DefaultValues_StructWithDefaults input) {
     final _processStructWithDefaultsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_DefaultValues_processStructWithDefaults__StructWithDefaults'));
     final _inputHandle = smokeDefaultvaluesStructwithdefaultsToFfi(input);
@@ -545,27 +681,41 @@ class DefaultValues$Impl extends __lib.NativeBase implements DefaultValues {
       return smokeDefaultvaluesStructwithdefaultsFromFfi(__resultHandle);
     } finally {
       smokeDefaultvaluesStructwithdefaultsReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeDefaultvaluesToFfi(DefaultValues value) =>
   _smokeDefaultvaluesCopyHandle((value as __lib.NativeBase).handle);
+
 DefaultValues smokeDefaultvaluesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DefaultValues) return instance;
+
   final _copiedHandle = _smokeDefaultvaluesCopyHandle(handle);
   final result = DefaultValues$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeDefaultvaluesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeDefaultvaluesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDefaultvaluesReleaseHandle(handle);
+
 Pointer<Void> smokeDefaultvaluesToFfiNullable(DefaultValues? value) =>
   value != null ? smokeDefaultvaluesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 DefaultValues? smokeDefaultvaluesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDefaultvaluesFromFfi(handle) : null;
+
 void smokeDefaultvaluesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDefaultvaluesReleaseHandle(handle);
+
 // End of DefaultValues "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -7,15 +9,23 @@ import 'package:library/src/fire/enum2.dart';
 import 'package:library/src/fire/enum3.dart';
 import 'package:library/src/fire/enum4.dart';
 import 'package:library/src/smoke/enum_wrapper.dart';
-abstract class EnumDefaults {
+
+abstract class EnumDefaults implements Finalizable {
+
 }
+
+
 class EnumDefaults_SimpleEnum {
   Enum1 enumField;
+
   EnumDefaults_SimpleEnum._(this.enumField);
   EnumDefaults_SimpleEnum()
     : enumField = Enum1.disabled;
 }
+
+
 // EnumDefaults_SimpleEnum "private" section, not exported.
+
 final _smokeEnumdefaultsSimpleenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -28,12 +38,16 @@ final _smokeEnumdefaultsSimpleenumGetFieldenumField = __lib.catchArgumentError((
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_SimpleEnum_get_field_enumField'));
+
+
+
 Pointer<Void> smokeEnumdefaultsSimpleenumToFfi(EnumDefaults_SimpleEnum value) {
   final _enumFieldHandle = fireEnum1ToFfi(value.enumField);
   final _result = _smokeEnumdefaultsSimpleenumCreateHandle(_enumFieldHandle);
   fireEnum1ReleaseFfiHandle(_enumFieldHandle);
   return _result;
 }
+
 EnumDefaults_SimpleEnum smokeEnumdefaultsSimpleenumFromFfi(Pointer<Void> handle) {
   final _enumFieldHandle = _smokeEnumdefaultsSimpleenumGetFieldenumField(handle);
   try {
@@ -44,8 +58,11 @@ EnumDefaults_SimpleEnum smokeEnumdefaultsSimpleenumFromFfi(Pointer<Void> handle)
     fireEnum1ReleaseFfiHandle(_enumFieldHandle);
   }
 }
+
 void smokeEnumdefaultsSimpleenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsSimpleenumReleaseHandle(handle);
+
 // Nullable EnumDefaults_SimpleEnum
+
 final _smokeEnumdefaultsSimpleenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -58,6 +75,7 @@ final _smokeEnumdefaultsSimpleenumGetValueNullable = __lib.catchArgumentError(()
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_SimpleEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsSimpleenumToFfiNullable(EnumDefaults_SimpleEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsSimpleenumToFfi(value);
@@ -65,6 +83,7 @@ Pointer<Void> smokeEnumdefaultsSimpleenumToFfiNullable(EnumDefaults_SimpleEnum? 
   smokeEnumdefaultsSimpleenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaults_SimpleEnum? smokeEnumdefaultsSimpleenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsSimpleenumGetValueNullable(handle);
@@ -72,17 +91,25 @@ EnumDefaults_SimpleEnum? smokeEnumdefaultsSimpleenumFromFfiNullable(Pointer<Void
   smokeEnumdefaultsSimpleenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsSimpleenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsSimpleenumReleaseHandleNullable(handle);
+
 // End of EnumDefaults_SimpleEnum "private" section.
+
 class EnumDefaults_NullableEnum {
   Enum2? enumField1;
+
   Enum2? enumField1;
+
   EnumDefaults_NullableEnum._(this.enumField1, this.enumField1);
   EnumDefaults_NullableEnum()
     : enumField1 = null, enumField1 = Enum2.disabled;
 }
+
+
 // EnumDefaults_NullableEnum "private" section, not exported.
+
 final _smokeEnumdefaultsNullableenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
@@ -99,6 +126,9 @@ final _smokeEnumdefaultsNullableenumGetFieldenumField1 = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_NullableEnum_get_field_enumField1'));
+
+
+
 Pointer<Void> smokeEnumdefaultsNullableenumToFfi(EnumDefaults_NullableEnum value) {
   final _enumField1Handle = fireEnum2ToFfiNullable(value.enumField1);
   final _enumField1Handle = fireEnum2ToFfiNullable(value.enumField1);
@@ -107,12 +137,13 @@ Pointer<Void> smokeEnumdefaultsNullableenumToFfi(EnumDefaults_NullableEnum value
   fireEnum2ReleaseFfiHandleNullable(_enumField1Handle);
   return _result;
 }
+
 EnumDefaults_NullableEnum smokeEnumdefaultsNullableenumFromFfi(Pointer<Void> handle) {
   final _enumField1Handle = _smokeEnumdefaultsNullableenumGetFieldenumField1(handle);
   final _enumField1Handle = _smokeEnumdefaultsNullableenumGetFieldenumField1(handle);
   try {
     return EnumDefaults_NullableEnum._(
-      fireEnum2FromFfiNullable(_enumField1Handle),
+      fireEnum2FromFfiNullable(_enumField1Handle), 
       fireEnum2FromFfiNullable(_enumField1Handle)
     );
   } finally {
@@ -120,8 +151,11 @@ EnumDefaults_NullableEnum smokeEnumdefaultsNullableenumFromFfi(Pointer<Void> han
     fireEnum2ReleaseFfiHandleNullable(_enumField1Handle);
   }
 }
+
 void smokeEnumdefaultsNullableenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsNullableenumReleaseHandle(handle);
+
 // Nullable EnumDefaults_NullableEnum
+
 final _smokeEnumdefaultsNullableenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -134,6 +168,7 @@ final _smokeEnumdefaultsNullableenumGetValueNullable = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_NullableEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsNullableenumToFfiNullable(EnumDefaults_NullableEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsNullableenumToFfi(value);
@@ -141,6 +176,7 @@ Pointer<Void> smokeEnumdefaultsNullableenumToFfiNullable(EnumDefaults_NullableEn
   smokeEnumdefaultsNullableenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaults_NullableEnum? smokeEnumdefaultsNullableenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsNullableenumGetValueNullable(handle);
@@ -148,16 +184,23 @@ EnumDefaults_NullableEnum? smokeEnumdefaultsNullableenumFromFfiNullable(Pointer<
   smokeEnumdefaultsNullableenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsNullableenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsNullableenumReleaseHandleNullable(handle);
+
 // End of EnumDefaults_NullableEnum "private" section.
+
 class EnumDefaults_AliasEnum {
   Enum3 enumField;
+
   EnumDefaults_AliasEnum._(this.enumField);
   EnumDefaults_AliasEnum()
     : enumField = Enum3.disabled;
 }
+
+
 // EnumDefaults_AliasEnum "private" section, not exported.
+
 final _smokeEnumdefaultsAliasenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -170,12 +213,16 @@ final _smokeEnumdefaultsAliasenumGetFieldenumField = __lib.catchArgumentError(()
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_AliasEnum_get_field_enumField'));
+
+
+
 Pointer<Void> smokeEnumdefaultsAliasenumToFfi(EnumDefaults_AliasEnum value) {
   final _enumFieldHandle = fireEnum3ToFfi(value.enumField);
   final _result = _smokeEnumdefaultsAliasenumCreateHandle(_enumFieldHandle);
   fireEnum3ReleaseFfiHandle(_enumFieldHandle);
   return _result;
 }
+
 EnumDefaults_AliasEnum smokeEnumdefaultsAliasenumFromFfi(Pointer<Void> handle) {
   final _enumFieldHandle = _smokeEnumdefaultsAliasenumGetFieldenumField(handle);
   try {
@@ -186,8 +233,11 @@ EnumDefaults_AliasEnum smokeEnumdefaultsAliasenumFromFfi(Pointer<Void> handle) {
     fireEnum3ReleaseFfiHandle(_enumFieldHandle);
   }
 }
+
 void smokeEnumdefaultsAliasenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsAliasenumReleaseHandle(handle);
+
 // Nullable EnumDefaults_AliasEnum
+
 final _smokeEnumdefaultsAliasenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -200,6 +250,7 @@ final _smokeEnumdefaultsAliasenumGetValueNullable = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_AliasEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsAliasenumToFfiNullable(EnumDefaults_AliasEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsAliasenumToFfi(value);
@@ -207,6 +258,7 @@ Pointer<Void> smokeEnumdefaultsAliasenumToFfiNullable(EnumDefaults_AliasEnum? va
   smokeEnumdefaultsAliasenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaults_AliasEnum? smokeEnumdefaultsAliasenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsAliasenumGetValueNullable(handle);
@@ -214,16 +266,23 @@ EnumDefaults_AliasEnum? smokeEnumdefaultsAliasenumFromFfiNullable(Pointer<Void> 
   smokeEnumdefaultsAliasenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsAliasenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsAliasenumReleaseHandleNullable(handle);
+
 // End of EnumDefaults_AliasEnum "private" section.
+
 class EnumDefaults_WrappedEnum {
   EnumWrapper structField;
+
   EnumDefaults_WrappedEnum._(this.structField);
   EnumDefaults_WrappedEnum()
     : structField = EnumWrapper(Enum4.disabled);
 }
+
+
 // EnumDefaults_WrappedEnum "private" section, not exported.
+
 final _smokeEnumdefaultsWrappedenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -236,12 +295,16 @@ final _smokeEnumdefaultsWrappedenumGetFieldstructField = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_WrappedEnum_get_field_structField'));
+
+
+
 Pointer<Void> smokeEnumdefaultsWrappedenumToFfi(EnumDefaults_WrappedEnum value) {
   final _structFieldHandle = smokeEnumwrapperToFfi(value.structField);
   final _result = _smokeEnumdefaultsWrappedenumCreateHandle(_structFieldHandle);
   smokeEnumwrapperReleaseFfiHandle(_structFieldHandle);
   return _result;
 }
+
 EnumDefaults_WrappedEnum smokeEnumdefaultsWrappedenumFromFfi(Pointer<Void> handle) {
   final _structFieldHandle = _smokeEnumdefaultsWrappedenumGetFieldstructField(handle);
   try {
@@ -252,8 +315,11 @@ EnumDefaults_WrappedEnum smokeEnumdefaultsWrappedenumFromFfi(Pointer<Void> handl
     smokeEnumwrapperReleaseFfiHandle(_structFieldHandle);
   }
 }
+
 void smokeEnumdefaultsWrappedenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsWrappedenumReleaseHandle(handle);
+
 // Nullable EnumDefaults_WrappedEnum
+
 final _smokeEnumdefaultsWrappedenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -266,6 +332,7 @@ final _smokeEnumdefaultsWrappedenumGetValueNullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_WrappedEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsWrappedenumToFfiNullable(EnumDefaults_WrappedEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsWrappedenumToFfi(value);
@@ -273,6 +340,7 @@ Pointer<Void> smokeEnumdefaultsWrappedenumToFfiNullable(EnumDefaults_WrappedEnum
   smokeEnumdefaultsWrappedenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaults_WrappedEnum? smokeEnumdefaultsWrappedenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsWrappedenumGetValueNullable(handle);
@@ -280,10 +348,14 @@ EnumDefaults_WrappedEnum? smokeEnumdefaultsWrappedenumFromFfiNullable(Pointer<Vo
   smokeEnumdefaultsWrappedenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsWrappedenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsWrappedenumReleaseHandleNullable(handle);
+
 // End of EnumDefaults_WrappedEnum "private" section.
+
 // EnumDefaults "private" section, not exported.
+
 final _smokeEnumdefaultsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -296,27 +368,42 @@ final _smokeEnumdefaultsReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnumDefaults_release_handle'));
+
+
 class EnumDefaults$Impl extends __lib.NativeBase implements EnumDefaults {
+
   EnumDefaults$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokeEnumdefaultsToFfi(EnumDefaults value) =>
   _smokeEnumdefaultsCopyHandle((value as __lib.NativeBase).handle);
+
 EnumDefaults smokeEnumdefaultsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnumDefaults) return instance;
+
   final _copiedHandle = _smokeEnumdefaultsCopyHandle(handle);
   final result = EnumDefaults$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeEnumdefaultsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEnumdefaultsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEnumdefaultsReleaseHandle(handle);
+
 Pointer<Void> smokeEnumdefaultsToFfiNullable(EnumDefaults? value) =>
   value != null ? smokeEnumdefaultsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 EnumDefaults? smokeEnumdefaultsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEnumdefaultsFromFfi(handle) : null;
+
 void smokeEnumdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsReleaseHandle(handle);
+
 // End of EnumDefaults "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
+++ b/gluecodium/src/test/resources/smoke/defaults_const/output/dart/lib/src/smoke/enum_defaults_external.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:foo/alien_enum1.dart' as alien_enum1;
 import 'package:foo/alien_enum2.dart' as alien_enum2;
@@ -10,15 +12,23 @@ import 'package:library/src/fire/external_enum1.dart';
 import 'package:library/src/fire/external_enum2.dart';
 import 'package:library/src/fire/external_enum3.dart';
 import 'package:library/src/smoke/enum_wrapper.dart';
-abstract class EnumDefaultsExternal {
+
+abstract class EnumDefaultsExternal implements Finalizable {
+
 }
+
+
 class EnumDefaultsExternal_SimpleEnum {
   alien_enum1.ExternalEnum1 enumField;
+
   EnumDefaultsExternal_SimpleEnum._(this.enumField);
   EnumDefaultsExternal_SimpleEnum()
     : enumField = alien_enum1.ExternalEnum1.disabled;
 }
+
+
 // EnumDefaultsExternal_SimpleEnum "private" section, not exported.
+
 final _smokeEnumdefaultsexternalSimpleenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -31,12 +41,16 @@ final _smokeEnumdefaultsexternalSimpleenumGetFieldenumField = __lib.catchArgumen
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_SimpleEnum_get_field_enumField'));
+
+
+
 Pointer<Void> smokeEnumdefaultsexternalSimpleenumToFfi(EnumDefaultsExternal_SimpleEnum value) {
   final _enumFieldHandle = fireExternalenum1ToFfi(value.enumField);
   final _result = _smokeEnumdefaultsexternalSimpleenumCreateHandle(_enumFieldHandle);
   fireExternalenum1ReleaseFfiHandle(_enumFieldHandle);
   return _result;
 }
+
 EnumDefaultsExternal_SimpleEnum smokeEnumdefaultsexternalSimpleenumFromFfi(Pointer<Void> handle) {
   final _enumFieldHandle = _smokeEnumdefaultsexternalSimpleenumGetFieldenumField(handle);
   try {
@@ -47,8 +61,11 @@ EnumDefaultsExternal_SimpleEnum smokeEnumdefaultsexternalSimpleenumFromFfi(Point
     fireExternalenum1ReleaseFfiHandle(_enumFieldHandle);
   }
 }
+
 void smokeEnumdefaultsexternalSimpleenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsexternalSimpleenumReleaseHandle(handle);
+
 // Nullable EnumDefaultsExternal_SimpleEnum
+
 final _smokeEnumdefaultsexternalSimpleenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -61,6 +78,7 @@ final _smokeEnumdefaultsexternalSimpleenumGetValueNullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_SimpleEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsexternalSimpleenumToFfiNullable(EnumDefaultsExternal_SimpleEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsexternalSimpleenumToFfi(value);
@@ -68,6 +86,7 @@ Pointer<Void> smokeEnumdefaultsexternalSimpleenumToFfiNullable(EnumDefaultsExter
   smokeEnumdefaultsexternalSimpleenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaultsExternal_SimpleEnum? smokeEnumdefaultsexternalSimpleenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsexternalSimpleenumGetValueNullable(handle);
@@ -75,17 +94,25 @@ EnumDefaultsExternal_SimpleEnum? smokeEnumdefaultsexternalSimpleenumFromFfiNulla
   smokeEnumdefaultsexternalSimpleenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsexternalSimpleenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsexternalSimpleenumReleaseHandleNullable(handle);
+
 // End of EnumDefaultsExternal_SimpleEnum "private" section.
+
 class EnumDefaultsExternal_NullableEnum {
   alien_enum2.ExternalEnum2? enumField1;
+
   alien_enum2.ExternalEnum2? enumField1;
+
   EnumDefaultsExternal_NullableEnum._(this.enumField1, this.enumField1);
   EnumDefaultsExternal_NullableEnum()
     : enumField1 = null, enumField1 = alien_enum2.ExternalEnum2.disabled;
 }
+
+
 // EnumDefaultsExternal_NullableEnum "private" section, not exported.
+
 final _smokeEnumdefaultsexternalNullableenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>)
@@ -102,6 +129,9 @@ final _smokeEnumdefaultsexternalNullableenumGetFieldenumField1 = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_NullableEnum_get_field_enumField1'));
+
+
+
 Pointer<Void> smokeEnumdefaultsexternalNullableenumToFfi(EnumDefaultsExternal_NullableEnum value) {
   final _enumField1Handle = fireExternalenum2ToFfiNullable(value.enumField1);
   final _enumField1Handle = fireExternalenum2ToFfiNullable(value.enumField1);
@@ -110,12 +140,13 @@ Pointer<Void> smokeEnumdefaultsexternalNullableenumToFfi(EnumDefaultsExternal_Nu
   fireExternalenum2ReleaseFfiHandleNullable(_enumField1Handle);
   return _result;
 }
+
 EnumDefaultsExternal_NullableEnum smokeEnumdefaultsexternalNullableenumFromFfi(Pointer<Void> handle) {
   final _enumField1Handle = _smokeEnumdefaultsexternalNullableenumGetFieldenumField1(handle);
   final _enumField1Handle = _smokeEnumdefaultsexternalNullableenumGetFieldenumField1(handle);
   try {
     return EnumDefaultsExternal_NullableEnum._(
-      fireExternalenum2FromFfiNullable(_enumField1Handle),
+      fireExternalenum2FromFfiNullable(_enumField1Handle), 
       fireExternalenum2FromFfiNullable(_enumField1Handle)
     );
   } finally {
@@ -123,8 +154,11 @@ EnumDefaultsExternal_NullableEnum smokeEnumdefaultsexternalNullableenumFromFfi(P
     fireExternalenum2ReleaseFfiHandleNullable(_enumField1Handle);
   }
 }
+
 void smokeEnumdefaultsexternalNullableenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsexternalNullableenumReleaseHandle(handle);
+
 // Nullable EnumDefaultsExternal_NullableEnum
+
 final _smokeEnumdefaultsexternalNullableenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -137,6 +171,7 @@ final _smokeEnumdefaultsexternalNullableenumGetValueNullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_NullableEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsexternalNullableenumToFfiNullable(EnumDefaultsExternal_NullableEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsexternalNullableenumToFfi(value);
@@ -144,6 +179,7 @@ Pointer<Void> smokeEnumdefaultsexternalNullableenumToFfiNullable(EnumDefaultsExt
   smokeEnumdefaultsexternalNullableenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaultsExternal_NullableEnum? smokeEnumdefaultsexternalNullableenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsexternalNullableenumGetValueNullable(handle);
@@ -151,16 +187,23 @@ EnumDefaultsExternal_NullableEnum? smokeEnumdefaultsexternalNullableenumFromFfiN
   smokeEnumdefaultsexternalNullableenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsexternalNullableenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsexternalNullableenumReleaseHandleNullable(handle);
+
 // End of EnumDefaultsExternal_NullableEnum "private" section.
+
 class EnumDefaultsExternal_AliasEnum {
   alien_enum3.alien_enum3.ExternalEnum3 enumField;
+
   EnumDefaultsExternal_AliasEnum._(this.enumField);
   EnumDefaultsExternal_AliasEnum()
     : enumField = alien_enum3.ExternalEnum3.disabled;
 }
+
+
 // EnumDefaultsExternal_AliasEnum "private" section, not exported.
+
 final _smokeEnumdefaultsexternalAliasenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -173,12 +216,16 @@ final _smokeEnumdefaultsexternalAliasenumGetFieldenumField = __lib.catchArgument
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_AliasEnum_get_field_enumField'));
+
+
+
 Pointer<Void> smokeEnumdefaultsexternalAliasenumToFfi(EnumDefaultsExternal_AliasEnum value) {
   final _enumFieldHandle = fireExternalenum3ToFfi(value.enumField);
   final _result = _smokeEnumdefaultsexternalAliasenumCreateHandle(_enumFieldHandle);
   fireExternalenum3ReleaseFfiHandle(_enumFieldHandle);
   return _result;
 }
+
 EnumDefaultsExternal_AliasEnum smokeEnumdefaultsexternalAliasenumFromFfi(Pointer<Void> handle) {
   final _enumFieldHandle = _smokeEnumdefaultsexternalAliasenumGetFieldenumField(handle);
   try {
@@ -189,8 +236,11 @@ EnumDefaultsExternal_AliasEnum smokeEnumdefaultsexternalAliasenumFromFfi(Pointer
     fireExternalenum3ReleaseFfiHandle(_enumFieldHandle);
   }
 }
+
 void smokeEnumdefaultsexternalAliasenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsexternalAliasenumReleaseHandle(handle);
+
 // Nullable EnumDefaultsExternal_AliasEnum
+
 final _smokeEnumdefaultsexternalAliasenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -203,6 +253,7 @@ final _smokeEnumdefaultsexternalAliasenumGetValueNullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_AliasEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsexternalAliasenumToFfiNullable(EnumDefaultsExternal_AliasEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsexternalAliasenumToFfi(value);
@@ -210,6 +261,7 @@ Pointer<Void> smokeEnumdefaultsexternalAliasenumToFfiNullable(EnumDefaultsExtern
   smokeEnumdefaultsexternalAliasenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaultsExternal_AliasEnum? smokeEnumdefaultsexternalAliasenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsexternalAliasenumGetValueNullable(handle);
@@ -217,16 +269,23 @@ EnumDefaultsExternal_AliasEnum? smokeEnumdefaultsexternalAliasenumFromFfiNullabl
   smokeEnumdefaultsexternalAliasenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsexternalAliasenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsexternalAliasenumReleaseHandleNullable(handle);
+
 // End of EnumDefaultsExternal_AliasEnum "private" section.
+
 class EnumDefaultsExternal_WrappedEnum {
   EnumWrapper structField;
+
   EnumDefaultsExternal_WrappedEnum._(this.structField);
   EnumDefaultsExternal_WrappedEnum()
     : structField = EnumWrapper(alien_enum4.ExternalEnum4.disabled);
 }
+
+
 // EnumDefaultsExternal_WrappedEnum "private" section, not exported.
+
 final _smokeEnumdefaultsexternalWrappedenumCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -239,12 +298,16 @@ final _smokeEnumdefaultsexternalWrappedenumGetFieldstructField = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_WrappedEnum_get_field_structField'));
+
+
+
 Pointer<Void> smokeEnumdefaultsexternalWrappedenumToFfi(EnumDefaultsExternal_WrappedEnum value) {
   final _structFieldHandle = smokeEnumwrapperToFfi(value.structField);
   final _result = _smokeEnumdefaultsexternalWrappedenumCreateHandle(_structFieldHandle);
   smokeEnumwrapperReleaseFfiHandle(_structFieldHandle);
   return _result;
 }
+
 EnumDefaultsExternal_WrappedEnum smokeEnumdefaultsexternalWrappedenumFromFfi(Pointer<Void> handle) {
   final _structFieldHandle = _smokeEnumdefaultsexternalWrappedenumGetFieldstructField(handle);
   try {
@@ -255,8 +318,11 @@ EnumDefaultsExternal_WrappedEnum smokeEnumdefaultsexternalWrappedenumFromFfi(Poi
     smokeEnumwrapperReleaseFfiHandle(_structFieldHandle);
   }
 }
+
 void smokeEnumdefaultsexternalWrappedenumReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumdefaultsexternalWrappedenumReleaseHandle(handle);
+
 // Nullable EnumDefaultsExternal_WrappedEnum
+
 final _smokeEnumdefaultsexternalWrappedenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -269,6 +335,7 @@ final _smokeEnumdefaultsexternalWrappedenumGetValueNullable = __lib.catchArgumen
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_WrappedEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumdefaultsexternalWrappedenumToFfiNullable(EnumDefaultsExternal_WrappedEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumdefaultsexternalWrappedenumToFfi(value);
@@ -276,6 +343,7 @@ Pointer<Void> smokeEnumdefaultsexternalWrappedenumToFfiNullable(EnumDefaultsExte
   smokeEnumdefaultsexternalWrappedenumReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumDefaultsExternal_WrappedEnum? smokeEnumdefaultsexternalWrappedenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumdefaultsexternalWrappedenumGetValueNullable(handle);
@@ -283,10 +351,14 @@ EnumDefaultsExternal_WrappedEnum? smokeEnumdefaultsexternalWrappedenumFromFfiNul
   smokeEnumdefaultsexternalWrappedenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumdefaultsexternalWrappedenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsexternalWrappedenumReleaseHandleNullable(handle);
+
 // End of EnumDefaultsExternal_WrappedEnum "private" section.
+
 // EnumDefaultsExternal "private" section, not exported.
+
 final _smokeEnumdefaultsexternalRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -299,27 +371,42 @@ final _smokeEnumdefaultsexternalReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnumDefaultsExternal_release_handle'));
+
+
 class EnumDefaultsExternal$Impl extends __lib.NativeBase implements EnumDefaultsExternal {
+
   EnumDefaultsExternal$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokeEnumdefaultsexternalToFfi(EnumDefaultsExternal value) =>
   _smokeEnumdefaultsexternalCopyHandle((value as __lib.NativeBase).handle);
+
 EnumDefaultsExternal smokeEnumdefaultsexternalFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnumDefaultsExternal) return instance;
+
   final _copiedHandle = _smokeEnumdefaultsexternalCopyHandle(handle);
   final result = EnumDefaultsExternal$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeEnumdefaultsexternalRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEnumdefaultsexternalReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEnumdefaultsexternalReleaseHandle(handle);
+
 Pointer<Void> smokeEnumdefaultsexternalToFfiNullable(EnumDefaultsExternal? value) =>
   value != null ? smokeEnumdefaultsexternalToFfi(value) : Pointer<Void>.fromAddress(0);
+
 EnumDefaultsExternal? smokeEnumdefaultsexternalFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEnumdefaultsexternalFromFfi(handle) : null;
+
 void smokeEnumdefaultsexternalReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumdefaultsexternalReleaseHandle(handle);
+
 // End of EnumDefaultsExternal "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_milliseconds.dart
@@ -1,20 +1,32 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class DurationMilliseconds {
+
+abstract class DurationMilliseconds implements Finalizable {
+
 
   Duration durationFunction(Duration input);
+
   Duration? nullableDurationFunction(Duration? input);
   Duration get durationProperty;
   set durationProperty(Duration value);
+
 }
+
+
 class DurationMilliseconds_DurationStruct {
   Duration durationField;
+
   DurationMilliseconds_DurationStruct(this.durationField);
 }
+
+
 // DurationMilliseconds_DurationStruct "private" section, not exported.
+
 final _smokeDurationmillisecondsDurationstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
@@ -27,12 +39,16 @@ final _smokeDurationmillisecondsDurationstructGetFielddurationField = __lib.catc
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DurationMilliseconds_DurationStruct_get_field_durationField'));
+
+
+
 Pointer<Void> smokeDurationmillisecondsDurationstructToFfi(DurationMilliseconds_DurationStruct value) {
   final _durationFieldHandle = durationToFfi(value.durationField);
   final _result = _smokeDurationmillisecondsDurationstructCreateHandle(_durationFieldHandle);
   durationReleaseFfiHandle(_durationFieldHandle);
   return _result;
 }
+
 DurationMilliseconds_DurationStruct smokeDurationmillisecondsDurationstructFromFfi(Pointer<Void> handle) {
   final _durationFieldHandle = _smokeDurationmillisecondsDurationstructGetFielddurationField(handle);
   try {
@@ -43,8 +59,11 @@ DurationMilliseconds_DurationStruct smokeDurationmillisecondsDurationstructFromF
     durationReleaseFfiHandle(_durationFieldHandle);
   }
 }
+
 void smokeDurationmillisecondsDurationstructReleaseFfiHandle(Pointer<Void> handle) => _smokeDurationmillisecondsDurationstructReleaseHandle(handle);
+
 // Nullable DurationMilliseconds_DurationStruct
+
 final _smokeDurationmillisecondsDurationstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -57,6 +76,7 @@ final _smokeDurationmillisecondsDurationstructGetValueNullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DurationMilliseconds_DurationStruct_get_value_nullable'));
+
 Pointer<Void> smokeDurationmillisecondsDurationstructToFfiNullable(DurationMilliseconds_DurationStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDurationmillisecondsDurationstructToFfi(value);
@@ -64,6 +84,7 @@ Pointer<Void> smokeDurationmillisecondsDurationstructToFfiNullable(DurationMilli
   smokeDurationmillisecondsDurationstructReleaseFfiHandle(_handle);
   return result;
 }
+
 DurationMilliseconds_DurationStruct? smokeDurationmillisecondsDurationstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDurationmillisecondsDurationstructGetValueNullable(handle);
@@ -71,10 +92,14 @@ DurationMilliseconds_DurationStruct? smokeDurationmillisecondsDurationstructFrom
   smokeDurationmillisecondsDurationstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDurationmillisecondsDurationstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDurationmillisecondsDurationstructReleaseHandleNullable(handle);
+
 // End of DurationMilliseconds_DurationStruct "private" section.
+
 // DurationMilliseconds "private" section, not exported.
+
 final _smokeDurationmillisecondsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -87,7 +112,12 @@ final _smokeDurationmillisecondsReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DurationMilliseconds_release_handle'));
+
+
+
+
 class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMilliseconds {
+
   DurationMilliseconds$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -101,8 +131,11 @@ class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMill
       return durationFromFfi(__resultHandle);
     } finally {
       durationReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Duration? nullableDurationFunction(Duration? input) {
     final _nullableDurationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DurationMilliseconds_nullableDurationFunction__Duration_'));
@@ -114,8 +147,11 @@ class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMill
       return durationFromFfiNullable(__resultHandle);
     } finally {
       durationReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   Duration get durationProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DurationMilliseconds_durationProperty_get'));
@@ -125,8 +161,11 @@ class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMill
       return durationFromFfi(__resultHandle);
     } finally {
       durationReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set durationProperty(Duration value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_DurationMilliseconds_durationProperty_set__Duration'));
@@ -134,26 +173,40 @@ class DurationMilliseconds$Impl extends __lib.NativeBase implements DurationMill
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     durationReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeDurationmillisecondsToFfi(DurationMilliseconds value) =>
   _smokeDurationmillisecondsCopyHandle((value as __lib.NativeBase).handle);
+
 DurationMilliseconds smokeDurationmillisecondsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DurationMilliseconds) return instance;
+
   final _copiedHandle = _smokeDurationmillisecondsCopyHandle(handle);
   final result = DurationMilliseconds$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeDurationmillisecondsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeDurationmillisecondsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDurationmillisecondsReleaseHandle(handle);
+
 Pointer<Void> smokeDurationmillisecondsToFfiNullable(DurationMilliseconds? value) =>
   value != null ? smokeDurationmillisecondsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 DurationMilliseconds? smokeDurationmillisecondsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDurationmillisecondsFromFfi(handle) : null;
+
 void smokeDurationmillisecondsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDurationmillisecondsReleaseHandle(handle);
+
 // End of DurationMilliseconds "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
+++ b/gluecodium/src/test/resources/smoke/durations/output/dart/lib/src/smoke/duration_seconds.dart
@@ -1,20 +1,32 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class DurationSeconds {
+
+abstract class DurationSeconds implements Finalizable {
+
 
   Duration durationFunction(Duration input);
+
   Duration? nullableDurationFunction(Duration? input);
   Duration get durationProperty;
   set durationProperty(Duration value);
+
 }
+
+
 class DurationSeconds_DurationStruct {
   Duration durationField;
+
   DurationSeconds_DurationStruct(this.durationField);
 }
+
+
 // DurationSeconds_DurationStruct "private" section, not exported.
+
 final _smokeDurationsecondsDurationstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint64),
     Pointer<Void> Function(int)
@@ -27,12 +39,16 @@ final _smokeDurationsecondsDurationstructGetFielddurationField = __lib.catchArgu
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DurationSeconds_DurationStruct_get_field_durationField'));
+
+
+
 Pointer<Void> smokeDurationsecondsDurationstructToFfi(DurationSeconds_DurationStruct value) {
   final _durationFieldHandle = durationToFfi(value.durationField);
   final _result = _smokeDurationsecondsDurationstructCreateHandle(_durationFieldHandle);
   durationReleaseFfiHandle(_durationFieldHandle);
   return _result;
 }
+
 DurationSeconds_DurationStruct smokeDurationsecondsDurationstructFromFfi(Pointer<Void> handle) {
   final _durationFieldHandle = _smokeDurationsecondsDurationstructGetFielddurationField(handle);
   try {
@@ -43,8 +59,11 @@ DurationSeconds_DurationStruct smokeDurationsecondsDurationstructFromFfi(Pointer
     durationReleaseFfiHandle(_durationFieldHandle);
   }
 }
+
 void smokeDurationsecondsDurationstructReleaseFfiHandle(Pointer<Void> handle) => _smokeDurationsecondsDurationstructReleaseHandle(handle);
+
 // Nullable DurationSeconds_DurationStruct
+
 final _smokeDurationsecondsDurationstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -57,6 +76,7 @@ final _smokeDurationsecondsDurationstructGetValueNullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_DurationSeconds_DurationStruct_get_value_nullable'));
+
 Pointer<Void> smokeDurationsecondsDurationstructToFfiNullable(DurationSeconds_DurationStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDurationsecondsDurationstructToFfi(value);
@@ -64,6 +84,7 @@ Pointer<Void> smokeDurationsecondsDurationstructToFfiNullable(DurationSeconds_Du
   smokeDurationsecondsDurationstructReleaseFfiHandle(_handle);
   return result;
 }
+
 DurationSeconds_DurationStruct? smokeDurationsecondsDurationstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDurationsecondsDurationstructGetValueNullable(handle);
@@ -71,10 +92,14 @@ DurationSeconds_DurationStruct? smokeDurationsecondsDurationstructFromFfiNullabl
   smokeDurationsecondsDurationstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDurationsecondsDurationstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDurationsecondsDurationstructReleaseHandleNullable(handle);
+
 // End of DurationSeconds_DurationStruct "private" section.
+
 // DurationSeconds "private" section, not exported.
+
 final _smokeDurationsecondsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -87,7 +112,12 @@ final _smokeDurationsecondsReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_DurationSeconds_release_handle'));
+
+
+
+
 class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
+
   DurationSeconds$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -101,8 +131,11 @@ class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
       return durationFromFfi(__resultHandle);
     } finally {
       durationReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Duration? nullableDurationFunction(Duration? input) {
     final _nullableDurationFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_DurationSeconds_nullableDurationFunction__Duration_'));
@@ -114,8 +147,11 @@ class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
       return durationFromFfiNullable(__resultHandle);
     } finally {
       durationReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   Duration get durationProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint64 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_DurationSeconds_durationProperty_get'));
@@ -125,8 +161,11 @@ class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
       return durationFromFfi(__resultHandle);
     } finally {
       durationReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set durationProperty(Duration value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint64), void Function(Pointer<Void>, int, int)>('library_smoke_DurationSeconds_durationProperty_set__Duration'));
@@ -134,26 +173,40 @@ class DurationSeconds$Impl extends __lib.NativeBase implements DurationSeconds {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     durationReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeDurationsecondsToFfi(DurationSeconds value) =>
   _smokeDurationsecondsCopyHandle((value as __lib.NativeBase).handle);
+
 DurationSeconds smokeDurationsecondsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is DurationSeconds) return instance;
+
   final _copiedHandle = _smokeDurationsecondsCopyHandle(handle);
   final result = DurationSeconds$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeDurationsecondsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeDurationsecondsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeDurationsecondsReleaseHandle(handle);
+
 Pointer<Void> smokeDurationsecondsToFfiNullable(DurationSeconds? value) =>
   value != null ? smokeDurationsecondsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 DurationSeconds? smokeDurationsecondsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeDurationsecondsFromFfi(handle) : null;
+
 void smokeDurationsecondsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDurationsecondsReleaseHandle(handle);
+
 // End of DurationSeconds "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -1,24 +1,35 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class Enums {
+
+abstract class Enums implements Finalizable {
+
 
   static Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) => $prototype.methodWithEnumeration(input);
+
   static Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) => $prototype.flipEnumValue(input);
+
   static Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) => $prototype.extractEnumFromStruct(input);
+
   static Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) => $prototype.createStructWithEnumInside(type, message);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Enums$Impl(Pointer<Void>.fromAddress(0));
 }
+
 enum Enums_SimpleEnum {
     first,
     second
 }
+
 // Enums_SimpleEnum "private" section, not exported.
+
 int smokeEnumsSimpleenumToFfi(Enums_SimpleEnum value) {
   switch (value) {
   case Enums_SimpleEnum.first:
@@ -29,6 +40,7 @@ int smokeEnumsSimpleenumToFfi(Enums_SimpleEnum value) {
     throw StateError("Invalid enum value $value for Enums_SimpleEnum enum.");
   }
 }
+
 Enums_SimpleEnum smokeEnumsSimpleenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -39,7 +51,9 @@ Enums_SimpleEnum smokeEnumsSimpleenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Enums_SimpleEnum enum.");
   }
 }
+
 void smokeEnumsSimpleenumReleaseFfiHandle(int handle) {}
+
 final _smokeEnumsSimpleenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -52,6 +66,7 @@ final _smokeEnumsSimpleenumGetValueNullable = __lib.catchArgumentError(() => __l
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_SimpleEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumsSimpleenumToFfiNullable(Enums_SimpleEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumsSimpleenumToFfi(value);
@@ -59,6 +74,7 @@ Pointer<Void> smokeEnumsSimpleenumToFfiNullable(Enums_SimpleEnum? value) {
   smokeEnumsSimpleenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Enums_SimpleEnum? smokeEnumsSimpleenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumsSimpleenumGetValueNullable(handle);
@@ -66,14 +82,18 @@ Enums_SimpleEnum? smokeEnumsSimpleenumFromFfiNullable(Pointer<Void> handle) {
   smokeEnumsSimpleenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumsSimpleenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumsSimpleenumReleaseHandleNullable(handle);
+
 // End of Enums_SimpleEnum "private" section.
 enum Enums_InternalErrorCode {
     errorNone,
     errorFatal
 }
+
 // Enums_InternalErrorCode "private" section, not exported.
+
 int smokeEnumsInternalerrorcodeToFfi(Enums_InternalErrorCode value) {
   switch (value) {
   case Enums_InternalErrorCode.errorNone:
@@ -84,6 +104,7 @@ int smokeEnumsInternalerrorcodeToFfi(Enums_InternalErrorCode value) {
     throw StateError("Invalid enum value $value for Enums_InternalErrorCode enum.");
   }
 }
+
 Enums_InternalErrorCode smokeEnumsInternalerrorcodeFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -94,7 +115,9 @@ Enums_InternalErrorCode smokeEnumsInternalerrorcodeFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Enums_InternalErrorCode enum.");
   }
 }
+
 void smokeEnumsInternalerrorcodeReleaseFfiHandle(int handle) {}
+
 final _smokeEnumsInternalerrorcodeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -107,6 +130,7 @@ final _smokeEnumsInternalerrorcodeGetValueNullable = __lib.catchArgumentError(()
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_InternalErrorCode_get_value_nullable'));
+
 Pointer<Void> smokeEnumsInternalerrorcodeToFfiNullable(Enums_InternalErrorCode? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumsInternalerrorcodeToFfi(value);
@@ -114,6 +138,7 @@ Pointer<Void> smokeEnumsInternalerrorcodeToFfiNullable(Enums_InternalErrorCode? 
   smokeEnumsInternalerrorcodeReleaseFfiHandle(_handle);
   return result;
 }
+
 Enums_InternalErrorCode? smokeEnumsInternalerrorcodeFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumsInternalerrorcodeGetValueNullable(handle);
@@ -121,15 +146,23 @@ Enums_InternalErrorCode? smokeEnumsInternalerrorcodeFromFfiNullable(Pointer<Void
   smokeEnumsInternalerrorcodeReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumsInternalerrorcodeReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumsInternalerrorcodeReleaseHandleNullable(handle);
+
 // End of Enums_InternalErrorCode "private" section.
+
 class Enums_ErrorStruct {
   Enums_InternalErrorCode type;
+
   String message;
+
   Enums_ErrorStruct(this.type, this.message);
 }
+
+
 // Enums_ErrorStruct "private" section, not exported.
+
 final _smokeEnumsErrorstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32, Pointer<Void>),
     Pointer<Void> Function(int, Pointer<Void>)
@@ -146,6 +179,9 @@ final _smokeEnumsErrorstructGetFieldmessage = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_get_field_message'));
+
+
+
 Pointer<Void> smokeEnumsErrorstructToFfi(Enums_ErrorStruct value) {
   final _typeHandle = smokeEnumsInternalerrorcodeToFfi(value.type);
   final _messageHandle = stringToFfi(value.message);
@@ -154,12 +190,13 @@ Pointer<Void> smokeEnumsErrorstructToFfi(Enums_ErrorStruct value) {
   stringReleaseFfiHandle(_messageHandle);
   return _result;
 }
+
 Enums_ErrorStruct smokeEnumsErrorstructFromFfi(Pointer<Void> handle) {
   final _typeHandle = _smokeEnumsErrorstructGetFieldtype(handle);
   final _messageHandle = _smokeEnumsErrorstructGetFieldmessage(handle);
   try {
     return Enums_ErrorStruct(
-      smokeEnumsInternalerrorcodeFromFfi(_typeHandle),
+      smokeEnumsInternalerrorcodeFromFfi(_typeHandle), 
       stringFromFfi(_messageHandle)
     );
   } finally {
@@ -167,8 +204,11 @@ Enums_ErrorStruct smokeEnumsErrorstructFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_messageHandle);
   }
 }
+
 void smokeEnumsErrorstructReleaseFfiHandle(Pointer<Void> handle) => _smokeEnumsErrorstructReleaseHandle(handle);
+
 // Nullable Enums_ErrorStruct
+
 final _smokeEnumsErrorstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -181,6 +221,7 @@ final _smokeEnumsErrorstructGetValueNullable = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Enums_ErrorStruct_get_value_nullable'));
+
 Pointer<Void> smokeEnumsErrorstructToFfiNullable(Enums_ErrorStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumsErrorstructToFfi(value);
@@ -188,6 +229,7 @@ Pointer<Void> smokeEnumsErrorstructToFfiNullable(Enums_ErrorStruct? value) {
   smokeEnumsErrorstructReleaseFfiHandle(_handle);
   return result;
 }
+
 Enums_ErrorStruct? smokeEnumsErrorstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumsErrorstructGetValueNullable(handle);
@@ -195,10 +237,14 @@ Enums_ErrorStruct? smokeEnumsErrorstructFromFfiNullable(Pointer<Void> handle) {
   smokeEnumsErrorstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumsErrorstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumsErrorstructReleaseHandleNullable(handle);
+
 // End of Enums_ErrorStruct "private" section.
+
 // Enums "private" section, not exported.
+
 final _smokeEnumsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -211,9 +257,16 @@ final _smokeEnumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_release_handle'));
+
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class Enums$Impl extends __lib.NativeBase implements Enums {
+
   Enums$Impl(Pointer<Void> handle) : super(handle);
 
   Enums_SimpleEnum methodWithEnumeration(Enums_SimpleEnum input) {
@@ -225,8 +278,11 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
       return smokeEnumsSimpleenumFromFfi(__resultHandle);
     } finally {
       smokeEnumsSimpleenumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   Enums_InternalErrorCode flipEnumValue(Enums_InternalErrorCode input) {
     final _flipEnumValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_Enums_flipEnumValue__InternalErrorCode'));
     final _inputHandle = smokeEnumsInternalerrorcodeToFfi(input);
@@ -236,8 +292,11 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
       return smokeEnumsInternalerrorcodeFromFfi(__resultHandle);
     } finally {
       smokeEnumsInternalerrorcodeReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   Enums_InternalErrorCode extractEnumFromStruct(Enums_ErrorStruct input) {
     final _extractEnumFromStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Pointer<Void>), int Function(int, Pointer<Void>)>('library_smoke_Enums_extractEnumFromStruct__ErrorStruct'));
     final _inputHandle = smokeEnumsErrorstructToFfi(input);
@@ -247,8 +306,11 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
       return smokeEnumsInternalerrorcodeFromFfi(__resultHandle);
     } finally {
       smokeEnumsInternalerrorcodeReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   Enums_ErrorStruct createStructWithEnumInside(Enums_InternalErrorCode type, String message) {
     final _createStructWithEnumInsideFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint32, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Enums_createStructWithEnumInside__InternalErrorCode_String'));
     final _typeHandle = smokeEnumsInternalerrorcodeToFfi(type);
@@ -260,27 +322,41 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
       return smokeEnumsErrorstructFromFfi(__resultHandle);
     } finally {
       smokeEnumsErrorstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeEnumsToFfi(Enums value) =>
   _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
+
 Enums smokeEnumsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Enums) return instance;
+
   final _copiedHandle = _smokeEnumsCopyHandle(handle);
   final result = Enums$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeEnumsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEnumsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEnumsReleaseHandle(handle);
+
 Pointer<Void> smokeEnumsToFfiNullable(Enums? value) =>
   value != null ? smokeEnumsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Enums? smokeEnumsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEnumsFromFfi(handle) : null;
+
 void smokeEnumsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumsReleaseHandle(handle);
+
 // End of Enums "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable_interface.dart
@@ -1,13 +1,19 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class EquatableInterface {
+
+abstract class EquatableInterface implements Finalizable {
 
 }
+
+
 // EquatableInterface "private" section, not exported.
+
 final _smokeEquatableinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -31,7 +37,10 @@ final __areEqual = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EquatableInterface_get_type_id'));
+
+
 class EquatableInterface$Impl extends __lib.NativeBase implements EquatableInterface {
+
   EquatableInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -40,23 +49,32 @@ class EquatableInterface$Impl extends __lib.NativeBase implements EquatableInter
     if (other is! EquatableInterface$Impl) return false;
     return __areEqual(this.handle, other.handle) != 0;
   }
+
 }
+
+
+
 Pointer<Void> smokeEquatableinterfaceToFfi(EquatableInterface value) {
   if (value is __lib.NativeBase) return _smokeEquatableinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeEquatableinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value
   );
+
   return result;
 }
+
 EquatableInterface smokeEquatableinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EquatableInterface) return instance;
+
   final _typeIdHandle = _smokeEquatableinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeEquatableinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -65,12 +83,19 @@ EquatableInterface smokeEquatableinterfaceFromFfi(Pointer<Void> handle) {
   _smokeEquatableinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEquatableinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEquatableinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeEquatableinterfaceToFfiNullable(EquatableInterface? value) =>
   value != null ? smokeEquatableinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 EquatableInterface? smokeEquatableinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEquatableinterfaceFromFfi(handle) : null;
+
 void smokeEquatableinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEquatableinterfaceReleaseHandle(handle);
+
 // End of EquatableInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,21 +8,32 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'package:meta/meta.dart';
-abstract class Errors {
+
+abstract class Errors implements Finalizable {
+
+
   static void methodWithErrors() => $prototype.methodWithErrors();
+
   static void methodWithExternalErrors() => $prototype.methodWithExternalErrors();
+
   static String methodWithErrorsAndReturnValue() => $prototype.methodWithErrorsAndReturnValue();
+
   static void methodWithPayloadError() => $prototype.methodWithPayloadError();
+
   static String methodWithPayloadErrorAndReturnValue() => $prototype.methodWithPayloadErrorAndReturnValue();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Errors$Impl(Pointer<Void>.fromAddress(0));
 }
+
 enum Errors_InternalErrorCode {
     errorNone,
     errorFatal
 }
+
 // Errors_InternalErrorCode "private" section, not exported.
+
 int smokeErrorsInternalerrorcodeToFfi(Errors_InternalErrorCode value) {
   switch (value) {
   case Errors_InternalErrorCode.errorNone:
@@ -31,6 +44,7 @@ int smokeErrorsInternalerrorcodeToFfi(Errors_InternalErrorCode value) {
     throw StateError("Invalid enum value $value for Errors_InternalErrorCode enum.");
   }
 }
+
 Errors_InternalErrorCode smokeErrorsInternalerrorcodeFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -41,7 +55,9 @@ Errors_InternalErrorCode smokeErrorsInternalerrorcodeFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Errors_InternalErrorCode enum.");
   }
 }
+
 void smokeErrorsInternalerrorcodeReleaseFfiHandle(int handle) {}
+
 final _smokeErrorsInternalerrorcodeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -54,6 +70,7 @@ final _smokeErrorsInternalerrorcodeGetValueNullable = __lib.catchArgumentError((
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_InternalErrorCode_get_value_nullable'));
+
 Pointer<Void> smokeErrorsInternalerrorcodeToFfiNullable(Errors_InternalErrorCode? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeErrorsInternalerrorcodeToFfi(value);
@@ -61,6 +78,7 @@ Pointer<Void> smokeErrorsInternalerrorcodeToFfiNullable(Errors_InternalErrorCode
   smokeErrorsInternalerrorcodeReleaseFfiHandle(_handle);
   return result;
 }
+
 Errors_InternalErrorCode? smokeErrorsInternalerrorcodeFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeErrorsInternalerrorcodeGetValueNullable(handle);
@@ -68,15 +86,19 @@ Errors_InternalErrorCode? smokeErrorsInternalerrorcodeFromFfiNullable(Pointer<Vo
   smokeErrorsInternalerrorcodeReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeErrorsInternalerrorcodeReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeErrorsInternalerrorcodeReleaseHandleNullable(handle);
+
 // End of Errors_InternalErrorCode "private" section.
 enum Errors_ExternalErrors {
     none,
     boom,
     bust
 }
+
 // Errors_ExternalErrors "private" section, not exported.
+
 int smokeErrorsExternalerrorsToFfi(Errors_ExternalErrors value) {
   switch (value) {
   case Errors_ExternalErrors.none:
@@ -89,6 +111,7 @@ int smokeErrorsExternalerrorsToFfi(Errors_ExternalErrors value) {
     throw StateError("Invalid enum value $value for Errors_ExternalErrors enum.");
   }
 }
+
 Errors_ExternalErrors smokeErrorsExternalerrorsFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -101,7 +124,9 @@ Errors_ExternalErrors smokeErrorsExternalerrorsFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Errors_ExternalErrors enum.");
   }
 }
+
 void smokeErrorsExternalerrorsReleaseFfiHandle(int handle) {}
+
 final _smokeErrorsExternalerrorsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -114,6 +139,7 @@ final _smokeErrorsExternalerrorsGetValueNullable = __lib.catchArgumentError(() =
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_ExternalErrors_get_value_nullable'));
+
 Pointer<Void> smokeErrorsExternalerrorsToFfiNullable(Errors_ExternalErrors? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeErrorsExternalerrorsToFfi(value);
@@ -121,6 +147,7 @@ Pointer<Void> smokeErrorsExternalerrorsToFfiNullable(Errors_ExternalErrors? valu
   smokeErrorsExternalerrorsReleaseFfiHandle(_handle);
   return result;
 }
+
 Errors_ExternalErrors? smokeErrorsExternalerrorsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeErrorsExternalerrorsGetValueNullable(handle);
@@ -128,8 +155,10 @@ Errors_ExternalErrors? smokeErrorsExternalerrorsFromFfiNullable(Pointer<Void> ha
   smokeErrorsExternalerrorsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeErrorsExternalerrorsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeErrorsExternalerrorsReleaseHandleNullable(handle);
+
 // End of Errors_ExternalErrors "private" section.
 class Errors_InternalException implements Exception {
   final Errors_InternalErrorCode error;
@@ -139,7 +168,9 @@ class Errors_ExternalException implements Exception {
   final Errors_ExternalErrors error;
   Errors_ExternalException(this.error);
 }
+
 // Errors "private" section, not exported.
+
 final _smokeErrorsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -152,6 +183,8 @@ final _smokeErrorsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Errors_release_handle'));
+
+
 final _methodWithErrorssmokeErrorsMethodwitherrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -164,6 +197,8 @@ final _methodWithErrorssmokeErrorsMethodwitherrorsReturnHasError = __lib.catchAr
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrors_return_has_error'));
+
+
 final _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -176,6 +211,8 @@ final _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnHasError
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithExternalErrors_return_has_error'));
+
+
 final _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -192,6 +229,8 @@ final _methodWithErrorsAndReturnValuesmokeErrorsMethodwitherrorsandreturnvalueRe
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithErrorsAndReturnValue_return_has_error'));
+
+
 final _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -204,6 +243,8 @@ final _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnHasError = _
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadError_return_has_error'));
+
+
 final _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -220,10 +261,14 @@ final _methodWithPayloadErrorAndReturnValuesmokeErrorsMethodwithpayloaderrorandr
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Errors_methodWithPayloadErrorAndReturnValue_return_has_error'));
+
+
 /// @nodoc
 @visibleForTesting
 class Errors$Impl extends __lib.NativeBase implements Errors {
+
   Errors$Impl(Pointer<Void> handle) : super(handle);
+
   void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrors'));
     final __callResultHandle = _methodWithErrorsFfi(__lib.LibraryContext.isolateId);
@@ -237,7 +282,9 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
         }
     }
     _methodWithErrorssmokeErrorsMethodwitherrorsReturnReleaseHandle(__callResultHandle);
+
   }
+
   void methodWithExternalErrors() {
     final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithExternalErrors'));
     final __callResultHandle = _methodWithExternalErrorsFfi(__lib.LibraryContext.isolateId);
@@ -251,7 +298,9 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
         }
     }
     _methodWithExternalErrorssmokeErrorsMethodwithexternalerrorsReturnReleaseHandle(__callResultHandle);
+
   }
+
   String methodWithErrorsAndReturnValue() {
     final _methodWithErrorsAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithErrorsAndReturnValue'));
     final __callResultHandle = _methodWithErrorsAndReturnValueFfi(__lib.LibraryContext.isolateId);
@@ -270,8 +319,11 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   void methodWithPayloadError() {
     final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadError'));
     final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
@@ -285,7 +337,9 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
         }
     }
     _methodWithPayloadErrorsmokeErrorsMethodwithpayloaderrorReturnReleaseHandle(__callResultHandle);
+
   }
+
   String methodWithPayloadErrorAndReturnValue() {
     final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Errors_methodWithPayloadErrorAndReturnValue'));
     final __callResultHandle = _methodWithPayloadErrorAndReturnValueFfi(__lib.LibraryContext.isolateId);
@@ -304,27 +358,41 @@ class Errors$Impl extends __lib.NativeBase implements Errors {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeErrorsToFfi(Errors value) =>
   _smokeErrorsCopyHandle((value as __lib.NativeBase).handle);
+
 Errors smokeErrorsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Errors) return instance;
+
   final _copiedHandle = _smokeErrorsCopyHandle(handle);
   final result = Errors$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeErrorsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeErrorsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeErrorsReleaseHandle(handle);
+
 Pointer<Void> smokeErrorsToFfiNullable(Errors? value) =>
   value != null ? smokeErrorsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Errors? smokeErrorsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeErrorsFromFfi(handle) : null;
+
 void smokeErrorsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeErrorsReleaseHandle(handle);
+
 // End of Errors "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -7,30 +9,44 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/payload.dart';
 import 'package:library/src/smoke/with_payload_exception.dart';
 import 'package:meta/meta.dart';
-abstract class ErrorsInterface {
+
+abstract class ErrorsInterface implements Finalizable {
+
   factory ErrorsInterface(
     void Function() methodWithErrorsLambda,
     void Function() methodWithExternalErrorsLambda,
     String Function() methodWithErrorsAndReturnValueLambda,
+
   ) => ErrorsInterface$Lambdas(
     methodWithErrorsLambda,
     methodWithExternalErrorsLambda,
     methodWithErrorsAndReturnValueLambda,
+
   );
+
+
   void methodWithErrors();
+
   void methodWithExternalErrors();
+
   String methodWithErrorsAndReturnValue();
+
   static void methodWithPayloadError() => $prototype.methodWithPayloadError();
+
   static String methodWithPayloadErrorAndReturnValue() => $prototype.methodWithPayloadErrorAndReturnValue();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = ErrorsInterface$Impl(Pointer<Void>.fromAddress(0));
 }
+
 enum ErrorsInterface_InternalError {
     errorNone,
     errorFatal
 }
+
 // ErrorsInterface_InternalError "private" section, not exported.
+
 int smokeErrorsinterfaceInternalerrorToFfi(ErrorsInterface_InternalError value) {
   switch (value) {
   case ErrorsInterface_InternalError.errorNone:
@@ -41,6 +57,7 @@ int smokeErrorsinterfaceInternalerrorToFfi(ErrorsInterface_InternalError value) 
     throw StateError("Invalid enum value $value for ErrorsInterface_InternalError enum.");
   }
 }
+
 ErrorsInterface_InternalError smokeErrorsinterfaceInternalerrorFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -51,7 +68,9 @@ ErrorsInterface_InternalError smokeErrorsinterfaceInternalerrorFromFfi(int handl
     throw StateError("Invalid numeric value $handle for ErrorsInterface_InternalError enum.");
   }
 }
+
 void smokeErrorsinterfaceInternalerrorReleaseFfiHandle(int handle) {}
+
 final _smokeErrorsinterfaceInternalerrorCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -64,6 +83,7 @@ final _smokeErrorsinterfaceInternalerrorGetValueNullable = __lib.catchArgumentEr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_InternalError_get_value_nullable'));
+
 Pointer<Void> smokeErrorsinterfaceInternalerrorToFfiNullable(ErrorsInterface_InternalError? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeErrorsinterfaceInternalerrorToFfi(value);
@@ -71,6 +91,7 @@ Pointer<Void> smokeErrorsinterfaceInternalerrorToFfiNullable(ErrorsInterface_Int
   smokeErrorsinterfaceInternalerrorReleaseFfiHandle(_handle);
   return result;
 }
+
 ErrorsInterface_InternalError? smokeErrorsinterfaceInternalerrorFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeErrorsinterfaceInternalerrorGetValueNullable(handle);
@@ -78,15 +99,19 @@ ErrorsInterface_InternalError? smokeErrorsinterfaceInternalerrorFromFfiNullable(
   smokeErrorsinterfaceInternalerrorReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeErrorsinterfaceInternalerrorReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeErrorsinterfaceInternalerrorReleaseHandleNullable(handle);
+
 // End of ErrorsInterface_InternalError "private" section.
 enum ErrorsInterface_ExternalErrors {
     none,
     boom,
     bust
 }
+
 // ErrorsInterface_ExternalErrors "private" section, not exported.
+
 int smokeErrorsinterfaceExternalerrorsToFfi(ErrorsInterface_ExternalErrors value) {
   switch (value) {
   case ErrorsInterface_ExternalErrors.none:
@@ -99,6 +124,7 @@ int smokeErrorsinterfaceExternalerrorsToFfi(ErrorsInterface_ExternalErrors value
     throw StateError("Invalid enum value $value for ErrorsInterface_ExternalErrors enum.");
   }
 }
+
 ErrorsInterface_ExternalErrors smokeErrorsinterfaceExternalerrorsFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -111,7 +137,9 @@ ErrorsInterface_ExternalErrors smokeErrorsinterfaceExternalerrorsFromFfi(int han
     throw StateError("Invalid numeric value $handle for ErrorsInterface_ExternalErrors enum.");
   }
 }
+
 void smokeErrorsinterfaceExternalerrorsReleaseFfiHandle(int handle) {}
+
 final _smokeErrorsinterfaceExternalerrorsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -124,6 +152,7 @@ final _smokeErrorsinterfaceExternalerrorsGetValueNullable = __lib.catchArgumentE
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_ExternalErrors_get_value_nullable'));
+
 Pointer<Void> smokeErrorsinterfaceExternalerrorsToFfiNullable(ErrorsInterface_ExternalErrors? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeErrorsinterfaceExternalerrorsToFfi(value);
@@ -131,6 +160,7 @@ Pointer<Void> smokeErrorsinterfaceExternalerrorsToFfiNullable(ErrorsInterface_Ex
   smokeErrorsinterfaceExternalerrorsReleaseFfiHandle(_handle);
   return result;
 }
+
 ErrorsInterface_ExternalErrors? smokeErrorsinterfaceExternalerrorsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeErrorsinterfaceExternalerrorsGetValueNullable(handle);
@@ -138,8 +168,10 @@ ErrorsInterface_ExternalErrors? smokeErrorsinterfaceExternalerrorsFromFfiNullabl
   smokeErrorsinterfaceExternalerrorsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeErrorsinterfaceExternalerrorsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeErrorsinterfaceExternalerrorsReleaseHandleNullable(handle);
+
 // End of ErrorsInterface_ExternalErrors "private" section.
 class ErrorsInterface_InternalException implements Exception {
   final ErrorsInterface_InternalError error;
@@ -149,7 +181,9 @@ class ErrorsInterface_ExternalException implements Exception {
   final ErrorsInterface_ExternalErrors error;
   ErrorsInterface_ExternalException(this.error);
 }
+
 // ErrorsInterface "private" section, not exported.
+
 final _smokeErrorsinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -170,6 +204,7 @@ final _smokeErrorsinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_get_type_id'));
+
 final _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -182,6 +217,8 @@ final _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnHasError = __li
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrors_return_has_error'));
+
+
 final _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -194,6 +231,8 @@ final _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsRetur
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithExternalErrors_return_has_error'));
+
+
 final _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -210,6 +249,8 @@ final _methodWithErrorsAndReturnValuesmokeErrorsinterfaceMethodwitherrorsandretu
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue_return_has_error'));
+
+
 final _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -222,6 +263,8 @@ final _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnHas
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadError_return_has_error'));
+
+
 final _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayloaderrorandreturnvalueReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -238,15 +281,20 @@ final _methodWithPayloadErrorAndReturnValuesmokeErrorsinterfaceMethodwithpayload
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue_return_has_error'));
+
+
 class ErrorsInterface$Lambdas implements ErrorsInterface {
   void Function() methodWithErrorsLambda;
   void Function() methodWithExternalErrorsLambda;
   String Function() methodWithErrorsAndReturnValueLambda;
+
   ErrorsInterface$Lambdas(
     this.methodWithErrorsLambda,
     this.methodWithExternalErrorsLambda,
     this.methodWithErrorsAndReturnValueLambda,
+
   );
+
   @override
   void methodWithErrors() =>
     methodWithErrorsLambda();
@@ -257,10 +305,13 @@ class ErrorsInterface$Lambdas implements ErrorsInterface {
   String methodWithErrorsAndReturnValue() =>
     methodWithErrorsAndReturnValueLambda();
 }
+
 /// @nodoc
 @visibleForTesting
 class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
+
   ErrorsInterface$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void methodWithErrors() {
     final _methodWithErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrors'));
@@ -276,7 +327,9 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
         }
     }
     _methodWithErrorssmokeErrorsinterfaceMethodwitherrorsReturnReleaseHandle(__callResultHandle);
+
   }
+
   @override
   void methodWithExternalErrors() {
     final _methodWithExternalErrorsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithExternalErrors'));
@@ -292,7 +345,9 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
         }
     }
     _methodWithExternalErrorssmokeErrorsinterfaceMethodwithexternalerrorsReturnReleaseHandle(__callResultHandle);
+
   }
+
   @override
   String methodWithErrorsAndReturnValue() {
     final _methodWithErrorsAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ErrorsInterface_methodWithErrorsAndReturnValue'));
@@ -313,8 +368,11 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   void methodWithPayloadError() {
     final _methodWithPayloadErrorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadError'));
     final __callResultHandle = _methodWithPayloadErrorFfi(__lib.LibraryContext.isolateId);
@@ -328,7 +386,9 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
         }
     }
     _methodWithPayloadErrorsmokeErrorsinterfaceMethodwithpayloaderrorReturnReleaseHandle(__callResultHandle);
+
   }
+
   String methodWithPayloadErrorAndReturnValue() {
     final _methodWithPayloadErrorAndReturnValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ErrorsInterface_methodWithPayloadErrorAndReturnValue'));
     final __callResultHandle = _methodWithPayloadErrorAndReturnValueFfi(__lib.LibraryContext.isolateId);
@@ -347,11 +407,17 @@ class ErrorsInterface$Impl extends __lib.NativeBase implements ErrorsInterface {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeErrorsinterfacemethodWithErrorsStatic(Object _obj, Pointer<Uint32> _error) {
   bool _errorFlag = false;
+
   try {
     (_obj as ErrorsInterface).methodWithErrors();
   } on ErrorsInterface_InternalException catch(e) {
@@ -364,6 +430,7 @@ int _smokeErrorsinterfacemethodWithErrorsStatic(Object _obj, Pointer<Uint32> _er
 }
 int _smokeErrorsinterfacemethodWithExternalErrorsStatic(Object _obj, Pointer<Uint32> _error) {
   bool _errorFlag = false;
+
   try {
     (_obj as ErrorsInterface).methodWithExternalErrors();
   } on ErrorsInterface_ExternalException catch(e) {
@@ -388,8 +455,11 @@ int _smokeErrorsinterfacemethodWithErrorsAndReturnValueStatic(Object _obj, Point
   }
   return _errorFlag ? 1 : 0;
 }
+
+
 Pointer<Void> smokeErrorsinterfaceToFfi(ErrorsInterface value) {
   if (value is __lib.NativeBase) return _smokeErrorsinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeErrorsinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -398,15 +468,19 @@ Pointer<Void> smokeErrorsinterfaceToFfi(ErrorsInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Uint32>)>(_smokeErrorsinterfacemethodWithExternalErrorsStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>, Pointer<Uint32>)>(_smokeErrorsinterfacemethodWithErrorsAndReturnValueStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 ErrorsInterface smokeErrorsinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ErrorsInterface) return instance;
+
   final _typeIdHandle = _smokeErrorsinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeErrorsinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -415,12 +489,19 @@ ErrorsInterface smokeErrorsinterfaceFromFfi(Pointer<Void> handle) {
   _smokeErrorsinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeErrorsinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeErrorsinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeErrorsinterfaceToFfiNullable(ErrorsInterface? value) =>
   value != null ? smokeErrorsinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ErrorsInterface? smokeErrorsinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeErrorsinterfaceFromFfi(handle) : null;
+
 void smokeErrorsinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeErrorsinterfaceReleaseHandle(handle);
+
 // End of ErrorsInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/class.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -8,16 +10,25 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/package/interface.dart';
 import 'package:library/src/package/types.dart';
 import 'package:meta/meta.dart';
-abstract class Class implements Interface {
+
+abstract class Class implements Interface, Finalizable {
+
   factory Class() => $prototype.constructor();
+
+
   Types_Struct fun(List<Types_Struct> double);
   Types_Enum get property;
   set property(Types_Enum value);
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Class$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // Class "private" section, not exported.
+
 final _packageClassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -34,6 +45,9 @@ final _packageClassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrar
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Class_get_type_id'));
+
+
+
 final _funpackageClassFunListofPackageTypesStructReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -50,22 +64,31 @@ final _funpackageClassFunListofPackageTypesStructReturnHasError = __lib.catchArg
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Class_fun__ListOf_package_Types_Struct_return_has_error'));
+
+
 /// @nodoc
 @visibleForTesting
 class Class$Impl extends __lib.NativeBase implements Class {
+
   Class$Impl(Pointer<Void> handle) : super(handle);
+
+
   Class constructor() {
     final _result_handle = _constructor();
     final _result = Class$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _packageClassRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _constructor() {
     final _constructorFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_package_Class_constructor'));
     final __resultHandle = _constructorFfi(__lib.LibraryContext.isolateId);
     return __resultHandle;
   }
+
   @override
   Types_Struct fun(List<Types_Struct> double) {
     final _funFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_package_Class_fun__ListOf_package_Types_Struct'));
@@ -88,8 +111,11 @@ class Class$Impl extends __lib.NativeBase implements Class {
       return packageTypesStructFromFfi(__resultHandle);
     } finally {
       packageTypesStructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Types_Enum get property {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_package_Class_property_get'));
@@ -99,8 +125,11 @@ class Class$Impl extends __lib.NativeBase implements Class {
       return packageTypesEnumFromFfi(__resultHandle);
     } finally {
       packageTypesEnumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set property(Types_Enum value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_package_Class_property_set__enum'));
@@ -108,17 +137,25 @@ class Class$Impl extends __lib.NativeBase implements Class {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     packageTypesEnumReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> packageClassToFfi(Class value) =>
   _packageClassCopyHandle((value as __lib.NativeBase).handle);
+
 Class packageClassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Class) return instance;
+
   final _typeIdHandle = _packageClassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _packageClassCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -127,12 +164,19 @@ Class packageClassFromFfi(Pointer<Void> handle) {
   _packageClassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void packageClassReleaseFfiHandle(Pointer<Void> handle) =>
   _packageClassReleaseHandle(handle);
+
 Pointer<Void> packageClassToFfiNullable(Class? value) =>
   value != null ? packageClassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Class? packageClassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? packageClassFromFfi(handle) : null;
+
 void packageClassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _packageClassReleaseHandle(handle);
+
 // End of Class "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/interface.dart
@@ -1,13 +1,19 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class Interface {
+
+abstract class Interface implements Finalizable {
 
 }
+
+
 // Interface "private" section, not exported.
+
 final _packageInterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -28,26 +34,38 @@ final _packageInterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativeLi
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Interface_get_type_id'));
+
+
 class Interface$Impl extends __lib.NativeBase implements Interface {
+
   Interface$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
+
+
 Pointer<Void> packageInterfaceToFfi(Interface value) {
   if (value is __lib.NativeBase) return _packageInterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _packageInterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value
   );
+
   return result;
 }
+
 Interface packageInterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Interface) return instance;
+
   final _typeIdHandle = _packageInterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _packageInterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -56,12 +74,19 @@ Interface packageInterfaceFromFfi(Pointer<Void> handle) {
   _packageInterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void packageInterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _packageInterfaceReleaseHandle(handle);
+
 Pointer<Void> packageInterfaceToFfiNullable(Interface? value) =>
   value != null ? packageInterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Interface? packageInterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? packageInterfaceFromFfi(handle) : null;
+
 void packageInterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _packageInterfaceReleaseHandle(handle);
+
 // End of Interface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -1,20 +1,28 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
-abstract class Enums {
+
+abstract class Enums implements Finalizable {
+
 
   static void methodWithExternalEnum(Enums_ExternalEnum input) => $prototype.methodWithExternalEnum(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Enums$Impl(Pointer<Void>.fromAddress(0));
 }
+
 enum Enums_ExternalEnum {
     fooValue,
     barValue
 }
+
 // Enums_ExternalEnum "private" section, not exported.
+
 int smokeEnumsExternalenumToFfi(Enums_ExternalEnum value) {
   switch (value) {
   case Enums_ExternalEnum.fooValue:
@@ -25,6 +33,7 @@ int smokeEnumsExternalenumToFfi(Enums_ExternalEnum value) {
     throw StateError("Invalid enum value $value for Enums_ExternalEnum enum.");
   }
 }
+
 Enums_ExternalEnum smokeEnumsExternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -35,7 +44,9 @@ Enums_ExternalEnum smokeEnumsExternalenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Enums_ExternalEnum enum.");
   }
 }
+
 void smokeEnumsExternalenumReleaseFfiHandle(int handle) {}
+
 final _smokeEnumsExternalenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -48,6 +59,7 @@ final _smokeEnumsExternalenumGetValueNullable = __lib.catchArgumentError(() => _
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_ExternalEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumsExternalenumToFfiNullable(Enums_ExternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumsExternalenumToFfi(value);
@@ -55,6 +67,7 @@ Pointer<Void> smokeEnumsExternalenumToFfiNullable(Enums_ExternalEnum? value) {
   smokeEnumsExternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Enums_ExternalEnum? smokeEnumsExternalenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumsExternalenumGetValueNullable(handle);
@@ -62,14 +75,18 @@ Enums_ExternalEnum? smokeEnumsExternalenumFromFfiNullable(Pointer<Void> handle) 
   smokeEnumsExternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumsExternalenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumsExternalenumReleaseHandleNullable(handle);
+
 // End of Enums_ExternalEnum "private" section.
 enum Enums_VeryExternalEnum {
     foo,
     bar
 }
+
 // Enums_VeryExternalEnum "private" section, not exported.
+
 int smokeEnumsVeryexternalenumToFfi(Enums_VeryExternalEnum value) {
   switch (value) {
   case Enums_VeryExternalEnum.foo:
@@ -80,6 +97,7 @@ int smokeEnumsVeryexternalenumToFfi(Enums_VeryExternalEnum value) {
     throw StateError("Invalid enum value $value for Enums_VeryExternalEnum enum.");
   }
 }
+
 Enums_VeryExternalEnum smokeEnumsVeryexternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -90,7 +108,9 @@ Enums_VeryExternalEnum smokeEnumsVeryexternalenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Enums_VeryExternalEnum enum.");
   }
 }
+
 void smokeEnumsVeryexternalenumReleaseFfiHandle(int handle) {}
+
 final _smokeEnumsVeryexternalenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -103,6 +123,7 @@ final _smokeEnumsVeryexternalenumGetValueNullable = __lib.catchArgumentError(() 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Enums_VeryExternalEnum_get_value_nullable'));
+
 Pointer<Void> smokeEnumsVeryexternalenumToFfiNullable(Enums_VeryExternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumsVeryexternalenumToFfi(value);
@@ -110,6 +131,7 @@ Pointer<Void> smokeEnumsVeryexternalenumToFfiNullable(Enums_VeryExternalEnum? va
   smokeEnumsVeryexternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Enums_VeryExternalEnum? smokeEnumsVeryexternalenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumsVeryexternalenumGetValueNullable(handle);
@@ -117,10 +139,14 @@ Enums_VeryExternalEnum? smokeEnumsVeryexternalenumFromFfiNullable(Pointer<Void> 
   smokeEnumsVeryexternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumsVeryexternalenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumsVeryexternalenumReleaseHandleNullable(handle);
+
 // End of Enums_VeryExternalEnum "private" section.
+
 // Enums "private" section, not exported.
+
 final _smokeEnumsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -133,9 +159,13 @@ final _smokeEnumsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Enums_release_handle'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class Enums$Impl extends __lib.NativeBase implements Enums {
+
   Enums$Impl(Pointer<Void> handle) : super(handle);
 
   void methodWithExternalEnum(Enums_ExternalEnum input) {
@@ -143,26 +173,39 @@ class Enums$Impl extends __lib.NativeBase implements Enums {
     final _inputHandle = smokeEnumsExternalenumToFfi(input);
     _methodWithExternalEnumFfi(__lib.LibraryContext.isolateId, _inputHandle);
     smokeEnumsExternalenumReleaseFfiHandle(_inputHandle);
+
   }
+
+
 }
+
 Pointer<Void> smokeEnumsToFfi(Enums value) =>
   _smokeEnumsCopyHandle((value as __lib.NativeBase).handle);
+
 Enums smokeEnumsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Enums) return instance;
+
   final _copiedHandle = _smokeEnumsCopyHandle(handle);
   final result = Enums$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeEnumsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEnumsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEnumsReleaseHandle(handle);
+
 Pointer<Void> smokeEnumsToFfiNullable(Enums? value) =>
   value != null ? smokeEnumsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Enums? smokeEnumsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEnumsFromFfi(handle) : null;
+
 void smokeEnumsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumsReleaseHandle(handle);
+
 // End of Enums "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -1,17 +1,25 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class ExternalClass {
+
+abstract class ExternalClass implements Finalizable {
+
 
   void someMethod(int someParameter);
   String get someProperty;
+
 }
+
 enum ExternalClass_SomeEnum {
     someValue
 }
+
 // ExternalClass_SomeEnum "private" section, not exported.
+
 int smokeExternalclassSomeenumToFfi(ExternalClass_SomeEnum value) {
   switch (value) {
   case ExternalClass_SomeEnum.someValue:
@@ -20,6 +28,7 @@ int smokeExternalclassSomeenumToFfi(ExternalClass_SomeEnum value) {
     throw StateError("Invalid enum value $value for ExternalClass_SomeEnum enum.");
   }
 }
+
 ExternalClass_SomeEnum smokeExternalclassSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -28,7 +37,9 @@ ExternalClass_SomeEnum smokeExternalclassSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for ExternalClass_SomeEnum enum.");
   }
 }
+
 void smokeExternalclassSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeExternalclassSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -41,6 +52,7 @@ final _smokeExternalclassSomeenumGetValueNullable = __lib.catchArgumentError(() 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeExternalclassSomeenumToFfiNullable(ExternalClass_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExternalclassSomeenumToFfi(value);
@@ -48,6 +60,7 @@ Pointer<Void> smokeExternalclassSomeenumToFfiNullable(ExternalClass_SomeEnum? va
   smokeExternalclassSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ExternalClass_SomeEnum? smokeExternalclassSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExternalclassSomeenumGetValueNullable(handle);
@@ -55,14 +68,21 @@ ExternalClass_SomeEnum? smokeExternalclassSomeenumFromFfiNullable(Pointer<Void> 
   smokeExternalclassSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExternalclassSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalclassSomeenumReleaseHandleNullable(handle);
+
 // End of ExternalClass_SomeEnum "private" section.
+
 class ExternalClass_SomeStruct {
   String someField;
+
   ExternalClass_SomeStruct(this.someField);
 }
+
+
 // ExternalClass_SomeStruct "private" section, not exported.
+
 final _smokeExternalclassSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -75,12 +95,16 @@ final _smokeExternalclassSomestructGetFieldsomeField = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeExternalclassSomestructToFfi(ExternalClass_SomeStruct value) {
   final _someFieldHandle = stringToFfi(value.someField);
   final _result = _smokeExternalclassSomestructCreateHandle(_someFieldHandle);
   stringReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 ExternalClass_SomeStruct smokeExternalclassSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeExternalclassSomestructGetFieldsomeField(handle);
   try {
@@ -91,8 +115,11 @@ ExternalClass_SomeStruct smokeExternalclassSomestructFromFfi(Pointer<Void> handl
     stringReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeExternalclassSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeExternalclassSomestructReleaseHandle(handle);
+
 // Nullable ExternalClass_SomeStruct
+
 final _smokeExternalclassSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -105,6 +132,7 @@ final _smokeExternalclassSomestructGetValueNullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeExternalclassSomestructToFfiNullable(ExternalClass_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExternalclassSomestructToFfi(value);
@@ -112,6 +140,7 @@ Pointer<Void> smokeExternalclassSomestructToFfiNullable(ExternalClass_SomeStruct
   smokeExternalclassSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 ExternalClass_SomeStruct? smokeExternalclassSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExternalclassSomestructGetValueNullable(handle);
@@ -119,10 +148,14 @@ ExternalClass_SomeStruct? smokeExternalclassSomestructFromFfiNullable(Pointer<Vo
   smokeExternalclassSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExternalclassSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalclassSomestructReleaseHandleNullable(handle);
+
 // End of ExternalClass_SomeStruct "private" section.
+
 // ExternalClass "private" section, not exported.
+
 final _smokeExternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -135,7 +168,11 @@ final _smokeExternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_release_handle'));
+
+
+
 class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
+
   ExternalClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -144,7 +181,10 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;
     _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
+
+
   }
+
   @override
   String get someProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalClass_someProperty_get'));
@@ -154,27 +194,42 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
+
 }
+
 Pointer<Void> smokeExternalclassToFfi(ExternalClass value) =>
   _smokeExternalclassCopyHandle((value as __lib.NativeBase).handle);
+
 ExternalClass smokeExternalclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExternalClass) return instance;
+
   final _copiedHandle = _smokeExternalclassCopyHandle(handle);
   final result = ExternalClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeExternalclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExternalclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExternalclassReleaseHandle(handle);
+
 Pointer<Void> smokeExternalclassToFfiNullable(ExternalClass? value) =>
   value != null ? smokeExternalclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExternalClass? smokeExternalclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExternalclassFromFfi(handle) : null;
+
 void smokeExternalclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalclassReleaseHandle(handle);
+
 // End of ExternalClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -1,10 +1,14 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class ExternalInterface {
+
+abstract class ExternalInterface implements Finalizable {
+
   factory ExternalInterface(
     void Function(int) someMethodLambda,
     String Function() somePropertyGetLambda
@@ -13,13 +17,18 @@ abstract class ExternalInterface {
     somePropertyGetLambda
   );
 
+
   void someMethod(int someParameter);
   String get someProperty;
+
 }
+
 enum ExternalInterface_SomeEnum {
     someValue
 }
+
 // ExternalInterface_SomeEnum "private" section, not exported.
+
 int smokeExternalinterfaceSomeenumToFfi(ExternalInterface_SomeEnum value) {
   switch (value) {
   case ExternalInterface_SomeEnum.someValue:
@@ -28,6 +37,7 @@ int smokeExternalinterfaceSomeenumToFfi(ExternalInterface_SomeEnum value) {
     throw StateError("Invalid enum value $value for ExternalInterface_SomeEnum enum.");
   }
 }
+
 ExternalInterface_SomeEnum smokeExternalinterfaceSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -36,7 +46,9 @@ ExternalInterface_SomeEnum smokeExternalinterfaceSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for ExternalInterface_SomeEnum enum.");
   }
 }
+
 void smokeExternalinterfaceSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeExternalinterfaceSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -49,6 +61,7 @@ final _smokeExternalinterfaceSomeenumGetValueNullable = __lib.catchArgumentError
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeExternalinterfaceSomeenumToFfiNullable(ExternalInterface_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExternalinterfaceSomeenumToFfi(value);
@@ -56,6 +69,7 @@ Pointer<Void> smokeExternalinterfaceSomeenumToFfiNullable(ExternalInterface_Some
   smokeExternalinterfaceSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ExternalInterface_SomeEnum? smokeExternalinterfaceSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExternalinterfaceSomeenumGetValueNullable(handle);
@@ -63,14 +77,21 @@ ExternalInterface_SomeEnum? smokeExternalinterfaceSomeenumFromFfiNullable(Pointe
   smokeExternalinterfaceSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExternalinterfaceSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalinterfaceSomeenumReleaseHandleNullable(handle);
+
 // End of ExternalInterface_SomeEnum "private" section.
+
 class ExternalInterface_SomeStruct {
   String someField;
+
   ExternalInterface_SomeStruct(this.someField);
 }
+
+
 // ExternalInterface_SomeStruct "private" section, not exported.
+
 final _smokeExternalinterfaceSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -83,12 +104,16 @@ final _smokeExternalinterfaceSomestructGetFieldsomeField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeExternalinterfaceSomestructToFfi(ExternalInterface_SomeStruct value) {
   final _someFieldHandle = stringToFfi(value.someField);
   final _result = _smokeExternalinterfaceSomestructCreateHandle(_someFieldHandle);
   stringReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 ExternalInterface_SomeStruct smokeExternalinterfaceSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeExternalinterfaceSomestructGetFieldsomeField(handle);
   try {
@@ -99,8 +124,11 @@ ExternalInterface_SomeStruct smokeExternalinterfaceSomestructFromFfi(Pointer<Voi
     stringReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeExternalinterfaceSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeExternalinterfaceSomestructReleaseHandle(handle);
+
 // Nullable ExternalInterface_SomeStruct
+
 final _smokeExternalinterfaceSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -113,6 +141,7 @@ final _smokeExternalinterfaceSomestructGetValueNullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeExternalinterfaceSomestructToFfiNullable(ExternalInterface_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExternalinterfaceSomestructToFfi(value);
@@ -120,6 +149,7 @@ Pointer<Void> smokeExternalinterfaceSomestructToFfiNullable(ExternalInterface_So
   smokeExternalinterfaceSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 ExternalInterface_SomeStruct? smokeExternalinterfaceSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExternalinterfaceSomestructGetValueNullable(handle);
@@ -127,10 +157,14 @@ ExternalInterface_SomeStruct? smokeExternalinterfaceSomestructFromFfiNullable(Po
   smokeExternalinterfaceSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExternalinterfaceSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalinterfaceSomestructReleaseHandleNullable(handle);
+
 // End of ExternalInterface_SomeStruct "private" section.
+
 // ExternalInterface "private" section, not exported.
+
 final _smokeExternalinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -151,9 +185,12 @@ final _smokeExternalinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalInterface_get_type_id'));
+
+
 class ExternalInterface$Lambdas implements ExternalInterface {
   void Function(int) someMethodLambda;
   String Function() somePropertyGetLambda;
+
   ExternalInterface$Lambdas(
     this.someMethodLambda,
     this.somePropertyGetLambda
@@ -165,7 +202,9 @@ class ExternalInterface$Lambdas implements ExternalInterface {
   @override
   String get someProperty => somePropertyGetLambda();
 }
+
 class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterface {
+
   ExternalInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -174,7 +213,10 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
     final _someParameterHandle = (someParameter);
     final _handle = this.handle;
     _someMethodFfi(_handle, __lib.LibraryContext.isolateId, _someParameterHandle);
+
+
   }
+
   String get someProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ExternalInterface_someProperty_get'));
     final _handle = this.handle;
@@ -183,22 +225,33 @@ class ExternalInterface$Impl extends __lib.NativeBase implements ExternalInterfa
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
+
 }
+
 int _smokeExternalinterfacesomeMethodStatic(Object _obj, int someParameter) {
+
   try {
     (_obj as ExternalInterface).someMethod((someParameter));
   } finally {
+    
   }
   return 0;
 }
+
 int _smokeExternalinterfacesomePropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as ExternalInterface).someProperty);
   return 0;
 }
+
 Pointer<Void> smokeExternalinterfaceToFfi(ExternalInterface value) {
   if (value is __lib.NativeBase) return _smokeExternalinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeExternalinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -206,15 +259,19 @@ Pointer<Void> smokeExternalinterfaceToFfi(ExternalInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Int8)>(_smokeExternalinterfacesomeMethodStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeExternalinterfacesomePropertyGetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 ExternalInterface smokeExternalinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExternalInterface) return instance;
+
   final _typeIdHandle = _smokeExternalinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeExternalinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -223,12 +280,19 @@ ExternalInterface smokeExternalinterfaceFromFfi(Pointer<Void> handle) {
   _smokeExternalinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExternalinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExternalinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeExternalinterfaceToFfiNullable(ExternalInterface? value) =>
   value != null ? smokeExternalinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExternalInterface? smokeExternalinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExternalinterfaceFromFfi(handle) : null;
+
 void smokeExternalinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalinterfaceReleaseHandle(handle);
+
 // End of ExternalInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/structs.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,22 +7,35 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class Structs {
+
+abstract class Structs implements Finalizable {
+
 
   static Structs_ExternalStruct getExternalStruct() => $prototype.getExternalStruct();
+
   static Structs_AnotherExternalStruct getAnotherExternalStruct() => $prototype.getAnotherExternalStruct();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Structs$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 class Structs_ExternalStruct {
   String stringField;
+
   String externalStringField;
+
   List<int> externalArrayField;
+
   Structs_AnotherExternalStruct externalStructField;
+
   Structs_ExternalStruct(this.stringField, this.externalStringField, this.externalArrayField, this.externalStructField);
 }
+
+
 // Structs_ExternalStruct "private" section, not exported.
+
 final _smokeStructsExternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -45,6 +60,9 @@ final _smokeStructsExternalstructGetFieldexternalStructField = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_field_externalStructField'));
+
+
+
 Pointer<Void> smokeStructsExternalstructToFfi(Structs_ExternalStruct value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _externalStringFieldHandle = stringToFfi(value.externalStringField);
@@ -57,6 +75,7 @@ Pointer<Void> smokeStructsExternalstructToFfi(Structs_ExternalStruct value) {
   smokeStructsAnotherexternalstructReleaseFfiHandle(_externalStructFieldHandle);
   return _result;
 }
+
 Structs_ExternalStruct smokeStructsExternalstructFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeStructsExternalstructGetFieldstringField(handle);
   final _externalStringFieldHandle = _smokeStructsExternalstructGetFieldexternalStringField(handle);
@@ -64,9 +83,9 @@ Structs_ExternalStruct smokeStructsExternalstructFromFfi(Pointer<Void> handle) {
   final _externalStructFieldHandle = _smokeStructsExternalstructGetFieldexternalStructField(handle);
   try {
     return Structs_ExternalStruct(
-      stringFromFfi(_stringFieldHandle),
-      stringFromFfi(_externalStringFieldHandle),
-      foobarListofByteFromFfi(_externalArrayFieldHandle),
+      stringFromFfi(_stringFieldHandle), 
+      stringFromFfi(_externalStringFieldHandle), 
+      foobarListofByteFromFfi(_externalArrayFieldHandle), 
       smokeStructsAnotherexternalstructFromFfi(_externalStructFieldHandle)
     );
   } finally {
@@ -76,8 +95,11 @@ Structs_ExternalStruct smokeStructsExternalstructFromFfi(Pointer<Void> handle) {
     smokeStructsAnotherexternalstructReleaseFfiHandle(_externalStructFieldHandle);
   }
 }
+
 void smokeStructsExternalstructReleaseFfiHandle(Pointer<Void> handle) => _smokeStructsExternalstructReleaseHandle(handle);
+
 // Nullable Structs_ExternalStruct
+
 final _smokeStructsExternalstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -90,6 +112,7 @@ final _smokeStructsExternalstructGetValueNullable = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_ExternalStruct_get_value_nullable'));
+
 Pointer<Void> smokeStructsExternalstructToFfiNullable(Structs_ExternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeStructsExternalstructToFfi(value);
@@ -97,6 +120,7 @@ Pointer<Void> smokeStructsExternalstructToFfiNullable(Structs_ExternalStruct? va
   smokeStructsExternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 Structs_ExternalStruct? smokeStructsExternalstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeStructsExternalstructGetValueNullable(handle);
@@ -104,14 +128,21 @@ Structs_ExternalStruct? smokeStructsExternalstructFromFfiNullable(Pointer<Void> 
   smokeStructsExternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeStructsExternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStructsExternalstructReleaseHandleNullable(handle);
+
 // End of Structs_ExternalStruct "private" section.
+
 class Structs_AnotherExternalStruct {
   int intField;
+
   Structs_AnotherExternalStruct(this.intField);
 }
+
+
 // Structs_AnotherExternalStruct "private" section, not exported.
+
 final _smokeStructsAnotherexternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Int8),
     Pointer<Void> Function(int)
@@ -124,11 +155,16 @@ final _smokeStructsAnotherexternalstructGetFieldintField = __lib.catchArgumentEr
     Int8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_get_field_intField'));
+
+
+
 Pointer<Void> smokeStructsAnotherexternalstructToFfi(Structs_AnotherExternalStruct value) {
   final _intFieldHandle = (value.intField);
   final _result = _smokeStructsAnotherexternalstructCreateHandle(_intFieldHandle);
+  
   return _result;
 }
+
 Structs_AnotherExternalStruct smokeStructsAnotherexternalstructFromFfi(Pointer<Void> handle) {
   final _intFieldHandle = _smokeStructsAnotherexternalstructGetFieldintField(handle);
   try {
@@ -136,10 +172,14 @@ Structs_AnotherExternalStruct smokeStructsAnotherexternalstructFromFfi(Pointer<V
       (_intFieldHandle)
     );
   } finally {
+    
   }
 }
+
 void smokeStructsAnotherexternalstructReleaseFfiHandle(Pointer<Void> handle) => _smokeStructsAnotherexternalstructReleaseHandle(handle);
+
 // Nullable Structs_AnotherExternalStruct
+
 final _smokeStructsAnotherexternalstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -152,6 +192,7 @@ final _smokeStructsAnotherexternalstructGetValueNullable = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Structs_AnotherExternalStruct_get_value_nullable'));
+
 Pointer<Void> smokeStructsAnotherexternalstructToFfiNullable(Structs_AnotherExternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeStructsAnotherexternalstructToFfi(value);
@@ -159,6 +200,7 @@ Pointer<Void> smokeStructsAnotherexternalstructToFfiNullable(Structs_AnotherExte
   smokeStructsAnotherexternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 Structs_AnotherExternalStruct? smokeStructsAnotherexternalstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeStructsAnotherexternalstructGetValueNullable(handle);
@@ -166,10 +208,14 @@ Structs_AnotherExternalStruct? smokeStructsAnotherexternalstructFromFfiNullable(
   smokeStructsAnotherexternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeStructsAnotherexternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStructsAnotherexternalstructReleaseHandleNullable(handle);
+
 // End of Structs_AnotherExternalStruct "private" section.
+
 // Structs "private" section, not exported.
+
 final _smokeStructsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -182,9 +228,14 @@ final _smokeStructsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Structs_release_handle'));
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class Structs$Impl extends __lib.NativeBase implements Structs {
+
   Structs$Impl(Pointer<Void> handle) : super(handle);
 
   Structs_ExternalStruct getExternalStruct() {
@@ -194,8 +245,11 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
       return smokeStructsExternalstructFromFfi(__resultHandle);
     } finally {
       smokeStructsExternalstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   Structs_AnotherExternalStruct getAnotherExternalStruct() {
     final _getAnotherExternalStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Structs_getAnotherExternalStruct'));
     final __resultHandle = _getAnotherExternalStructFfi(__lib.LibraryContext.isolateId);
@@ -203,27 +257,41 @@ class Structs$Impl extends __lib.NativeBase implements Structs {
       return smokeStructsAnotherexternalstructFromFfi(__resultHandle);
     } finally {
       smokeStructsAnotherexternalstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeStructsToFfi(Structs value) =>
   _smokeStructsCopyHandle((value as __lib.NativeBase).handle);
+
 Structs smokeStructsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Structs) return instance;
+
   final _copiedHandle = _smokeStructsCopyHandle(handle);
   final result = Structs$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeStructsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeStructsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeStructsReleaseHandle(handle);
+
 Pointer<Void> smokeStructsToFfiNullable(Structs? value) =>
   value != null ? smokeStructsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Structs? smokeStructsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeStructsFromFfi(handle) : null;
+
 void smokeStructsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStructsReleaseHandle(handle);
+
 // End of Structs "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_generics.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_generics.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'dart:math' as math;
 import 'package:foo/bar.dart' as bar;
@@ -5,10 +7,16 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
-abstract class UseDartExternalGenerics {
+
+abstract class UseDartExternalGenerics implements Finalizable {
+
+
   Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> useGenerics(List<math.Rectangle<int>> list, Set<bar.HttpClientResponseCompressionState> set);
 }
+
+
 // UseDartExternalGenerics "private" section, not exported.
+
 final _smokeUsedartexternalgenericsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -21,8 +29,13 @@ final _smokeUsedartexternalgenericsReleaseHandle = __lib.catchArgumentError(() =
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseDartExternalGenerics_release_handle'));
+
+
+
 class UseDartExternalGenerics$Impl extends __lib.NativeBase implements UseDartExternalGenerics {
+
   UseDartExternalGenerics$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   Map<bar.HttpClientResponseCompressionState, math.Rectangle<int>> useGenerics(List<math.Rectangle<int>> list, Set<bar.HttpClientResponseCompressionState> set) {
     final _useGenericsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, Pointer<Void>)>('library_smoke_UseDartExternalGenerics_useGenerics__ListOf_smoke_Rectangle_SetOf_smoke_CompressionState'));
@@ -36,27 +49,41 @@ class UseDartExternalGenerics$Impl extends __lib.NativeBase implements UseDartEx
       return foobarMapofSmokeCompressionstateToSmokeRectangleFromFfi(__resultHandle);
     } finally {
       foobarMapofSmokeCompressionstateToSmokeRectangleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeUsedartexternalgenericsToFfi(UseDartExternalGenerics value) =>
   _smokeUsedartexternalgenericsCopyHandle((value as __lib.NativeBase).handle);
+
 UseDartExternalGenerics smokeUsedartexternalgenericsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseDartExternalGenerics) return instance;
+
   final _copiedHandle = _smokeUsedartexternalgenericsCopyHandle(handle);
   final result = UseDartExternalGenerics$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeUsedartexternalgenericsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeUsedartexternalgenericsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeUsedartexternalgenericsReleaseHandle(handle);
+
 Pointer<Void> smokeUsedartexternalgenericsToFfiNullable(UseDartExternalGenerics? value) =>
   value != null ? smokeUsedartexternalgenericsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 UseDartExternalGenerics? smokeUsedartexternalgenericsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeUsedartexternalgenericsFromFfi(handle) : null;
+
 void smokeUsedartexternalgenericsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeUsedartexternalgenericsReleaseHandle(handle);
+
 // End of UseDartExternalGenerics "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/use_dart_external_types.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'dart:math' as math;
 import 'package:foo/bar.dart' as bar;
@@ -9,17 +11,26 @@ import 'package:library/src/smoke/int.dart';
 import 'package:library/src/smoke/rectangle_int_.dart';
 import 'package:library/src/smoke/string.dart';
 import 'package:meta/meta.dart';
-abstract class UseDartExternalTypes {
+
+abstract class UseDartExternalTypes implements Finalizable {
+
 
   static math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) => $prototype.rectangleRoundTrip(input);
+
   static bar.HttpClientResponseCompressionState compressionStateRoundTrip(bar.HttpClientResponseCompressionState input) => $prototype.compressionStateRoundTrip(input);
+
   static int colorRoundTrip(int input) => $prototype.colorRoundTrip(input);
+
   static String seasonRoundTrip(String input) => $prototype.seasonRoundTrip(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = UseDartExternalTypes$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // UseDartExternalTypes "private" section, not exported.
+
 final _smokeUsedartexternaltypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -32,9 +43,16 @@ final _smokeUsedartexternaltypesReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseDartExternalTypes_release_handle'));
+
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExternalTypes {
+
   UseDartExternalTypes$Impl(Pointer<Void> handle) : super(handle);
 
   math.Rectangle<int> rectangleRoundTrip(math.Rectangle<int> input) {
@@ -46,8 +64,11 @@ class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExter
       return smokeRectangleFromFfi(__resultHandle);
     } finally {
       smokeRectangleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   bar.HttpClientResponseCompressionState compressionStateRoundTrip(bar.HttpClientResponseCompressionState input) {
     final _compressionStateRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_compressionStateRoundTrip__CompressionState'));
     final _inputHandle = smokeCompressionstateToFfi(input);
@@ -57,8 +78,11 @@ class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExter
       return smokeCompressionstateFromFfi(__resultHandle);
     } finally {
       smokeCompressionstateReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   int colorRoundTrip(int input) {
     final _colorRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_UseDartExternalTypes_colorRoundTrip__DartColor'));
     final _inputHandle = smokeDartcolorToFfi(input);
@@ -68,8 +92,11 @@ class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExter
       return smokeDartcolorFromFfi(__resultHandle);
     } finally {
       smokeDartcolorReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   String seasonRoundTrip(String input) {
     final _seasonRoundTripFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Int32, Uint32), int Function(int, int)>('library_smoke_UseDartExternalTypes_seasonRoundTrip__DartSeason'));
     final _inputHandle = smokeDartseasonToFfi(input);
@@ -79,27 +106,41 @@ class UseDartExternalTypes$Impl extends __lib.NativeBase implements UseDartExter
       return smokeDartseasonFromFfi(__resultHandle);
     } finally {
       smokeDartseasonReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeUsedartexternaltypesToFfi(UseDartExternalTypes value) =>
   _smokeUsedartexternaltypesCopyHandle((value as __lib.NativeBase).handle);
+
 UseDartExternalTypes smokeUsedartexternaltypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseDartExternalTypes) return instance;
+
   final _copiedHandle = _smokeUsedartexternaltypesCopyHandle(handle);
   final result = UseDartExternalTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeUsedartexternaltypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeUsedartexternaltypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeUsedartexternaltypesReleaseHandle(handle);
+
 Pointer<Void> smokeUsedartexternaltypesToFfiNullable(UseDartExternalTypes? value) =>
   value != null ? smokeUsedartexternaltypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 UseDartExternalTypes? smokeUsedartexternaltypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeUsedartexternaltypesFromFfi(handle) : null;
+
 void smokeUsedartexternaltypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeUsedartexternaltypesReleaseHandle(handle);
+
 // End of UseDartExternalTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/outer_name.dart
@@ -1,16 +1,25 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class OuterName {
+
+abstract class OuterName implements Finalizable {
 
 }
+
+
 class Futhark {
   String stringField;
+
   Futhark(this.stringField);
 }
+
+
 // Futhark "private" section, not exported.
+
 final _smokeOuternameInnernameCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -23,12 +32,16 @@ final _smokeOuternameInnernameGetFieldstringField = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterName_InnerName_get_field_stringField'));
+
+
+
 Pointer<Void> smokeOuternameInnernameToFfi(Futhark value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeOuternameInnernameCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 Futhark smokeOuternameInnernameFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeOuternameInnernameGetFieldstringField(handle);
   try {
@@ -39,8 +52,11 @@ Futhark smokeOuternameInnernameFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeOuternameInnernameReleaseFfiHandle(Pointer<Void> handle) => _smokeOuternameInnernameReleaseHandle(handle);
+
 // Nullable Futhark
+
 final _smokeOuternameInnernameCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -53,6 +69,7 @@ final _smokeOuternameInnernameGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterName_InnerName_get_value_nullable'));
+
 Pointer<Void> smokeOuternameInnernameToFfiNullable(Futhark? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeOuternameInnernameToFfi(value);
@@ -60,6 +77,7 @@ Pointer<Void> smokeOuternameInnernameToFfiNullable(Futhark? value) {
   smokeOuternameInnernameReleaseFfiHandle(_handle);
   return result;
 }
+
 Futhark? smokeOuternameInnernameFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeOuternameInnernameGetValueNullable(handle);
@@ -67,10 +85,14 @@ Futhark? smokeOuternameInnernameFromFfiNullable(Pointer<Void> handle) {
   smokeOuternameInnernameReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeOuternameInnernameReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuternameInnernameReleaseHandleNullable(handle);
+
 // End of Futhark "private" section.
+
 // OuterName "private" section, not exported.
+
 final _smokeOuternameRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -83,28 +105,42 @@ final _smokeOuternameReleaseHandle = __lib.catchArgumentError(() => __lib.native
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterName_release_handle'));
+
+
 class OuterName$Impl extends __lib.NativeBase implements OuterName {
+
   OuterName$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeOuternameToFfi(OuterName value) =>
   _smokeOuternameCopyHandle((value as __lib.NativeBase).handle);
+
 OuterName smokeOuternameFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterName) return instance;
+
   final _copiedHandle = _smokeOuternameCopyHandle(handle);
   final result = OuterName$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeOuternameRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuternameReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuternameReleaseHandle(handle);
+
 Pointer<Void> smokeOuternameToFfiNullable(OuterName? value) =>
   value != null ? smokeOuternameToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterName? smokeOuternameFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuternameFromFfi(handle) : null;
+
 void smokeOuternameReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuternameReleaseHandle(handle);
+
 // End of OuterName "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
+++ b/gluecodium/src/test/resources/smoke/full_name/output/dart/lib/src/smoke/use_inner_name.dart
@@ -1,13 +1,20 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/outer_name.dart';
-abstract class UseInnerName {
+
+abstract class UseInnerName implements Finalizable {
+
 
   Futhark doFoo();
 }
+
+
 // UseInnerName "private" section, not exported.
+
 final _smokeUseinnernameRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -20,7 +27,11 @@ final _smokeUseinnernameReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseInnerName_release_handle'));
+
+
+
 class UseInnerName$Impl extends __lib.NativeBase implements UseInnerName {
+
   UseInnerName$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -32,27 +43,41 @@ class UseInnerName$Impl extends __lib.NativeBase implements UseInnerName {
       return smokeOuternameInnernameFromFfi(__resultHandle);
     } finally {
       smokeOuternameInnernameReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeUseinnernameToFfi(UseInnerName value) =>
   _smokeUseinnernameCopyHandle((value as __lib.NativeBase).handle);
+
 UseInnerName smokeUseinnernameFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseInnerName) return instance;
+
   final _copiedHandle = _smokeUseinnernameCopyHandle(handle);
   final result = UseInnerName$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeUseinnernameRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeUseinnernameReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeUseinnernameReleaseHandle(handle);
+
 Pointer<Void> smokeUseinnernameToFfiNullable(UseInnerName? value) =>
   value != null ? smokeUseinnernameToFfi(value) : Pointer<Void>.fromAddress(0);
+
 UseInnerName? smokeUseinnernameFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeUseinnernameFromFfi(handle) : null;
+
 void smokeUseinnernameReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeUseinnernameReleaseHandle(handle);
+
 // End of UseInnerName "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_basic_types.dart
@@ -1,30 +1,50 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
-abstract class GenericTypesWithBasicTypes {
+
+abstract class GenericTypesWithBasicTypes implements Finalizable {
+
 
   List<int> methodWithList(List<int> input);
+
   Map<int, bool> methodWithMap(Map<int, bool> input);
+
   Set<int> methodWithSet(Set<int> input);
+
   List<String> methodWithListTypeAlias(List<String> input);
+
   Map<String, String> methodWithMapTypeAlias(Map<String, String> input);
+
   Set<String> methodWithSetTypeAlias(Set<String> input);
   List<double> get listProperty;
   set listProperty(List<double> value);
+
   Map<double, double> get mapProperty;
   set mapProperty(Map<double, double> value);
+
   Set<double> get setProperty;
   set setProperty(Set<double> value);
+
 }
+
+
 class GenericTypesWithBasicTypes_StructWithGenerics {
   List<int> numbersList;
+
   Map<int, String> numbersMap;
+
   Set<int> numbersSet;
+
   GenericTypesWithBasicTypes_StructWithGenerics(this.numbersList, this.numbersMap, this.numbersSet);
 }
+
+
 // GenericTypesWithBasicTypes_StructWithGenerics "private" section, not exported.
+
 final _smokeGenerictypeswithbasictypesStructwithgenericsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -45,6 +65,9 @@ final _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersSet = __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_field_numbersSet'));
+
+
+
 Pointer<Void> smokeGenerictypeswithbasictypesStructwithgenericsToFfi(GenericTypesWithBasicTypes_StructWithGenerics value) {
   final _numbersListHandle = foobarListofUbyteToFfi(value.numbersList);
   final _numbersMapHandle = foobarMapofUbyteToStringToFfi(value.numbersMap);
@@ -55,14 +78,15 @@ Pointer<Void> smokeGenerictypeswithbasictypesStructwithgenericsToFfi(GenericType
   foobarSetofUbyteReleaseFfiHandle(_numbersSetHandle);
   return _result;
 }
+
 GenericTypesWithBasicTypes_StructWithGenerics smokeGenerictypeswithbasictypesStructwithgenericsFromFfi(Pointer<Void> handle) {
   final _numbersListHandle = _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersList(handle);
   final _numbersMapHandle = _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersMap(handle);
   final _numbersSetHandle = _smokeGenerictypeswithbasictypesStructwithgenericsGetFieldnumbersSet(handle);
   try {
     return GenericTypesWithBasicTypes_StructWithGenerics(
-      foobarListofUbyteFromFfi(_numbersListHandle),
-      foobarMapofUbyteToStringFromFfi(_numbersMapHandle),
+      foobarListofUbyteFromFfi(_numbersListHandle), 
+      foobarMapofUbyteToStringFromFfi(_numbersMapHandle), 
       foobarSetofUbyteFromFfi(_numbersSetHandle)
     );
   } finally {
@@ -71,8 +95,11 @@ GenericTypesWithBasicTypes_StructWithGenerics smokeGenerictypeswithbasictypesStr
     foobarSetofUbyteReleaseFfiHandle(_numbersSetHandle);
   }
 }
+
 void smokeGenerictypeswithbasictypesStructwithgenericsReleaseFfiHandle(Pointer<Void> handle) => _smokeGenerictypeswithbasictypesStructwithgenericsReleaseHandle(handle);
+
 // Nullable GenericTypesWithBasicTypes_StructWithGenerics
+
 final _smokeGenerictypeswithbasictypesStructwithgenericsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -85,6 +112,7 @@ final _smokeGenerictypeswithbasictypesStructwithgenericsGetValueNullable = __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_StructWithGenerics_get_value_nullable'));
+
 Pointer<Void> smokeGenerictypeswithbasictypesStructwithgenericsToFfiNullable(GenericTypesWithBasicTypes_StructWithGenerics? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeGenerictypeswithbasictypesStructwithgenericsToFfi(value);
@@ -92,6 +120,7 @@ Pointer<Void> smokeGenerictypeswithbasictypesStructwithgenericsToFfiNullable(Gen
   smokeGenerictypeswithbasictypesStructwithgenericsReleaseFfiHandle(_handle);
   return result;
 }
+
 GenericTypesWithBasicTypes_StructWithGenerics? smokeGenerictypeswithbasictypesStructwithgenericsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeGenerictypeswithbasictypesStructwithgenericsGetValueNullable(handle);
@@ -99,10 +128,14 @@ GenericTypesWithBasicTypes_StructWithGenerics? smokeGenerictypeswithbasictypesSt
   smokeGenerictypeswithbasictypesStructwithgenericsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeGenerictypeswithbasictypesStructwithgenericsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithbasictypesStructwithgenericsReleaseHandleNullable(handle);
+
 // End of GenericTypesWithBasicTypes_StructWithGenerics "private" section.
+
 // GenericTypesWithBasicTypes "private" section, not exported.
+
 final _smokeGenerictypeswithbasictypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -115,7 +148,16 @@ final _smokeGenerictypeswithbasictypesReleaseHandle = __lib.catchArgumentError((
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithBasicTypes_release_handle'));
+
+
+
+
+
+
+
+
 class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements GenericTypesWithBasicTypes {
+
   GenericTypesWithBasicTypes$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -129,8 +171,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarListofIntFromFfi(__resultHandle);
     } finally {
       foobarListofIntReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<int, bool> methodWithMap(Map<int, bool> input) {
     final _methodWithMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMap__MapOf_Int_to_Boolean'));
@@ -142,8 +187,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarMapofIntToBooleanFromFfi(__resultHandle);
     } finally {
       foobarMapofIntToBooleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Set<int> methodWithSet(Set<int> input) {
     final _methodWithSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSet__SetOf_Int'));
@@ -155,8 +203,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarSetofIntFromFfi(__resultHandle);
     } finally {
       foobarSetofIntReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   List<String> methodWithListTypeAlias(List<String> input) {
     final _methodWithListTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithListTypeAlias__ListOf_String'));
@@ -168,8 +219,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarListofStringFromFfi(__resultHandle);
     } finally {
       foobarListofStringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<String, String> methodWithMapTypeAlias(Map<String, String> input) {
     final _methodWithMapTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithMapTypeAlias__MapOf_String_to_String'));
@@ -181,8 +235,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarMapofStringToStringFromFfi(__resultHandle);
     } finally {
       foobarMapofStringToStringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Set<String> methodWithSetTypeAlias(Set<String> input) {
     final _methodWithSetTypeAliasFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_methodWithSetTypeAlias__SetOf_String'));
@@ -194,8 +251,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarSetofStringFromFfi(__resultHandle);
     } finally {
       foobarSetofStringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   List<double> get listProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_listProperty_get'));
@@ -205,8 +265,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarListofFloatFromFfi(__resultHandle);
     } finally {
       foobarListofFloatReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set listProperty(List<double> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_listProperty_set__ListOf_Float'));
@@ -214,7 +277,10 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofFloatReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   Map<double, double> get mapProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_get'));
@@ -224,8 +290,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarMapofFloatToDoubleFromFfi(__resultHandle);
     } finally {
       foobarMapofFloatToDoubleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set mapProperty(Map<double, double> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_mapProperty_set__MapOf_Float_to_Double'));
@@ -233,7 +302,10 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarMapofFloatToDoubleReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   Set<double> get setProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_GenericTypesWithBasicTypes_setProperty_get'));
@@ -243,8 +315,11 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
       return foobarSetofFloatFromFfi(__resultHandle);
     } finally {
       foobarSetofFloatReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set setProperty(Set<double> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithBasicTypes_setProperty_set__SetOf_Float'));
@@ -252,26 +327,40 @@ class GenericTypesWithBasicTypes$Impl extends __lib.NativeBase implements Generi
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarSetofFloatReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeGenerictypeswithbasictypesToFfi(GenericTypesWithBasicTypes value) =>
   _smokeGenerictypeswithbasictypesCopyHandle((value as __lib.NativeBase).handle);
+
 GenericTypesWithBasicTypes smokeGenerictypeswithbasictypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is GenericTypesWithBasicTypes) return instance;
+
   final _copiedHandle = _smokeGenerictypeswithbasictypesCopyHandle(handle);
   final result = GenericTypesWithBasicTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeGenerictypeswithbasictypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeGenerictypeswithbasictypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeGenerictypeswithbasictypesReleaseHandle(handle);
+
 Pointer<Void> smokeGenerictypeswithbasictypesToFfiNullable(GenericTypesWithBasicTypes? value) =>
   value != null ? smokeGenerictypeswithbasictypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 GenericTypesWithBasicTypes? smokeGenerictypeswithbasictypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeGenerictypeswithbasictypesFromFfi(handle) : null;
+
 void smokeGenerictypeswithbasictypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithbasictypesReleaseHandle(handle);
+
 // End of GenericTypesWithBasicTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,22 +8,34 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/dummy_class.dart';
 import 'package:library/src/smoke/dummy_interface.dart';
-abstract class GenericTypesWithCompoundTypes {
+
+abstract class GenericTypesWithCompoundTypes implements Finalizable {
+
 
   List<GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructList(List<GenericTypesWithCompoundTypes_BasicStruct> input);
+
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input);
+
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input);
+
   Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input);
+
   Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input);
+
   Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input);
+
   List<DummyInterface> methodWithInstancesList(List<DummyClass> input);
+
   Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input);
 }
+
 enum GenericTypesWithCompoundTypes_SomeEnum {
     foo,
     bar
 }
+
 // GenericTypesWithCompoundTypes_SomeEnum "private" section, not exported.
+
 int smokeGenerictypeswithcompoundtypesSomeenumToFfi(GenericTypesWithCompoundTypes_SomeEnum value) {
   switch (value) {
   case GenericTypesWithCompoundTypes_SomeEnum.foo:
@@ -32,6 +46,7 @@ int smokeGenerictypeswithcompoundtypesSomeenumToFfi(GenericTypesWithCompoundType
     throw StateError("Invalid enum value $value for GenericTypesWithCompoundTypes_SomeEnum enum.");
   }
 }
+
 GenericTypesWithCompoundTypes_SomeEnum smokeGenerictypeswithcompoundtypesSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -42,7 +57,9 @@ GenericTypesWithCompoundTypes_SomeEnum smokeGenerictypeswithcompoundtypesSomeenu
     throw StateError("Invalid numeric value $handle for GenericTypesWithCompoundTypes_SomeEnum enum.");
   }
 }
+
 void smokeGenerictypeswithcompoundtypesSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeGenerictypeswithcompoundtypesSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -55,6 +72,7 @@ final _smokeGenerictypeswithcompoundtypesSomeenumGetValueNullable = __lib.catchA
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesSomeenumToFfiNullable(GenericTypesWithCompoundTypes_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeGenerictypeswithcompoundtypesSomeenumToFfi(value);
@@ -62,6 +80,7 @@ Pointer<Void> smokeGenerictypeswithcompoundtypesSomeenumToFfiNullable(GenericTyp
   smokeGenerictypeswithcompoundtypesSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 GenericTypesWithCompoundTypes_SomeEnum? smokeGenerictypeswithcompoundtypesSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeGenerictypeswithcompoundtypesSomeenumGetValueNullable(handle);
@@ -69,14 +88,18 @@ GenericTypesWithCompoundTypes_SomeEnum? smokeGenerictypeswithcompoundtypesSomeen
   smokeGenerictypeswithcompoundtypesSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeGenerictypeswithcompoundtypesSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithcompoundtypesSomeenumReleaseHandleNullable(handle);
+
 // End of GenericTypesWithCompoundTypes_SomeEnum "private" section.
 enum GenericTypesWithCompoundTypes_ExternalEnum {
     on,
     off
 }
+
 // GenericTypesWithCompoundTypes_ExternalEnum "private" section, not exported.
+
 int smokeGenerictypeswithcompoundtypesExternalenumToFfi(GenericTypesWithCompoundTypes_ExternalEnum value) {
   switch (value) {
   case GenericTypesWithCompoundTypes_ExternalEnum.on:
@@ -87,6 +110,7 @@ int smokeGenerictypeswithcompoundtypesExternalenumToFfi(GenericTypesWithCompound
     throw StateError("Invalid enum value $value for GenericTypesWithCompoundTypes_ExternalEnum enum.");
   }
 }
+
 GenericTypesWithCompoundTypes_ExternalEnum smokeGenerictypeswithcompoundtypesExternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -97,7 +121,9 @@ GenericTypesWithCompoundTypes_ExternalEnum smokeGenerictypeswithcompoundtypesExt
     throw StateError("Invalid numeric value $handle for GenericTypesWithCompoundTypes_ExternalEnum enum.");
   }
 }
+
 void smokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(int handle) {}
+
 final _smokeGenerictypeswithcompoundtypesExternalenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -110,6 +136,7 @@ final _smokeGenerictypeswithcompoundtypesExternalenumGetValueNullable = __lib.ca
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalEnum_get_value_nullable'));
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesExternalenumToFfiNullable(GenericTypesWithCompoundTypes_ExternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeGenerictypeswithcompoundtypesExternalenumToFfi(value);
@@ -117,6 +144,7 @@ Pointer<Void> smokeGenerictypeswithcompoundtypesExternalenumToFfiNullable(Generi
   smokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 GenericTypesWithCompoundTypes_ExternalEnum? smokeGenerictypeswithcompoundtypesExternalenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeGenerictypeswithcompoundtypesExternalenumGetValueNullable(handle);
@@ -124,14 +152,21 @@ GenericTypesWithCompoundTypes_ExternalEnum? smokeGenerictypeswithcompoundtypesEx
   smokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithcompoundtypesExternalenumReleaseHandleNullable(handle);
+
 // End of GenericTypesWithCompoundTypes_ExternalEnum "private" section.
+
 class GenericTypesWithCompoundTypes_BasicStruct {
   double value;
+
   GenericTypesWithCompoundTypes_BasicStruct(this.value);
 }
+
+
 // GenericTypesWithCompoundTypes_BasicStruct "private" section, not exported.
+
 final _smokeGenerictypeswithcompoundtypesBasicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
@@ -144,11 +179,16 @@ final _smokeGenerictypeswithcompoundtypesBasicstructGetFieldvalue = __lib.catchA
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_field_value'));
+
+
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesBasicstructToFfi(GenericTypesWithCompoundTypes_BasicStruct value) {
   final _valueHandle = (value.value);
   final _result = _smokeGenerictypeswithcompoundtypesBasicstructCreateHandle(_valueHandle);
+  
   return _result;
 }
+
 GenericTypesWithCompoundTypes_BasicStruct smokeGenerictypeswithcompoundtypesBasicstructFromFfi(Pointer<Void> handle) {
   final _valueHandle = _smokeGenerictypeswithcompoundtypesBasicstructGetFieldvalue(handle);
   try {
@@ -156,10 +196,14 @@ GenericTypesWithCompoundTypes_BasicStruct smokeGenerictypeswithcompoundtypesBasi
       (_valueHandle)
     );
   } finally {
+    
   }
 }
+
 void smokeGenerictypeswithcompoundtypesBasicstructReleaseFfiHandle(Pointer<Void> handle) => _smokeGenerictypeswithcompoundtypesBasicstructReleaseHandle(handle);
+
 // Nullable GenericTypesWithCompoundTypes_BasicStruct
+
 final _smokeGenerictypeswithcompoundtypesBasicstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -172,6 +216,7 @@ final _smokeGenerictypeswithcompoundtypesBasicstructGetValueNullable = __lib.cat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_BasicStruct_get_value_nullable'));
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesBasicstructToFfiNullable(GenericTypesWithCompoundTypes_BasicStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeGenerictypeswithcompoundtypesBasicstructToFfi(value);
@@ -179,6 +224,7 @@ Pointer<Void> smokeGenerictypeswithcompoundtypesBasicstructToFfiNullable(Generic
   smokeGenerictypeswithcompoundtypesBasicstructReleaseFfiHandle(_handle);
   return result;
 }
+
 GenericTypesWithCompoundTypes_BasicStruct? smokeGenerictypeswithcompoundtypesBasicstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeGenerictypeswithcompoundtypesBasicstructGetValueNullable(handle);
@@ -186,14 +232,21 @@ GenericTypesWithCompoundTypes_BasicStruct? smokeGenerictypeswithcompoundtypesBas
   smokeGenerictypeswithcompoundtypesBasicstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeGenerictypeswithcompoundtypesBasicstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithcompoundtypesBasicstructReleaseHandleNullable(handle);
+
 // End of GenericTypesWithCompoundTypes_BasicStruct "private" section.
+
 class GenericTypesWithCompoundTypes_ExternalStruct {
   String string;
+
   GenericTypesWithCompoundTypes_ExternalStruct(this.string);
 }
+
+
 // GenericTypesWithCompoundTypes_ExternalStruct "private" section, not exported.
+
 final _smokeGenerictypeswithcompoundtypesExternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -206,12 +259,16 @@ final _smokeGenerictypeswithcompoundtypesExternalstructGetFieldstring = __lib.ca
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_field_string'));
+
+
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesExternalstructToFfi(GenericTypesWithCompoundTypes_ExternalStruct value) {
   final _stringHandle = stringToFfi(value.string);
   final _result = _smokeGenerictypeswithcompoundtypesExternalstructCreateHandle(_stringHandle);
   stringReleaseFfiHandle(_stringHandle);
   return _result;
 }
+
 GenericTypesWithCompoundTypes_ExternalStruct smokeGenerictypeswithcompoundtypesExternalstructFromFfi(Pointer<Void> handle) {
   final _stringHandle = _smokeGenerictypeswithcompoundtypesExternalstructGetFieldstring(handle);
   try {
@@ -222,8 +279,11 @@ GenericTypesWithCompoundTypes_ExternalStruct smokeGenerictypeswithcompoundtypesE
     stringReleaseFfiHandle(_stringHandle);
   }
 }
+
 void smokeGenerictypeswithcompoundtypesExternalstructReleaseFfiHandle(Pointer<Void> handle) => _smokeGenerictypeswithcompoundtypesExternalstructReleaseHandle(handle);
+
 // Nullable GenericTypesWithCompoundTypes_ExternalStruct
+
 final _smokeGenerictypeswithcompoundtypesExternalstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -236,6 +296,7 @@ final _smokeGenerictypeswithcompoundtypesExternalstructGetValueNullable = __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_ExternalStruct_get_value_nullable'));
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesExternalstructToFfiNullable(GenericTypesWithCompoundTypes_ExternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeGenerictypeswithcompoundtypesExternalstructToFfi(value);
@@ -243,6 +304,7 @@ Pointer<Void> smokeGenerictypeswithcompoundtypesExternalstructToFfiNullable(Gene
   smokeGenerictypeswithcompoundtypesExternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 GenericTypesWithCompoundTypes_ExternalStruct? smokeGenerictypeswithcompoundtypesExternalstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeGenerictypeswithcompoundtypesExternalstructGetValueNullable(handle);
@@ -250,10 +312,14 @@ GenericTypesWithCompoundTypes_ExternalStruct? smokeGenerictypeswithcompoundtypes
   smokeGenerictypeswithcompoundtypesExternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeGenerictypeswithcompoundtypesExternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithcompoundtypesExternalstructReleaseHandleNullable(handle);
+
 // End of GenericTypesWithCompoundTypes_ExternalStruct "private" section.
+
 // GenericTypesWithCompoundTypes "private" section, not exported.
+
 final _smokeGenerictypeswithcompoundtypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -266,7 +332,18 @@ final _smokeGenerictypeswithcompoundtypesReleaseHandle = __lib.catchArgumentErro
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithCompoundTypes_release_handle'));
+
+
+
+
+
+
+
+
+
+
 class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements GenericTypesWithCompoundTypes {
+
   GenericTypesWithCompoundTypes$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -280,8 +357,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarListofSmokeGenerictypeswithcompoundtypesExternalstructFromFfi(__resultHandle);
     } finally {
       foobarListofSmokeGenerictypeswithcompoundtypesExternalstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<String, GenericTypesWithCompoundTypes_ExternalStruct> methodWithStructMap(Map<String, GenericTypesWithCompoundTypes_BasicStruct> input) {
     final _methodWithStructMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithStructMap__MapOf_String_to_smoke_GenericTypesWithCompoundTypes_BasicStruct'));
@@ -293,8 +373,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructFromFfi(__resultHandle);
     } finally {
       foobarMapofStringToSmokeGenerictypeswithcompoundtypesExternalstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   List<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumList(List<GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumList__ListOf_smoke_GenericTypesWithCompoundTypes_SomeEnum'));
@@ -306,8 +389,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarListofSmokeGenerictypeswithcompoundtypesExternalenumFromFfi(__resultHandle);
     } finally {
       foobarListofSmokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<GenericTypesWithCompoundTypes_ExternalEnum, bool> methodWithEnumMapKey(Map<GenericTypesWithCompoundTypes_SomeEnum, bool> input) {
     final _methodWithEnumMapKeyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapKey__MapOf_smoke_GenericTypesWithCompoundTypes_SomeEnum_to_Boolean'));
@@ -319,8 +405,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanFromFfi(__resultHandle);
     } finally {
       foobarMapofSmokeGenerictypeswithcompoundtypesExternalenumToBooleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<int, GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumMapValue(Map<int, GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumMapValueFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumMapValue__MapOf_Int_to_smoke_GenericTypesWithCompoundTypes_SomeEnum'));
@@ -332,8 +421,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumFromFfi(__resultHandle);
     } finally {
       foobarMapofIntToSmokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Set<GenericTypesWithCompoundTypes_ExternalEnum> methodWithEnumSet(Set<GenericTypesWithCompoundTypes_SomeEnum> input) {
     final _methodWithEnumSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithEnumSet__SetOf_smoke_GenericTypesWithCompoundTypes_SomeEnum'));
@@ -345,8 +437,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumFromFfi(__resultHandle);
     } finally {
       foobarSetofSmokeGenerictypeswithcompoundtypesExternalenumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   List<DummyInterface> methodWithInstancesList(List<DummyClass> input) {
     final _methodWithInstancesListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesList__ListOf_smoke_DummyClass'));
@@ -358,8 +453,11 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarListofSmokeDummyinterfaceFromFfi(__resultHandle);
     } finally {
       foobarListofSmokeDummyinterfaceReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<int, DummyInterface> methodWithInstancesMap(Map<int, DummyClass> input) {
     final _methodWithInstancesMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithCompoundTypes_methodWithInstancesMap__MapOf_Int_to_smoke_DummyClass'));
@@ -371,27 +469,41 @@ class GenericTypesWithCompoundTypes$Impl extends __lib.NativeBase implements Gen
       return foobarMapofIntToSmokeDummyinterfaceFromFfi(__resultHandle);
     } finally {
       foobarMapofIntToSmokeDummyinterfaceReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesToFfi(GenericTypesWithCompoundTypes value) =>
   _smokeGenerictypeswithcompoundtypesCopyHandle((value as __lib.NativeBase).handle);
+
 GenericTypesWithCompoundTypes smokeGenerictypeswithcompoundtypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is GenericTypesWithCompoundTypes) return instance;
+
   final _copiedHandle = _smokeGenerictypeswithcompoundtypesCopyHandle(handle);
   final result = GenericTypesWithCompoundTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeGenerictypeswithcompoundtypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeGenerictypeswithcompoundtypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeGenerictypeswithcompoundtypesReleaseHandle(handle);
+
 Pointer<Void> smokeGenerictypeswithcompoundtypesToFfiNullable(GenericTypesWithCompoundTypes? value) =>
   value != null ? smokeGenerictypeswithcompoundtypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 GenericTypesWithCompoundTypes? smokeGenerictypeswithcompoundtypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeGenerictypeswithcompoundtypesFromFfi(handle) : null;
+
 void smokeGenerictypeswithcompoundtypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithcompoundtypesReleaseHandle(handle);
+
 // End of GenericTypesWithCompoundTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_generic_types.dart
@@ -1,19 +1,32 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/generic_types__conversion.dart';
-abstract class GenericTypesWithGenericTypes {
+
+abstract class GenericTypesWithGenericTypes implements Finalizable {
+
 
   List<List<int>> methodWithListOfLists(List<List<int>> input);
+
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input);
+
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input);
+
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input);
+
   Set<List<int>> methodWithListAndSet(List<Set<int>> input);
+
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input);
+
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input);
 }
+
+
 // GenericTypesWithGenericTypes "private" section, not exported.
+
 final _smokeGenerictypeswithgenerictypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -26,7 +39,17 @@ final _smokeGenerictypeswithgenerictypesReleaseHandle = __lib.catchArgumentError
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_GenericTypesWithGenericTypes_release_handle'));
+
+
+
+
+
+
+
+
+
 class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements GenericTypesWithGenericTypes {
+
   GenericTypesWithGenericTypes$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -40,8 +63,11 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
       return foobarListofFoobarListofIntFromFfi(__resultHandle);
     } finally {
       foobarListofFoobarListofIntReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<Map<int, bool>, bool> methodWithMapOfMaps(Map<int, Map<int, bool>> input) {
     final _methodWithMapOfMapsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapOfMaps__MapOf_Int_to_foobar_MapOf_Int_to_Boolean'));
@@ -53,8 +79,11 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
       return foobarMapofFoobarMapofIntToBooleanToBooleanFromFfi(__resultHandle);
     } finally {
       foobarMapofFoobarMapofIntToBooleanToBooleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Set<Set<int>> methodWithSetOfSets(Set<Set<int>> input) {
     final _methodWithSetOfSetsFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithSetOfSets__SetOf_foobar_SetOf_Int'));
@@ -66,8 +95,11 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
       return foobarSetofFoobarSetofIntFromFfi(__resultHandle);
     } finally {
       foobarSetofFoobarSetofIntReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<int, List<int>> methodWithListAndMap(List<Map<int, bool>> input) {
     final _methodWithListAndMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndMap__ListOf_foobar_MapOf_Int_to_Boolean'));
@@ -79,8 +111,11 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
       return foobarMapofIntToFoobarListofIntFromFfi(__resultHandle);
     } finally {
       foobarMapofIntToFoobarListofIntReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Set<List<int>> methodWithListAndSet(List<Set<int>> input) {
     final _methodWithListAndSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithListAndSet__ListOf_foobar_SetOf_Int'));
@@ -92,8 +127,11 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
       return foobarSetofFoobarListofIntFromFfi(__resultHandle);
     } finally {
       foobarSetofFoobarListofIntReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Set<Map<int, bool>> methodWithMapAndSet(Map<int, Set<int>> input) {
     final _methodWithMapAndSetFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapAndSet__MapOf_Int_to_foobar_SetOf_Int'));
@@ -105,8 +143,11 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
       return foobarSetofFoobarMapofIntToBooleanFromFfi(__resultHandle);
     } finally {
       foobarSetofFoobarMapofIntToBooleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<List<int>, bool> methodWithMapGenericKeys(Map<Set<int>, bool> input) {
     final _methodWithMapGenericKeysFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_GenericTypesWithGenericTypes_methodWithMapGenericKeys__MapOf_foobar_SetOf_Int_to_Boolean'));
@@ -118,27 +159,41 @@ class GenericTypesWithGenericTypes$Impl extends __lib.NativeBase implements Gene
       return foobarMapofFoobarListofIntToBooleanFromFfi(__resultHandle);
     } finally {
       foobarMapofFoobarListofIntToBooleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeGenerictypeswithgenerictypesToFfi(GenericTypesWithGenericTypes value) =>
   _smokeGenerictypeswithgenerictypesCopyHandle((value as __lib.NativeBase).handle);
+
 GenericTypesWithGenericTypes smokeGenerictypeswithgenerictypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is GenericTypesWithGenericTypes) return instance;
+
   final _copiedHandle = _smokeGenerictypeswithgenerictypesCopyHandle(handle);
   final result = GenericTypesWithGenericTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeGenerictypeswithgenerictypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeGenerictypeswithgenerictypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeGenerictypeswithgenerictypesReleaseHandle(handle);
+
 Pointer<Void> smokeGenerictypeswithgenerictypesToFfiNullable(GenericTypesWithGenericTypes? value) =>
   value != null ? smokeGenerictypeswithgenerictypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 GenericTypesWithGenericTypes? smokeGenerictypeswithgenerictypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeGenerictypeswithgenerictypesFromFfi(handle) : null;
+
 void smokeGenerictypeswithgenerictypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeGenerictypeswithgenerictypesReleaseHandle(handle);
+
 // End of GenericTypesWithGenericTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/use_optimized_list.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_lazy_list.dart' as __lib;
 import 'package:library/src/_library_context.dart' as __lib;
@@ -7,15 +9,22 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/unreasonably_lazy_class.dart';
 import 'package:library/src/smoke/very_big_struct.dart';
 import 'package:meta/meta.dart';
-abstract class UseOptimizedList {
+
+abstract class UseOptimizedList implements Finalizable {
+
 
   static List<VeryBigStruct> fetchTheBigOnes() => $prototype.fetchTheBigOnes();
   static List<UnreasonablyLazyClass> get lazyOnes => $prototype.lazyOnes;
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = UseOptimizedList$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // UseOptimizedList "private" section, not exported.
+
 final _smokeUseoptimizedlistRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -28,6 +37,7 @@ final _smokeUseoptimizedlistReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseOptimizedList_release_handle'));
+
 final _smokeUseoptimizedlistsmokeUnreasonablylazyclassLazyListGetSize = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Uint64 Function(Pointer<Void>),
     int Function(Pointer<Void>)
@@ -52,9 +62,12 @@ final _smokeUseoptimizedlistsmokeVerybigstructLazyListRegisterFinalizer = __lib.
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
   >('library_smoke_UseOptimizedList_smoke_VeryBigStructLazyList_register_finalizer'));
+
+
 /// @nodoc
 @visibleForTesting
 class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList {
+
   UseOptimizedList$Impl(Pointer<Void> handle) : super(handle);
 
   List<VeryBigStruct> fetchTheBigOnes() {
@@ -71,7 +84,9 @@ class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList
         },
         (obj) => _smokeUseoptimizedlistsmokeVerybigstructLazyListRegisterFinalizer(__resultHandle, __lib.LibraryContext.isolateId, obj)
       );
+
   }
+
   List<UnreasonablyLazyClass> get lazyOnes {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_UseOptimizedList_lazyOnes_get'));
     final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
@@ -86,26 +101,40 @@ class UseOptimizedList$Impl extends __lib.NativeBase implements UseOptimizedList
         },
         (obj) => _smokeUseoptimizedlistsmokeUnreasonablylazyclassLazyListRegisterFinalizer(__resultHandle, __lib.LibraryContext.isolateId, obj)
       );
+
   }
+
+
+
 }
+
 Pointer<Void> smokeUseoptimizedlistToFfi(UseOptimizedList value) =>
   _smokeUseoptimizedlistCopyHandle((value as __lib.NativeBase).handle);
+
 UseOptimizedList smokeUseoptimizedlistFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseOptimizedList) return instance;
+
   final _copiedHandle = _smokeUseoptimizedlistCopyHandle(handle);
   final result = UseOptimizedList$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeUseoptimizedlistRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeUseoptimizedlistReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeUseoptimizedlistReleaseHandle(handle);
+
 Pointer<Void> smokeUseoptimizedlistToFfiNullable(UseOptimizedList? value) =>
   value != null ? smokeUseoptimizedlistToFfi(value) : Pointer<Void>.fromAddress(0);
+
 UseOptimizedList? smokeUseoptimizedlistFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeUseoptimizedlistFromFfi(handle) : null;
+
 void smokeUseoptimizedlistReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeUseoptimizedlistReleaseHandle(handle);
+
 // End of UseOptimizedList "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,11 +7,16 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
-abstract class ChildClassFromClass implements ParentClass {
+
+abstract class ChildClassFromClass implements ParentClass, Finalizable {
+
 
   void childClassMethod();
 }
+
+
 // ChildClassFromClass "private" section, not exported.
+
 final _smokeChildclassfromclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -26,7 +33,11 @@ final _smokeChildclassfromclassGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromClass_get_type_id'));
+
+
+
 class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFromClass {
+
   ChildClassFromClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -34,17 +45,24 @@ class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFro
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromClass_childClassMethod'));
     final _handle = this.handle;
     _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokeChildclassfromclassToFfi(ChildClassFromClass value) =>
   _smokeChildclassfromclassCopyHandle((value as __lib.NativeBase).handle);
+
 ChildClassFromClass smokeChildclassfromclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildClassFromClass) return instance;
+
   final _typeIdHandle = _smokeChildclassfromclassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeChildclassfromclassCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -53,12 +71,19 @@ ChildClassFromClass smokeChildclassfromclassFromFfi(Pointer<Void> handle) {
   _smokeChildclassfromclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeChildclassfromclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeChildclassfromclassReleaseHandle(handle);
+
 Pointer<Void> smokeChildclassfromclassToFfiNullable(ChildClassFromClass? value) =>
   value != null ? smokeChildclassfromclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ChildClassFromClass? smokeChildclassfromclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeChildclassfromclassFromFfi(handle) : null;
+
 void smokeChildclassfromclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeChildclassfromclassReleaseHandle(handle);
+
 // End of ChildClassFromClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_interface.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,10 +7,16 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
-abstract class ChildClassFromInterface implements ParentInterface {
+
+abstract class ChildClassFromInterface implements ParentInterface, Finalizable {
+
+
   void childClassMethod();
 }
+
+
 // ChildClassFromInterface "private" section, not exported.
+
 final _smokeChildclassfrominterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -25,20 +33,29 @@ final _smokeChildclassfrominterfaceGetTypeId = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassFromInterface_get_type_id'));
+
+
+
 class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClassFromInterface {
+
   ChildClassFromInterface$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void childClassMethod() {
     final _childClassMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_childClassMethod'));
     final _handle = this.handle;
     _childClassMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void rootMethod() {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_rootMethod'));
     final _handle = this.handle;
     _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   String get rootProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ChildClassFromInterface_rootProperty_get'));
@@ -48,8 +65,11 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set rootProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ChildClassFromInterface_rootProperty_set'));
@@ -57,17 +77,25 @@ class ChildClassFromInterface$Impl extends __lib.NativeBase implements ChildClas
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeChildclassfrominterfaceToFfi(ChildClassFromInterface value) =>
   _smokeChildclassfrominterfaceCopyHandle((value as __lib.NativeBase).handle);
+
 ChildClassFromInterface smokeChildclassfrominterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildClassFromInterface) return instance;
+
   final _typeIdHandle = _smokeChildclassfrominterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeChildclassfrominterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -76,12 +104,19 @@ ChildClassFromInterface smokeChildclassfrominterfaceFromFfi(Pointer<Void> handle
   _smokeChildclassfrominterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeChildclassfrominterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeChildclassfrominterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeChildclassfrominterfaceToFfiNullable(ChildClassFromInterface? value) =>
   value != null ? smokeChildclassfrominterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ChildClassFromInterface? smokeChildclassfrominterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeChildclassfrominterfaceFromFfi(handle) : null;
+
 void smokeChildclassfrominterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeChildclassfrominterfaceReleaseHandle(handle);
+
 // End of ChildClassFromInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,10 +7,14 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class_with_imports.dart';
-abstract class ChildClassWithImports implements ParentClassWithImports {
+
+abstract class ChildClassWithImports implements ParentClassWithImports, Finalizable {
 
 }
+
+
 // ChildClassWithImports "private" section, not exported.
+
 final _smokeChildclasswithimportsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -25,19 +31,27 @@ final _smokeChildclasswithimportsGetTypeId = __lib.catchArgumentError(() => __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildClassWithImports_get_type_id'));
+
+
 class ChildClassWithImports$Impl extends ParentClassWithImports$Impl implements ChildClassWithImports {
+
   ChildClassWithImports$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeChildclasswithimportsToFfi(ChildClassWithImports value) =>
   _smokeChildclasswithimportsCopyHandle((value as __lib.NativeBase).handle);
+
 ChildClassWithImports smokeChildclasswithimportsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildClassWithImports) return instance;
+
   final _typeIdHandle = _smokeChildclasswithimportsGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeChildclasswithimportsCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -46,12 +60,19 @@ ChildClassWithImports smokeChildclasswithimportsFromFfi(Pointer<Void> handle) {
   _smokeChildclasswithimportsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeChildclasswithimportsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeChildclasswithimportsReleaseHandle(handle);
+
 Pointer<Void> smokeChildclasswithimportsToFfiNullable(ChildClassWithImports? value) =>
   value != null ? smokeChildclasswithimportsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ChildClassWithImports? smokeChildclasswithimportsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeChildclasswithimportsFromFfi(handle) : null;
+
 void smokeChildclasswithimportsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeChildclasswithimportsReleaseHandle(handle);
+
 // End of ChildClassWithImports "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_interface.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,7 +8,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/grand_child_interface.dart';
 import 'package:library/src/smoke/parent_interface.dart';
-abstract class ChildInterface implements ParentInterface {
+
+abstract class ChildInterface implements ParentInterface, Finalizable {
+
   factory ChildInterface(
     void Function() rootMethodLambda,
     void Function() childMethodLambda,
@@ -19,9 +23,13 @@ abstract class ChildInterface implements ParentInterface {
     rootPropertySetLambda
   );
 
+
   void childMethod();
 }
+
+
 // ChildInterface "private" section, not exported.
+
 final _smokeChildinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -42,11 +50,14 @@ final _smokeChildinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativ
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildInterface_get_type_id'));
+
+
 class ChildInterface$Lambdas implements ChildInterface {
   void Function() rootMethodLambda;
   void Function() childMethodLambda;
   String Function() rootPropertyGetLambda;
   void Function(String) rootPropertySetLambda;
+
   ChildInterface$Lambdas(
     this.rootMethodLambda,
     this.childMethodLambda,
@@ -65,7 +76,9 @@ class ChildInterface$Lambdas implements ChildInterface {
   @override
   set rootProperty(String value) => rootPropertySetLambda(value);
 }
+
 class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
+
   ChildInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -73,13 +86,17 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
     _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void childMethod() {
     final _childMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ChildInterface_childMethod'));
     final _handle = this.handle;
     _childMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   String get rootProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
     final _handle = this.handle;
@@ -88,17 +105,27 @@ class ChildInterface$Impl extends __lib.NativeBase implements ChildInterface {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set rootProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeChildinterfacerootMethodStatic(Object _obj) {
+
   try {
     (_obj as ChildInterface).rootMethod();
   } finally {
@@ -106,16 +133,19 @@ int _smokeChildinterfacerootMethodStatic(Object _obj) {
   return 0;
 }
 int _smokeChildinterfacechildMethodStatic(Object _obj) {
+
   try {
     (_obj as ChildInterface).childMethod();
   } finally {
   }
   return 0;
 }
+
 int _smokeChildinterfacerootPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as ChildInterface).rootProperty);
   return 0;
 }
+
 int _smokeChildinterfacerootPropertySetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ChildInterface).rootProperty =
@@ -125,12 +155,15 @@ int _smokeChildinterfacerootPropertySetStatic(Object _obj, Pointer<Void> _value)
   }
   return 0;
 }
+
 Pointer<Void> smokeChildinterfaceToFfi(ChildInterface value) {
   if (value is __lib.NativeBase) return _smokeChildinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final descendantResult = tryDescendantToFfi(value);
   if (descendantResult != null) {
     return descendantResult;
   }
+
   final result = _smokeChildinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -140,15 +173,19 @@ Pointer<Void> smokeChildinterfaceToFfi(ChildInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeChildinterfacerootPropertyGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeChildinterfacerootPropertySetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 ChildInterface smokeChildinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildInterface) return instance;
+
   final _typeIdHandle = _smokeChildinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeChildinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -157,16 +194,24 @@ ChildInterface smokeChildinterfaceFromFfi(Pointer<Void> handle) {
   _smokeChildinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeChildinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeChildinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeChildinterfaceToFfiNullable(ChildInterface? value) =>
   value != null ? smokeChildinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ChildInterface? smokeChildinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeChildinterfaceFromFfi(handle) : null;
+
 void smokeChildinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeChildinterfaceReleaseHandle(handle);
+
 Pointer<Void>? tryDescendantToFfi(ChildInterface value) {
   if (value is GrandChildInterface) return smokeGrandchildinterfaceToFfi(value);
   return null;
 }
+
 // End of ChildInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_with_parent_class_references.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -7,9 +9,14 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
-abstract class ChildWithParentClassReferences implements ParentWithClassReferences {
+
+abstract class ChildWithParentClassReferences implements ParentWithClassReferences, Finalizable {
+
 }
+
+
 // ChildWithParentClassReferences "private" section, not exported.
+
 final _smokeChildwithparentclassreferencesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -26,8 +33,12 @@ final _smokeChildwithparentclassreferencesGetTypeId = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ChildWithParentClassReferences_get_type_id'));
+
+
 class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements ChildWithParentClassReferences {
+
   ChildWithParentClassReferences$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   ChildClassFromClass classFunction() {
     final _classFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ChildWithParentClassReferences_classFunction'));
@@ -37,8 +48,11 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
       return smokeChildclassfromclassFromFfi(__resultHandle);
     } finally {
       smokeChildclassfromclassReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   ParentClass get classProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ChildWithParentClassReferences_classProperty_get'));
@@ -48,8 +62,11 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
       return smokeParentclassFromFfi(__resultHandle);
     } finally {
       smokeParentclassReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set classProperty(ParentClass value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ChildWithParentClassReferences_classProperty_set'));
@@ -57,17 +74,25 @@ class ChildWithParentClassReferences$Impl extends __lib.NativeBase implements Ch
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeParentclassReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeChildwithparentclassreferencesToFfi(ChildWithParentClassReferences value) =>
   _smokeChildwithparentclassreferencesCopyHandle((value as __lib.NativeBase).handle);
+
 ChildWithParentClassReferences smokeChildwithparentclassreferencesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ChildWithParentClassReferences) return instance;
+
   final _typeIdHandle = _smokeChildwithparentclassreferencesGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeChildwithparentclassreferencesCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -76,12 +101,19 @@ ChildWithParentClassReferences smokeChildwithparentclassreferencesFromFfi(Pointe
   _smokeChildwithparentclassreferencesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeChildwithparentclassreferencesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeChildwithparentclassreferencesReleaseHandle(handle);
+
 Pointer<Void> smokeChildwithparentclassreferencesToFfiNullable(ChildWithParentClassReferences? value) =>
   value != null ? smokeChildwithparentclassreferencesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ChildWithParentClassReferences? smokeChildwithparentclassreferencesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeChildwithparentclassreferencesFromFfi(handle) : null;
+
 void smokeChildwithparentclassreferencesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeChildwithparentclassreferencesReleaseHandle(handle);
+
 // End of ChildWithParentClassReferences "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_class.dart
@@ -1,16 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class ParentClass {
+
+abstract class ParentClass implements Finalizable {
+
 
   void rootMethod();
   String get rootProperty;
   set rootProperty(String value);
+
 }
+
+
 // ParentClass "private" section, not exported.
+
 final _smokeParentclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -27,7 +35,11 @@ final _smokeParentclassGetTypeId = __lib.catchArgumentError(() => __lib.nativeLi
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentClass_get_type_id'));
+
+
+
 class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
+
   ParentClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -35,7 +47,9 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootMethod'));
     final _handle = this.handle;
     _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   String get rootProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentClass_rootProperty_get'));
@@ -45,8 +59,11 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set rootProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentClass_rootProperty_set__String'));
@@ -54,17 +71,25 @@ class ParentClass$Impl extends __lib.NativeBase implements ParentClass {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeParentclassToFfi(ParentClass value) =>
   _smokeParentclassCopyHandle((value as __lib.NativeBase).handle);
+
 ParentClass smokeParentclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ParentClass) return instance;
+
   final _typeIdHandle = _smokeParentclassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeParentclassCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -73,12 +98,19 @@ ParentClass smokeParentclassFromFfi(Pointer<Void> handle) {
   _smokeParentclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeParentclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeParentclassReleaseHandle(handle);
+
 Pointer<Void> smokeParentclassToFfiNullable(ParentClass? value) =>
   value != null ? smokeParentclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ParentClass? smokeParentclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeParentclassFromFfi(handle) : null;
+
 void smokeParentclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeParentclassReleaseHandle(handle);
+
 // End of ParentClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/parent_interface.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,7 +8,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/child_interface.dart';
 import 'package:library/src/smoke/grand_child_interface.dart';
-abstract class ParentInterface {
+
+abstract class ParentInterface implements Finalizable {
+
   factory ParentInterface(
     void Function() rootMethodLambda,
     String Function() rootPropertyGetLambda,
@@ -17,11 +21,16 @@ abstract class ParentInterface {
     rootPropertySetLambda
   );
 
+
   void rootMethod();
   String get rootProperty;
   set rootProperty(String value);
+
 }
+
+
 // ParentInterface "private" section, not exported.
+
 final _smokeParentinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -42,10 +51,13 @@ final _smokeParentinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentInterface_get_type_id'));
+
+
 class ParentInterface$Lambdas implements ParentInterface {
   void Function() rootMethodLambda;
   String Function() rootPropertyGetLambda;
   void Function(String) rootPropertySetLambda;
+
   ParentInterface$Lambdas(
     this.rootMethodLambda,
     this.rootPropertyGetLambda,
@@ -60,7 +72,9 @@ class ParentInterface$Lambdas implements ParentInterface {
   @override
   set rootProperty(String value) => rootPropertySetLambda(value);
 }
+
 class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
+
   ParentInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -68,7 +82,9 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
     final _rootMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootMethod'));
     final _handle = this.handle;
     _rootMethodFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   String get rootProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_rootProperty_get'));
     final _handle = this.handle;
@@ -77,27 +93,39 @@ class ParentInterface$Impl extends __lib.NativeBase implements ParentInterface {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set rootProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_rootProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeParentinterfacerootMethodStatic(Object _obj) {
+
   try {
     (_obj as ParentInterface).rootMethod();
   } finally {
   }
   return 0;
 }
+
 int _smokeParentinterfacerootPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as ParentInterface).rootProperty);
   return 0;
 }
+
 int _smokeParentinterfacerootPropertySetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ParentInterface).rootProperty =
@@ -107,12 +135,15 @@ int _smokeParentinterfacerootPropertySetStatic(Object _obj, Pointer<Void> _value
   }
   return 0;
 }
+
 Pointer<Void> smokeParentinterfaceToFfi(ParentInterface value) {
   if (value is __lib.NativeBase) return _smokeParentinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final descendantResult = tryDescendantToFfi(value);
   if (descendantResult != null) {
     return descendantResult;
   }
+
   final result = _smokeParentinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -121,15 +152,19 @@ Pointer<Void> smokeParentinterfaceToFfi(ParentInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeParentinterfacerootPropertyGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeParentinterfacerootPropertySetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 ParentInterface smokeParentinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ParentInterface) return instance;
+
   final _typeIdHandle = _smokeParentinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeParentinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -138,17 +173,25 @@ ParentInterface smokeParentinterfaceFromFfi(Pointer<Void> handle) {
   _smokeParentinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeParentinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeParentinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeParentinterfaceToFfiNullable(ParentInterface? value) =>
   value != null ? smokeParentinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ParentInterface? smokeParentinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeParentinterfaceFromFfi(handle) : null;
+
 void smokeParentinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeParentinterfaceReleaseHandle(handle);
+
 Pointer<Void>? tryDescendantToFfi(ParentInterface value) {
   if (value is GrandChildInterface) return smokeGrandchildinterfaceToFfi(value);
   if (value is ChildInterface) return smokeChildinterfaceToFfi(value);
   return null;
 }
+
 // End of ParentInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_class.dart
@@ -1,14 +1,22 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class SimpleClass {
+
+abstract class SimpleClass implements Finalizable {
+
 
   String getStringValue();
+
   SimpleClass useSimpleClass(SimpleClass input);
 }
+
+
 // SimpleClass "private" section, not exported.
+
 final _smokeSimpleclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -21,7 +29,12 @@ final _smokeSimpleclassReleaseHandle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SimpleClass_release_handle'));
+
+
+
+
 class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
+
   SimpleClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -33,8 +46,11 @@ class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   SimpleClass useSimpleClass(SimpleClass input) {
     final _useSimpleClassFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleClass_useSimpleClass__SimpleClass'));
@@ -46,27 +62,41 @@ class SimpleClass$Impl extends __lib.NativeBase implements SimpleClass {
       return smokeSimpleclassFromFfi(__resultHandle);
     } finally {
       smokeSimpleclassReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeSimpleclassToFfi(SimpleClass value) =>
   _smokeSimpleclassCopyHandle((value as __lib.NativeBase).handle);
+
 SimpleClass smokeSimpleclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SimpleClass) return instance;
+
   final _copiedHandle = _smokeSimpleclassCopyHandle(handle);
   final result = SimpleClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSimpleclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSimpleclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSimpleclassReleaseHandle(handle);
+
 Pointer<Void> smokeSimpleclassToFfiNullable(SimpleClass? value) =>
   value != null ? smokeSimpleclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SimpleClass? smokeSimpleclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSimpleclassFromFfi(handle) : null;
+
 void smokeSimpleclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSimpleclassReleaseHandle(handle);
+
 // End of SimpleClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
+++ b/gluecodium/src/test/resources/smoke/instances/output/dart/lib/src/smoke/simple_interface.dart
@@ -1,22 +1,33 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class SimpleInterface {
+
+abstract class SimpleInterface implements Finalizable {
+
   factory SimpleInterface(
     String Function() getStringValueLambda,
     SimpleInterface Function(SimpleInterface) useSimpleInterfaceLambda,
+
   ) => SimpleInterface$Lambdas(
     getStringValueLambda,
     useSimpleInterfaceLambda,
+
   );
 
+
   String getStringValue();
+
   SimpleInterface useSimpleInterface(SimpleInterface input);
 }
+
+
 // SimpleInterface "private" section, not exported.
+
 final _smokeSimpleinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -37,12 +48,17 @@ final _smokeSimpleinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SimpleInterface_get_type_id'));
+
+
+
 class SimpleInterface$Lambdas implements SimpleInterface {
   String Function() getStringValueLambda;
   SimpleInterface Function(SimpleInterface) useSimpleInterfaceLambda;
+
   SimpleInterface$Lambdas(
     this.getStringValueLambda,
     this.useSimpleInterfaceLambda,
+
   );
 
   @override
@@ -52,7 +68,9 @@ class SimpleInterface$Lambdas implements SimpleInterface {
   SimpleInterface useSimpleInterface(SimpleInterface input) =>
     useSimpleInterfaceLambda(input);
 }
+
 class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
+
   SimpleInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -64,8 +82,11 @@ class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   SimpleInterface useSimpleInterface(SimpleInterface input) {
     final _useSimpleInterfaceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SimpleInterface_useSimpleInterface__SimpleInterface'));
@@ -77,9 +98,14 @@ class SimpleInterface$Impl extends __lib.NativeBase implements SimpleInterface {
       return smokeSimpleinterfaceFromFfi(__resultHandle);
     } finally {
       smokeSimpleinterfaceReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeSimpleinterfacegetStringValueStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -99,8 +125,11 @@ int _smokeSimpleinterfaceuseSimpleInterfaceStatic(Object _obj, Pointer<Void> inp
   }
   return 0;
 }
+
+
 Pointer<Void> smokeSimpleinterfaceToFfi(SimpleInterface value) {
   if (value is __lib.NativeBase) return _smokeSimpleinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeSimpleinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -108,15 +137,19 @@ Pointer<Void> smokeSimpleinterfaceToFfi(SimpleInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeSimpleinterfacegetStringValueStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeSimpleinterfaceuseSimpleInterfaceStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 SimpleInterface smokeSimpleinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SimpleInterface) return instance;
+
   final _typeIdHandle = _smokeSimpleinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeSimpleinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -125,12 +158,19 @@ SimpleInterface smokeSimpleinterfaceFromFfi(Pointer<Void> handle) {
   _smokeSimpleinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSimpleinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSimpleinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeSimpleinterfaceToFfiNullable(SimpleInterface? value) =>
   value != null ? smokeSimpleinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SimpleInterface? smokeSimpleinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSimpleinterfaceFromFfi(handle) : null;
+
 void smokeSimpleinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSimpleinterfaceReleaseHandle(handle);
+
 // End of SimpleInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -39,7 +39,7 @@ final _smokeClasswithinternallambdaInternalnestedlambdaCreateProxy = __lib.catch
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_ClassWithInternalLambda_InternalNestedLambda_create_proxy'));
 
-class ClassWithInternalLambda_InternalNestedLambda$Impl {
+class ClassWithInternalLambda_InternalNestedLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   ClassWithInternalLambda_InternalNestedLambda$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/class_with_internal_lambda.dart
@@ -1,18 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class ClassWithInternalLambda {
+
+abstract class ClassWithInternalLambda implements Finalizable {
+
+
   static bool invokeInternalLambda(ClassWithInternalLambda_InternalNestedLambda lambda, String value) => $prototype.invokeInternalLambda(lambda, value);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = ClassWithInternalLambda$Impl(Pointer<Void>.fromAddress(0));
 }
+
 /// @nodoc
 typedef ClassWithInternalLambda_InternalNestedLambda = bool Function(String);
+
 // ClassWithInternalLambda_InternalNestedLambda "private" section, not exported.
+
 final _smokeClasswithinternallambdaInternalnestedlambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -29,9 +38,11 @@ final _smokeClasswithinternallambdaInternalnestedlambdaCreateProxy = __lib.catch
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_ClassWithInternalLambda_InternalNestedLambda_create_proxy'));
+
 class ClassWithInternalLambda_InternalNestedLambda$Impl {
   final Pointer<Void> handle;
   ClassWithInternalLambda_InternalNestedLambda$Impl(this.handle);
+
   bool call(String p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_InternalNestedLambda_call__String'));
     final _p0Handle = stringToFfi(p0);
@@ -42,9 +53,13 @@ class ClassWithInternalLambda_InternalNestedLambda$Impl {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeClasswithinternallambdaInternalnestedlambdacallStatic(Object _obj, Pointer<Void> p0, Pointer<Uint8> _result) {
   bool? _resultObject;
   try {
@@ -55,6 +70,7 @@ int _smokeClasswithinternallambdaInternalnestedlambdacallStatic(Object _obj, Poi
   }
   return 0;
 }
+
 Pointer<Void> smokeClasswithinternallambdaInternalnestedlambdaToFfi(ClassWithInternalLambda_InternalNestedLambda value) =>
   _smokeClasswithinternallambdaInternalnestedlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -62,6 +78,7 @@ Pointer<Void> smokeClasswithinternallambdaInternalnestedlambdaToFfi(ClassWithInt
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Uint8>)>(_smokeClasswithinternallambdaInternalnestedlambdacallStatic, __lib.unknownError)
   );
+
 ClassWithInternalLambda_InternalNestedLambda smokeClasswithinternallambdaInternalnestedlambdaFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeClasswithinternallambdaInternalnestedlambdaCopyHandle(handle);
   final _impl = ClassWithInternalLambda_InternalNestedLambda$Impl(_copiedHandle);
@@ -69,9 +86,12 @@ ClassWithInternalLambda_InternalNestedLambda smokeClasswithinternallambdaInterna
   _smokeClasswithinternallambdaInternalnestedlambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeClasswithinternallambdaInternalnestedlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeClasswithinternallambdaInternalnestedlambdaReleaseHandle(handle);
+
 // Nullable ClassWithInternalLambda_InternalNestedLambda
+
 final _smokeClasswithinternallambdaInternalnestedlambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -84,6 +104,7 @@ final _smokeClasswithinternallambdaInternalnestedlambdaGetValueNullable = __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_InternalNestedLambda_get_value_nullable'));
+
 Pointer<Void> smokeClasswithinternallambdaInternalnestedlambdaToFfiNullable(ClassWithInternalLambda_InternalNestedLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeClasswithinternallambdaInternalnestedlambdaToFfi(value);
@@ -91,6 +112,7 @@ Pointer<Void> smokeClasswithinternallambdaInternalnestedlambdaToFfiNullable(Clas
   smokeClasswithinternallambdaInternalnestedlambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 ClassWithInternalLambda_InternalNestedLambda? smokeClasswithinternallambdaInternalnestedlambdaFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeClasswithinternallambdaInternalnestedlambdaGetValueNullable(handle);
@@ -98,10 +120,14 @@ ClassWithInternalLambda_InternalNestedLambda? smokeClasswithinternallambdaIntern
   smokeClasswithinternallambdaInternalnestedlambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeClasswithinternallambdaInternalnestedlambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeClasswithinternallambdaInternalnestedlambdaReleaseHandleNullable(handle);
+
 // End of ClassWithInternalLambda_InternalNestedLambda "private" section.
+
 // ClassWithInternalLambda "private" section, not exported.
+
 final _smokeClasswithinternallambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -114,10 +140,15 @@ final _smokeClasswithinternallambdaReleaseHandle = __lib.catchArgumentError(() =
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ClassWithInternalLambda_release_handle'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class ClassWithInternalLambda$Impl extends __lib.NativeBase implements ClassWithInternalLambda {
+
   ClassWithInternalLambda$Impl(Pointer<Void> handle) : super(handle);
+
   bool invokeInternalLambda(ClassWithInternalLambda_InternalNestedLambda lambda, String value) {
     final _invokeInternalLambdaFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Pointer<Void>, Pointer<Void>), int Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_ClassWithInternalLambda_invokeInternalLambda__InternalNestedLambda_String'));
     final _lambdaHandle = smokeClasswithinternallambdaInternalnestedlambdaToFfi(lambda);
@@ -129,27 +160,41 @@ class ClassWithInternalLambda$Impl extends __lib.NativeBase implements ClassWith
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeClasswithinternallambdaToFfi(ClassWithInternalLambda value) =>
   _smokeClasswithinternallambdaCopyHandle((value as __lib.NativeBase).handle);
+
 ClassWithInternalLambda smokeClasswithinternallambdaFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ClassWithInternalLambda) return instance;
+
   final _copiedHandle = _smokeClasswithinternallambdaCopyHandle(handle);
   final result = ClassWithInternalLambda$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeClasswithinternallambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeClasswithinternallambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeClasswithinternallambdaReleaseHandle(handle);
+
 Pointer<Void> smokeClasswithinternallambdaToFfiNullable(ClassWithInternalLambda? value) =>
   value != null ? smokeClasswithinternallambdaToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ClassWithInternalLambda? smokeClasswithinternallambdaFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeClasswithinternallambdaFromFfi(handle) : null;
+
 void smokeClasswithinternallambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeClasswithinternallambdaReleaseHandle(handle);
+
 // End of ClassWithInternalLambda "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,16 +7,23 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class Lambdas {
+
+abstract class Lambdas implements Finalizable {
+
 
   Lambdas_Producer deconfuse(String value, Lambdas_Confuser confuser);
+
   static Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) => $prototype.fuse(items, callback);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Lambdas$Impl(Pointer<Void>.fromAddress(0));
 }
+
 typedef Lambdas_Producer = String Function();
+
 // Lambdas_Producer "private" section, not exported.
+
 final _smokeLambdasProducerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -31,9 +40,11 @@ final _smokeLambdasProducerCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Producer_create_proxy'));
+
 class Lambdas_Producer$Impl {
   final Pointer<Void> handle;
   Lambdas_Producer$Impl(this.handle);
+
   String call() {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Lambdas_Producer_call'));
     final _handle = this.handle;
@@ -42,9 +53,13 @@ class Lambdas_Producer$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdasProducercallStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -54,6 +69,7 @@ int _smokeLambdasProducercallStatic(Object _obj, Pointer<Pointer<Void>> _result)
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdasProducerToFfi(Lambdas_Producer value) =>
   _smokeLambdasProducerCreateProxy(
     __lib.getObjectToken(value),
@@ -61,6 +77,7 @@ Pointer<Void> smokeLambdasProducerToFfi(Lambdas_Producer value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Pointer<Void>>)>(_smokeLambdasProducercallStatic, __lib.unknownError)
   );
+
 Lambdas_Producer smokeLambdasProducerFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdasProducerCopyHandle(handle);
   final _impl = Lambdas_Producer$Impl(_copiedHandle);
@@ -68,9 +85,12 @@ Lambdas_Producer smokeLambdasProducerFromFfi(Pointer<Void> handle) {
   _smokeLambdasProducerRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdasProducerReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdasProducerReleaseHandle(handle);
+
 // Nullable Lambdas_Producer
+
 final _smokeLambdasProducerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -83,6 +103,7 @@ final _smokeLambdasProducerGetValueNullable = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Producer_get_value_nullable'));
+
 Pointer<Void> smokeLambdasProducerToFfiNullable(Lambdas_Producer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdasProducerToFfi(value);
@@ -90,6 +111,7 @@ Pointer<Void> smokeLambdasProducerToFfiNullable(Lambdas_Producer? value) {
   smokeLambdasProducerReleaseFfiHandle(_handle);
   return result;
 }
+
 Lambdas_Producer? smokeLambdasProducerFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdasProducerGetValueNullable(handle);
@@ -97,12 +119,16 @@ Lambdas_Producer? smokeLambdasProducerFromFfiNullable(Pointer<Void> handle) {
   smokeLambdasProducerReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdasProducerReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdasProducerReleaseHandleNullable(handle);
+
 // End of Lambdas_Producer "private" section.
 /// Should confuse everyone thoroughly
 typedef Lambdas_Confuser = Lambdas_Producer Function(String);
+
 // Lambdas_Confuser "private" section, not exported.
+
 final _smokeLambdasConfuserRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -119,9 +145,11 @@ final _smokeLambdasConfuserCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Confuser_create_proxy'));
+
 class Lambdas_Confuser$Impl {
   final Pointer<Void> handle;
   Lambdas_Confuser$Impl(this.handle);
+
   Lambdas_Producer call(String p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Confuser_call__String'));
     final _p0Handle = stringToFfi(p0);
@@ -132,9 +160,13 @@ class Lambdas_Confuser$Impl {
       return smokeLambdasProducerFromFfi(__resultHandle);
     } finally {
       smokeLambdasProducerReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdasConfusercallStatic(Object _obj, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
   Lambdas_Producer? _resultObject;
   try {
@@ -145,6 +177,7 @@ int _smokeLambdasConfusercallStatic(Object _obj, Pointer<Void> p0, Pointer<Point
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdasConfuserToFfi(Lambdas_Confuser value) =>
   _smokeLambdasConfuserCreateProxy(
     __lib.getObjectToken(value),
@@ -152,6 +185,7 @@ Pointer<Void> smokeLambdasConfuserToFfi(Lambdas_Confuser value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdasConfusercallStatic, __lib.unknownError)
   );
+
 Lambdas_Confuser smokeLambdasConfuserFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdasConfuserCopyHandle(handle);
   final _impl = Lambdas_Confuser$Impl(_copiedHandle);
@@ -159,9 +193,12 @@ Lambdas_Confuser smokeLambdasConfuserFromFfi(Pointer<Void> handle) {
   _smokeLambdasConfuserRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdasConfuserReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdasConfuserReleaseHandle(handle);
+
 // Nullable Lambdas_Confuser
+
 final _smokeLambdasConfuserCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -174,6 +211,7 @@ final _smokeLambdasConfuserGetValueNullable = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Confuser_get_value_nullable'));
+
 Pointer<Void> smokeLambdasConfuserToFfiNullable(Lambdas_Confuser? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdasConfuserToFfi(value);
@@ -181,6 +219,7 @@ Pointer<Void> smokeLambdasConfuserToFfiNullable(Lambdas_Confuser? value) {
   smokeLambdasConfuserReleaseFfiHandle(_handle);
   return result;
 }
+
 Lambdas_Confuser? smokeLambdasConfuserFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdasConfuserGetValueNullable(handle);
@@ -188,11 +227,15 @@ Lambdas_Confuser? smokeLambdasConfuserFromFfiNullable(Pointer<Void> handle) {
   smokeLambdasConfuserReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdasConfuserReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdasConfuserReleaseHandleNullable(handle);
+
 // End of Lambdas_Confuser "private" section.
 typedef Lambdas_Consumer = void Function(String);
+
 // Lambdas_Consumer "private" section, not exported.
+
 final _smokeLambdasConsumerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -209,18 +252,24 @@ final _smokeLambdasConsumerCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Consumer_create_proxy'));
+
 class Lambdas_Consumer$Impl {
   final Pointer<Void> handle;
   Lambdas_Consumer$Impl(this.handle);
+
   void call(String p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_Consumer_call__String'));
     final _p0Handle = stringToFfi(p0);
     final _handle = this.handle;
     _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     stringReleaseFfiHandle(_p0Handle);
+
   }
+
 }
+
 int _smokeLambdasConsumercallStatic(Object _obj, Pointer<Void> p0) {
+  
   try {
     (_obj as Lambdas_Consumer)(stringFromFfi(p0));
   } finally {
@@ -228,6 +277,7 @@ int _smokeLambdasConsumercallStatic(Object _obj, Pointer<Void> p0) {
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdasConsumerToFfi(Lambdas_Consumer value) =>
   _smokeLambdasConsumerCreateProxy(
     __lib.getObjectToken(value),
@@ -235,6 +285,7 @@ Pointer<Void> smokeLambdasConsumerToFfi(Lambdas_Consumer value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>)>(_smokeLambdasConsumercallStatic, __lib.unknownError)
   );
+
 Lambdas_Consumer smokeLambdasConsumerFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdasConsumerCopyHandle(handle);
   final _impl = Lambdas_Consumer$Impl(_copiedHandle);
@@ -242,9 +293,12 @@ Lambdas_Consumer smokeLambdasConsumerFromFfi(Pointer<Void> handle) {
   _smokeLambdasConsumerRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdasConsumerReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdasConsumerReleaseHandle(handle);
+
 // Nullable Lambdas_Consumer
+
 final _smokeLambdasConsumerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -257,6 +311,7 @@ final _smokeLambdasConsumerGetValueNullable = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Consumer_get_value_nullable'));
+
 Pointer<Void> smokeLambdasConsumerToFfiNullable(Lambdas_Consumer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdasConsumerToFfi(value);
@@ -264,6 +319,7 @@ Pointer<Void> smokeLambdasConsumerToFfiNullable(Lambdas_Consumer? value) {
   smokeLambdasConsumerReleaseFfiHandle(_handle);
   return result;
 }
+
 Lambdas_Consumer? smokeLambdasConsumerFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdasConsumerGetValueNullable(handle);
@@ -271,11 +327,15 @@ Lambdas_Consumer? smokeLambdasConsumerFromFfiNullable(Pointer<Void> handle) {
   smokeLambdasConsumerReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdasConsumerReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdasConsumerReleaseHandleNullable(handle);
+
 // End of Lambdas_Consumer "private" section.
 typedef Lambdas_Indexer = int Function(String, double);
+
 // Lambdas_Indexer "private" section, not exported.
+
 final _smokeLambdasIndexerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -292,9 +352,11 @@ final _smokeLambdasIndexerCreateProxy = __lib.catchArgumentError(() => __lib.nat
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Indexer_create_proxy'));
+
 class Lambdas_Indexer$Impl {
   final Pointer<Void> handle;
   Lambdas_Indexer$Impl(this.handle);
+
   int call(String p0, double p1) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Pointer<Void>, Int32, Pointer<Void>, Float), int Function(Pointer<Void>, int, Pointer<Void>, double)>('library_smoke_Lambdas_Indexer_call__String_Float'));
     final _p0Handle = stringToFfi(p0);
@@ -302,12 +364,18 @@ class Lambdas_Indexer$Impl {
     final _handle = this.handle;
     final __resultHandle = _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle, _p1Handle);
     stringReleaseFfiHandle(_p0Handle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
 }
+
 int _smokeLambdasIndexercallStatic(Object _obj, Pointer<Void> p0, double p1, Pointer<Int32> _result) {
   int? _resultObject;
   try {
@@ -315,9 +383,11 @@ int _smokeLambdasIndexercallStatic(Object _obj, Pointer<Void> p0, double p1, Poi
     _result.value = (_resultObject);
   } finally {
     stringReleaseFfiHandle(p0);
+    
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdasIndexerToFfi(Lambdas_Indexer value) =>
   _smokeLambdasIndexerCreateProxy(
     __lib.getObjectToken(value),
@@ -325,6 +395,7 @@ Pointer<Void> smokeLambdasIndexerToFfi(Lambdas_Indexer value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Float, Pointer<Int32>)>(_smokeLambdasIndexercallStatic, __lib.unknownError)
   );
+
 Lambdas_Indexer smokeLambdasIndexerFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdasIndexerCopyHandle(handle);
   final _impl = Lambdas_Indexer$Impl(_copiedHandle);
@@ -332,9 +403,12 @@ Lambdas_Indexer smokeLambdasIndexerFromFfi(Pointer<Void> handle) {
   _smokeLambdasIndexerRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdasIndexerReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdasIndexerReleaseHandle(handle);
+
 // Nullable Lambdas_Indexer
+
 final _smokeLambdasIndexerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -347,6 +421,7 @@ final _smokeLambdasIndexerGetValueNullable = __lib.catchArgumentError(() => __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_Indexer_get_value_nullable'));
+
 Pointer<Void> smokeLambdasIndexerToFfiNullable(Lambdas_Indexer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdasIndexerToFfi(value);
@@ -354,6 +429,7 @@ Pointer<Void> smokeLambdasIndexerToFfiNullable(Lambdas_Indexer? value) {
   smokeLambdasIndexerReleaseFfiHandle(_handle);
   return result;
 }
+
 Lambdas_Indexer? smokeLambdasIndexerFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdasIndexerGetValueNullable(handle);
@@ -361,11 +437,15 @@ Lambdas_Indexer? smokeLambdasIndexerFromFfiNullable(Pointer<Void> handle) {
   smokeLambdasIndexerReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdasIndexerReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdasIndexerReleaseHandleNullable(handle);
+
 // End of Lambdas_Indexer "private" section.
 typedef Lambdas_NullableConfuser = Lambdas_Producer? Function(String?);
+
 // Lambdas_NullableConfuser "private" section, not exported.
+
 final _smokeLambdasNullableconfuserRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -382,9 +462,11 @@ final _smokeLambdasNullableconfuserCreateProxy = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_NullableConfuser_create_proxy'));
+
 class Lambdas_NullableConfuser$Impl {
   final Pointer<Void> handle;
   Lambdas_NullableConfuser$Impl(this.handle);
+
   Lambdas_Producer? call(String? p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Lambdas_NullableConfuser_call__String_'));
     final _p0Handle = stringToFfiNullable(p0);
@@ -395,9 +477,13 @@ class Lambdas_NullableConfuser$Impl {
       return smokeLambdasProducerFromFfiNullable(__resultHandle);
     } finally {
       smokeLambdasProducerReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeLambdasNullableconfusercallStatic(Object _obj, Pointer<Void> p0, Pointer<Pointer<Void>> _result) {
   Lambdas_Producer? _resultObject;
   try {
@@ -408,6 +494,7 @@ int _smokeLambdasNullableconfusercallStatic(Object _obj, Pointer<Void> p0, Point
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdasNullableconfuserToFfi(Lambdas_NullableConfuser value) =>
   _smokeLambdasNullableconfuserCreateProxy(
     __lib.getObjectToken(value),
@@ -415,6 +502,7 @@ Pointer<Void> smokeLambdasNullableconfuserToFfi(Lambdas_NullableConfuser value) 
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeLambdasNullableconfusercallStatic, __lib.unknownError)
   );
+
 Lambdas_NullableConfuser smokeLambdasNullableconfuserFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdasNullableconfuserCopyHandle(handle);
   final _impl = Lambdas_NullableConfuser$Impl(_copiedHandle);
@@ -422,9 +510,12 @@ Lambdas_NullableConfuser smokeLambdasNullableconfuserFromFfi(Pointer<Void> handl
   _smokeLambdasNullableconfuserRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdasNullableconfuserReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdasNullableconfuserReleaseHandle(handle);
+
 // Nullable Lambdas_NullableConfuser
+
 final _smokeLambdasNullableconfuserCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -437,6 +528,7 @@ final _smokeLambdasNullableconfuserGetValueNullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Lambdas_NullableConfuser_get_value_nullable'));
+
 Pointer<Void> smokeLambdasNullableconfuserToFfiNullable(Lambdas_NullableConfuser? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdasNullableconfuserToFfi(value);
@@ -444,6 +536,7 @@ Pointer<Void> smokeLambdasNullableconfuserToFfiNullable(Lambdas_NullableConfuser
   smokeLambdasNullableconfuserReleaseFfiHandle(_handle);
   return result;
 }
+
 Lambdas_NullableConfuser? smokeLambdasNullableconfuserFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdasNullableconfuserGetValueNullable(handle);
@@ -451,10 +544,14 @@ Lambdas_NullableConfuser? smokeLambdasNullableconfuserFromFfiNullable(Pointer<Vo
   smokeLambdasNullableconfuserReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdasNullableconfuserReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdasNullableconfuserReleaseHandleNullable(handle);
+
 // End of Lambdas_NullableConfuser "private" section.
+
 // Lambdas "private" section, not exported.
+
 final _smokeLambdasRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -467,9 +564,14 @@ final _smokeLambdasReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Lambdas_release_handle'));
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
+
   Lambdas$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -485,8 +587,11 @@ class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
       return smokeLambdasProducerFromFfi(__resultHandle);
     } finally {
       smokeLambdasProducerReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   Map<int, String> fuse(List<String> items, Lambdas_Indexer callback) {
     final _fuseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Lambdas_fuse__ListOf_String_Indexer'));
     final _itemsHandle = foobarListofStringToFfi(items);
@@ -498,27 +603,41 @@ class Lambdas$Impl extends __lib.NativeBase implements Lambdas {
       return foobarMapofIntToStringFromFfi(__resultHandle);
     } finally {
       foobarMapofIntToStringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeLambdasToFfi(Lambdas value) =>
   _smokeLambdasCopyHandle((value as __lib.NativeBase).handle);
+
 Lambdas smokeLambdasFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Lambdas) return instance;
+
   final _copiedHandle = _smokeLambdasCopyHandle(handle);
   final result = Lambdas$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeLambdasRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdasReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdasReleaseHandle(handle);
+
 Pointer<Void> smokeLambdasToFfiNullable(Lambdas? value) =>
   value != null ? smokeLambdasToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Lambdas? smokeLambdasFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeLambdasFromFfi(handle) : null;
+
 void smokeLambdasReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdasReleaseHandle(handle);
+
 // End of Lambdas "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas.dart
@@ -41,7 +41,7 @@ final _smokeLambdasProducerCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Producer_create_proxy'));
 
-class Lambdas_Producer$Impl {
+class Lambdas_Producer$Impl implements Finalizable {
   final Pointer<Void> handle;
   Lambdas_Producer$Impl(this.handle);
 
@@ -146,7 +146,7 @@ final _smokeLambdasConfuserCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Confuser_create_proxy'));
 
-class Lambdas_Confuser$Impl {
+class Lambdas_Confuser$Impl implements Finalizable {
   final Pointer<Void> handle;
   Lambdas_Confuser$Impl(this.handle);
 
@@ -253,7 +253,7 @@ final _smokeLambdasConsumerCreateProxy = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Consumer_create_proxy'));
 
-class Lambdas_Consumer$Impl {
+class Lambdas_Consumer$Impl implements Finalizable {
   final Pointer<Void> handle;
   Lambdas_Consumer$Impl(this.handle);
 
@@ -353,7 +353,7 @@ final _smokeLambdasIndexerCreateProxy = __lib.catchArgumentError(() => __lib.nat
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_Indexer_create_proxy'));
 
-class Lambdas_Indexer$Impl {
+class Lambdas_Indexer$Impl implements Finalizable {
   final Pointer<Void> handle;
   Lambdas_Indexer$Impl(this.handle);
 
@@ -463,7 +463,7 @@ final _smokeLambdasNullableconfuserCreateProxy = __lib.catchArgumentError(() => 
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_Lambdas_NullableConfuser_create_proxy'));
 
-class Lambdas_NullableConfuser$Impl {
+class Lambdas_NullableConfuser$Impl implements Finalizable {
   final Pointer<Void> handle;
   Lambdas_NullableConfuser$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -1,16 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/smoke/lambdas_declaration_order.dart';
 import 'package:library/src/smoke/lambdas_interface.dart';
-abstract class LambdasWithStructuredTypes {
+
+abstract class LambdasWithStructuredTypes implements Finalizable {
+
 
   void doClassStuff(LambdasWithStructuredTypes_ClassCallback callback);
+
   void doStructStuff(LambdasWithStructuredTypes_StructCallback callback);
 }
+
 typedef LambdasWithStructuredTypes_ClassCallback = void Function(LambdasInterface);
+
 // LambdasWithStructuredTypes_ClassCallback "private" section, not exported.
+
 final _smokeLambdaswithstructuredtypesClasscallbackRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -27,18 +35,24 @@ final _smokeLambdaswithstructuredtypesClasscallbackCreateProxy = __lib.catchArgu
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy'));
+
 class LambdasWithStructuredTypes_ClassCallback$Impl {
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_ClassCallback$Impl(this.handle);
+
   void call(LambdasInterface p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_ClassCallback_call__LambdasInterface'));
     final _p0Handle = smokeLambdasinterfaceToFfi(p0);
     final _handle = this.handle;
     _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     smokeLambdasinterfaceReleaseFfiHandle(_p0Handle);
+
   }
+
 }
+
 int _smokeLambdaswithstructuredtypesClasscallbackcallStatic(Object _obj, Pointer<Void> p0) {
+  
   try {
     (_obj as LambdasWithStructuredTypes_ClassCallback)(smokeLambdasinterfaceFromFfi(p0));
   } finally {
@@ -46,6 +60,7 @@ int _smokeLambdaswithstructuredtypesClasscallbackcallStatic(Object _obj, Pointer
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdaswithstructuredtypesClasscallbackToFfi(LambdasWithStructuredTypes_ClassCallback value) =>
   _smokeLambdaswithstructuredtypesClasscallbackCreateProxy(
     __lib.getObjectToken(value),
@@ -53,6 +68,7 @@ Pointer<Void> smokeLambdaswithstructuredtypesClasscallbackToFfi(LambdasWithStruc
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>)>(_smokeLambdaswithstructuredtypesClasscallbackcallStatic, __lib.unknownError)
   );
+
 LambdasWithStructuredTypes_ClassCallback smokeLambdaswithstructuredtypesClasscallbackFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdaswithstructuredtypesClasscallbackCopyHandle(handle);
   final _impl = LambdasWithStructuredTypes_ClassCallback$Impl(_copiedHandle);
@@ -60,9 +76,12 @@ LambdasWithStructuredTypes_ClassCallback smokeLambdaswithstructuredtypesClasscal
   _smokeLambdaswithstructuredtypesClasscallbackRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdaswithstructuredtypesClasscallbackReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdaswithstructuredtypesClasscallbackReleaseHandle(handle);
+
 // Nullable LambdasWithStructuredTypes_ClassCallback
+
 final _smokeLambdaswithstructuredtypesClasscallbackCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -75,6 +94,7 @@ final _smokeLambdaswithstructuredtypesClasscallbackGetValueNullable = __lib.catc
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_get_value_nullable'));
+
 Pointer<Void> smokeLambdaswithstructuredtypesClasscallbackToFfiNullable(LambdasWithStructuredTypes_ClassCallback? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdaswithstructuredtypesClasscallbackToFfi(value);
@@ -82,6 +102,7 @@ Pointer<Void> smokeLambdaswithstructuredtypesClasscallbackToFfiNullable(LambdasW
   smokeLambdaswithstructuredtypesClasscallbackReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdasWithStructuredTypes_ClassCallback? smokeLambdaswithstructuredtypesClasscallbackFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdaswithstructuredtypesClasscallbackGetValueNullable(handle);
@@ -89,11 +110,15 @@ LambdasWithStructuredTypes_ClassCallback? smokeLambdaswithstructuredtypesClassca
   smokeLambdaswithstructuredtypesClasscallbackReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdaswithstructuredtypesClasscallbackReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdaswithstructuredtypesClasscallbackReleaseHandleNullable(handle);
+
 // End of LambdasWithStructuredTypes_ClassCallback "private" section.
 typedef LambdasWithStructuredTypes_StructCallback = void Function(LambdasDeclarationOrder_SomeStruct);
+
 // LambdasWithStructuredTypes_StructCallback "private" section, not exported.
+
 final _smokeLambdaswithstructuredtypesStructcallbackRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -110,18 +135,24 @@ final _smokeLambdaswithstructuredtypesStructcallbackCreateProxy = __lib.catchArg
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_proxy'));
+
 class LambdasWithStructuredTypes_StructCallback$Impl {
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_StructCallback$Impl(this.handle);
+
   void call(LambdasDeclarationOrder_SomeStruct p0) {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_StructCallback_call__SomeStruct'));
     final _p0Handle = smokeLambdasdeclarationorderSomestructToFfi(p0);
     final _handle = this.handle;
     _callFfi(_handle, __lib.LibraryContext.isolateId, _p0Handle);
     smokeLambdasdeclarationorderSomestructReleaseFfiHandle(_p0Handle);
+
   }
+
 }
+
 int _smokeLambdaswithstructuredtypesStructcallbackcallStatic(Object _obj, Pointer<Void> p0) {
+  
   try {
     (_obj as LambdasWithStructuredTypes_StructCallback)(smokeLambdasdeclarationorderSomestructFromFfi(p0));
   } finally {
@@ -129,6 +160,7 @@ int _smokeLambdaswithstructuredtypesStructcallbackcallStatic(Object _obj, Pointe
   }
   return 0;
 }
+
 Pointer<Void> smokeLambdaswithstructuredtypesStructcallbackToFfi(LambdasWithStructuredTypes_StructCallback value) =>
   _smokeLambdaswithstructuredtypesStructcallbackCreateProxy(
     __lib.getObjectToken(value),
@@ -136,6 +168,7 @@ Pointer<Void> smokeLambdaswithstructuredtypesStructcallbackToFfi(LambdasWithStru
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Void>)>(_smokeLambdaswithstructuredtypesStructcallbackcallStatic, __lib.unknownError)
   );
+
 LambdasWithStructuredTypes_StructCallback smokeLambdaswithstructuredtypesStructcallbackFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeLambdaswithstructuredtypesStructcallbackCopyHandle(handle);
   final _impl = LambdasWithStructuredTypes_StructCallback$Impl(_copiedHandle);
@@ -143,9 +176,12 @@ LambdasWithStructuredTypes_StructCallback smokeLambdaswithstructuredtypesStructc
   _smokeLambdaswithstructuredtypesStructcallbackRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdaswithstructuredtypesStructcallbackReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdaswithstructuredtypesStructcallbackReleaseHandle(handle);
+
 // Nullable LambdasWithStructuredTypes_StructCallback
+
 final _smokeLambdaswithstructuredtypesStructcallbackCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -158,6 +194,7 @@ final _smokeLambdaswithstructuredtypesStructcallbackGetValueNullable = __lib.cat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_get_value_nullable'));
+
 Pointer<Void> smokeLambdaswithstructuredtypesStructcallbackToFfiNullable(LambdasWithStructuredTypes_StructCallback? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLambdaswithstructuredtypesStructcallbackToFfi(value);
@@ -165,6 +202,7 @@ Pointer<Void> smokeLambdaswithstructuredtypesStructcallbackToFfiNullable(Lambdas
   smokeLambdaswithstructuredtypesStructcallbackReleaseFfiHandle(_handle);
   return result;
 }
+
 LambdasWithStructuredTypes_StructCallback? smokeLambdaswithstructuredtypesStructcallbackFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLambdaswithstructuredtypesStructcallbackGetValueNullable(handle);
@@ -172,10 +210,14 @@ LambdasWithStructuredTypes_StructCallback? smokeLambdaswithstructuredtypesStruct
   smokeLambdaswithstructuredtypesStructcallbackReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLambdaswithstructuredtypesStructcallbackReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdaswithstructuredtypesStructcallbackReleaseHandleNullable(handle);
+
 // End of LambdasWithStructuredTypes_StructCallback "private" section.
+
 // LambdasWithStructuredTypes "private" section, not exported.
+
 final _smokeLambdaswithstructuredtypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -188,7 +230,12 @@ final _smokeLambdaswithstructuredtypesReleaseHandle = __lib.catchArgumentError((
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LambdasWithStructuredTypes_release_handle'));
+
+
+
+
 class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements LambdasWithStructuredTypes {
+
   LambdasWithStructuredTypes$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -198,7 +245,9 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
     final _handle = this.handle;
     _doClassStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
     smokeLambdaswithstructuredtypesClasscallbackReleaseFfiHandle(_callbackHandle);
+
   }
+
   @override
   void doStructStuff(LambdasWithStructuredTypes_StructCallback callback) {
     final _doStructStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_LambdasWithStructuredTypes_doStructStuff__StructCallback'));
@@ -206,26 +255,39 @@ class LambdasWithStructuredTypes$Impl extends __lib.NativeBase implements Lambda
     final _handle = this.handle;
     _doStructStuffFfi(_handle, __lib.LibraryContext.isolateId, _callbackHandle);
     smokeLambdaswithstructuredtypesStructcallbackReleaseFfiHandle(_callbackHandle);
+
   }
+
+
 }
+
 Pointer<Void> smokeLambdaswithstructuredtypesToFfi(LambdasWithStructuredTypes value) =>
   _smokeLambdaswithstructuredtypesCopyHandle((value as __lib.NativeBase).handle);
+
 LambdasWithStructuredTypes smokeLambdaswithstructuredtypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LambdasWithStructuredTypes) return instance;
+
   final _copiedHandle = _smokeLambdaswithstructuredtypesCopyHandle(handle);
   final result = LambdasWithStructuredTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeLambdaswithstructuredtypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLambdaswithstructuredtypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLambdaswithstructuredtypesReleaseHandle(handle);
+
 Pointer<Void> smokeLambdaswithstructuredtypesToFfiNullable(LambdasWithStructuredTypes? value) =>
   value != null ? smokeLambdaswithstructuredtypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 LambdasWithStructuredTypes? smokeLambdaswithstructuredtypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeLambdaswithstructuredtypesFromFfi(handle) : null;
+
 void smokeLambdaswithstructuredtypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLambdaswithstructuredtypesReleaseHandle(handle);
+
 // End of LambdasWithStructuredTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/lambdas_with_structured_types.dart
@@ -36,7 +36,7 @@ final _smokeLambdaswithstructuredtypesClasscallbackCreateProxy = __lib.catchArgu
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_ClassCallback_create_proxy'));
 
-class LambdasWithStructuredTypes_ClassCallback$Impl {
+class LambdasWithStructuredTypes_ClassCallback$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_ClassCallback$Impl(this.handle);
 
@@ -136,7 +136,7 @@ final _smokeLambdaswithstructuredtypesStructcallbackCreateProxy = __lib.catchArg
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_LambdasWithStructuredTypes_StructCallback_create_proxy'));
 
-class LambdasWithStructuredTypes_StructCallback$Impl {
+class LambdasWithStructuredTypes_StructCallback$Impl implements Finalizable {
   final Pointer<Void> handle;
   LambdasWithStructuredTypes_StructCallback$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/dart/lib/src/smoke/standalone_producer.dart
@@ -1,9 +1,14 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 typedef StandaloneProducer = String Function();
+
 // StandaloneProducer "private" section, not exported.
+
 final _smokeStandaloneproducerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -20,9 +25,11 @@ final _smokeStandaloneproducerCreateProxy = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_StandaloneProducer_create_proxy'));
-class StandaloneProducer$Impl {
+
+class StandaloneProducer$Impl implements Finalizable {
   final Pointer<Void> handle;
   StandaloneProducer$Impl(this.handle);
+
   String call() {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_StandaloneProducer_call'));
     final _handle = this.handle;
@@ -31,9 +38,13 @@ class StandaloneProducer$Impl {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 int _smokeStandaloneproducercallStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -43,6 +54,7 @@ int _smokeStandaloneproducercallStatic(Object _obj, Pointer<Pointer<Void>> _resu
   }
   return 0;
 }
+
 Pointer<Void> smokeStandaloneproducerToFfi(StandaloneProducer value) =>
   _smokeStandaloneproducerCreateProxy(
     __lib.getObjectToken(value),
@@ -50,6 +62,7 @@ Pointer<Void> smokeStandaloneproducerToFfi(StandaloneProducer value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle, Pointer<Pointer<Void>>)>(_smokeStandaloneproducercallStatic, __lib.unknownError)
   );
+
 StandaloneProducer smokeStandaloneproducerFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeStandaloneproducerCopyHandle(handle);
   final _impl = StandaloneProducer$Impl(_copiedHandle);
@@ -57,9 +70,12 @@ StandaloneProducer smokeStandaloneproducerFromFfi(Pointer<Void> handle) {
   _smokeStandaloneproducerRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeStandaloneproducerReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeStandaloneproducerReleaseHandle(handle);
+
 // Nullable StandaloneProducer
+
 final _smokeStandaloneproducerCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -72,6 +88,7 @@ final _smokeStandaloneproducerGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_StandaloneProducer_get_value_nullable'));
+
 Pointer<Void> smokeStandaloneproducerToFfiNullable(StandaloneProducer? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeStandaloneproducerToFfi(value);
@@ -79,6 +96,7 @@ Pointer<Void> smokeStandaloneproducerToFfiNullable(StandaloneProducer? value) {
   smokeStandaloneproducerReleaseFfiHandle(_handle);
   return result;
 }
+
 StandaloneProducer? smokeStandaloneproducerFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeStandaloneproducerGetValueNullable(handle);
@@ -86,6 +104,10 @@ StandaloneProducer? smokeStandaloneproducerFromFfiNullable(Pointer<Void> handle)
   smokeStandaloneproducerReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeStandaloneproducerReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeStandaloneproducerReleaseHandleNullable(handle);
+
 // End of StandaloneProducer "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/calculator_listener.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,7 +8,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-abstract class CalculatorListener {
+
+abstract class CalculatorListener implements Finalizable {
+
   factory CalculatorListener(
     void Function(double) onCalculationResultLambda,
     void Function(double) onCalculationResultConstLambda,
@@ -14,6 +18,7 @@ abstract class CalculatorListener {
     void Function(List<double>) onCalculationResultArrayLambda,
     void Function(Map<String, double>) onCalculationResultMapLambda,
     void Function(CalculationResult) onCalculationResultInstanceLambda,
+
   ) => CalculatorListener$Lambdas(
     onCalculationResultLambda,
     onCalculationResultConstLambda,
@@ -21,20 +26,33 @@ abstract class CalculatorListener {
     onCalculationResultArrayLambda,
     onCalculationResultMapLambda,
     onCalculationResultInstanceLambda,
+
   );
 
+
   void onCalculationResult(double calculationResult);
+
   void onCalculationResultConst(double calculationResult);
+
   void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult);
+
   void onCalculationResultArray(List<double> calculationResult);
+
   void onCalculationResultMap(Map<String, double> calculationResults);
+
   void onCalculationResultInstance(CalculationResult calculationResult);
 }
+
+
 class CalculatorListener_ResultStruct {
   double result;
+
   CalculatorListener_ResultStruct(this.result);
 }
+
+
 // CalculatorListener_ResultStruct "private" section, not exported.
+
 final _smokeCalculatorlistenerResultstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
@@ -47,11 +65,16 @@ final _smokeCalculatorlistenerResultstructGetFieldresult = __lib.catchArgumentEr
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_get_field_result'));
+
+
+
 Pointer<Void> smokeCalculatorlistenerResultstructToFfi(CalculatorListener_ResultStruct value) {
   final _resultHandle = (value.result);
   final _result = _smokeCalculatorlistenerResultstructCreateHandle(_resultHandle);
+  
   return _result;
 }
+
 CalculatorListener_ResultStruct smokeCalculatorlistenerResultstructFromFfi(Pointer<Void> handle) {
   final _resultHandle = _smokeCalculatorlistenerResultstructGetFieldresult(handle);
   try {
@@ -59,10 +82,14 @@ CalculatorListener_ResultStruct smokeCalculatorlistenerResultstructFromFfi(Point
       (_resultHandle)
     );
   } finally {
+    
   }
 }
+
 void smokeCalculatorlistenerResultstructReleaseFfiHandle(Pointer<Void> handle) => _smokeCalculatorlistenerResultstructReleaseHandle(handle);
+
 // Nullable CalculatorListener_ResultStruct
+
 final _smokeCalculatorlistenerResultstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -75,6 +102,7 @@ final _smokeCalculatorlistenerResultstructGetValueNullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_ResultStruct_get_value_nullable'));
+
 Pointer<Void> smokeCalculatorlistenerResultstructToFfiNullable(CalculatorListener_ResultStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCalculatorlistenerResultstructToFfi(value);
@@ -82,6 +110,7 @@ Pointer<Void> smokeCalculatorlistenerResultstructToFfiNullable(CalculatorListene
   smokeCalculatorlistenerResultstructReleaseFfiHandle(_handle);
   return result;
 }
+
 CalculatorListener_ResultStruct? smokeCalculatorlistenerResultstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCalculatorlistenerResultstructGetValueNullable(handle);
@@ -89,10 +118,14 @@ CalculatorListener_ResultStruct? smokeCalculatorlistenerResultstructFromFfiNulla
   smokeCalculatorlistenerResultstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCalculatorlistenerResultstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCalculatorlistenerResultstructReleaseHandleNullable(handle);
+
 // End of CalculatorListener_ResultStruct "private" section.
+
 // CalculatorListener "private" section, not exported.
+
 final _smokeCalculatorlistenerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -113,6 +146,13 @@ final _smokeCalculatorlistenerGetTypeId = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_CalculatorListener_get_type_id'));
+
+
+
+
+
+
+
 class CalculatorListener$Lambdas implements CalculatorListener {
   void Function(double) onCalculationResultLambda;
   void Function(double) onCalculationResultConstLambda;
@@ -120,6 +160,7 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   void Function(List<double>) onCalculationResultArrayLambda;
   void Function(Map<String, double>) onCalculationResultMapLambda;
   void Function(CalculationResult) onCalculationResultInstanceLambda;
+
   CalculatorListener$Lambdas(
     this.onCalculationResultLambda,
     this.onCalculationResultConstLambda,
@@ -127,6 +168,7 @@ class CalculatorListener$Lambdas implements CalculatorListener {
     this.onCalculationResultArrayLambda,
     this.onCalculationResultMapLambda,
     this.onCalculationResultInstanceLambda,
+
   );
 
   @override
@@ -148,7 +190,9 @@ class CalculatorListener$Lambdas implements CalculatorListener {
   void onCalculationResultInstance(CalculationResult calculationResult) =>
     onCalculationResultInstanceLambda(calculationResult);
 }
+
 class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorListener {
+
   CalculatorListener$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -157,14 +201,20 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
     _onCalculationResultFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+
+
   }
+
   @override
   void onCalculationResultConst(double calculationResult) {
     final _onCalculationResultConstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Double), void Function(Pointer<Void>, int, double)>('library_smoke_CalculatorListener_onCalculationResultConst__Double'));
     final _calculationResultHandle = (calculationResult);
     final _handle = this.handle;
     _onCalculationResultConstFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
+
+
   }
+
   @override
   void onCalculationResultStruct(CalculatorListener_ResultStruct calculationResult) {
     final _onCalculationResultStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultStruct__ResultStruct'));
@@ -172,7 +222,9 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _handle = this.handle;
     _onCalculationResultStructFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
     smokeCalculatorlistenerResultstructReleaseFfiHandle(_calculationResultHandle);
+
   }
+
   @override
   void onCalculationResultArray(List<double> calculationResult) {
     final _onCalculationResultArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultArray__ListOf_Double'));
@@ -180,7 +232,9 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _handle = this.handle;
     _onCalculationResultArrayFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
     foobarListofDoubleReleaseFfiHandle(_calculationResultHandle);
+
   }
+
   @override
   void onCalculationResultMap(Map<String, double> calculationResults) {
     final _onCalculationResultMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultMap__MapOf_String_to_Double'));
@@ -188,7 +242,9 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _handle = this.handle;
     _onCalculationResultMapFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultsHandle);
     foobarMapofStringToDoubleReleaseFfiHandle(_calculationResultsHandle);
+
   }
+
   @override
   void onCalculationResultInstance(CalculationResult calculationResult) {
     final _onCalculationResultInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_CalculatorListener_onCalculationResultInstance__CalculationResult'));
@@ -196,23 +252,32 @@ class CalculatorListener$Impl extends __lib.NativeBase implements CalculatorList
     final _handle = this.handle;
     _onCalculationResultInstanceFfi(_handle, __lib.LibraryContext.isolateId, _calculationResultHandle);
     smokeCalculationresultReleaseFfiHandle(_calculationResultHandle);
+
   }
+
+
 }
+
 int _smokeCalculatorlisteneronCalculationResultStatic(Object _obj, double calculationResult) {
+
   try {
     (_obj as CalculatorListener).onCalculationResult((calculationResult));
   } finally {
+    
   }
   return 0;
 }
 int _smokeCalculatorlisteneronCalculationResultConstStatic(Object _obj, double calculationResult) {
+
   try {
     (_obj as CalculatorListener).onCalculationResultConst((calculationResult));
   } finally {
+    
   }
   return 0;
 }
 int _smokeCalculatorlisteneronCalculationResultStructStatic(Object _obj, Pointer<Void> calculationResult) {
+
   try {
     (_obj as CalculatorListener).onCalculationResultStruct(smokeCalculatorlistenerResultstructFromFfi(calculationResult));
   } finally {
@@ -221,6 +286,7 @@ int _smokeCalculatorlisteneronCalculationResultStructStatic(Object _obj, Pointer
   return 0;
 }
 int _smokeCalculatorlisteneronCalculationResultArrayStatic(Object _obj, Pointer<Void> calculationResult) {
+
   try {
     (_obj as CalculatorListener).onCalculationResultArray(foobarListofDoubleFromFfi(calculationResult));
   } finally {
@@ -229,6 +295,7 @@ int _smokeCalculatorlisteneronCalculationResultArrayStatic(Object _obj, Pointer<
   return 0;
 }
 int _smokeCalculatorlisteneronCalculationResultMapStatic(Object _obj, Pointer<Void> calculationResults) {
+
   try {
     (_obj as CalculatorListener).onCalculationResultMap(foobarMapofStringToDoubleFromFfi(calculationResults));
   } finally {
@@ -237,6 +304,7 @@ int _smokeCalculatorlisteneronCalculationResultMapStatic(Object _obj, Pointer<Vo
   return 0;
 }
 int _smokeCalculatorlisteneronCalculationResultInstanceStatic(Object _obj, Pointer<Void> calculationResult) {
+
   try {
     (_obj as CalculatorListener).onCalculationResultInstance(smokeCalculationresultFromFfi(calculationResult));
   } finally {
@@ -244,8 +312,11 @@ int _smokeCalculatorlisteneronCalculationResultInstanceStatic(Object _obj, Point
   }
   return 0;
 }
+
+
 Pointer<Void> smokeCalculatorlistenerToFfi(CalculatorListener value) {
   if (value is __lib.NativeBase) return _smokeCalculatorlistenerCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeCalculatorlistenerCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -257,15 +328,19 @@ Pointer<Void> smokeCalculatorlistenerToFfi(CalculatorListener value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeCalculatorlisteneronCalculationResultMapStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeCalculatorlisteneronCalculationResultInstanceStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 CalculatorListener smokeCalculatorlistenerFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CalculatorListener) return instance;
+
   final _typeIdHandle = _smokeCalculatorlistenerGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeCalculatorlistenerCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -274,12 +349,19 @@ CalculatorListener smokeCalculatorlistenerFromFfi(Pointer<Void> handle) {
   _smokeCalculatorlistenerRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCalculatorlistenerReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCalculatorlistenerReleaseHandle(handle);
+
 Pointer<Void> smokeCalculatorlistenerToFfiNullable(CalculatorListener? value) =>
   value != null ? smokeCalculatorlistenerToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CalculatorListener? smokeCalculatorlistenerFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCalculatorlistenerFromFfi(handle) : null;
+
 void smokeCalculatorlistenerReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCalculatorlistenerReleaseHandle(handle);
+
 // End of CalculatorListener "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/interface_with_static.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,28 +7,40 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class InterfaceWithStatic {
+
+abstract class InterfaceWithStatic implements Finalizable {
+
   factory InterfaceWithStatic(
     String Function() regularFunctionLambda,
     String Function() regularPropertyGetLambda,
     void Function(String) regularPropertySetLambda,
+
   ) => InterfaceWithStatic$Lambdas(
     regularFunctionLambda,
     regularPropertyGetLambda,
     regularPropertySetLambda,
+
   );
 
+
   String regularFunction();
+
   static String staticFunction() => $prototype.staticFunction();
   String get regularProperty;
   set regularProperty(String value);
+
   static String get staticProperty => $prototype.staticProperty;
   static set staticProperty(String value) { $prototype.staticProperty = value; }
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = InterfaceWithStatic$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // InterfaceWithStatic "private" section, not exported.
+
 final _smokeInterfacewithstaticRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -47,14 +61,19 @@ final _smokeInterfacewithstaticGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InterfaceWithStatic_get_type_id'));
+
+
+
 class InterfaceWithStatic$Lambdas implements InterfaceWithStatic {
   String Function() regularFunctionLambda;
   String Function() regularPropertyGetLambda;
   void Function(String) regularPropertySetLambda;
+
   InterfaceWithStatic$Lambdas(
     this.regularFunctionLambda,
     this.regularPropertyGetLambda,
     this.regularPropertySetLambda,
+
   );
 
   @override
@@ -65,9 +84,11 @@ class InterfaceWithStatic$Lambdas implements InterfaceWithStatic {
   @override
   set regularProperty(String value) => regularPropertySetLambda(value);
 }
+
 /// @nodoc
 @visibleForTesting
 class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWithStatic {
+
   InterfaceWithStatic$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -79,8 +100,11 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   String staticFunction() {
     final _staticFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticFunction'));
     final __resultHandle = _staticFunctionFfi(__lib.LibraryContext.isolateId);
@@ -88,8 +112,11 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   String get regularProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_InterfaceWithStatic_regularProperty_get'));
     final _handle = this.handle;
@@ -98,15 +125,22 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set regularProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_regularProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   String get staticProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InterfaceWithStatic_staticProperty_get'));
     final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
@@ -114,15 +148,24 @@ class InterfaceWithStatic$Impl extends __lib.NativeBase implements InterfaceWith
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set staticProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InterfaceWithStatic_staticProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeInterfacewithstaticregularFunctionStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -132,10 +175,12 @@ int _smokeInterfacewithstaticregularFunctionStatic(Object _obj, Pointer<Pointer<
   }
   return 0;
 }
+
 int _smokeInterfacewithstaticregularPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as InterfaceWithStatic).regularProperty);
   return 0;
 }
+
 int _smokeInterfacewithstaticregularPropertySetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as InterfaceWithStatic).regularProperty =
@@ -145,8 +190,10 @@ int _smokeInterfacewithstaticregularPropertySetStatic(Object _obj, Pointer<Void>
   }
   return 0;
 }
+
 Pointer<Void> smokeInterfacewithstaticToFfi(InterfaceWithStatic value) {
   if (value is __lib.NativeBase) return _smokeInterfacewithstaticCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeInterfacewithstaticCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -155,15 +202,19 @@ Pointer<Void> smokeInterfacewithstaticToFfi(InterfaceWithStatic value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeInterfacewithstaticregularPropertyGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeInterfacewithstaticregularPropertySetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 InterfaceWithStatic smokeInterfacewithstaticFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InterfaceWithStatic) return instance;
+
   final _typeIdHandle = _smokeInterfacewithstaticGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeInterfacewithstaticCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -172,12 +223,19 @@ InterfaceWithStatic smokeInterfacewithstaticFromFfi(Pointer<Void> handle) {
   _smokeInterfacewithstaticRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInterfacewithstaticReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInterfacewithstaticReleaseHandle(handle);
+
 Pointer<Void> smokeInterfacewithstaticToFfiNullable(InterfaceWithStatic? value) =>
   value != null ? smokeInterfacewithstaticToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InterfaceWithStatic? smokeInterfacewithstaticFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInterfacewithstaticFromFfi(handle) : null;
+
 void smokeInterfacewithstaticReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInterfacewithstaticReleaseHandle(handle);
+
 // End of InterfaceWithStatic "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:library/src/_library_context.dart' as __lib;
@@ -7,7 +9,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-abstract class ListenerWithProperties {
+
+abstract class ListenerWithProperties implements Finalizable {
+
   factory ListenerWithProperties(
     String Function() messageGetLambda,
     void Function(String) messageSetLambda,
@@ -42,24 +46,34 @@ abstract class ListenerWithProperties {
 
   String get message;
   set message(String value);
+
   CalculationResult get packedMessage;
   set packedMessage(CalculationResult value);
+
   ListenerWithProperties_ResultStruct get structuredMessage;
   set structuredMessage(ListenerWithProperties_ResultStruct value);
+
   ListenerWithProperties_ResultEnum get enumeratedMessage;
   set enumeratedMessage(ListenerWithProperties_ResultEnum value);
+
   List<String> get arrayedMessage;
   set arrayedMessage(List<String> value);
+
   Map<String, double> get mappedMessage;
   set mappedMessage(Map<String, double> value);
+
   Uint8List get bufferedMessage;
   set bufferedMessage(Uint8List value);
+
 }
+
 enum ListenerWithProperties_ResultEnum {
     none,
     result
 }
+
 // ListenerWithProperties_ResultEnum "private" section, not exported.
+
 int smokeListenerwithpropertiesResultenumToFfi(ListenerWithProperties_ResultEnum value) {
   switch (value) {
   case ListenerWithProperties_ResultEnum.none:
@@ -70,6 +84,7 @@ int smokeListenerwithpropertiesResultenumToFfi(ListenerWithProperties_ResultEnum
     throw StateError("Invalid enum value $value for ListenerWithProperties_ResultEnum enum.");
   }
 }
+
 ListenerWithProperties_ResultEnum smokeListenerwithpropertiesResultenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -80,7 +95,9 @@ ListenerWithProperties_ResultEnum smokeListenerwithpropertiesResultenumFromFfi(i
     throw StateError("Invalid numeric value $handle for ListenerWithProperties_ResultEnum enum.");
   }
 }
+
 void smokeListenerwithpropertiesResultenumReleaseFfiHandle(int handle) {}
+
 final _smokeListenerwithpropertiesResultenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -93,6 +110,7 @@ final _smokeListenerwithpropertiesResultenumGetValueNullable = __lib.catchArgume
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultEnum_get_value_nullable'));
+
 Pointer<Void> smokeListenerwithpropertiesResultenumToFfiNullable(ListenerWithProperties_ResultEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeListenerwithpropertiesResultenumToFfi(value);
@@ -100,6 +118,7 @@ Pointer<Void> smokeListenerwithpropertiesResultenumToFfiNullable(ListenerWithPro
   smokeListenerwithpropertiesResultenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ListenerWithProperties_ResultEnum? smokeListenerwithpropertiesResultenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeListenerwithpropertiesResultenumGetValueNullable(handle);
@@ -107,14 +126,21 @@ ListenerWithProperties_ResultEnum? smokeListenerwithpropertiesResultenumFromFfiN
   smokeListenerwithpropertiesResultenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeListenerwithpropertiesResultenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeListenerwithpropertiesResultenumReleaseHandleNullable(handle);
+
 // End of ListenerWithProperties_ResultEnum "private" section.
+
 class ListenerWithProperties_ResultStruct {
   double result;
+
   ListenerWithProperties_ResultStruct(this.result);
 }
+
+
 // ListenerWithProperties_ResultStruct "private" section, not exported.
+
 final _smokeListenerwithpropertiesResultstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
@@ -127,11 +153,16 @@ final _smokeListenerwithpropertiesResultstructGetFieldresult = __lib.catchArgume
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_get_field_result'));
+
+
+
 Pointer<Void> smokeListenerwithpropertiesResultstructToFfi(ListenerWithProperties_ResultStruct value) {
   final _resultHandle = (value.result);
   final _result = _smokeListenerwithpropertiesResultstructCreateHandle(_resultHandle);
+  
   return _result;
 }
+
 ListenerWithProperties_ResultStruct smokeListenerwithpropertiesResultstructFromFfi(Pointer<Void> handle) {
   final _resultHandle = _smokeListenerwithpropertiesResultstructGetFieldresult(handle);
   try {
@@ -139,10 +170,14 @@ ListenerWithProperties_ResultStruct smokeListenerwithpropertiesResultstructFromF
       (_resultHandle)
     );
   } finally {
+    
   }
 }
+
 void smokeListenerwithpropertiesResultstructReleaseFfiHandle(Pointer<Void> handle) => _smokeListenerwithpropertiesResultstructReleaseHandle(handle);
+
 // Nullable ListenerWithProperties_ResultStruct
+
 final _smokeListenerwithpropertiesResultstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -155,6 +190,7 @@ final _smokeListenerwithpropertiesResultstructGetValueNullable = __lib.catchArgu
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_ResultStruct_get_value_nullable'));
+
 Pointer<Void> smokeListenerwithpropertiesResultstructToFfiNullable(ListenerWithProperties_ResultStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeListenerwithpropertiesResultstructToFfi(value);
@@ -162,6 +198,7 @@ Pointer<Void> smokeListenerwithpropertiesResultstructToFfiNullable(ListenerWithP
   smokeListenerwithpropertiesResultstructReleaseFfiHandle(_handle);
   return result;
 }
+
 ListenerWithProperties_ResultStruct? smokeListenerwithpropertiesResultstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeListenerwithpropertiesResultstructGetValueNullable(handle);
@@ -169,10 +206,14 @@ ListenerWithProperties_ResultStruct? smokeListenerwithpropertiesResultstructFrom
   smokeListenerwithpropertiesResultstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeListenerwithpropertiesResultstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeListenerwithpropertiesResultstructReleaseHandleNullable(handle);
+
 // End of ListenerWithProperties_ResultStruct "private" section.
+
 // ListenerWithProperties "private" section, not exported.
+
 final _smokeListenerwithpropertiesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -193,6 +234,7 @@ final _smokeListenerwithpropertiesGetTypeId = __lib.catchArgumentError(() => __l
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenerWithProperties_get_type_id'));
+
 class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   String Function() messageGetLambda;
   void Function(String) messageSetLambda;
@@ -208,6 +250,7 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   void Function(Map<String, double>) mappedMessageSetLambda;
   Uint8List Function() bufferedMessageGetLambda;
   void Function(Uint8List) bufferedMessageSetLambda;
+
   ListenerWithProperties$Lambdas(
     this.messageGetLambda,
     this.messageSetLambda,
@@ -254,7 +297,9 @@ class ListenerWithProperties$Lambdas implements ListenerWithProperties {
   @override
   set bufferedMessage(Uint8List value) => bufferedMessageSetLambda(value);
 }
+
 class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWithProperties {
+
   ListenerWithProperties$Impl(Pointer<Void> handle) : super(handle);
 
   String get message {
@@ -265,15 +310,22 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set message(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_message_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   CalculationResult get packedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_packedMessage_get'));
     final _handle = this.handle;
@@ -282,15 +334,22 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       return smokeCalculationresultFromFfi(__resultHandle);
     } finally {
       smokeCalculationresultReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set packedMessage(CalculationResult value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_packedMessage_set__CalculationResult'));
     final _valueHandle = smokeCalculationresultToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeCalculationresultReleaseFfiHandle(_valueHandle);
+
   }
+
+
   ListenerWithProperties_ResultStruct get structuredMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_structuredMessage_get'));
     final _handle = this.handle;
@@ -299,15 +358,22 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       return smokeListenerwithpropertiesResultstructFromFfi(__resultHandle);
     } finally {
       smokeListenerwithpropertiesResultstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set structuredMessage(ListenerWithProperties_ResultStruct value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_structuredMessage_set__ResultStruct'));
     final _valueHandle = smokeListenerwithpropertiesResultstructToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeListenerwithpropertiesResultstructReleaseFfiHandle(_valueHandle);
+
   }
+
+
   ListenerWithProperties_ResultEnum get enumeratedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_get'));
     final _handle = this.handle;
@@ -316,15 +382,22 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       return smokeListenerwithpropertiesResultenumFromFfi(__resultHandle);
     } finally {
       smokeListenerwithpropertiesResultenumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set enumeratedMessage(ListenerWithProperties_ResultEnum value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_ListenerWithProperties_enumeratedMessage_set__ResultEnum'));
     final _valueHandle = smokeListenerwithpropertiesResultenumToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeListenerwithpropertiesResultenumReleaseFfiHandle(_valueHandle);
+
   }
+
+
   List<String> get arrayedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_arrayedMessage_get'));
     final _handle = this.handle;
@@ -333,15 +406,22 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       return foobarListofStringFromFfi(__resultHandle);
     } finally {
       foobarListofStringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set arrayedMessage(List<String> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_arrayedMessage_set__ListOf_String'));
     final _valueHandle = foobarListofStringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   Map<String, double> get mappedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_mappedMessage_get'));
     final _handle = this.handle;
@@ -350,15 +430,22 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       return foobarMapofStringToDoubleFromFfi(__resultHandle);
     } finally {
       foobarMapofStringToDoubleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set mappedMessage(Map<String, double> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_mappedMessage_set__MapOf_String_to_Double'));
     final _valueHandle = foobarMapofStringToDoubleToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarMapofStringToDoubleReleaseFfiHandle(_valueHandle);
+
   }
+
+
   Uint8List get bufferedMessage {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenerWithProperties_bufferedMessage_get'));
     final _handle = this.handle;
@@ -367,20 +454,31 @@ class ListenerWithProperties$Impl extends __lib.NativeBase implements ListenerWi
       return blobFromFfi(__resultHandle);
     } finally {
       blobReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set bufferedMessage(Uint8List value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ListenerWithProperties_bufferedMessage_set__Blob'));
     final _valueHandle = blobToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     blobReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
+
 int _smokeListenerwithpropertiesmessageGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as ListenerWithProperties).message);
   return 0;
 }
+
 int _smokeListenerwithpropertiesmessageSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ListenerWithProperties).message =
@@ -394,6 +492,7 @@ int _smokeListenerwithpropertiespackedMessageGetStatic(Object _obj, Pointer<Poin
   _result.value = smokeCalculationresultToFfi((_obj as ListenerWithProperties).packedMessage);
   return 0;
 }
+
 int _smokeListenerwithpropertiespackedMessageSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ListenerWithProperties).packedMessage =
@@ -407,6 +506,7 @@ int _smokeListenerwithpropertiesstructuredMessageGetStatic(Object _obj, Pointer<
   _result.value = smokeListenerwithpropertiesResultstructToFfi((_obj as ListenerWithProperties).structuredMessage);
   return 0;
 }
+
 int _smokeListenerwithpropertiesstructuredMessageSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ListenerWithProperties).structuredMessage =
@@ -420,6 +520,7 @@ int _smokeListenerwithpropertiesenumeratedMessageGetStatic(Object _obj, Pointer<
   _result.value = smokeListenerwithpropertiesResultenumToFfi((_obj as ListenerWithProperties).enumeratedMessage);
   return 0;
 }
+
 int _smokeListenerwithpropertiesenumeratedMessageSetStatic(Object _obj, int _value) {
   try {
     (_obj as ListenerWithProperties).enumeratedMessage =
@@ -433,6 +534,7 @@ int _smokeListenerwithpropertiesarrayedMessageGetStatic(Object _obj, Pointer<Poi
   _result.value = foobarListofStringToFfi((_obj as ListenerWithProperties).arrayedMessage);
   return 0;
 }
+
 int _smokeListenerwithpropertiesarrayedMessageSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ListenerWithProperties).arrayedMessage =
@@ -446,6 +548,7 @@ int _smokeListenerwithpropertiesmappedMessageGetStatic(Object _obj, Pointer<Poin
   _result.value = foobarMapofStringToDoubleToFfi((_obj as ListenerWithProperties).mappedMessage);
   return 0;
 }
+
 int _smokeListenerwithpropertiesmappedMessageSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ListenerWithProperties).mappedMessage =
@@ -459,6 +562,7 @@ int _smokeListenerwithpropertiesbufferedMessageGetStatic(Object _obj, Pointer<Po
   _result.value = blobToFfi((_obj as ListenerWithProperties).bufferedMessage);
   return 0;
 }
+
 int _smokeListenerwithpropertiesbufferedMessageSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ListenerWithProperties).bufferedMessage =
@@ -468,8 +572,10 @@ int _smokeListenerwithpropertiesbufferedMessageSetStatic(Object _obj, Pointer<Vo
   }
   return 0;
 }
+
 Pointer<Void> smokeListenerwithpropertiesToFfi(ListenerWithProperties value) {
   if (value is __lib.NativeBase) return _smokeListenerwithpropertiesCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeListenerwithpropertiesCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -489,15 +595,19 @@ Pointer<Void> smokeListenerwithpropertiesToFfi(ListenerWithProperties value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeListenerwithpropertiesbufferedMessageGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeListenerwithpropertiesbufferedMessageSetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 ListenerWithProperties smokeListenerwithpropertiesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ListenerWithProperties) return instance;
+
   final _typeIdHandle = _smokeListenerwithpropertiesGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeListenerwithpropertiesCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -506,12 +616,19 @@ ListenerWithProperties smokeListenerwithpropertiesFromFfi(Pointer<Void> handle) 
   _smokeListenerwithpropertiesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeListenerwithpropertiesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeListenerwithpropertiesReleaseHandle(handle);
+
 Pointer<Void> smokeListenerwithpropertiesToFfiNullable(ListenerWithProperties? value) =>
   value != null ? smokeListenerwithpropertiesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ListenerWithProperties? smokeListenerwithpropertiesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeListenerwithpropertiesFromFfi(handle) : null;
+
 void smokeListenerwithpropertiesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeListenerwithpropertiesReleaseHandle(handle);
+
 // End of ListenerWithProperties "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,7 +8,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/calculation_result.dart';
-abstract class ListenersWithReturnValues {
+
+abstract class ListenersWithReturnValues implements Finalizable {
+
   factory ListenersWithReturnValues(
     double Function() fetchDataDoubleLambda,
     String Function() fetchDataStringLambda,
@@ -15,6 +19,7 @@ abstract class ListenersWithReturnValues {
     List<double> Function() fetchDataArrayLambda,
     Map<String, double> Function() fetchDataMapLambda,
     CalculationResult Function() fetchDataInstanceLambda,
+
   ) => ListenersWithReturnValues$Lambdas(
     fetchDataDoubleLambda,
     fetchDataStringLambda,
@@ -23,21 +28,32 @@ abstract class ListenersWithReturnValues {
     fetchDataArrayLambda,
     fetchDataMapLambda,
     fetchDataInstanceLambda,
+
   );
 
+
   double fetchDataDouble();
+
   String fetchDataString();
+
   ListenersWithReturnValues_ResultStruct fetchDataStruct();
+
   ListenersWithReturnValues_ResultEnum fetchDataEnum();
+
   List<double> fetchDataArray();
+
   Map<String, double> fetchDataMap();
+
   CalculationResult fetchDataInstance();
 }
+
 enum ListenersWithReturnValues_ResultEnum {
     none,
     result
 }
+
 // ListenersWithReturnValues_ResultEnum "private" section, not exported.
+
 int smokeListenerswithreturnvaluesResultenumToFfi(ListenersWithReturnValues_ResultEnum value) {
   switch (value) {
   case ListenersWithReturnValues_ResultEnum.none:
@@ -48,6 +64,7 @@ int smokeListenerswithreturnvaluesResultenumToFfi(ListenersWithReturnValues_Resu
     throw StateError("Invalid enum value $value for ListenersWithReturnValues_ResultEnum enum.");
   }
 }
+
 ListenersWithReturnValues_ResultEnum smokeListenerswithreturnvaluesResultenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -58,7 +75,9 @@ ListenersWithReturnValues_ResultEnum smokeListenerswithreturnvaluesResultenumFro
     throw StateError("Invalid numeric value $handle for ListenersWithReturnValues_ResultEnum enum.");
   }
 }
+
 void smokeListenerswithreturnvaluesResultenumReleaseFfiHandle(int handle) {}
+
 final _smokeListenerswithreturnvaluesResultenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -71,6 +90,7 @@ final _smokeListenerswithreturnvaluesResultenumGetValueNullable = __lib.catchArg
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultEnum_get_value_nullable'));
+
 Pointer<Void> smokeListenerswithreturnvaluesResultenumToFfiNullable(ListenersWithReturnValues_ResultEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeListenerswithreturnvaluesResultenumToFfi(value);
@@ -78,6 +98,7 @@ Pointer<Void> smokeListenerswithreturnvaluesResultenumToFfiNullable(ListenersWit
   smokeListenerswithreturnvaluesResultenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ListenersWithReturnValues_ResultEnum? smokeListenerswithreturnvaluesResultenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeListenerswithreturnvaluesResultenumGetValueNullable(handle);
@@ -85,14 +106,21 @@ ListenersWithReturnValues_ResultEnum? smokeListenerswithreturnvaluesResultenumFr
   smokeListenerswithreturnvaluesResultenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeListenerswithreturnvaluesResultenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeListenerswithreturnvaluesResultenumReleaseHandleNullable(handle);
+
 // End of ListenersWithReturnValues_ResultEnum "private" section.
+
 class ListenersWithReturnValues_ResultStruct {
   double result;
+
   ListenersWithReturnValues_ResultStruct(this.result);
 }
+
+
 // ListenersWithReturnValues_ResultStruct "private" section, not exported.
+
 final _smokeListenerswithreturnvaluesResultstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
@@ -105,11 +133,16 @@ final _smokeListenerswithreturnvaluesResultstructGetFieldresult = __lib.catchArg
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_get_field_result'));
+
+
+
 Pointer<Void> smokeListenerswithreturnvaluesResultstructToFfi(ListenersWithReturnValues_ResultStruct value) {
   final _resultHandle = (value.result);
   final _result = _smokeListenerswithreturnvaluesResultstructCreateHandle(_resultHandle);
+  
   return _result;
 }
+
 ListenersWithReturnValues_ResultStruct smokeListenerswithreturnvaluesResultstructFromFfi(Pointer<Void> handle) {
   final _resultHandle = _smokeListenerswithreturnvaluesResultstructGetFieldresult(handle);
   try {
@@ -117,10 +150,14 @@ ListenersWithReturnValues_ResultStruct smokeListenerswithreturnvaluesResultstruc
       (_resultHandle)
     );
   } finally {
+    
   }
 }
+
 void smokeListenerswithreturnvaluesResultstructReleaseFfiHandle(Pointer<Void> handle) => _smokeListenerswithreturnvaluesResultstructReleaseHandle(handle);
+
 // Nullable ListenersWithReturnValues_ResultStruct
+
 final _smokeListenerswithreturnvaluesResultstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -133,6 +170,7 @@ final _smokeListenerswithreturnvaluesResultstructGetValueNullable = __lib.catchA
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_ResultStruct_get_value_nullable'));
+
 Pointer<Void> smokeListenerswithreturnvaluesResultstructToFfiNullable(ListenersWithReturnValues_ResultStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeListenerswithreturnvaluesResultstructToFfi(value);
@@ -140,6 +178,7 @@ Pointer<Void> smokeListenerswithreturnvaluesResultstructToFfiNullable(ListenersW
   smokeListenerswithreturnvaluesResultstructReleaseFfiHandle(_handle);
   return result;
 }
+
 ListenersWithReturnValues_ResultStruct? smokeListenerswithreturnvaluesResultstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeListenerswithreturnvaluesResultstructGetValueNullable(handle);
@@ -147,10 +186,14 @@ ListenersWithReturnValues_ResultStruct? smokeListenerswithreturnvaluesResultstru
   smokeListenerswithreturnvaluesResultstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeListenerswithreturnvaluesResultstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeListenerswithreturnvaluesResultstructReleaseHandleNullable(handle);
+
 // End of ListenersWithReturnValues_ResultStruct "private" section.
+
 // ListenersWithReturnValues "private" section, not exported.
+
 final _smokeListenerswithreturnvaluesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -171,6 +214,14 @@ final _smokeListenerswithreturnvaluesGetTypeId = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ListenersWithReturnValues_get_type_id'));
+
+
+
+
+
+
+
+
 class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   double Function() fetchDataDoubleLambda;
   String Function() fetchDataStringLambda;
@@ -179,6 +230,7 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   List<double> Function() fetchDataArrayLambda;
   Map<String, double> Function() fetchDataMapLambda;
   CalculationResult Function() fetchDataInstanceLambda;
+
   ListenersWithReturnValues$Lambdas(
     this.fetchDataDoubleLambda,
     this.fetchDataStringLambda,
@@ -187,6 +239,7 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
     this.fetchDataArrayLambda,
     this.fetchDataMapLambda,
     this.fetchDataInstanceLambda,
+
   );
 
   @override
@@ -211,7 +264,9 @@ class ListenersWithReturnValues$Lambdas implements ListenersWithReturnValues {
   CalculationResult fetchDataInstance() =>
     fetchDataInstanceLambda();
 }
+
 class ListenersWithReturnValues$Impl extends __lib.NativeBase implements ListenersWithReturnValues {
+
   ListenersWithReturnValues$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -222,8 +277,12 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   @override
   String fetchDataString() {
     final _fetchDataStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataString'));
@@ -233,8 +292,11 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   ListenersWithReturnValues_ResultStruct fetchDataStruct() {
     final _fetchDataStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataStruct'));
@@ -244,8 +306,11 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
       return smokeListenerswithreturnvaluesResultstructFromFfi(__resultHandle);
     } finally {
       smokeListenerswithreturnvaluesResultstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   ListenersWithReturnValues_ResultEnum fetchDataEnum() {
     final _fetchDataEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataEnum'));
@@ -255,8 +320,11 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
       return smokeListenerswithreturnvaluesResultenumFromFfi(__resultHandle);
     } finally {
       smokeListenerswithreturnvaluesResultenumReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   List<double> fetchDataArray() {
     final _fetchDataArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataArray'));
@@ -266,8 +334,11 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
       return foobarListofDoubleFromFfi(__resultHandle);
     } finally {
       foobarListofDoubleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Map<String, double> fetchDataMap() {
     final _fetchDataMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataMap'));
@@ -277,8 +348,11 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
       return foobarMapofStringToDoubleFromFfi(__resultHandle);
     } finally {
       foobarMapofStringToDoubleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   CalculationResult fetchDataInstance() {
     final _fetchDataInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ListenersWithReturnValues_fetchDataInstance'));
@@ -288,9 +362,14 @@ class ListenersWithReturnValues$Impl extends __lib.NativeBase implements Listene
       return smokeCalculationresultFromFfi(__resultHandle);
     } finally {
       smokeCalculationresultReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeListenerswithreturnvaluesfetchDataDoubleStatic(Object _obj, Pointer<Double> _result) {
   double? _resultObject;
   try {
@@ -354,8 +433,11 @@ int _smokeListenerswithreturnvaluesfetchDataInstanceStatic(Object _obj, Pointer<
   }
   return 0;
 }
+
+
 Pointer<Void> smokeListenerswithreturnvaluesToFfi(ListenersWithReturnValues value) {
   if (value is __lib.NativeBase) return _smokeListenerswithreturnvaluesCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeListenerswithreturnvaluesCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -368,15 +450,19 @@ Pointer<Void> smokeListenerswithreturnvaluesToFfi(ListenersWithReturnValues valu
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeListenerswithreturnvaluesfetchDataMapStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeListenerswithreturnvaluesfetchDataInstanceStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 ListenersWithReturnValues smokeListenerswithreturnvaluesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ListenersWithReturnValues) return instance;
+
   final _typeIdHandle = _smokeListenerswithreturnvaluesGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeListenerswithreturnvaluesCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -385,12 +471,19 @@ ListenersWithReturnValues smokeListenerswithreturnvaluesFromFfi(Pointer<Void> ha
   _smokeListenerswithreturnvaluesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeListenerswithreturnvaluesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeListenerswithreturnvaluesReleaseHandle(handle);
+
 Pointer<Void> smokeListenerswithreturnvaluesToFfiNullable(ListenersWithReturnValues? value) =>
   value != null ? smokeListenerswithreturnvaluesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ListenersWithReturnValues? smokeListenerswithreturnvaluesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeListenerswithreturnvaluesFromFfi(handle) : null;
+
 void smokeListenerswithreturnvaluesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeListenerswithreturnvaluesReleaseHandle(handle);
+
 // End of ListenersWithReturnValues "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
+++ b/gluecodium/src/test/resources/smoke/locales/output/dart/lib/src/smoke/locales.dart
@@ -1,20 +1,31 @@
+
+
 import 'dart:ffi';
 import 'package:intl/locale.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class Locales {
+
+abstract class Locales implements Finalizable {
+
 
   Locale localeMethod(Locale input);
   Locale get localeProperty;
   set localeProperty(Locale value);
+
 }
+
+
 class Locales_LocaleStruct {
   Locale localeField;
+
   Locales_LocaleStruct(this.localeField);
 }
+
+
 // Locales_LocaleStruct "private" section, not exported.
+
 final _smokeLocalesLocalestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -27,12 +38,16 @@ final _smokeLocalesLocalestructGetFieldlocaleField = __lib.catchArgumentError(()
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_get_field_localeField'));
+
+
+
 Pointer<Void> smokeLocalesLocalestructToFfi(Locales_LocaleStruct value) {
   final _localeFieldHandle = localeToFfi(value.localeField);
   final _result = _smokeLocalesLocalestructCreateHandle(_localeFieldHandle);
   localeReleaseFfiHandle(_localeFieldHandle);
   return _result;
 }
+
 Locales_LocaleStruct smokeLocalesLocalestructFromFfi(Pointer<Void> handle) {
   final _localeFieldHandle = _smokeLocalesLocalestructGetFieldlocaleField(handle);
   try {
@@ -43,8 +58,11 @@ Locales_LocaleStruct smokeLocalesLocalestructFromFfi(Pointer<Void> handle) {
     localeReleaseFfiHandle(_localeFieldHandle);
   }
 }
+
 void smokeLocalesLocalestructReleaseFfiHandle(Pointer<Void> handle) => _smokeLocalesLocalestructReleaseHandle(handle);
+
 // Nullable Locales_LocaleStruct
+
 final _smokeLocalesLocalestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -57,6 +75,7 @@ final _smokeLocalesLocalestructGetValueNullable = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Locales_LocaleStruct_get_value_nullable'));
+
 Pointer<Void> smokeLocalesLocalestructToFfiNullable(Locales_LocaleStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLocalesLocalestructToFfi(value);
@@ -64,6 +83,7 @@ Pointer<Void> smokeLocalesLocalestructToFfiNullable(Locales_LocaleStruct? value)
   smokeLocalesLocalestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Locales_LocaleStruct? smokeLocalesLocalestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLocalesLocalestructGetValueNullable(handle);
@@ -71,10 +91,14 @@ Locales_LocaleStruct? smokeLocalesLocalestructFromFfiNullable(Pointer<Void> hand
   smokeLocalesLocalestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLocalesLocalestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLocalesLocalestructReleaseHandleNullable(handle);
+
 // End of Locales_LocaleStruct "private" section.
+
 // Locales "private" section, not exported.
+
 final _smokeLocalesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -87,7 +111,11 @@ final _smokeLocalesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Locales_release_handle'));
+
+
+
 class Locales$Impl extends __lib.NativeBase implements Locales {
+
   Locales$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -101,8 +129,11 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
       return localeFromFfi(__resultHandle);
     } finally {
       localeReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   Locale get localeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Locales_localeProperty_get'));
@@ -112,8 +143,11 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
       return localeFromFfi(__resultHandle);
     } finally {
       localeReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set localeProperty(Locale value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Locales_localeProperty_set__Locale'));
@@ -121,26 +155,40 @@ class Locales$Impl extends __lib.NativeBase implements Locales {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     localeReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeLocalesToFfi(Locales value) =>
   _smokeLocalesCopyHandle((value as __lib.NativeBase).handle);
+
 Locales smokeLocalesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Locales) return instance;
+
   final _copiedHandle = _smokeLocalesCopyHandle(handle);
   final result = Locales$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeLocalesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLocalesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLocalesReleaseHandle(handle);
+
 Pointer<Void> smokeLocalesToFfiNullable(Locales? value) =>
   value != null ? smokeLocalesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Locales? smokeLocalesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeLocalesFromFfi(handle) : null;
+
 void smokeLocalesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLocalesReleaseHandle(handle);
+
 // End of Locales "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/method_overloads.dart
@@ -1,28 +1,48 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
-abstract class MethodOverloads {
+
+abstract class MethodOverloads implements Finalizable {
+
 
   bool isBoolean(bool input);
+
   bool isBooleanByte(int input);
+
   bool isBooleanString(String input);
+
   bool isBooleanPoint(MethodOverloads_Point input);
+
   bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4);
+
   bool isBooleanStringArray(List<String> input);
+
   bool isBooleanIntArray(List<int> input);
+
   bool isBooleanConst();
+
   bool isFloatString(String input);
+
   bool isFloatList(List<int> input);
 }
+
+
 class MethodOverloads_Point {
   double x;
+
   double y;
+
   MethodOverloads_Point(this.x, this.y);
 }
+
+
 // MethodOverloads_Point "private" section, not exported.
+
 final _smokeMethodoverloadsPointCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double, Double),
     Pointer<Void> Function(double, double)
@@ -39,25 +59,36 @@ final _smokeMethodoverloadsPointGetFieldy = __lib.catchArgumentError(() => __lib
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_get_field_y'));
+
+
+
 Pointer<Void> smokeMethodoverloadsPointToFfi(MethodOverloads_Point value) {
   final _xHandle = (value.x);
   final _yHandle = (value.y);
   final _result = _smokeMethodoverloadsPointCreateHandle(_xHandle, _yHandle);
+  
+  
   return _result;
 }
+
 MethodOverloads_Point smokeMethodoverloadsPointFromFfi(Pointer<Void> handle) {
   final _xHandle = _smokeMethodoverloadsPointGetFieldx(handle);
   final _yHandle = _smokeMethodoverloadsPointGetFieldy(handle);
   try {
     return MethodOverloads_Point(
-      (_xHandle),
+      (_xHandle), 
       (_yHandle)
     );
   } finally {
+    
+    
   }
 }
+
 void smokeMethodoverloadsPointReleaseFfiHandle(Pointer<Void> handle) => _smokeMethodoverloadsPointReleaseHandle(handle);
+
 // Nullable MethodOverloads_Point
+
 final _smokeMethodoverloadsPointCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -70,6 +101,7 @@ final _smokeMethodoverloadsPointGetValueNullable = __lib.catchArgumentError(() =
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_Point_get_value_nullable'));
+
 Pointer<Void> smokeMethodoverloadsPointToFfiNullable(MethodOverloads_Point? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeMethodoverloadsPointToFfi(value);
@@ -77,6 +109,7 @@ Pointer<Void> smokeMethodoverloadsPointToFfiNullable(MethodOverloads_Point? valu
   smokeMethodoverloadsPointReleaseFfiHandle(_handle);
   return result;
 }
+
 MethodOverloads_Point? smokeMethodoverloadsPointFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeMethodoverloadsPointGetValueNullable(handle);
@@ -84,10 +117,14 @@ MethodOverloads_Point? smokeMethodoverloadsPointFromFfiNullable(Pointer<Void> ha
   smokeMethodoverloadsPointReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeMethodoverloadsPointReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeMethodoverloadsPointReleaseHandleNullable(handle);
+
 // End of MethodOverloads_Point "private" section.
+
 // MethodOverloads "private" section, not exported.
+
 final _smokeMethodoverloadsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -100,7 +137,20 @@ final _smokeMethodoverloadsReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_MethodOverloads_release_handle'));
+
+
+
+
+
+
+
+
+
+
+
+
 class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
+
   MethodOverloads$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -114,20 +164,27 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isBooleanByte(int input) {
     final _isBooleanByteFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Int8), int Function(Pointer<Void>, int, int)>('library_smoke_MethodOverloads_isBoolean__Byte'));
     final _inputHandle = (input);
     final _handle = this.handle;
     final __resultHandle = _isBooleanByteFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isBooleanString(String input) {
     final _isBooleanStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__String'));
@@ -139,8 +196,11 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isBooleanPoint(MethodOverloads_Point input) {
     final _isBooleanPointFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Point'));
@@ -152,8 +212,11 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isBooleanMulti(bool input1, int input2, String input3, MethodOverloads_Point input4) {
     final _isBooleanMultiFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8, Int8, Pointer<Void>, Pointer<Void>), int Function(Pointer<Void>, int, int, int, Pointer<Void>, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__Boolean_Byte_String_Point'));
@@ -164,14 +227,18 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
     final _handle = this.handle;
     final __resultHandle = _isBooleanMultiFfi(_handle, __lib.LibraryContext.isolateId, _input1Handle, _input2Handle, _input3Handle, _input4Handle);
     booleanReleaseFfiHandle(_input1Handle);
+
     stringReleaseFfiHandle(_input3Handle);
     smokeMethodoverloadsPointReleaseFfiHandle(_input4Handle);
     try {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isBooleanStringArray(List<String> input) {
     final _isBooleanStringArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_String'));
@@ -183,8 +250,11 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isBooleanIntArray(List<int> input) {
     final _isBooleanIntArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isBoolean__ListOf_Byte'));
@@ -196,8 +266,11 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isBooleanConst() {
     final _isBooleanConstFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_MethodOverloads_isBoolean'));
@@ -207,8 +280,11 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isFloatString(String input) {
     final _isFloatStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__String'));
@@ -220,8 +296,11 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool isFloatList(List<int> input) {
     final _isFloatListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Pointer<Void>), int Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_MethodOverloads_isFloat__ListOf_Byte'));
@@ -233,27 +312,41 @@ class MethodOverloads$Impl extends __lib.NativeBase implements MethodOverloads {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeMethodoverloadsToFfi(MethodOverloads value) =>
   _smokeMethodoverloadsCopyHandle((value as __lib.NativeBase).handle);
+
 MethodOverloads smokeMethodoverloadsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is MethodOverloads) return instance;
+
   final _copiedHandle = _smokeMethodoverloadsCopyHandle(handle);
   final result = MethodOverloads$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeMethodoverloadsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeMethodoverloadsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeMethodoverloadsReleaseHandle(handle);
+
 Pointer<Void> smokeMethodoverloadsToFfiNullable(MethodOverloads? value) =>
   value != null ? smokeMethodoverloadsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 MethodOverloads? smokeMethodoverloadsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeMethodoverloadsFromFfi(handle) : null;
+
 void smokeMethodoverloadsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeMethodoverloadsReleaseHandle(handle);
+
 // End of MethodOverloads "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/dart/lib/src/smoke/special_names.dart
@@ -1,21 +1,33 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class SpecialNames {
+
+abstract class SpecialNames implements Finalizable {
+
   factory SpecialNames(String result) => $prototype.make(result);
 
+
   void create();
+
   void reallyRelease();
+
   void createProxy();
+
   void Uppercase();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = SpecialNames$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // SpecialNames "private" section, not exported.
+
 final _smokeSpecialnamesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -28,42 +40,62 @@ final _smokeSpecialnamesReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SpecialNames_release_handle'));
+
+
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
+
   SpecialNames$Impl(Pointer<Void> handle) : super(handle);
+
 
   SpecialNames make(String result) {
     final _result_handle = _make(result);
     final _result = SpecialNames$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeSpecialnamesRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   @override
   void create() {
     final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_create'));
     final _handle = this.handle;
     _createFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void reallyRelease() {
     final _reallyReleaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_release'));
     final _handle = this.handle;
     _reallyReleaseFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void createProxy() {
     final _createProxyFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_createProxy'));
     final _handle = this.handle;
     _createProxyFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void Uppercase() {
     final _UppercaseFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SpecialNames_Uppercase'));
     final _handle = this.handle;
     _UppercaseFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   static Pointer<Void> _make(String result) {
     final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SpecialNames_make__String'));
     final _resultHandle = stringToFfi(result);
@@ -71,25 +103,37 @@ class SpecialNames$Impl extends __lib.NativeBase implements SpecialNames {
     stringReleaseFfiHandle(_resultHandle);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeSpecialnamesToFfi(SpecialNames value) =>
   _smokeSpecialnamesCopyHandle((value as __lib.NativeBase).handle);
+
 SpecialNames smokeSpecialnamesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SpecialNames) return instance;
+
   final _copiedHandle = _smokeSpecialnamesCopyHandle(handle);
   final result = SpecialNames$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSpecialnamesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSpecialnamesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSpecialnamesReleaseHandle(handle);
+
 Pointer<Void> smokeSpecialnamesToFfiNullable(SpecialNames? value) =>
   value != null ? smokeSpecialnamesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SpecialNames? smokeSpecialnamesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSpecialnamesFromFfi(handle) : null;
+
 void smokeSpecialnamesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSpecialnamesReleaseHandle(handle);
+
 // End of SpecialNames "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,12 +8,19 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
 import 'package:library/src/smoke/parent_narrow_one.dart';
-abstract class FirstParentIsClassClass implements ParentClass, ParentNarrowOne {
+
+abstract class FirstParentIsClassClass implements ParentClass, ParentNarrowOne, Finalizable {
+
+
   void childFunction();
   String get childProperty;
   set childProperty(String value);
+
 }
+
+
 // FirstParentIsClassClass "private" section, not exported.
+
 final _smokeFirstparentisclassclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -28,20 +37,29 @@ final _smokeFirstparentisclassclassGetTypeId = __lib.catchArgumentError(() => __
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FirstParentIsClassClass_get_type_id'));
+
+
+
 class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstParentIsClassClass {
+
   FirstParentIsClassClass$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void childFunction() {
     final _childFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_childFunction'));
     final _handle = this.handle;
     _childFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void parentFunctionOne() {
     final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_parentFunctionOne'));
     final _handle = this.handle;
     _parentFunctionOneFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   String get childProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_childProperty_get'));
@@ -51,8 +69,11 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set childProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_FirstParentIsClassClass_childProperty_set__String'));
@@ -60,7 +81,10 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   String get parentPropertyOne {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FirstParentIsClassClass_parentPropertyOne_get'));
@@ -70,8 +94,11 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set parentPropertyOne(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_FirstParentIsClassClass_parentPropertyOne_set'));
@@ -79,17 +106,25 @@ class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstPare
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeFirstparentisclassclassToFfi(FirstParentIsClassClass value) =>
   _smokeFirstparentisclassclassCopyHandle((value as __lib.NativeBase).handle);
+
 FirstParentIsClassClass smokeFirstparentisclassclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is FirstParentIsClassClass) return instance;
+
   final _typeIdHandle = _smokeFirstparentisclassclassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeFirstparentisclassclassCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -98,12 +133,19 @@ FirstParentIsClassClass smokeFirstparentisclassclassFromFfi(Pointer<Void> handle
   _smokeFirstparentisclassclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeFirstparentisclassclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeFirstparentisclassclassReleaseHandle(handle);
+
 Pointer<Void> smokeFirstparentisclassclassToFfiNullable(FirstParentIsClassClass? value) =>
   value != null ? smokeFirstparentisclassclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 FirstParentIsClassClass? smokeFirstparentisclassclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeFirstparentisclassclassFromFfi(handle) : null;
+
 void smokeFirstparentisclassclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFirstparentisclassclassReleaseHandle(handle);
+
 // End of FirstParentIsClassClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_interface_interface.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,7 +8,9 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'package:library/src/smoke/parent_narrow_one.dart';
-abstract class FirstParentIsInterfaceInterface implements ParentInterface, ParentNarrowOne {
+
+abstract class FirstParentIsInterfaceInterface implements ParentInterface, ParentNarrowOne, Finalizable {
+
   factory FirstParentIsInterfaceInterface(
     void Function() parentFunctionLambda,
     void Function() parentFunctionOneLambda,
@@ -29,11 +33,16 @@ abstract class FirstParentIsInterfaceInterface implements ParentInterface, Paren
     childPropertySetLambda
   );
 
+
   void childFunction();
   String get childProperty;
   set childProperty(String value);
+
 }
+
+
 // FirstParentIsInterfaceInterface "private" section, not exported.
+
 final _smokeFirstparentisinterfaceinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -54,6 +63,8 @@ final _smokeFirstparentisinterfaceinterfaceGetTypeId = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FirstParentIsInterfaceInterface_get_type_id'));
+
+
 class FirstParentIsInterfaceInterface$Lambdas implements FirstParentIsInterfaceInterface {
   void Function() parentFunctionLambda;
   void Function() parentFunctionOneLambda;
@@ -64,6 +75,7 @@ class FirstParentIsInterfaceInterface$Lambdas implements FirstParentIsInterfaceI
   void Function(String) parentPropertyOneSetLambda;
   String Function() childPropertyGetLambda;
   void Function(String) childPropertySetLambda;
+
   FirstParentIsInterfaceInterface$Lambdas(
     this.parentFunctionLambda,
     this.parentFunctionOneLambda,
@@ -98,7 +110,9 @@ class FirstParentIsInterfaceInterface$Lambdas implements FirstParentIsInterfaceI
   @override
   set childProperty(String value) => childPropertySetLambda(value);
 }
+
 class FirstParentIsInterfaceInterface$Impl extends __lib.NativeBase implements FirstParentIsInterfaceInterface {
+
   FirstParentIsInterfaceInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -106,19 +120,25 @@ class FirstParentIsInterfaceInterface$Impl extends __lib.NativeBase implements F
     final _parentFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentInterface_parentFunction'));
     final _handle = this.handle;
     _parentFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void parentFunctionOne() {
     final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentFunctionOne'));
     final _handle = this.handle;
     _parentFunctionOneFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void childFunction() {
     final _childFunctionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_FirstParentIsInterfaceInterface_childFunction'));
     final _handle = this.handle;
     _childFunctionFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   String get parentProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentInterface_parentProperty_get'));
     final _handle = this.handle;
@@ -127,15 +147,22 @@ class FirstParentIsInterfaceInterface$Impl extends __lib.NativeBase implements F
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set parentProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentInterface_parentProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   String get parentPropertyOne {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentPropertyOne_get'));
     final _handle = this.handle;
@@ -144,15 +171,22 @@ class FirstParentIsInterfaceInterface$Impl extends __lib.NativeBase implements F
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set parentPropertyOne(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentNarrowOne_parentPropertyOne_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   String get childProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_FirstParentIsInterfaceInterface_childProperty_get'));
     final _handle = this.handle;
@@ -161,17 +195,27 @@ class FirstParentIsInterfaceInterface$Impl extends __lib.NativeBase implements F
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set childProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_FirstParentIsInterfaceInterface_childProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeFirstparentisinterfaceinterfaceparentFunctionStatic(Object _obj) {
+
   try {
     (_obj as FirstParentIsInterfaceInterface).parentFunction();
   } finally {
@@ -179,6 +223,7 @@ int _smokeFirstparentisinterfaceinterfaceparentFunctionStatic(Object _obj) {
   return 0;
 }
 int _smokeFirstparentisinterfaceinterfaceparentFunctionOneStatic(Object _obj) {
+
   try {
     (_obj as FirstParentIsInterfaceInterface).parentFunctionOne();
   } finally {
@@ -186,16 +231,19 @@ int _smokeFirstparentisinterfaceinterfaceparentFunctionOneStatic(Object _obj) {
   return 0;
 }
 int _smokeFirstparentisinterfaceinterfacechildFunctionStatic(Object _obj) {
+
   try {
     (_obj as FirstParentIsInterfaceInterface).childFunction();
   } finally {
   }
   return 0;
 }
+
 int _smokeFirstparentisinterfaceinterfaceparentPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as FirstParentIsInterfaceInterface).parentProperty);
   return 0;
 }
+
 int _smokeFirstparentisinterfaceinterfaceparentPropertySetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as FirstParentIsInterfaceInterface).parentProperty =
@@ -209,6 +257,7 @@ int _smokeFirstparentisinterfaceinterfaceparentPropertyOneGetStatic(Object _obj,
   _result.value = stringToFfi((_obj as FirstParentIsInterfaceInterface).parentPropertyOne);
   return 0;
 }
+
 int _smokeFirstparentisinterfaceinterfaceparentPropertyOneSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as FirstParentIsInterfaceInterface).parentPropertyOne =
@@ -222,6 +271,7 @@ int _smokeFirstparentisinterfaceinterfacechildPropertyGetStatic(Object _obj, Poi
   _result.value = stringToFfi((_obj as FirstParentIsInterfaceInterface).childProperty);
   return 0;
 }
+
 int _smokeFirstparentisinterfaceinterfacechildPropertySetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as FirstParentIsInterfaceInterface).childProperty =
@@ -231,8 +281,10 @@ int _smokeFirstparentisinterfaceinterfacechildPropertySetStatic(Object _obj, Poi
   }
   return 0;
 }
+
 Pointer<Void> smokeFirstparentisinterfaceinterfaceToFfi(FirstParentIsInterfaceInterface value) {
   if (value is __lib.NativeBase) return _smokeFirstparentisinterfaceinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeFirstparentisinterfaceinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -247,15 +299,19 @@ Pointer<Void> smokeFirstparentisinterfaceinterfaceToFfi(FirstParentIsInterfaceIn
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeFirstparentisinterfaceinterfacechildPropertyGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeFirstparentisinterfaceinterfacechildPropertySetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 FirstParentIsInterfaceInterface smokeFirstparentisinterfaceinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is FirstParentIsInterfaceInterface) return instance;
+
   final _typeIdHandle = _smokeFirstparentisinterfaceinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeFirstparentisinterfaceinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -264,12 +320,19 @@ FirstParentIsInterfaceInterface smokeFirstparentisinterfaceinterfaceFromFfi(Poin
   _smokeFirstparentisinterfaceinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeFirstparentisinterfaceinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeFirstparentisinterfaceinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeFirstparentisinterfaceinterfaceToFfiNullable(FirstParentIsInterfaceInterface? value) =>
   value != null ? smokeFirstparentisinterfaceinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 FirstParentIsInterfaceInterface? smokeFirstparentisinterfaceinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeFirstparentisinterfaceinterfaceFromFfi(handle) : null;
+
 void smokeFirstparentisinterfaceinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFirstparentisinterfaceinterfaceReleaseHandle(handle);
+
 // End of FirstParentIsInterfaceInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/parent_narrow_one.dart
@@ -1,10 +1,14 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class ParentNarrowOne {
+
+abstract class ParentNarrowOne implements Finalizable {
+
   factory ParentNarrowOne(
     void Function() parentFunctionOneLambda,
     String Function() parentPropertyOneGetLambda,
@@ -15,11 +19,16 @@ abstract class ParentNarrowOne {
     parentPropertyOneSetLambda
   );
 
+
   void parentFunctionOne();
   String get parentPropertyOne;
   set parentPropertyOne(String value);
+
 }
+
+
 // ParentNarrowOne "private" section, not exported.
+
 final _smokeParentnarrowoneRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -40,10 +49,13 @@ final _smokeParentnarrowoneGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ParentNarrowOne_get_type_id'));
+
+
 class ParentNarrowOne$Lambdas implements ParentNarrowOne {
   void Function() parentFunctionOneLambda;
   String Function() parentPropertyOneGetLambda;
   void Function(String) parentPropertyOneSetLambda;
+
   ParentNarrowOne$Lambdas(
     this.parentFunctionOneLambda,
     this.parentPropertyOneGetLambda,
@@ -58,7 +70,9 @@ class ParentNarrowOne$Lambdas implements ParentNarrowOne {
   @override
   set parentPropertyOne(String value) => parentPropertyOneSetLambda(value);
 }
+
 class ParentNarrowOne$Impl extends __lib.NativeBase implements ParentNarrowOne {
+
   ParentNarrowOne$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -66,7 +80,9 @@ class ParentNarrowOne$Impl extends __lib.NativeBase implements ParentNarrowOne {
     final _parentFunctionOneFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentFunctionOne'));
     final _handle = this.handle;
     _parentFunctionOneFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   String get parentPropertyOne {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_ParentNarrowOne_parentPropertyOne_get'));
     final _handle = this.handle;
@@ -75,27 +91,39 @@ class ParentNarrowOne$Impl extends __lib.NativeBase implements ParentNarrowOne {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set parentPropertyOne(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_ParentNarrowOne_parentPropertyOne_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeParentnarrowoneparentFunctionOneStatic(Object _obj) {
+
   try {
     (_obj as ParentNarrowOne).parentFunctionOne();
   } finally {
   }
   return 0;
 }
+
 int _smokeParentnarrowoneparentPropertyOneGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as ParentNarrowOne).parentPropertyOne);
   return 0;
 }
+
 int _smokeParentnarrowoneparentPropertyOneSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as ParentNarrowOne).parentPropertyOne =
@@ -105,7 +133,9 @@ int _smokeParentnarrowoneparentPropertyOneSetStatic(Object _obj, Pointer<Void> _
   }
   return 0;
 }
+
 Pointer<Void> smokeParentnarrowoneToFfi(ParentNarrowOne value) {
+
   final result = _smokeParentnarrowoneCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -114,15 +144,19 @@ Pointer<Void> smokeParentnarrowoneToFfi(ParentNarrowOne value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeParentnarrowoneparentPropertyOneGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeParentnarrowoneparentPropertyOneSetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 ParentNarrowOne smokeParentnarrowoneFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ParentNarrowOne) return instance;
+
   final _typeIdHandle = _smokeParentnarrowoneGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeParentnarrowoneCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -131,12 +165,19 @@ ParentNarrowOne smokeParentnarrowoneFromFfi(Pointer<Void> handle) {
   _smokeParentnarrowoneRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeParentnarrowoneReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeParentnarrowoneReleaseHandle(handle);
+
 Pointer<Void> smokeParentnarrowoneToFfiNullable(ParentNarrowOne? value) =>
   value != null ? smokeParentnarrowoneToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ParentNarrowOne? smokeParentnarrowoneFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeParentnarrowoneFromFfi(handle) : null;
+
 void smokeParentnarrowoneReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeParentnarrowoneReleaseHandle(handle);
+
 // End of ParentNarrowOne "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,20 +8,27 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/outer_class.dart';
 import 'package:library/src/smoke/outer_interface.dart';
 import 'package:meta/meta.dart';
-abstract class LevelOne {
+
+abstract class LevelOne implements Finalizable {
 
 }
-abstract class LevelOne_LevelTwo {
+
+abstract class LevelOne_LevelTwo implements Finalizable {
 
 }
-abstract class LevelOne_LevelTwo_LevelThree {
+
+abstract class LevelOne_LevelTwo_LevelThree implements Finalizable {
+
 
   OuterInterface_InnerClass foo(OuterClass_InnerInterface input);
 }
+
 enum LevelOne_LevelTwo_LevelThree_LevelFourEnum {
     none
 }
+
 // LevelOne_LevelTwo_LevelThree_LevelFourEnum "private" section, not exported.
+
 int smokeLeveloneLeveltwoLevelthreeLevelfourenumToFfi(LevelOne_LevelTwo_LevelThree_LevelFourEnum value) {
   switch (value) {
   case LevelOne_LevelTwo_LevelThree_LevelFourEnum.none:
@@ -28,6 +37,7 @@ int smokeLeveloneLeveltwoLevelthreeLevelfourenumToFfi(LevelOne_LevelTwo_LevelThr
     throw StateError("Invalid enum value $value for LevelOne_LevelTwo_LevelThree_LevelFourEnum enum.");
   }
 }
+
 LevelOne_LevelTwo_LevelThree_LevelFourEnum smokeLeveloneLeveltwoLevelthreeLevelfourenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -36,7 +46,9 @@ LevelOne_LevelTwo_LevelThree_LevelFourEnum smokeLeveloneLeveltwoLevelthreeLevelf
     throw StateError("Invalid numeric value $handle for LevelOne_LevelTwo_LevelThree_LevelFourEnum enum.");
   }
 }
+
 void smokeLeveloneLeveltwoLevelthreeLevelfourenumReleaseFfiHandle(int handle) {}
+
 final _smokeLeveloneLeveltwoLevelthreeLevelfourenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -49,6 +61,7 @@ final _smokeLeveloneLeveltwoLevelthreeLevelfourenumGetValueNullable = __lib.catc
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFourEnum_get_value_nullable'));
+
 Pointer<Void> smokeLeveloneLeveltwoLevelthreeLevelfourenumToFfiNullable(LevelOne_LevelTwo_LevelThree_LevelFourEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLeveloneLeveltwoLevelthreeLevelfourenumToFfi(value);
@@ -56,6 +69,7 @@ Pointer<Void> smokeLeveloneLeveltwoLevelthreeLevelfourenumToFfiNullable(LevelOne
   smokeLeveloneLeveltwoLevelthreeLevelfourenumReleaseFfiHandle(_handle);
   return result;
 }
+
 LevelOne_LevelTwo_LevelThree_LevelFourEnum? smokeLeveloneLeveltwoLevelthreeLevelfourenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLeveloneLeveltwoLevelthreeLevelfourenumGetValueNullable(handle);
@@ -63,19 +77,30 @@ LevelOne_LevelTwo_LevelThree_LevelFourEnum? smokeLeveloneLeveltwoLevelthreeLevel
   smokeLeveloneLeveltwoLevelthreeLevelfourenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLeveloneLeveltwoLevelthreeLevelfourenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLeveloneLeveltwoLevelthreeLevelfourenumReleaseHandleNullable(handle);
+
 // End of LevelOne_LevelTwo_LevelThree_LevelFourEnum "private" section.
+
+
 class LevelOne_LevelTwo_LevelThree_LevelFour {
   String stringField;
+
   LevelOne_LevelTwo_LevelThree_LevelFour(this.stringField);
   static final bool foo = false;
+
+
   static LevelOne_LevelTwo_LevelThree_LevelFour fooFactory() => $prototype.fooFactory();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = LevelOne_LevelTwo_LevelThree_LevelFour$Impl();
 }
+
+
 // LevelOne_LevelTwo_LevelThree_LevelFour "private" section, not exported.
+
 final _smokeLeveloneLeveltwoLevelthreeLevelfourCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -88,6 +113,9 @@ final _smokeLeveloneLeveltwoLevelthreeLevelfourGetFieldstringField = __lib.catch
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_field_stringField'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class LevelOne_LevelTwo_LevelThree_LevelFour$Impl {
@@ -98,15 +126,20 @@ class LevelOne_LevelTwo_LevelThree_LevelFour$Impl {
       return smokeLeveloneLeveltwoLevelthreeLevelfourFromFfi(__resultHandle);
     } finally {
       smokeLeveloneLeveltwoLevelthreeLevelfourReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 Pointer<Void> smokeLeveloneLeveltwoLevelthreeLevelfourToFfi(LevelOne_LevelTwo_LevelThree_LevelFour value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeLeveloneLeveltwoLevelthreeLevelfourCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 LevelOne_LevelTwo_LevelThree_LevelFour smokeLeveloneLeveltwoLevelthreeLevelfourFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeLeveloneLeveltwoLevelthreeLevelfourGetFieldstringField(handle);
   try {
@@ -117,8 +150,11 @@ LevelOne_LevelTwo_LevelThree_LevelFour smokeLeveloneLeveltwoLevelthreeLevelfourF
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeLeveloneLeveltwoLevelthreeLevelfourReleaseFfiHandle(Pointer<Void> handle) => _smokeLeveloneLeveltwoLevelthreeLevelfourReleaseHandle(handle);
+
 // Nullable LevelOne_LevelTwo_LevelThree_LevelFour
+
 final _smokeLeveloneLeveltwoLevelthreeLevelfourCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -131,6 +167,7 @@ final _smokeLeveloneLeveltwoLevelthreeLevelfourGetValueNullable = __lib.catchArg
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_LevelFour_get_value_nullable'));
+
 Pointer<Void> smokeLeveloneLeveltwoLevelthreeLevelfourToFfiNullable(LevelOne_LevelTwo_LevelThree_LevelFour? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeLeveloneLeveltwoLevelthreeLevelfourToFfi(value);
@@ -138,6 +175,7 @@ Pointer<Void> smokeLeveloneLeveltwoLevelthreeLevelfourToFfiNullable(LevelOne_Lev
   smokeLeveloneLeveltwoLevelthreeLevelfourReleaseFfiHandle(_handle);
   return result;
 }
+
 LevelOne_LevelTwo_LevelThree_LevelFour? smokeLeveloneLeveltwoLevelthreeLevelfourFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeLeveloneLeveltwoLevelthreeLevelfourGetValueNullable(handle);
@@ -145,10 +183,14 @@ LevelOne_LevelTwo_LevelThree_LevelFour? smokeLeveloneLeveltwoLevelthreeLevelfour
   smokeLeveloneLeveltwoLevelthreeLevelfourReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeLeveloneLeveltwoLevelthreeLevelfourReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLeveloneLeveltwoLevelthreeLevelfourReleaseHandleNullable(handle);
+
 // End of LevelOne_LevelTwo_LevelThree_LevelFour "private" section.
+
 // LevelOne_LevelTwo_LevelThree "private" section, not exported.
+
 final _smokeLeveloneLeveltwoLevelthreeRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -161,7 +203,11 @@ final _smokeLeveloneLeveltwoLevelthreeReleaseHandle = __lib.catchArgumentError((
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_LevelThree_release_handle'));
+
+
+
 class LevelOne_LevelTwo_LevelThree$Impl extends __lib.NativeBase implements LevelOne_LevelTwo_LevelThree {
+
   LevelOne_LevelTwo_LevelThree$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -175,31 +221,45 @@ class LevelOne_LevelTwo_LevelThree$Impl extends __lib.NativeBase implements Leve
       return smokeOuterinterfaceInnerclassFromFfi(__resultHandle);
     } finally {
       smokeOuterinterfaceInnerclassReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeLeveloneLeveltwoLevelthreeToFfi(LevelOne_LevelTwo_LevelThree value) =>
   _smokeLeveloneLeveltwoLevelthreeCopyHandle((value as __lib.NativeBase).handle);
+
 LevelOne_LevelTwo_LevelThree smokeLeveloneLeveltwoLevelthreeFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LevelOne_LevelTwo_LevelThree) return instance;
+
   final _copiedHandle = _smokeLeveloneLeveltwoLevelthreeCopyHandle(handle);
   final result = LevelOne_LevelTwo_LevelThree$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeLeveloneLeveltwoLevelthreeRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLeveloneLeveltwoLevelthreeReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLeveloneLeveltwoLevelthreeReleaseHandle(handle);
+
 Pointer<Void> smokeLeveloneLeveltwoLevelthreeToFfiNullable(LevelOne_LevelTwo_LevelThree? value) =>
   value != null ? smokeLeveloneLeveltwoLevelthreeToFfi(value) : Pointer<Void>.fromAddress(0);
+
 LevelOne_LevelTwo_LevelThree? smokeLeveloneLeveltwoLevelthreeFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeLeveloneLeveltwoLevelthreeFromFfi(handle) : null;
+
 void smokeLeveloneLeveltwoLevelthreeReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLeveloneLeveltwoLevelthreeReleaseHandle(handle);
+
 // End of LevelOne_LevelTwo_LevelThree "private" section.
+
 // LevelOne_LevelTwo "private" section, not exported.
+
 final _smokeLeveloneLeveltwoRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -212,32 +272,46 @@ final _smokeLeveloneLeveltwoReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_LevelTwo_release_handle'));
+
+
 class LevelOne_LevelTwo$Impl extends __lib.NativeBase implements LevelOne_LevelTwo {
+
   LevelOne_LevelTwo$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeLeveloneLeveltwoToFfi(LevelOne_LevelTwo value) =>
   _smokeLeveloneLeveltwoCopyHandle((value as __lib.NativeBase).handle);
+
 LevelOne_LevelTwo smokeLeveloneLeveltwoFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LevelOne_LevelTwo) return instance;
+
   final _copiedHandle = _smokeLeveloneLeveltwoCopyHandle(handle);
   final result = LevelOne_LevelTwo$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeLeveloneLeveltwoRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLeveloneLeveltwoReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLeveloneLeveltwoReleaseHandle(handle);
+
 Pointer<Void> smokeLeveloneLeveltwoToFfiNullable(LevelOne_LevelTwo? value) =>
   value != null ? smokeLeveloneLeveltwoToFfi(value) : Pointer<Void>.fromAddress(0);
+
 LevelOne_LevelTwo? smokeLeveloneLeveltwoFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeLeveloneLeveltwoFromFfi(handle) : null;
+
 void smokeLeveloneLeveltwoReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLeveloneLeveltwoReleaseHandle(handle);
+
 // End of LevelOne_LevelTwo "private" section.
+
 // LevelOne "private" section, not exported.
+
 final _smokeLeveloneRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -250,28 +324,42 @@ final _smokeLeveloneReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_LevelOne_release_handle'));
+
+
 class LevelOne$Impl extends __lib.NativeBase implements LevelOne {
+
   LevelOne$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeLeveloneToFfi(LevelOne value) =>
   _smokeLeveloneCopyHandle((value as __lib.NativeBase).handle);
+
 LevelOne smokeLeveloneFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is LevelOne) return instance;
+
   final _copiedHandle = _smokeLeveloneCopyHandle(handle);
   final result = LevelOne$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeLeveloneRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeLeveloneReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeLeveloneReleaseHandle(handle);
+
 Pointer<Void> smokeLeveloneToFfiNullable(LevelOne? value) =>
   value != null ? smokeLeveloneToFfi(value) : Pointer<Void>.fromAddress(0);
+
 LevelOne? smokeLeveloneFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeLeveloneFromFfi(handle) : null;
+
 void smokeLeveloneReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeLeveloneReleaseHandle(handle);
+
 // End of LevelOne "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -88,7 +88,7 @@ void smokeOuterclassInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclassInnerclassReleaseHandle(handle);
 
 // End of OuterClass_InnerClass "private" section.
-abstract class OuterClass_InnerInterface {
+abstract class OuterClass_InnerInterface implements Finalizable {
 
   factory OuterClass_InnerInterface(
     String Function(String) fooLambda,

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class.dart
@@ -1,18 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class OuterClass {
+
+abstract class OuterClass implements Finalizable {
+
 
   String foo(String input);
 }
-abstract class OuterClass_InnerClass {
+
+abstract class OuterClass_InnerClass implements Finalizable {
+
 
   String foo(String input);
 }
+
+
 // OuterClass_InnerClass "private" section, not exported.
+
 final _smokeOuterclassInnerclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -25,7 +34,11 @@ final _smokeOuterclassInnerclassReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerClass_release_handle'));
+
+
+
 class OuterClass_InnerClass$Impl extends __lib.NativeBase implements OuterClass_InnerClass {
+
   OuterClass_InnerClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -39,40 +52,59 @@ class OuterClass_InnerClass$Impl extends __lib.NativeBase implements OuterClass_
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeOuterclassInnerclassToFfi(OuterClass_InnerClass value) =>
   _smokeOuterclassInnerclassCopyHandle((value as __lib.NativeBase).handle);
+
 OuterClass_InnerClass smokeOuterclassInnerclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClass_InnerClass) return instance;
+
   final _copiedHandle = _smokeOuterclassInnerclassCopyHandle(handle);
   final result = OuterClass_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeOuterclassInnerclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterclassInnerclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterclassInnerclassReleaseHandle(handle);
+
 Pointer<Void> smokeOuterclassInnerclassToFfiNullable(OuterClass_InnerClass? value) =>
   value != null ? smokeOuterclassInnerclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterClass_InnerClass? smokeOuterclassInnerclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterclassInnerclassFromFfi(handle) : null;
+
 void smokeOuterclassInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclassInnerclassReleaseHandle(handle);
+
 // End of OuterClass_InnerClass "private" section.
 abstract class OuterClass_InnerInterface {
+
   factory OuterClass_InnerInterface(
     String Function(String) fooLambda,
+
   ) => OuterClass_InnerInterface$Lambdas(
     fooLambda,
+
   );
+
 
   String foo(String input);
 }
+
+
 // OuterClass_InnerInterface "private" section, not exported.
+
 final _smokeOuterclassInnerinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -93,17 +125,23 @@ final _smokeOuterclassInnerinterfaceGetTypeId = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClass_InnerInterface_get_type_id'));
+
+
 class OuterClass_InnerInterface$Lambdas implements OuterClass_InnerInterface {
   String Function(String) fooLambda;
+
   OuterClass_InnerInterface$Lambdas(
     this.fooLambda,
+
   );
 
   @override
   String foo(String input) =>
     fooLambda(input);
 }
+
 class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterClass_InnerInterface {
+
   OuterClass_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -117,9 +155,14 @@ class OuterClass_InnerInterface$Impl extends __lib.NativeBase implements OuterCl
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeOuterclassInnerinterfacefooStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -130,23 +173,30 @@ int _smokeOuterclassInnerinterfacefooStatic(Object _obj, Pointer<Void> input, Po
   }
   return 0;
 }
+
+
 Pointer<Void> smokeOuterclassInnerinterfaceToFfi(OuterClass_InnerInterface value) {
   if (value is __lib.NativeBase) return _smokeOuterclassInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeOuterclassInnerinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterclassInnerinterfacefooStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 OuterClass_InnerInterface smokeOuterclassInnerinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClass_InnerInterface) return instance;
+
   final _typeIdHandle = _smokeOuterclassInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeOuterclassInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -155,16 +205,23 @@ OuterClass_InnerInterface smokeOuterclassInnerinterfaceFromFfi(Pointer<Void> han
   _smokeOuterclassInnerinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterclassInnerinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterclassInnerinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeOuterclassInnerinterfaceToFfiNullable(OuterClass_InnerInterface? value) =>
   value != null ? smokeOuterclassInnerinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterClass_InnerInterface? smokeOuterclassInnerinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterclassInnerinterfaceFromFfi(handle) : null;
+
 void smokeOuterclassInnerinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclassInnerinterfaceReleaseHandle(handle);
+
 // End of OuterClass_InnerInterface "private" section.
+
 // OuterClass "private" section, not exported.
+
 final _smokeOuterclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -177,7 +234,11 @@ final _smokeOuterclassReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClass_release_handle'));
+
+
+
 class OuterClass$Impl extends __lib.NativeBase implements OuterClass {
+
   OuterClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -191,27 +252,41 @@ class OuterClass$Impl extends __lib.NativeBase implements OuterClass {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeOuterclassToFfi(OuterClass value) =>
   _smokeOuterclassCopyHandle((value as __lib.NativeBase).handle);
+
 OuterClass smokeOuterclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClass) return instance;
+
   final _copiedHandle = _smokeOuterclassCopyHandle(handle);
   final result = OuterClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeOuterclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterclassReleaseHandle(handle);
+
 Pointer<Void> smokeOuterclassToFfiNullable(OuterClass? value) =>
   value != null ? smokeOuterclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterClass? smokeOuterclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterclassFromFfi(handle) : null;
+
 void smokeOuterclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclassReleaseHandle(handle);
+
 // End of OuterClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,15 +7,22 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/parent_class.dart';
-abstract class OuterClassWithInheritance implements ParentClass {
+
+abstract class OuterClassWithInheritance implements ParentClass, Finalizable {
+
 
   String foo(String input);
 }
-abstract class OuterClassWithInheritance_InnerClass {
+
+abstract class OuterClassWithInheritance_InnerClass implements Finalizable {
+
 
   String bar(String input);
 }
+
+
 // OuterClassWithInheritance_InnerClass "private" section, not exported.
+
 final _smokeOuterclasswithinheritanceInnerclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -26,7 +35,11 @@ final _smokeOuterclasswithinheritanceInnerclassReleaseHandle = __lib.catchArgume
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerClass_release_handle'));
+
+
+
 class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerClass {
+
   OuterClassWithInheritance_InnerClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -40,40 +53,59 @@ class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase impleme
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeOuterclasswithinheritanceInnerclassToFfi(OuterClassWithInheritance_InnerClass value) =>
   _smokeOuterclasswithinheritanceInnerclassCopyHandle((value as __lib.NativeBase).handle);
+
 OuterClassWithInheritance_InnerClass smokeOuterclasswithinheritanceInnerclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClassWithInheritance_InnerClass) return instance;
+
   final _copiedHandle = _smokeOuterclasswithinheritanceInnerclassCopyHandle(handle);
   final result = OuterClassWithInheritance_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeOuterclasswithinheritanceInnerclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterclasswithinheritanceInnerclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterclasswithinheritanceInnerclassReleaseHandle(handle);
+
 Pointer<Void> smokeOuterclasswithinheritanceInnerclassToFfiNullable(OuterClassWithInheritance_InnerClass? value) =>
   value != null ? smokeOuterclasswithinheritanceInnerclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterClassWithInheritance_InnerClass? smokeOuterclasswithinheritanceInnerclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterclasswithinheritanceInnerclassFromFfi(handle) : null;
+
 void smokeOuterclasswithinheritanceInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclasswithinheritanceInnerclassReleaseHandle(handle);
+
 // End of OuterClassWithInheritance_InnerClass "private" section.
 abstract class OuterClassWithInheritance_InnerInterface {
+
   factory OuterClassWithInheritance_InnerInterface(
     String Function(String) bazLambda,
+
   ) => OuterClassWithInheritance_InnerInterface$Lambdas(
     bazLambda,
+
   );
+
 
   String baz(String input);
 }
+
+
 // OuterClassWithInheritance_InnerInterface "private" section, not exported.
+
 final _smokeOuterclasswithinheritanceInnerinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -94,17 +126,23 @@ final _smokeOuterclasswithinheritanceInnerinterfaceGetTypeId = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_InnerInterface_get_type_id'));
+
+
 class OuterClassWithInheritance_InnerInterface$Lambdas implements OuterClassWithInheritance_InnerInterface {
   String Function(String) bazLambda;
+
   OuterClassWithInheritance_InnerInterface$Lambdas(
     this.bazLambda,
+
   );
 
   @override
   String baz(String input) =>
     bazLambda(input);
 }
+
 class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerInterface {
+
   OuterClassWithInheritance_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -118,9 +156,14 @@ class OuterClassWithInheritance_InnerInterface$Impl extends __lib.NativeBase imp
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeOuterclasswithinheritanceInnerinterfacebazStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -131,23 +174,30 @@ int _smokeOuterclasswithinheritanceInnerinterfacebazStatic(Object _obj, Pointer<
   }
   return 0;
 }
+
+
 Pointer<Void> smokeOuterclasswithinheritanceInnerinterfaceToFfi(OuterClassWithInheritance_InnerInterface value) {
   if (value is __lib.NativeBase) return _smokeOuterclasswithinheritanceInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeOuterclasswithinheritanceInnerinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterclasswithinheritanceInnerinterfacebazStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 OuterClassWithInheritance_InnerInterface smokeOuterclasswithinheritanceInnerinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClassWithInheritance_InnerInterface) return instance;
+
   final _typeIdHandle = _smokeOuterclasswithinheritanceInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeOuterclasswithinheritanceInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -156,16 +206,23 @@ OuterClassWithInheritance_InnerInterface smokeOuterclasswithinheritanceInnerinte
   _smokeOuterclasswithinheritanceInnerinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterclasswithinheritanceInnerinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterclasswithinheritanceInnerinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeOuterclasswithinheritanceInnerinterfaceToFfiNullable(OuterClassWithInheritance_InnerInterface? value) =>
   value != null ? smokeOuterclasswithinheritanceInnerinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterClassWithInheritance_InnerInterface? smokeOuterclasswithinheritanceInnerinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterclasswithinheritanceInnerinterfaceFromFfi(handle) : null;
+
 void smokeOuterclasswithinheritanceInnerinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclasswithinheritanceInnerinterfaceReleaseHandle(handle);
+
 // End of OuterClassWithInheritance_InnerInterface "private" section.
+
 // OuterClassWithInheritance "private" section, not exported.
+
 final _smokeOuterclasswithinheritanceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -182,7 +239,11 @@ final _smokeOuterclasswithinheritanceGetTypeId = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterClassWithInheritance_get_type_id'));
+
+
+
 class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterClassWithInheritance {
+
   OuterClassWithInheritance$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -196,18 +257,26 @@ class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterCl
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeOuterclasswithinheritanceToFfi(OuterClassWithInheritance value) =>
   _smokeOuterclasswithinheritanceCopyHandle((value as __lib.NativeBase).handle);
+
 OuterClassWithInheritance smokeOuterclasswithinheritanceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterClassWithInheritance) return instance;
+
   final _typeIdHandle = _smokeOuterclasswithinheritanceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeOuterclasswithinheritanceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -216,12 +285,19 @@ OuterClassWithInheritance smokeOuterclasswithinheritanceFromFfi(Pointer<Void> ha
   _smokeOuterclasswithinheritanceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterclasswithinheritanceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterclasswithinheritanceReleaseHandle(handle);
+
 Pointer<Void> smokeOuterclasswithinheritanceToFfiNullable(OuterClassWithInheritance? value) =>
   value != null ? smokeOuterclasswithinheritanceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterClassWithInheritance? smokeOuterclasswithinheritanceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterclasswithinheritanceFromFfi(handle) : null;
+
 void smokeOuterclasswithinheritanceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterclasswithinheritanceReleaseHandle(handle);
+
 // End of OuterClassWithInheritance "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -89,7 +89,7 @@ void smokeOuterclasswithinheritanceInnerclassReleaseFfiHandleNullable(Pointer<Vo
   _smokeOuterclasswithinheritanceInnerclassReleaseHandle(handle);
 
 // End of OuterClassWithInheritance_InnerClass "private" section.
-abstract class OuterClassWithInheritance_InnerInterface {
+abstract class OuterClassWithInheritance_InnerInterface implements Finalizable {
 
   factory OuterClassWithInheritance_InnerInterface(
     String Function(String) bazLambda,

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -7,7 +7,7 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 
-abstract class OuterInterface {
+abstract class OuterInterface implements Finalizable {
 
   factory OuterInterface(
     String Function(String) fooLambda,
@@ -96,7 +96,7 @@ void smokeOuterinterfaceInnerclassReleaseFfiHandleNullable(Pointer<Void> handle)
   _smokeOuterinterfaceInnerclassReleaseHandle(handle);
 
 // End of OuterInterface_InnerClass "private" section.
-abstract class OuterInterface_InnerInterface {
+abstract class OuterInterface_InnerInterface implements Finalizable {
 
   factory OuterInterface_InnerInterface(
     String Function(String) fooLambda,

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_interface.dart
@@ -1,23 +1,35 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 abstract class OuterInterface {
+
   factory OuterInterface(
     String Function(String) fooLambda,
+
   ) => OuterInterface$Lambdas(
     fooLambda,
+
   );
 
-  String foo(String input);
-}
-abstract class OuterInterface_InnerClass {
 
   String foo(String input);
 }
+
+abstract class OuterInterface_InnerClass implements Finalizable {
+
+
+  String foo(String input);
+}
+
+
 // OuterInterface_InnerClass "private" section, not exported.
+
 final _smokeOuterinterfaceInnerclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -30,7 +42,11 @@ final _smokeOuterinterfaceInnerclassReleaseHandle = __lib.catchArgumentError(() 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerClass_release_handle'));
+
+
+
 class OuterInterface_InnerClass$Impl extends __lib.NativeBase implements OuterInterface_InnerClass {
+
   OuterInterface_InnerClass$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -44,40 +60,59 @@ class OuterInterface_InnerClass$Impl extends __lib.NativeBase implements OuterIn
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeOuterinterfaceInnerclassToFfi(OuterInterface_InnerClass value) =>
   _smokeOuterinterfaceInnerclassCopyHandle((value as __lib.NativeBase).handle);
+
 OuterInterface_InnerClass smokeOuterinterfaceInnerclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterInterface_InnerClass) return instance;
+
   final _copiedHandle = _smokeOuterinterfaceInnerclassCopyHandle(handle);
   final result = OuterInterface_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeOuterinterfaceInnerclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterinterfaceInnerclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterinterfaceInnerclassReleaseHandle(handle);
+
 Pointer<Void> smokeOuterinterfaceInnerclassToFfiNullable(OuterInterface_InnerClass? value) =>
   value != null ? smokeOuterinterfaceInnerclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterInterface_InnerClass? smokeOuterinterfaceInnerclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterinterfaceInnerclassFromFfi(handle) : null;
+
 void smokeOuterinterfaceInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterinterfaceInnerclassReleaseHandle(handle);
+
 // End of OuterInterface_InnerClass "private" section.
 abstract class OuterInterface_InnerInterface {
+
   factory OuterInterface_InnerInterface(
     String Function(String) fooLambda,
+
   ) => OuterInterface_InnerInterface$Lambdas(
     fooLambda,
+
   );
+
 
   String foo(String input);
 }
+
+
 // OuterInterface_InnerInterface "private" section, not exported.
+
 final _smokeOuterinterfaceInnerinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -98,17 +133,23 @@ final _smokeOuterinterfaceInnerinterfaceGetTypeId = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_InnerInterface_get_type_id'));
+
+
 class OuterInterface_InnerInterface$Lambdas implements OuterInterface_InnerInterface {
   String Function(String) fooLambda;
+
   OuterInterface_InnerInterface$Lambdas(
     this.fooLambda,
+
   );
 
   @override
   String foo(String input) =>
     fooLambda(input);
 }
+
 class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements OuterInterface_InnerInterface {
+
   OuterInterface_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -122,9 +163,14 @@ class OuterInterface_InnerInterface$Impl extends __lib.NativeBase implements Out
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeOuterinterfaceInnerinterfacefooStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -135,23 +181,30 @@ int _smokeOuterinterfaceInnerinterfacefooStatic(Object _obj, Pointer<Void> input
   }
   return 0;
 }
+
+
 Pointer<Void> smokeOuterinterfaceInnerinterfaceToFfi(OuterInterface_InnerInterface value) {
   if (value is __lib.NativeBase) return _smokeOuterinterfaceInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeOuterinterfaceInnerinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterinterfaceInnerinterfacefooStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 OuterInterface_InnerInterface smokeOuterinterfaceInnerinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterInterface_InnerInterface) return instance;
+
   final _typeIdHandle = _smokeOuterinterfaceInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeOuterinterfaceInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -160,16 +213,23 @@ OuterInterface_InnerInterface smokeOuterinterfaceInnerinterfaceFromFfi(Pointer<V
   _smokeOuterinterfaceInnerinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterinterfaceInnerinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterinterfaceInnerinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeOuterinterfaceInnerinterfaceToFfiNullable(OuterInterface_InnerInterface? value) =>
   value != null ? smokeOuterinterfaceInnerinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterInterface_InnerInterface? smokeOuterinterfaceInnerinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterinterfaceInnerinterfaceFromFfi(handle) : null;
+
 void smokeOuterinterfaceInnerinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterinterfaceInnerinterfaceReleaseHandle(handle);
+
 // End of OuterInterface_InnerInterface "private" section.
+
 // OuterInterface "private" section, not exported.
+
 final _smokeOuterinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -190,17 +250,23 @@ final _smokeOuterinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nativ
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterInterface_get_type_id'));
+
+
 class OuterInterface$Lambdas implements OuterInterface {
   String Function(String) fooLambda;
+
   OuterInterface$Lambdas(
     this.fooLambda,
+
   );
 
   @override
   String foo(String input) =>
     fooLambda(input);
 }
+
 class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
+
   OuterInterface$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -214,9 +280,14 @@ class OuterInterface$Impl extends __lib.NativeBase implements OuterInterface {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeOuterinterfacefooStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -227,23 +298,30 @@ int _smokeOuterinterfacefooStatic(Object _obj, Pointer<Void> input, Pointer<Poin
   }
   return 0;
 }
+
+
 Pointer<Void> smokeOuterinterfaceToFfi(OuterInterface value) {
   if (value is __lib.NativeBase) return _smokeOuterinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeOuterinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeOuterinterfacefooStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 OuterInterface smokeOuterinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterInterface) return instance;
+
   final _typeIdHandle = _smokeOuterinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeOuterinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -252,12 +330,19 @@ OuterInterface smokeOuterinterfaceFromFfi(Pointer<Void> handle) {
   _smokeOuterinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeOuterinterfaceToFfiNullable(OuterInterface? value) =>
   value != null ? smokeOuterinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterInterface? smokeOuterinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterinterfaceFromFfi(handle) : null;
+
 void smokeOuterinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterinterfaceReleaseHandle(handle);
+
 // End of OuterInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:intl/locale.dart';
@@ -8,6 +10,7 @@ import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
+
 final _doNothingsmokeOuterstructDonothingReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -20,19 +23,28 @@ final _doNothingsmokeOuterstructDonothingReturnHasError = __lib.catchArgumentErr
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_doNothing_return_has_error'));
+
+
+
 class OuterStruct {
   String field;
+
   OuterStruct(this.field);
+
   void doNothing() => $prototype.doNothing(this);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = OuterStruct$Impl();
 }
+
 enum OuterStruct_InnerEnum {
     foo,
     bar
 }
+
 // OuterStruct_InnerEnum "private" section, not exported.
+
 int smokeOuterstructInnerenumToFfi(OuterStruct_InnerEnum value) {
   switch (value) {
   case OuterStruct_InnerEnum.foo:
@@ -43,6 +55,7 @@ int smokeOuterstructInnerenumToFfi(OuterStruct_InnerEnum value) {
     throw StateError("Invalid enum value $value for OuterStruct_InnerEnum enum.");
   }
 }
+
 OuterStruct_InnerEnum smokeOuterstructInnerenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -53,7 +66,9 @@ OuterStruct_InnerEnum smokeOuterstructInnerenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for OuterStruct_InnerEnum enum.");
   }
 }
+
 void smokeOuterstructInnerenumReleaseFfiHandle(int handle) {}
+
 final _smokeOuterstructInnerenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -66,6 +81,7 @@ final _smokeOuterstructInnerenumGetValueNullable = __lib.catchArgumentError(() =
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerEnum_get_value_nullable'));
+
 Pointer<Void> smokeOuterstructInnerenumToFfiNullable(OuterStruct_InnerEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeOuterstructInnerenumToFfi(value);
@@ -73,6 +89,7 @@ Pointer<Void> smokeOuterstructInnerenumToFfiNullable(OuterStruct_InnerEnum? valu
   smokeOuterstructInnerenumReleaseFfiHandle(_handle);
   return result;
 }
+
 OuterStruct_InnerEnum? smokeOuterstructInnerenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeOuterstructInnerenumGetValueNullable(handle);
@@ -80,22 +97,32 @@ OuterStruct_InnerEnum? smokeOuterstructInnerenumFromFfiNullable(Pointer<Void> ha
   smokeOuterstructInnerenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeOuterstructInnerenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerenumReleaseHandleNullable(handle);
+
 // End of OuterStruct_InnerEnum "private" section.
 class OuterStruct_InstantiationException implements Exception {
   final OuterStruct_InnerEnum error;
   OuterStruct_InstantiationException(this.error);
 }
+
+
 class OuterStruct_InnerStruct {
   List<DateTime> otherField;
+
   OuterStruct_InnerStruct(this.otherField);
+
   void doSomething() => $prototype.doSomething(this);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = OuterStruct_InnerStruct$Impl();
 }
+
+
 // OuterStruct_InnerStruct "private" section, not exported.
+
 final _smokeOuterstructInnerstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -108,6 +135,9 @@ final _smokeOuterstructInnerstructGetFieldotherField = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_get_field_otherField'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class OuterStruct_InnerStruct$Impl {
@@ -116,14 +146,18 @@ class OuterStruct_InnerStruct$Impl {
     final _handle = smokeOuterstructInnerstructToFfi($that);
     _doSomethingFfi(_handle, __lib.LibraryContext.isolateId);
     smokeOuterstructInnerstructReleaseFfiHandle(_handle);
+
   }
+
 }
+
 Pointer<Void> smokeOuterstructInnerstructToFfi(OuterStruct_InnerStruct value) {
   final _otherFieldHandle = foobarListofDateToFfi(value.otherField);
   final _result = _smokeOuterstructInnerstructCreateHandle(_otherFieldHandle);
   foobarListofDateReleaseFfiHandle(_otherFieldHandle);
   return _result;
 }
+
 OuterStruct_InnerStruct smokeOuterstructInnerstructFromFfi(Pointer<Void> handle) {
   final _otherFieldHandle = _smokeOuterstructInnerstructGetFieldotherField(handle);
   try {
@@ -134,8 +168,11 @@ OuterStruct_InnerStruct smokeOuterstructInnerstructFromFfi(Pointer<Void> handle)
     foobarListofDateReleaseFfiHandle(_otherFieldHandle);
   }
 }
+
 void smokeOuterstructInnerstructReleaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructInnerstructReleaseHandle(handle);
+
 // Nullable OuterStruct_InnerStruct
+
 final _smokeOuterstructInnerstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -148,6 +185,7 @@ final _smokeOuterstructInnerstructGetValueNullable = __lib.catchArgumentError(()
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerStruct_get_value_nullable'));
+
 Pointer<Void> smokeOuterstructInnerstructToFfiNullable(OuterStruct_InnerStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeOuterstructInnerstructToFfi(value);
@@ -155,6 +193,7 @@ Pointer<Void> smokeOuterstructInnerstructToFfiNullable(OuterStruct_InnerStruct? 
   smokeOuterstructInnerstructReleaseFfiHandle(_handle);
   return result;
 }
+
 OuterStruct_InnerStruct? smokeOuterstructInnerstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeOuterstructInnerstructGetValueNullable(handle);
@@ -162,13 +201,20 @@ OuterStruct_InnerStruct? smokeOuterstructInnerstructFromFfiNullable(Pointer<Void
   smokeOuterstructInnerstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeOuterstructInnerstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerstructReleaseHandleNullable(handle);
+
 // End of OuterStruct_InnerStruct "private" section.
-abstract class OuterStruct_InnerClass {
+abstract class OuterStruct_InnerClass implements Finalizable {
+
+
   Set<Locale> fooBar();
 }
+
+
 // OuterStruct_InnerClass "private" section, not exported.
+
 final _smokeOuterstructInnerclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -181,8 +227,13 @@ final _smokeOuterstructInnerclassReleaseHandle = __lib.catchArgumentError(() => 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerClass_release_handle'));
+
+
+
 class OuterStruct_InnerClass$Impl extends __lib.NativeBase implements OuterStruct_InnerClass {
+
   OuterStruct_InnerClass$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   Set<Locale> fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerClass_fooBar'));
@@ -192,39 +243,59 @@ class OuterStruct_InnerClass$Impl extends __lib.NativeBase implements OuterStruc
       return foobarSetofLocaleFromFfi(__resultHandle);
     } finally {
       foobarSetofLocaleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeOuterstructInnerclassToFfi(OuterStruct_InnerClass value) =>
   _smokeOuterstructInnerclassCopyHandle((value as __lib.NativeBase).handle);
+
 OuterStruct_InnerClass smokeOuterstructInnerclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterStruct_InnerClass) return instance;
+
   final _copiedHandle = _smokeOuterstructInnerclassCopyHandle(handle);
   final result = OuterStruct_InnerClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeOuterstructInnerclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterstructInnerclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterstructInnerclassReleaseHandle(handle);
+
 Pointer<Void> smokeOuterstructInnerclassToFfiNullable(OuterStruct_InnerClass? value) =>
   value != null ? smokeOuterstructInnerclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterStruct_InnerClass? smokeOuterstructInnerclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterstructInnerclassFromFfi(handle) : null;
+
 void smokeOuterstructInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerclassReleaseHandle(handle);
+
 // End of OuterStruct_InnerClass "private" section.
 abstract class OuterStruct_InnerInterface {
+
   factory OuterStruct_InnerInterface(
     Map<String, Uint8List> Function() barBazLambda,
+
   ) => OuterStruct_InnerInterface$Lambdas(
     barBazLambda,
+
   );
+
+
   Map<String, Uint8List> barBaz();
 }
+
+
 // OuterStruct_InnerInterface "private" section, not exported.
+
 final _smokeOuterstructInnerinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -245,17 +316,25 @@ final _smokeOuterstructInnerinterfaceGetTypeId = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerInterface_get_type_id'));
+
+
 class OuterStruct_InnerInterface$Lambdas implements OuterStruct_InnerInterface {
   Map<String, Uint8List> Function() barBazLambda;
+
   OuterStruct_InnerInterface$Lambdas(
     this.barBazLambda,
+
   );
+
   @override
   Map<String, Uint8List> barBaz() =>
     barBazLambda();
 }
+
 class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterStruct_InnerInterface {
+
   OuterStruct_InnerInterface$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   Map<String, Uint8List> barBaz() {
     final _barBazFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerInterface_barBaz'));
@@ -265,9 +344,14 @@ class OuterStruct_InnerInterface$Impl extends __lib.NativeBase implements OuterS
       return foobarMapofStringToBlobFromFfi(__resultHandle);
     } finally {
       foobarMapofStringToBlobReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 int _smokeOuterstructInnerinterfacebarBazStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   Map<String, Uint8List>? _resultObject;
   try {
@@ -277,23 +361,30 @@ int _smokeOuterstructInnerinterfacebarBazStatic(Object _obj, Pointer<Pointer<Voi
   }
   return 0;
 }
+
+
 Pointer<Void> smokeOuterstructInnerinterfaceToFfi(OuterStruct_InnerInterface value) {
   if (value is __lib.NativeBase) return _smokeOuterstructInnerinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeOuterstructInnerinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeOuterstructInnerinterfacebarBazStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 OuterStruct_InnerInterface smokeOuterstructInnerinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is OuterStruct_InnerInterface) return instance;
+
   final _typeIdHandle = _smokeOuterstructInnerinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeOuterstructInnerinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -302,17 +393,24 @@ OuterStruct_InnerInterface smokeOuterstructInnerinterfaceFromFfi(Pointer<Void> h
   _smokeOuterstructInnerinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterstructInnerinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterstructInnerinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeOuterstructInnerinterfaceToFfiNullable(OuterStruct_InnerInterface? value) =>
   value != null ? smokeOuterstructInnerinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 OuterStruct_InnerInterface? smokeOuterstructInnerinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOuterstructInnerinterfaceFromFfi(handle) : null;
+
 void smokeOuterstructInnerinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerinterfaceReleaseHandle(handle);
+
 // End of OuterStruct_InnerInterface "private" section.
 typedef OuterStruct_InnerLambda = void Function();
+
 // OuterStruct_InnerLambda "private" section, not exported.
+
 final _smokeOuterstructInnerlambdaRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -329,22 +427,29 @@ final _smokeOuterstructInnerlambdaCreateProxy = __lib.catchArgumentError(() => _
     Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_OuterStruct_InnerLambda_create_proxy'));
+
 class OuterStruct_InnerLambda$Impl {
   final Pointer<Void> handle;
   OuterStruct_InnerLambda$Impl(this.handle);
+
   void call() {
     final _callFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_OuterStruct_InnerLambda_call'));
     final _handle = this.handle;
     _callFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
 }
+
 int _smokeOuterstructInnerlambdacallStatic(Object _obj) {
+  
   try {
     (_obj as OuterStruct_InnerLambda)();
   } finally {
   }
   return 0;
 }
+
 Pointer<Void> smokeOuterstructInnerlambdaToFfi(OuterStruct_InnerLambda value) =>
   _smokeOuterstructInnerlambdaCreateProxy(
     __lib.getObjectToken(value),
@@ -352,6 +457,7 @@ Pointer<Void> smokeOuterstructInnerlambdaToFfi(OuterStruct_InnerLambda value) =>
     value,
     Pointer.fromFunction<Int64 Function(Handle)>(_smokeOuterstructInnerlambdacallStatic, __lib.unknownError)
   );
+
 OuterStruct_InnerLambda smokeOuterstructInnerlambdaFromFfi(Pointer<Void> handle) {
   final _copiedHandle = _smokeOuterstructInnerlambdaCopyHandle(handle);
   final _impl = OuterStruct_InnerLambda$Impl(_copiedHandle);
@@ -359,9 +465,12 @@ OuterStruct_InnerLambda smokeOuterstructInnerlambdaFromFfi(Pointer<Void> handle)
   _smokeOuterstructInnerlambdaRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOuterstructInnerlambdaReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOuterstructInnerlambdaReleaseHandle(handle);
+
 // Nullable OuterStruct_InnerLambda
+
 final _smokeOuterstructInnerlambdaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -374,6 +483,7 @@ final _smokeOuterstructInnerlambdaGetValueNullable = __lib.catchArgumentError(()
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_InnerLambda_get_value_nullable'));
+
 Pointer<Void> smokeOuterstructInnerlambdaToFfiNullable(OuterStruct_InnerLambda? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeOuterstructInnerlambdaToFfi(value);
@@ -381,6 +491,7 @@ Pointer<Void> smokeOuterstructInnerlambdaToFfiNullable(OuterStruct_InnerLambda? 
   smokeOuterstructInnerlambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 OuterStruct_InnerLambda? smokeOuterstructInnerlambdaFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeOuterstructInnerlambdaGetValueNullable(handle);
@@ -388,10 +499,14 @@ OuterStruct_InnerLambda? smokeOuterstructInnerlambdaFromFfiNullable(Pointer<Void
   smokeOuterstructInnerlambdaReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeOuterstructInnerlambdaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerlambdaReleaseHandleNullable(handle);
+
 // End of OuterStruct_InnerLambda "private" section.
+
 // OuterStruct "private" section, not exported.
+
 final _smokeOuterstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -404,6 +519,9 @@ final _smokeOuterstructGetFieldfield = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_get_field_field'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class OuterStruct$Impl {
@@ -422,14 +540,18 @@ class OuterStruct$Impl {
         }
     }
     _doNothingsmokeOuterstructDonothingReturnReleaseHandle(__callResultHandle);
+
   }
+
 }
+
 Pointer<Void> smokeOuterstructToFfi(OuterStruct value) {
   final _fieldHandle = stringToFfi(value.field);
   final _result = _smokeOuterstructCreateHandle(_fieldHandle);
   stringReleaseFfiHandle(_fieldHandle);
   return _result;
 }
+
 OuterStruct smokeOuterstructFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeOuterstructGetFieldfield(handle);
   try {
@@ -440,8 +562,11 @@ OuterStruct smokeOuterstructFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_fieldHandle);
   }
 }
+
 void smokeOuterstructReleaseFfiHandle(Pointer<Void> handle) => _smokeOuterstructReleaseHandle(handle);
+
 // Nullable OuterStruct
+
 final _smokeOuterstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -454,6 +579,7 @@ final _smokeOuterstructGetValueNullable = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_OuterStruct_get_value_nullable'));
+
 Pointer<Void> smokeOuterstructToFfiNullable(OuterStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeOuterstructToFfi(value);
@@ -461,6 +587,7 @@ Pointer<Void> smokeOuterstructToFfiNullable(OuterStruct? value) {
   smokeOuterstructReleaseFfiHandle(_handle);
   return result;
 }
+
 OuterStruct? smokeOuterstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeOuterstructGetValueNullable(handle);
@@ -468,6 +595,10 @@ OuterStruct? smokeOuterstructFromFfiNullable(Pointer<Void> handle) {
   smokeOuterstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeOuterstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructReleaseHandleNullable(handle);
+
 // End of OuterStruct "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -279,7 +279,7 @@ void smokeOuterstructInnerclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOuterstructInnerclassReleaseHandle(handle);
 
 // End of OuterStruct_InnerClass "private" section.
-abstract class OuterStruct_InnerInterface {
+abstract class OuterStruct_InnerInterface implements Finalizable {
 
   factory OuterStruct_InnerInterface(
     Map<String, Uint8List> Function() barBazLambda,

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -428,7 +428,7 @@ final _smokeOuterstructInnerlambdaCreateProxy = __lib.catchArgumentError(() => _
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_OuterStruct_InnerLambda_create_proxy'));
 
-class OuterStruct_InnerLambda$Impl {
+class OuterStruct_InnerLambda$Impl implements Finalizable {
   final Pointer<Void> handle;
   OuterStruct_InnerLambda$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/use_free_types.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,10 +8,16 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/free_enum.dart';
 import 'package:library/src/smoke/free_exception.dart';
 import 'package:library/src/smoke/free_point.dart';
-abstract class UseFreeTypes {
+
+abstract class UseFreeTypes implements Finalizable {
+
+
   DateTime doStuff(FreePoint point, FreeEnum mode);
 }
+
+
 // UseFreeTypes "private" section, not exported.
+
 final _smokeUsefreetypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -22,6 +30,8 @@ final _smokeUsefreetypesReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_release_handle'));
+
+
 final _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -38,8 +48,12 @@ final _doStuffsmokeUsefreetypesDostuffFreepointFreeenumReturnHasError = __lib.ca
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum_return_has_error'));
+
+
 class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
+
   UseFreeTypes$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   DateTime doStuff(FreePoint point, FreeEnum mode) {
     final _doStuffFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>, Uint32), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>, int)>('library_smoke_UseFreeTypes_doStuff__FreePoint_FreeEnum'));
@@ -64,27 +78,41 @@ class UseFreeTypes$Impl extends __lib.NativeBase implements UseFreeTypes {
       return dateFromFfi(__resultHandle);
     } finally {
       dateReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeUsefreetypesToFfi(UseFreeTypes value) =>
   _smokeUsefreetypesCopyHandle((value as __lib.NativeBase).handle);
+
 UseFreeTypes smokeUsefreetypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is UseFreeTypes) return instance;
+
   final _copiedHandle = _smokeUsefreetypesCopyHandle(handle);
   final result = UseFreeTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeUsefreetypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeUsefreetypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeUsefreetypesReleaseHandle(handle);
+
 Pointer<Void> smokeUsefreetypesToFfiNullable(UseFreeTypes? value) =>
   value != null ? smokeUsefreetypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 UseFreeTypes? smokeUsefreetypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeUsefreetypesFromFfi(handle) : null;
+
 void smokeUsefreetypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeUsefreetypesReleaseHandle(handle);
+
 // End of UseFreeTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_class.dart
@@ -1,15 +1,25 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:meta/meta.dart';
-abstract class NoCacheClass {
+
+abstract class NoCacheClass implements Finalizable {
+
   factory NoCacheClass() => $prototype.make();
+
+
   void foo();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = NoCacheClass$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // NoCacheClass "private" section, not exported.
+
 final _smokeNocacheclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -22,43 +32,66 @@ final _smokeNocacheclassReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_NoCacheClass_release_handle'));
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class NoCacheClass$Impl extends __lib.NativeBase implements NoCacheClass {
+
   NoCacheClass$Impl(Pointer<Void> handle) : super(handle);
+
+
   NoCacheClass make() {
     final _result_handle = _make();
     final _result = NoCacheClass$Impl(_result_handle);
+
     _smokeNocacheclassRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _make() {
     final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_NoCacheClass_make'));
     final __resultHandle = _makeFfi(__lib.LibraryContext.isolateId);
     return __resultHandle;
   }
+
   @override
   void foo() {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_NoCacheClass_foo'));
     final _handle = this.handle;
     _fooFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokeNocacheclassToFfi(NoCacheClass value) =>
   _smokeNocacheclassCopyHandle((value as __lib.NativeBase).handle);
+
 NoCacheClass smokeNocacheclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
+
   final _copiedHandle = _smokeNocacheclassCopyHandle(handle);
   final result = NoCacheClass$Impl(_copiedHandle);
   _smokeNocacheclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeNocacheclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeNocacheclassReleaseHandle(handle);
+
 Pointer<Void> smokeNocacheclassToFfiNullable(NoCacheClass? value) =>
   value != null ? smokeNocacheclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 NoCacheClass? smokeNocacheclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeNocacheclassFromFfi(handle) : null;
+
 void smokeNocacheclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeNocacheclassReleaseHandle(handle);
+
 // End of NoCacheClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_interface.dart
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/dart/lib/src/smoke/no_cache_interface.dart
@@ -1,18 +1,29 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class NoCacheInterface {
+
+abstract class NoCacheInterface implements Finalizable {
+
   factory NoCacheInterface(
     void Function() fooLambda,
+
   ) => NoCacheInterface$Lambdas(
     fooLambda,
+
   );
+
+
   void foo();
 }
+
+
 // NoCacheInterface "private" section, not exported.
+
 final _smokeNocacheinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -33,46 +44,66 @@ final _smokeNocacheinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_NoCacheInterface_get_type_id'));
+
+
 class NoCacheInterface$Lambdas implements NoCacheInterface {
   void Function() fooLambda;
+
   NoCacheInterface$Lambdas(
     this.fooLambda,
+
   );
+
   @override
   void foo() =>
     fooLambda();
 }
+
 class NoCacheInterface$Impl extends __lib.NativeBase implements NoCacheInterface {
+
   NoCacheInterface$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void foo() {
     final _fooFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_NoCacheInterface_foo'));
     final _handle = this.handle;
     _fooFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 int _smokeNocacheinterfacefooStatic(Object _obj) {
+
   try {
     (_obj as NoCacheInterface).foo();
   } finally {
   }
   return 0;
 }
+
+
 Pointer<Void> smokeNocacheinterfaceToFfi(NoCacheInterface value) {
   if (value is __lib.NativeBase) return _smokeNocacheinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeNocacheinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle)>(_smokeNocacheinterfacefooStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 NoCacheInterface smokeNocacheinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
+
   final _typeIdHandle = _smokeNocacheinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeNocacheinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -80,12 +111,19 @@ NoCacheInterface smokeNocacheinterfaceFromFfi(Pointer<Void> handle) {
   _smokeNocacheinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeNocacheinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeNocacheinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeNocacheinterfaceToFfiNullable(NoCacheInterface? value) =>
   value != null ? smokeNocacheinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 NoCacheInterface? smokeNocacheinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeNocacheinterfaceFromFfi(handle) : null;
+
 void smokeNocacheinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeNocacheinterfaceReleaseHandle(handle);
+
 // End of NoCacheInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,43 +7,68 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/some_interface.dart';
-abstract class Nullable {
+
+abstract class Nullable implements Finalizable {
+
+
   String? methodWithString(String? input);
+
   bool? methodWithBoolean(bool? input);
+
   double? methodWithDouble(double? input);
+
   int? methodWithInt(int? input);
+
   Nullable_SomeStruct? methodWithSomeStruct(Nullable_SomeStruct? input);
+
   Nullable_SomeEnum? methodWithSomeEnum(Nullable_SomeEnum? input);
+
   List<String>? methodWithSomeArray(List<String>? input);
+
   List<String>? methodWithInlineArray(List<String>? input);
+
   Map<int, String>? methodWithSomeMap(Map<int, String>? input);
+
   SomeInterface? methodWithInstance(SomeInterface? input);
   String? get stringProperty;
   set stringProperty(String? value);
+
   bool? get isBoolProperty;
   set isBoolProperty(bool? value);
+
   double? get doubleProperty;
   set doubleProperty(double? value);
+
   int? get intProperty;
   set intProperty(int? value);
+
   Nullable_SomeStruct? get structProperty;
   set structProperty(Nullable_SomeStruct? value);
+
   Nullable_SomeEnum? get enumProperty;
   set enumProperty(Nullable_SomeEnum? value);
+
   List<String>? get arrayProperty;
   set arrayProperty(List<String>? value);
+
   List<String>? get inlineArrayProperty;
   set inlineArrayProperty(List<String>? value);
+
   Map<int, String>? get mapProperty;
   set mapProperty(Map<int, String>? value);
+
   SomeInterface? get instanceProperty;
   set instanceProperty(SomeInterface? value);
+
 }
+
 enum Nullable_SomeEnum {
     on,
     off
 }
+
 // Nullable_SomeEnum "private" section, not exported.
+
 int smokeNullableSomeenumToFfi(Nullable_SomeEnum value) {
   switch (value) {
   case Nullable_SomeEnum.on:
@@ -52,6 +79,7 @@ int smokeNullableSomeenumToFfi(Nullable_SomeEnum value) {
     throw StateError("Invalid enum value $value for Nullable_SomeEnum enum.");
   }
 }
+
 Nullable_SomeEnum smokeNullableSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -62,7 +90,9 @@ Nullable_SomeEnum smokeNullableSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Nullable_SomeEnum enum.");
   }
 }
+
 void smokeNullableSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeNullableSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -75,6 +105,7 @@ final _smokeNullableSomeenumGetValueNullable = __lib.catchArgumentError(() => __
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeNullableSomeenumToFfiNullable(Nullable_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeNullableSomeenumToFfi(value);
@@ -82,6 +113,7 @@ Pointer<Void> smokeNullableSomeenumToFfiNullable(Nullable_SomeEnum? value) {
   smokeNullableSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Nullable_SomeEnum? smokeNullableSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeNullableSomeenumGetValueNullable(handle);
@@ -89,14 +121,21 @@ Nullable_SomeEnum? smokeNullableSomeenumFromFfiNullable(Pointer<Void> handle) {
   smokeNullableSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeNullableSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeNullableSomeenumReleaseHandleNullable(handle);
+
 // End of Nullable_SomeEnum "private" section.
+
 class Nullable_SomeStruct {
   String stringField;
+
   Nullable_SomeStruct(this.stringField);
 }
+
+
 // Nullable_SomeStruct "private" section, not exported.
+
 final _smokeNullableSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -109,12 +148,16 @@ final _smokeNullableSomestructGetFieldstringField = __lib.catchArgumentError(() 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_get_field_stringField'));
+
+
+
 Pointer<Void> smokeNullableSomestructToFfi(Nullable_SomeStruct value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokeNullableSomestructCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 Nullable_SomeStruct smokeNullableSomestructFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeNullableSomestructGetFieldstringField(handle);
   try {
@@ -125,8 +168,11 @@ Nullable_SomeStruct smokeNullableSomestructFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokeNullableSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeNullableSomestructReleaseHandle(handle);
+
 // Nullable Nullable_SomeStruct
+
 final _smokeNullableSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -139,6 +185,7 @@ final _smokeNullableSomestructGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeNullableSomestructToFfiNullable(Nullable_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeNullableSomestructToFfi(value);
@@ -146,6 +193,7 @@ Pointer<Void> smokeNullableSomestructToFfiNullable(Nullable_SomeStruct? value) {
   smokeNullableSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Nullable_SomeStruct? smokeNullableSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeNullableSomestructGetValueNullable(handle);
@@ -153,24 +201,39 @@ Nullable_SomeStruct? smokeNullableSomestructFromFfiNullable(Pointer<Void> handle
   smokeNullableSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeNullableSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeNullableSomestructReleaseHandleNullable(handle);
+
 // End of Nullable_SomeStruct "private" section.
+
 class Nullable_NullableStruct {
   String? stringField;
+
   bool? boolField;
+
   double? doubleField;
+
   Nullable_SomeStruct? structField;
+
   Nullable_SomeEnum? enumField;
+
   List<String>? arrayField;
+
   List<String>? inlineArrayField;
+
   Map<int, String>? mapField;
+
   SomeInterface? instanceField;
+
   Nullable_NullableStruct._(this.stringField, this.boolField, this.doubleField, this.structField, this.enumField, this.arrayField, this.inlineArrayField, this.mapField, this.instanceField);
   Nullable_NullableStruct()
     : stringField = null, boolField = null, doubleField = null, structField = null, enumField = null, arrayField = null, inlineArrayField = null, mapField = null, instanceField = null;
 }
+
+
 // Nullable_NullableStruct "private" section, not exported.
+
 final _smokeNullableNullablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -215,6 +278,9 @@ final _smokeNullableNullablestructGetFieldinstanceField = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_field_instanceField'));
+
+
+
 Pointer<Void> smokeNullableNullablestructToFfi(Nullable_NullableStruct value) {
   final _stringFieldHandle = stringToFfiNullable(value.stringField);
   final _boolFieldHandle = booleanToFfiNullable(value.boolField);
@@ -237,6 +303,7 @@ Pointer<Void> smokeNullableNullablestructToFfi(Nullable_NullableStruct value) {
   smokeSomeinterfaceReleaseFfiHandleNullable(_instanceFieldHandle);
   return _result;
 }
+
 Nullable_NullableStruct smokeNullableNullablestructFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeNullableNullablestructGetFieldstringField(handle);
   final _boolFieldHandle = _smokeNullableNullablestructGetFieldboolField(handle);
@@ -249,14 +316,14 @@ Nullable_NullableStruct smokeNullableNullablestructFromFfi(Pointer<Void> handle)
   final _instanceFieldHandle = _smokeNullableNullablestructGetFieldinstanceField(handle);
   try {
     return Nullable_NullableStruct._(
-      stringFromFfiNullable(_stringFieldHandle),
-      booleanFromFfiNullable(_boolFieldHandle),
-      doubleFromFfiNullable(_doubleFieldHandle),
-      smokeNullableSomestructFromFfiNullable(_structFieldHandle),
-      smokeNullableSomeenumFromFfiNullable(_enumFieldHandle),
-      foobarListofStringFromFfiNullable(_arrayFieldHandle),
-      foobarListofStringFromFfiNullable(_inlineArrayFieldHandle),
-      foobarMapofLongToStringFromFfiNullable(_mapFieldHandle),
+      stringFromFfiNullable(_stringFieldHandle), 
+      booleanFromFfiNullable(_boolFieldHandle), 
+      doubleFromFfiNullable(_doubleFieldHandle), 
+      smokeNullableSomestructFromFfiNullable(_structFieldHandle), 
+      smokeNullableSomeenumFromFfiNullable(_enumFieldHandle), 
+      foobarListofStringFromFfiNullable(_arrayFieldHandle), 
+      foobarListofStringFromFfiNullable(_inlineArrayFieldHandle), 
+      foobarMapofLongToStringFromFfiNullable(_mapFieldHandle), 
       smokeSomeinterfaceFromFfiNullable(_instanceFieldHandle)
     );
   } finally {
@@ -271,8 +338,11 @@ Nullable_NullableStruct smokeNullableNullablestructFromFfi(Pointer<Void> handle)
     smokeSomeinterfaceReleaseFfiHandleNullable(_instanceFieldHandle);
   }
 }
+
 void smokeNullableNullablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeNullableNullablestructReleaseHandle(handle);
+
 // Nullable Nullable_NullableStruct
+
 final _smokeNullableNullablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -285,6 +355,7 @@ final _smokeNullableNullablestructGetValueNullable = __lib.catchArgumentError(()
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableStruct_get_value_nullable'));
+
 Pointer<Void> smokeNullableNullablestructToFfiNullable(Nullable_NullableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeNullableNullablestructToFfi(value);
@@ -292,6 +363,7 @@ Pointer<Void> smokeNullableNullablestructToFfiNullable(Nullable_NullableStruct? 
   smokeNullableNullablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Nullable_NullableStruct? smokeNullableNullablestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeNullableNullablestructGetValueNullable(handle);
@@ -299,23 +371,37 @@ Nullable_NullableStruct? smokeNullableNullablestructFromFfiNullable(Pointer<Void
   smokeNullableNullablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeNullableNullablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeNullableNullablestructReleaseHandleNullable(handle);
+
 // End of Nullable_NullableStruct "private" section.
+
 class Nullable_NullableIntsStruct {
   int? int8Field;
+
   int? int16Field;
+
   int? int32Field;
+
   int? int64Field;
+
   int? uint8Field;
+
   int? uint16Field;
+
   int? uint32Field;
+
   int? uint64Field;
+
   Nullable_NullableIntsStruct._(this.int8Field, this.int16Field, this.int32Field, this.int64Field, this.uint8Field, this.uint16Field, this.uint32Field, this.uint64Field);
   Nullable_NullableIntsStruct()
     : int8Field = null, int16Field = null, int32Field = null, int64Field = null, uint8Field = null, uint16Field = null, uint32Field = null, uint64Field = null;
 }
+
+
 // Nullable_NullableIntsStruct "private" section, not exported.
+
 final _smokeNullableNullableintsstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -356,6 +442,9 @@ final _smokeNullableNullableintsstructGetFielduint64Field = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_field_uint64Field'));
+
+
+
 Pointer<Void> smokeNullableNullableintsstructToFfi(Nullable_NullableIntsStruct value) {
   final _int8FieldHandle = byteToFfiNullable(value.int8Field);
   final _int16FieldHandle = shortToFfiNullable(value.int16Field);
@@ -376,6 +465,7 @@ Pointer<Void> smokeNullableNullableintsstructToFfi(Nullable_NullableIntsStruct v
   uLongReleaseFfiHandleNullable(_uint64FieldHandle);
   return _result;
 }
+
 Nullable_NullableIntsStruct smokeNullableNullableintsstructFromFfi(Pointer<Void> handle) {
   final _int8FieldHandle = _smokeNullableNullableintsstructGetFieldint8Field(handle);
   final _int16FieldHandle = _smokeNullableNullableintsstructGetFieldint16Field(handle);
@@ -387,13 +477,13 @@ Nullable_NullableIntsStruct smokeNullableNullableintsstructFromFfi(Pointer<Void>
   final _uint64FieldHandle = _smokeNullableNullableintsstructGetFielduint64Field(handle);
   try {
     return Nullable_NullableIntsStruct._(
-      byteFromFfiNullable(_int8FieldHandle),
-      shortFromFfiNullable(_int16FieldHandle),
-      intFromFfiNullable(_int32FieldHandle),
-      longFromFfiNullable(_int64FieldHandle),
-      uByteFromFfiNullable(_uint8FieldHandle),
-      uShortFromFfiNullable(_uint16FieldHandle),
-      uIntFromFfiNullable(_uint32FieldHandle),
+      byteFromFfiNullable(_int8FieldHandle), 
+      shortFromFfiNullable(_int16FieldHandle), 
+      intFromFfiNullable(_int32FieldHandle), 
+      longFromFfiNullable(_int64FieldHandle), 
+      uByteFromFfiNullable(_uint8FieldHandle), 
+      uShortFromFfiNullable(_uint16FieldHandle), 
+      uIntFromFfiNullable(_uint32FieldHandle), 
       uLongFromFfiNullable(_uint64FieldHandle)
     );
   } finally {
@@ -407,8 +497,11 @@ Nullable_NullableIntsStruct smokeNullableNullableintsstructFromFfi(Pointer<Void>
     uLongReleaseFfiHandleNullable(_uint64FieldHandle);
   }
 }
+
 void smokeNullableNullableintsstructReleaseFfiHandle(Pointer<Void> handle) => _smokeNullableNullableintsstructReleaseHandle(handle);
+
 // Nullable Nullable_NullableIntsStruct
+
 final _smokeNullableNullableintsstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -421,6 +514,7 @@ final _smokeNullableNullableintsstructGetValueNullable = __lib.catchArgumentErro
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Nullable_NullableIntsStruct_get_value_nullable'));
+
 Pointer<Void> smokeNullableNullableintsstructToFfiNullable(Nullable_NullableIntsStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeNullableNullableintsstructToFfi(value);
@@ -428,6 +522,7 @@ Pointer<Void> smokeNullableNullableintsstructToFfiNullable(Nullable_NullableInts
   smokeNullableNullableintsstructReleaseFfiHandle(_handle);
   return result;
 }
+
 Nullable_NullableIntsStruct? smokeNullableNullableintsstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeNullableNullableintsstructGetValueNullable(handle);
@@ -435,10 +530,14 @@ Nullable_NullableIntsStruct? smokeNullableNullableintsstructFromFfiNullable(Poin
   smokeNullableNullableintsstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeNullableNullableintsstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeNullableNullableintsstructReleaseHandleNullable(handle);
+
 // End of Nullable_NullableIntsStruct "private" section.
+
 // Nullable "private" section, not exported.
+
 final _smokeNullableRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -451,8 +550,22 @@ final _smokeNullableReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Nullable_release_handle'));
+
+
+
+
+
+
+
+
+
+
+
+
 class Nullable$Impl extends __lib.NativeBase implements Nullable {
+
   Nullable$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   String? methodWithString(String? input) {
     final _methodWithStringFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithString__String_'));
@@ -464,8 +577,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return stringFromFfiNullable(__resultHandle);
     } finally {
       stringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   bool? methodWithBoolean(bool? input) {
     final _methodWithBooleanFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithBoolean__Boolean_'));
@@ -477,8 +593,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return booleanFromFfiNullable(__resultHandle);
     } finally {
       booleanReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   double? methodWithDouble(double? input) {
     final _methodWithDoubleFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithDouble__Double_'));
@@ -490,8 +609,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return doubleFromFfiNullable(__resultHandle);
     } finally {
       doubleReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   int? methodWithInt(int? input) {
     final _methodWithIntFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInt__Long_'));
@@ -503,8 +625,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return longFromFfiNullable(__resultHandle);
     } finally {
       longReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   Nullable_SomeStruct? methodWithSomeStruct(Nullable_SomeStruct? input) {
     final _methodWithSomeStructFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeStruct__SomeStruct_'));
@@ -516,8 +641,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return smokeNullableSomestructFromFfiNullable(__resultHandle);
     } finally {
       smokeNullableSomestructReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   Nullable_SomeEnum? methodWithSomeEnum(Nullable_SomeEnum? input) {
     final _methodWithSomeEnumFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeEnum__SomeEnum_'));
@@ -529,8 +657,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return smokeNullableSomeenumFromFfiNullable(__resultHandle);
     } finally {
       smokeNullableSomeenumReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   List<String>? methodWithSomeArray(List<String>? input) {
     final _methodWithSomeArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeArray__ListOf_String_'));
@@ -542,8 +673,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return foobarListofStringFromFfiNullable(__resultHandle);
     } finally {
       foobarListofStringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   List<String>? methodWithInlineArray(List<String>? input) {
     final _methodWithInlineArrayFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInlineArray__ListOf_String_'));
@@ -555,8 +689,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return foobarListofStringFromFfiNullable(__resultHandle);
     } finally {
       foobarListofStringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   Map<int, String>? methodWithSomeMap(Map<int, String>? input) {
     final _methodWithSomeMapFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithSomeMap__MapOf_Long_to_String_'));
@@ -568,8 +705,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return foobarMapofLongToStringFromFfiNullable(__resultHandle);
     } finally {
       foobarMapofLongToStringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   SomeInterface? methodWithInstance(SomeInterface? input) {
     final _methodWithInstanceFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_methodWithInstance__SomeInterface_'));
@@ -581,8 +721,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return smokeSomeinterfaceFromFfiNullable(__resultHandle);
     } finally {
       smokeSomeinterfaceReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   String? get stringProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_stringProperty_get'));
@@ -592,8 +735,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return stringFromFfiNullable(__resultHandle);
     } finally {
       stringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set stringProperty(String? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_stringProperty_set__String_'));
@@ -601,7 +747,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   bool? get isBoolProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_isBoolProperty_get'));
@@ -611,8 +760,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return booleanFromFfiNullable(__resultHandle);
     } finally {
       booleanReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set isBoolProperty(bool? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_isBoolProperty_set__Boolean_'));
@@ -620,7 +772,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   double? get doubleProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_doubleProperty_get'));
@@ -630,8 +785,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return doubleFromFfiNullable(__resultHandle);
     } finally {
       doubleReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set doubleProperty(double? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_doubleProperty_set__Double_'));
@@ -639,7 +797,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     doubleReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   int? get intProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_intProperty_get'));
@@ -649,8 +810,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return longFromFfiNullable(__resultHandle);
     } finally {
       longReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set intProperty(int? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_intProperty_set__Long_'));
@@ -658,7 +822,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     longReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   Nullable_SomeStruct? get structProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_structProperty_get'));
@@ -668,8 +835,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return smokeNullableSomestructFromFfiNullable(__resultHandle);
     } finally {
       smokeNullableSomestructReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set structProperty(Nullable_SomeStruct? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_structProperty_set__SomeStruct_'));
@@ -677,7 +847,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeNullableSomestructReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   Nullable_SomeEnum? get enumProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_enumProperty_get'));
@@ -687,8 +860,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return smokeNullableSomeenumFromFfiNullable(__resultHandle);
     } finally {
       smokeNullableSomeenumReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set enumProperty(Nullable_SomeEnum? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_enumProperty_set__SomeEnum_'));
@@ -696,7 +872,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeNullableSomeenumReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   List<String>? get arrayProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_arrayProperty_get'));
@@ -706,8 +885,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return foobarListofStringFromFfiNullable(__resultHandle);
     } finally {
       foobarListofStringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set arrayProperty(List<String>? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_arrayProperty_set__ListOf_String_'));
@@ -715,7 +897,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   List<String>? get inlineArrayProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_inlineArrayProperty_get'));
@@ -725,8 +910,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return foobarListofStringFromFfiNullable(__resultHandle);
     } finally {
       foobarListofStringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set inlineArrayProperty(List<String>? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_inlineArrayProperty_set__ListOf_String_'));
@@ -734,7 +922,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   Map<int, String>? get mapProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_mapProperty_get'));
@@ -744,8 +935,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return foobarMapofLongToStringFromFfiNullable(__resultHandle);
     } finally {
       foobarMapofLongToStringReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set mapProperty(Map<int, String>? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_mapProperty_set__MapOf_Long_to_String_'));
@@ -753,7 +947,10 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarMapofLongToStringReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
   @override
   SomeInterface? get instanceProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Nullable_instanceProperty_get'));
@@ -763,8 +960,11 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
       return smokeSomeinterfaceFromFfiNullable(__resultHandle);
     } finally {
       smokeSomeinterfaceReleaseFfiHandleNullable(__resultHandle);
+
     }
+
   }
+
   @override
   set instanceProperty(SomeInterface? value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Nullable_instanceProperty_set__SomeInterface_'));
@@ -772,26 +972,40 @@ class Nullable$Impl extends __lib.NativeBase implements Nullable {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokeSomeinterfaceReleaseFfiHandleNullable(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeNullableToFfi(Nullable value) =>
   _smokeNullableCopyHandle((value as __lib.NativeBase).handle);
+
 Nullable smokeNullableFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Nullable) return instance;
+
   final _copiedHandle = _smokeNullableCopyHandle(handle);
   final result = Nullable$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeNullableRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeNullableReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeNullableReleaseHandle(handle);
+
 Pointer<Void> smokeNullableToFfiNullable(Nullable? value) =>
   value != null ? smokeNullableToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Nullable? smokeNullableFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeNullableFromFfi(handle) : null;
+
 void smokeNullableReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeNullableReleaseHandle(handle);
+
 // End of Nullable "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
+++ b/gluecodium/src/test/resources/smoke/packages/output/dart/lib/src/smoke/off/nested_packages.dart
@@ -1,21 +1,32 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class NestedPackages {
+
+abstract class NestedPackages implements Finalizable {
+
 
   static NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) => $prototype.basicMethod(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = NestedPackages$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 class NestedPackages_SomeStruct {
   String someField;
+
   NestedPackages_SomeStruct(this.someField);
 }
+
+
 // NestedPackages_SomeStruct "private" section, not exported.
+
 final _smokeOffNestedpackagesSomestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -28,12 +39,16 @@ final _smokeOffNestedpackagesSomestructGetFieldsomeField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_get_field_someField'));
+
+
+
 Pointer<Void> smokeOffNestedpackagesSomestructToFfi(NestedPackages_SomeStruct value) {
   final _someFieldHandle = stringToFfi(value.someField);
   final _result = _smokeOffNestedpackagesSomestructCreateHandle(_someFieldHandle);
   stringReleaseFfiHandle(_someFieldHandle);
   return _result;
 }
+
 NestedPackages_SomeStruct smokeOffNestedpackagesSomestructFromFfi(Pointer<Void> handle) {
   final _someFieldHandle = _smokeOffNestedpackagesSomestructGetFieldsomeField(handle);
   try {
@@ -44,8 +59,11 @@ NestedPackages_SomeStruct smokeOffNestedpackagesSomestructFromFfi(Pointer<Void> 
     stringReleaseFfiHandle(_someFieldHandle);
   }
 }
+
 void smokeOffNestedpackagesSomestructReleaseFfiHandle(Pointer<Void> handle) => _smokeOffNestedpackagesSomestructReleaseHandle(handle);
+
 // Nullable NestedPackages_SomeStruct
+
 final _smokeOffNestedpackagesSomestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -58,6 +76,7 @@ final _smokeOffNestedpackagesSomestructGetValueNullable = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_SomeStruct_get_value_nullable'));
+
 Pointer<Void> smokeOffNestedpackagesSomestructToFfiNullable(NestedPackages_SomeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeOffNestedpackagesSomestructToFfi(value);
@@ -65,6 +84,7 @@ Pointer<Void> smokeOffNestedpackagesSomestructToFfiNullable(NestedPackages_SomeS
   smokeOffNestedpackagesSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 NestedPackages_SomeStruct? smokeOffNestedpackagesSomestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeOffNestedpackagesSomestructGetValueNullable(handle);
@@ -72,10 +92,14 @@ NestedPackages_SomeStruct? smokeOffNestedpackagesSomestructFromFfiNullable(Point
   smokeOffNestedpackagesSomestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeOffNestedpackagesSomestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOffNestedpackagesSomestructReleaseHandleNullable(handle);
+
 // End of NestedPackages_SomeStruct "private" section.
+
 // NestedPackages "private" section, not exported.
+
 final _smokeOffNestedpackagesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -88,9 +112,13 @@ final _smokeOffNestedpackagesReleaseHandle = __lib.catchArgumentError(() => __li
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_off_NestedPackages_release_handle'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class NestedPackages$Impl extends __lib.NativeBase implements NestedPackages {
+
   NestedPackages$Impl(Pointer<Void> handle) : super(handle);
 
   NestedPackages_SomeStruct basicMethod(NestedPackages_SomeStruct input) {
@@ -102,27 +130,41 @@ class NestedPackages$Impl extends __lib.NativeBase implements NestedPackages {
       return smokeOffNestedpackagesSomestructFromFfi(__resultHandle);
     } finally {
       smokeOffNestedpackagesSomestructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeOffNestedpackagesToFfi(NestedPackages value) =>
   _smokeOffNestedpackagesCopyHandle((value as __lib.NativeBase).handle);
+
 NestedPackages smokeOffNestedpackagesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is NestedPackages) return instance;
+
   final _copiedHandle = _smokeOffNestedpackagesCopyHandle(handle);
   final result = NestedPackages$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeOffNestedpackagesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeOffNestedpackagesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeOffNestedpackagesReleaseHandle(handle);
+
 Pointer<Void> smokeOffNestedpackagesToFfiNullable(NestedPackages? value) =>
   value != null ? smokeOffNestedpackagesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 NestedPackages? smokeOffNestedpackagesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeOffNestedpackagesFromFfi(handle) : null;
+
 void smokeOffNestedpackagesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeOffNestedpackagesReleaseHandle(handle);
+
 // End of NestedPackages "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_interface.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,16 +7,25 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/wee_types.dart';
 import 'package:meta/meta.dart';
-abstract class weeInterface {
+
+abstract class weeInterface implements Finalizable {
+
   factory weeInterface.make(String makeParameter) => $prototype.make(makeParameter);
+
+
   weeTypes_weeStruct WeeMethod(String WeeParameter);
   int get WEE_PROPERTY;
   set WEE_PROPERTY(int value);
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = weeInterface$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // weeInterface "private" section, not exported.
+
 final _smokePlatformnamesinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -27,17 +38,27 @@ final _smokePlatformnamesinterfaceReleaseHandle = __lib.catchArgumentError(() =>
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNamesInterface_release_handle'));
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
+
   weeInterface$Impl(Pointer<Void> handle) : super(handle);
+
+
   weeInterface make(String makeParameter) {
     final _result_handle = _make(makeParameter);
     final _result = weeInterface$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokePlatformnamesinterfaceRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   @override
   weeTypes_weeStruct WeeMethod(String WeeParameter) {
     final _WeeMethodFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32, Pointer<Void>), Pointer<Void> Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_basicMethod__String'));
@@ -49,8 +70,11 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
       return smokePlatformnamesBasicstructFromFfi(__resultHandle);
     } finally {
       smokePlatformnamesBasicstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   static Pointer<Void> _make(String makeParameter) {
     final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_PlatformNamesInterface_create__String'));
     final _makeParameterHandle = stringToFfi(makeParameter);
@@ -58,6 +82,7 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
     stringReleaseFfiHandle(_makeParameterHandle);
     return __resultHandle;
   }
+
   @override
   int get WEE_PROPERTY {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_PlatformNamesInterface_basicProperty_get'));
@@ -66,34 +91,53 @@ class weeInterface$Impl extends __lib.NativeBase implements weeInterface {
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   @override
   set WEE_PROPERTY(int value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_PlatformNamesInterface_basicProperty_set__UInt'));
     final _valueHandle = (value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+
+
   }
+
+
+
 }
+
 Pointer<Void> smokePlatformnamesinterfaceToFfi(weeInterface value) =>
   _smokePlatformnamesinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
 weeInterface smokePlatformnamesinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is weeInterface) return instance;
+
   final _copiedHandle = _smokePlatformnamesinterfaceCopyHandle(handle);
   final result = weeInterface$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokePlatformnamesinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePlatformnamesinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePlatformnamesinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokePlatformnamesinterfaceToFfiNullable(weeInterface? value) =>
   value != null ? smokePlatformnamesinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 weeInterface? smokePlatformnamesinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePlatformnamesinterfaceFromFfi(handle) : null;
+
 void smokePlatformnamesinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformnamesinterfaceReleaseHandle(handle);
+
 // End of weeInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_listener.dart
@@ -1,19 +1,29 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class weeListener {
+
+abstract class weeListener implements Finalizable {
+
   factory weeListener(
     void Function(String) WeeMethodLambda,
+
   ) => weeListener$Lambdas(
     WeeMethodLambda,
+
   );
+
 
   void WeeMethod(String WeeParameter);
 }
+
+
 // weeListener "private" section, not exported.
+
 final _smokePlatformnameslistenerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -34,17 +44,23 @@ final _smokePlatformnameslistenerGetTypeId = __lib.catchArgumentError(() => __li
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNamesListener_get_type_id'));
+
+
 class weeListener$Lambdas implements weeListener {
   void Function(String) WeeMethodLambda;
+
   weeListener$Lambdas(
     this.WeeMethodLambda,
+
   );
 
   @override
   void WeeMethod(String WeeParameter) =>
     WeeMethodLambda(WeeParameter);
 }
+
 class weeListener$Impl extends __lib.NativeBase implements weeListener {
+
   weeListener$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -54,9 +70,14 @@ class weeListener$Impl extends __lib.NativeBase implements weeListener {
     final _handle = this.handle;
     _WeeMethodFfi(_handle, __lib.LibraryContext.isolateId, _WeeParameterHandle);
     stringReleaseFfiHandle(_WeeParameterHandle);
+
   }
+
+
 }
+
 int _smokePlatformnameslistenerWeeMethodStatic(Object _obj, Pointer<Void> WeeParameter) {
+
   try {
     (_obj as weeListener).WeeMethod(stringFromFfi(WeeParameter));
   } finally {
@@ -64,23 +85,30 @@ int _smokePlatformnameslistenerWeeMethodStatic(Object _obj, Pointer<Void> WeePar
   }
   return 0;
 }
+
+
 Pointer<Void> smokePlatformnameslistenerToFfi(weeListener value) {
   if (value is __lib.NativeBase) return _smokePlatformnameslistenerCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokePlatformnameslistenerCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokePlatformnameslistenerWeeMethodStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 weeListener smokePlatformnameslistenerFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is weeListener) return instance;
+
   final _typeIdHandle = _smokePlatformnameslistenerGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokePlatformnameslistenerCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -89,12 +117,19 @@ weeListener smokePlatformnameslistenerFromFfi(Pointer<Void> handle) {
   _smokePlatformnameslistenerRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePlatformnameslistenerReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePlatformnameslistenerReleaseHandle(handle);
+
 Pointer<Void> smokePlatformnameslistenerToFfiNullable(weeListener? value) =>
   value != null ? smokePlatformnameslistenerToFfi(value) : Pointer<Void>.fromAddress(0);
+
 weeListener? smokePlatformnameslistenerFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePlatformnameslistenerFromFfi(handle) : null;
+
 void smokePlatformnameslistenerReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformnameslistenerReleaseHandle(handle);
+
 // End of weeListener "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/cached_properties.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:library/src/_library_context.dart' as __lib;
@@ -6,15 +8,22 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class CachedProperties {
+
+abstract class CachedProperties implements Finalizable {
 
   List<String> get cachedProperty;
+
   static Uint8List get staticCachedProperty => $prototype.staticCachedProperty;
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = CachedProperties$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // CachedProperties "private" section, not exported.
+
 final _smokeCachedpropertiesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -27,14 +36,19 @@ final _smokeCachedpropertiesReleaseHandle = __lib.catchArgumentError(() => __lib
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_CachedProperties_release_handle'));
+
+
 /// @nodoc
 @visibleForTesting
 class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties {
+
   CachedProperties$Impl(Pointer<Void> handle) : super(handle);
+
 
   late List<String> _cachedPropertyCache;
   bool _cachedPropertyIsCached = false;
   @override
+
   List<String> get cachedProperty {
     if (!_cachedPropertyIsCached) {
       final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_CachedProperties_cachedProperty_get'));
@@ -43,13 +57,17 @@ class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties
         _cachedPropertyCache = foobarListofStringFromFfi(__resultHandle);
       } finally {
         foobarListofStringReleaseFfiHandle(__resultHandle);
+
       }
       _cachedPropertyIsCached = true;
     }
     return _cachedPropertyCache;
   }
+
+
   late Uint8List _staticCachedPropertyCache;
   bool _staticCachedPropertyIsCached = false;
+
   Uint8List get staticCachedProperty {
     if (!_staticCachedPropertyIsCached) {
       final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_CachedProperties_staticCachedProperty_get'));
@@ -58,30 +76,43 @@ class CachedProperties$Impl extends __lib.NativeBase implements CachedProperties
         _staticCachedPropertyCache = blobFromFfi(__resultHandle);
       } finally {
         blobReleaseFfiHandle(__resultHandle);
+
       }
       _staticCachedPropertyIsCached = true;
     }
     return _staticCachedPropertyCache;
   }
+
+
 }
+
 Pointer<Void> smokeCachedpropertiesToFfi(CachedProperties value) =>
   _smokeCachedpropertiesCopyHandle((value as __lib.NativeBase).handle);
+
 CachedProperties smokeCachedpropertiesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is CachedProperties) return instance;
+
   final _copiedHandle = _smokeCachedpropertiesCopyHandle(handle);
   final result = CachedProperties$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeCachedpropertiesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeCachedpropertiesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeCachedpropertiesReleaseHandle(handle);
+
 Pointer<Void> smokeCachedpropertiesToFfiNullable(CachedProperties? value) =>
   value != null ? smokeCachedpropertiesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 CachedProperties? smokeCachedpropertiesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeCachedpropertiesFromFfi(handle) : null;
+
 void smokeCachedpropertiesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCachedpropertiesReleaseHandle(handle);
+
 // End of CachedProperties "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'dart:typed_data';
 import 'package:library/src/_library_context.dart' as __lib;
@@ -7,35 +9,50 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/properties_interface.dart';
 import 'package:meta/meta.dart';
-abstract class Properties {
+
+abstract class Properties implements Finalizable {
 
   int get builtInTypeProperty;
   set builtInTypeProperty(int value);
+
   double get readonlyProperty;
+
   Properties_ExampleStruct get structProperty;
   set structProperty(Properties_ExampleStruct value);
+
   List<String> get arrayProperty;
   set arrayProperty(List<String> value);
+
   Properties_InternalErrorCode get complexTypeProperty;
   set complexTypeProperty(Properties_InternalErrorCode value);
+
   Uint8List get byteBufferProperty;
   set byteBufferProperty(Uint8List value);
+
   PropertiesInterface get instanceProperty;
   set instanceProperty(PropertiesInterface value);
+
   bool get isBooleanProperty;
   set isBooleanProperty(bool value);
+
   static String get staticProperty => $prototype.staticProperty;
   static set staticProperty(String value) { $prototype.staticProperty = value; }
+
   static Properties_ExampleStruct get staticReadonlyProperty => $prototype.staticReadonlyProperty;
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = Properties$Impl(Pointer<Void>.fromAddress(0));
 }
+
 enum Properties_InternalErrorCode {
     errorNone,
     errorFatal
 }
+
 // Properties_InternalErrorCode "private" section, not exported.
+
 int smokePropertiesInternalerrorcodeToFfi(Properties_InternalErrorCode value) {
   switch (value) {
   case Properties_InternalErrorCode.errorNone:
@@ -46,6 +63,7 @@ int smokePropertiesInternalerrorcodeToFfi(Properties_InternalErrorCode value) {
     throw StateError("Invalid enum value $value for Properties_InternalErrorCode enum.");
   }
 }
+
 Properties_InternalErrorCode smokePropertiesInternalerrorcodeFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -56,7 +74,9 @@ Properties_InternalErrorCode smokePropertiesInternalerrorcodeFromFfi(int handle)
     throw StateError("Invalid numeric value $handle for Properties_InternalErrorCode enum.");
   }
 }
+
 void smokePropertiesInternalerrorcodeReleaseFfiHandle(int handle) {}
+
 final _smokePropertiesInternalerrorcodeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -69,6 +89,7 @@ final _smokePropertiesInternalerrorcodeGetValueNullable = __lib.catchArgumentErr
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Properties_InternalErrorCode_get_value_nullable'));
+
 Pointer<Void> smokePropertiesInternalerrorcodeToFfiNullable(Properties_InternalErrorCode? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePropertiesInternalerrorcodeToFfi(value);
@@ -76,6 +97,7 @@ Pointer<Void> smokePropertiesInternalerrorcodeToFfiNullable(Properties_InternalE
   smokePropertiesInternalerrorcodeReleaseFfiHandle(_handle);
   return result;
 }
+
 Properties_InternalErrorCode? smokePropertiesInternalerrorcodeFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePropertiesInternalerrorcodeGetValueNullable(handle);
@@ -83,14 +105,21 @@ Properties_InternalErrorCode? smokePropertiesInternalerrorcodeFromFfiNullable(Po
   smokePropertiesInternalerrorcodeReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePropertiesInternalerrorcodeReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePropertiesInternalerrorcodeReleaseHandleNullable(handle);
+
 // End of Properties_InternalErrorCode "private" section.
+
 class Properties_ExampleStruct {
   double value;
+
   Properties_ExampleStruct(this.value);
 }
+
+
 // Properties_ExampleStruct "private" section, not exported.
+
 final _smokePropertiesExamplestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
@@ -103,11 +132,16 @@ final _smokePropertiesExamplestructGetFieldvalue = __lib.catchArgumentError(() =
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_get_field_value'));
+
+
+
 Pointer<Void> smokePropertiesExamplestructToFfi(Properties_ExampleStruct value) {
   final _valueHandle = (value.value);
   final _result = _smokePropertiesExamplestructCreateHandle(_valueHandle);
+  
   return _result;
 }
+
 Properties_ExampleStruct smokePropertiesExamplestructFromFfi(Pointer<Void> handle) {
   final _valueHandle = _smokePropertiesExamplestructGetFieldvalue(handle);
   try {
@@ -115,10 +149,14 @@ Properties_ExampleStruct smokePropertiesExamplestructFromFfi(Pointer<Void> handl
       (_valueHandle)
     );
   } finally {
+    
   }
 }
+
 void smokePropertiesExamplestructReleaseFfiHandle(Pointer<Void> handle) => _smokePropertiesExamplestructReleaseHandle(handle);
+
 // Nullable Properties_ExampleStruct
+
 final _smokePropertiesExamplestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -131,6 +169,7 @@ final _smokePropertiesExamplestructGetValueNullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Properties_ExampleStruct_get_value_nullable'));
+
 Pointer<Void> smokePropertiesExamplestructToFfiNullable(Properties_ExampleStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePropertiesExamplestructToFfi(value);
@@ -138,6 +177,7 @@ Pointer<Void> smokePropertiesExamplestructToFfiNullable(Properties_ExampleStruct
   smokePropertiesExamplestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Properties_ExampleStruct? smokePropertiesExamplestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePropertiesExamplestructGetValueNullable(handle);
@@ -145,10 +185,14 @@ Properties_ExampleStruct? smokePropertiesExamplestructFromFfiNullable(Pointer<Vo
   smokePropertiesExamplestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePropertiesExamplestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePropertiesExamplestructReleaseHandleNullable(handle);
+
 // End of Properties_ExampleStruct "private" section.
+
 // Properties "private" section, not exported.
+
 final _smokePropertiesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -161,9 +205,12 @@ final _smokePropertiesReleaseHandle = __lib.catchArgumentError(() => __lib.nativ
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Properties_release_handle'));
+
+
 /// @nodoc
 @visibleForTesting
 class Properties$Impl extends __lib.NativeBase implements Properties {
+
   Properties$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -174,15 +221,23 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   @override
   set builtInTypeProperty(int value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_builtInTypeProperty_set__UInt'));
     final _valueHandle = (value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+
+
   }
+
+
   @override
   double get readonlyProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Properties_readonlyProperty_get'));
@@ -191,8 +246,13 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
+
   @override
   Properties_ExampleStruct get structProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_structProperty_get'));
@@ -202,8 +262,11 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return smokePropertiesExamplestructFromFfi(__resultHandle);
     } finally {
       smokePropertiesExamplestructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set structProperty(Properties_ExampleStruct value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_structProperty_set__ExampleStruct'));
@@ -211,7 +274,10 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesExamplestructReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   List<String> get arrayProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_arrayProperty_get'));
@@ -221,8 +287,11 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return foobarListofStringFromFfi(__resultHandle);
     } finally {
       foobarListofStringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set arrayProperty(List<String> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_arrayProperty_set__ListOf_String'));
@@ -230,7 +299,10 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofStringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   Properties_InternalErrorCode get complexTypeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint32 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_complexTypeProperty_get'));
@@ -240,8 +312,11 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return smokePropertiesInternalerrorcodeFromFfi(__resultHandle);
     } finally {
       smokePropertiesInternalerrorcodeReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set complexTypeProperty(Properties_InternalErrorCode value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint32), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_complexTypeProperty_set__InternalErrorCode'));
@@ -249,7 +324,10 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesInternalerrorcodeReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   Uint8List get byteBufferProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_byteBufferProperty_get'));
@@ -259,8 +337,11 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return blobFromFfi(__resultHandle);
     } finally {
       blobReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set byteBufferProperty(Uint8List value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_byteBufferProperty_set__Blob'));
@@ -268,7 +349,10 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     blobReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   PropertiesInterface get instanceProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_Properties_instanceProperty_get'));
@@ -278,8 +362,11 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return smokePropertiesinterfaceFromFfi(__resultHandle);
     } finally {
       smokePropertiesinterfaceReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set instanceProperty(PropertiesInterface value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_Properties_instanceProperty_set__PropertiesInterface'));
@@ -287,7 +374,10 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesinterfaceReleaseFfiHandle(_valueHandle);
+
   }
+
+
   @override
   bool get isBooleanProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_Properties_isBooleanProperty_get'));
@@ -297,8 +387,11 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set isBooleanProperty(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_Properties_isBooleanProperty_set__Boolean'));
@@ -306,7 +399,10 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
   String get staticProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticProperty_get'));
     final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
@@ -314,14 +410,20 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   set staticProperty(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_Properties_staticProperty_set__String'));
     final _valueHandle = stringToFfi(value);
     _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   Properties_ExampleStruct get staticReadonlyProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_Properties_staticReadonlyProperty_get'));
     final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
@@ -329,27 +431,42 @@ class Properties$Impl extends __lib.NativeBase implements Properties {
       return smokePropertiesExamplestructFromFfi(__resultHandle);
     } finally {
       smokePropertiesExamplestructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
+
 }
+
 Pointer<Void> smokePropertiesToFfi(Properties value) =>
   _smokePropertiesCopyHandle((value as __lib.NativeBase).handle);
+
 Properties smokePropertiesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is Properties) return instance;
+
   final _copiedHandle = _smokePropertiesCopyHandle(handle);
   final result = Properties$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokePropertiesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePropertiesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePropertiesReleaseHandle(handle);
+
 Pointer<Void> smokePropertiesToFfiNullable(Properties? value) =>
   value != null ? smokePropertiesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 Properties? smokePropertiesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePropertiesFromFfi(handle) : null;
+
 void smokePropertiesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePropertiesReleaseHandle(handle);
+
 // End of Properties "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties_interface.dart
@@ -1,10 +1,14 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class PropertiesInterface {
+
+abstract class PropertiesInterface implements Finalizable {
+
   factory PropertiesInterface(
     PropertiesInterface_ExampleStruct Function() structPropertyGetLambda,
     void Function(PropertiesInterface_ExampleStruct) structPropertySetLambda
@@ -15,12 +19,19 @@ abstract class PropertiesInterface {
 
   PropertiesInterface_ExampleStruct get structProperty;
   set structProperty(PropertiesInterface_ExampleStruct value);
+
 }
+
+
 class PropertiesInterface_ExampleStruct {
   double value;
+
   PropertiesInterface_ExampleStruct(this.value);
 }
+
+
 // PropertiesInterface_ExampleStruct "private" section, not exported.
+
 final _smokePropertiesinterfaceExamplestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
@@ -33,11 +44,16 @@ final _smokePropertiesinterfaceExamplestructGetFieldvalue = __lib.catchArgumentE
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_get_field_value'));
+
+
+
 Pointer<Void> smokePropertiesinterfaceExamplestructToFfi(PropertiesInterface_ExampleStruct value) {
   final _valueHandle = (value.value);
   final _result = _smokePropertiesinterfaceExamplestructCreateHandle(_valueHandle);
+  
   return _result;
 }
+
 PropertiesInterface_ExampleStruct smokePropertiesinterfaceExamplestructFromFfi(Pointer<Void> handle) {
   final _valueHandle = _smokePropertiesinterfaceExamplestructGetFieldvalue(handle);
   try {
@@ -45,10 +61,14 @@ PropertiesInterface_ExampleStruct smokePropertiesinterfaceExamplestructFromFfi(P
       (_valueHandle)
     );
   } finally {
+    
   }
 }
+
 void smokePropertiesinterfaceExamplestructReleaseFfiHandle(Pointer<Void> handle) => _smokePropertiesinterfaceExamplestructReleaseHandle(handle);
+
 // Nullable PropertiesInterface_ExampleStruct
+
 final _smokePropertiesinterfaceExamplestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -61,6 +81,7 @@ final _smokePropertiesinterfaceExamplestructGetValueNullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_ExampleStruct_get_value_nullable'));
+
 Pointer<Void> smokePropertiesinterfaceExamplestructToFfiNullable(PropertiesInterface_ExampleStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePropertiesinterfaceExamplestructToFfi(value);
@@ -68,6 +89,7 @@ Pointer<Void> smokePropertiesinterfaceExamplestructToFfiNullable(PropertiesInter
   smokePropertiesinterfaceExamplestructReleaseFfiHandle(_handle);
   return result;
 }
+
 PropertiesInterface_ExampleStruct? smokePropertiesinterfaceExamplestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePropertiesinterfaceExamplestructGetValueNullable(handle);
@@ -75,10 +97,14 @@ PropertiesInterface_ExampleStruct? smokePropertiesinterfaceExamplestructFromFfiN
   smokePropertiesinterfaceExamplestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePropertiesinterfaceExamplestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePropertiesinterfaceExamplestructReleaseHandleNullable(handle);
+
 // End of PropertiesInterface_ExampleStruct "private" section.
+
 // PropertiesInterface "private" section, not exported.
+
 final _smokePropertiesinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -99,9 +125,11 @@ final _smokePropertiesinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PropertiesInterface_get_type_id'));
+
 class PropertiesInterface$Lambdas implements PropertiesInterface {
   PropertiesInterface_ExampleStruct Function() structPropertyGetLambda;
   void Function(PropertiesInterface_ExampleStruct) structPropertySetLambda;
+
   PropertiesInterface$Lambdas(
     this.structPropertyGetLambda,
     this.structPropertySetLambda
@@ -112,7 +140,9 @@ class PropertiesInterface$Lambdas implements PropertiesInterface {
   @override
   set structProperty(PropertiesInterface_ExampleStruct value) => structPropertySetLambda(value);
 }
+
 class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInterface {
+
   PropertiesInterface$Impl(Pointer<Void> handle) : super(handle);
 
   PropertiesInterface_ExampleStruct get structProperty {
@@ -123,20 +153,31 @@ class PropertiesInterface$Impl extends __lib.NativeBase implements PropertiesInt
       return smokePropertiesinterfaceExamplestructFromFfi(__resultHandle);
     } finally {
       smokePropertiesinterfaceExamplestructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set structProperty(PropertiesInterface_ExampleStruct value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_PropertiesInterface_structProperty_set__ExampleStruct'));
     final _valueHandle = smokePropertiesinterfaceExamplestructToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     smokePropertiesinterfaceExamplestructReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
+
 int _smokePropertiesinterfacestructPropertyGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = smokePropertiesinterfaceExamplestructToFfi((_obj as PropertiesInterface).structProperty);
   return 0;
 }
+
 int _smokePropertiesinterfacestructPropertySetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as PropertiesInterface).structProperty =
@@ -146,8 +187,10 @@ int _smokePropertiesinterfacestructPropertySetStatic(Object _obj, Pointer<Void> 
   }
   return 0;
 }
+
 Pointer<Void> smokePropertiesinterfaceToFfi(PropertiesInterface value) {
   if (value is __lib.NativeBase) return _smokePropertiesinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokePropertiesinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -155,15 +198,19 @@ Pointer<Void> smokePropertiesinterfaceToFfi(PropertiesInterface value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokePropertiesinterfacestructPropertyGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokePropertiesinterfacestructPropertySetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 PropertiesInterface smokePropertiesinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PropertiesInterface) return instance;
+
   final _typeIdHandle = _smokePropertiesinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokePropertiesinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -172,12 +219,19 @@ PropertiesInterface smokePropertiesinterfaceFromFfi(Pointer<Void> handle) {
   _smokePropertiesinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePropertiesinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePropertiesinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokePropertiesinterfaceToFfiNullable(PropertiesInterface? value) =>
   value != null ? smokePropertiesinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 PropertiesInterface? smokePropertiesinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePropertiesinterfaceFromFfi(handle) : null;
+
 void smokePropertiesinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePropertiesinterfaceReleaseHandle(handle);
+
 // End of PropertiesInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/class_with_struct_with_skip_lambda_in_platform.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/class_with_struct_with_skip_lambda_in_platform.dart
@@ -5,7 +5,7 @@ import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 
-abstract class ClassWithStructWithSkipLambdaInPlatform {
+abstract class ClassWithStructWithSkipLambdaInPlatform implements Finalizable {
 
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_enabled.dart
@@ -1,22 +1,36 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:meta/meta.dart';
-abstract class EnableIfEnabled {
+
+abstract class EnableIfEnabled implements Finalizable {
+
 
   static void enableIfUnquoted() => $prototype.enableIfUnquoted();
+
   static void enableIfUnquotedList() => $prototype.enableIfUnquotedList();
+
   static void enableIfQuoted() => $prototype.enableIfQuoted();
+
   static void enableIfQuotedList() => $prototype.enableIfQuotedList();
+
   static void enableIfTagged() => $prototype.enableIfTagged();
+
   static void enableIfTaggedList() => $prototype.enableIfTaggedList();
+
   static void enableIfMixedList() => $prototype.enableIfMixedList();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = EnableIfEnabled$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // EnableIfEnabled "private" section, not exported.
+
 final _smokeEnableifenabledRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -29,58 +43,93 @@ final _smokeEnableifenabledReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnableIfEnabled_release_handle'));
+
+
+
+
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class EnableIfEnabled$Impl extends __lib.NativeBase implements EnableIfEnabled {
+
   EnableIfEnabled$Impl(Pointer<Void> handle) : super(handle);
 
   void enableIfUnquoted() {
     final _enableIfUnquotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquoted'));
     _enableIfUnquotedFfi(__lib.LibraryContext.isolateId);
+
   }
+
   void enableIfUnquotedList() {
     final _enableIfUnquotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfUnquotedList'));
     _enableIfUnquotedListFfi(__lib.LibraryContext.isolateId);
+
   }
+
   void enableIfQuoted() {
     final _enableIfQuotedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuoted'));
     _enableIfQuotedFfi(__lib.LibraryContext.isolateId);
+
   }
+
   void enableIfQuotedList() {
     final _enableIfQuotedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfQuotedList'));
     _enableIfQuotedListFfi(__lib.LibraryContext.isolateId);
+
   }
+
   void enableIfTagged() {
     final _enableIfTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTagged'));
     _enableIfTaggedFfi(__lib.LibraryContext.isolateId);
+
   }
+
   void enableIfTaggedList() {
     final _enableIfTaggedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfTaggedList'));
     _enableIfTaggedListFfi(__lib.LibraryContext.isolateId);
+
   }
+
   void enableIfMixedList() {
     final _enableIfMixedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32), void Function(int)>('library_smoke_EnableIfEnabled_enableIfMixedList'));
     _enableIfMixedListFfi(__lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokeEnableifenabledToFfi(EnableIfEnabled value) =>
   _smokeEnableifenabledCopyHandle((value as __lib.NativeBase).handle);
+
 EnableIfEnabled smokeEnableifenabledFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnableIfEnabled) return instance;
+
   final _copiedHandle = _smokeEnableifenabledCopyHandle(handle);
   final result = EnableIfEnabled$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeEnableifenabledRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEnableifenabledReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEnableifenabledReleaseHandle(handle);
+
 Pointer<Void> smokeEnableifenabledToFfiNullable(EnableIfEnabled? value) =>
   value != null ? smokeEnableifenabledToFfi(value) : Pointer<Void>.fromAddress(0);
+
 EnableIfEnabled? smokeEnableifenabledFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEnableifenabledFromFfi(handle) : null;
+
 void smokeEnableifenabledReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnableifenabledReleaseHandle(handle);
+
 // End of EnableIfEnabled "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_if_skipped.dart
@@ -1,11 +1,17 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class EnableIfSkipped {
+
+abstract class EnableIfSkipped implements Finalizable {
 
 }
+
+
 // EnableIfSkipped "private" section, not exported.
+
 final _smokeEnableifskippedRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -18,28 +24,42 @@ final _smokeEnableifskippedReleaseHandle = __lib.catchArgumentError(() => __lib.
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_EnableIfSkipped_release_handle'));
+
+
 class EnableIfSkipped$Impl extends __lib.NativeBase implements EnableIfSkipped {
+
   EnableIfSkipped$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeEnableifskippedToFfi(EnableIfSkipped value) =>
   _smokeEnableifskippedCopyHandle((value as __lib.NativeBase).handle);
+
 EnableIfSkipped smokeEnableifskippedFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnableIfSkipped) return instance;
+
   final _copiedHandle = _smokeEnableifskippedCopyHandle(handle);
   final result = EnableIfSkipped$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeEnableifskippedRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEnableifskippedReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEnableifskippedReleaseHandle(handle);
+
 Pointer<Void> smokeEnableifskippedToFfiNullable(EnableIfSkipped? value) =>
   value != null ? smokeEnableifskippedToFfi(value) : Pointer<Void>.fromAddress(0);
+
 EnableIfSkipped? smokeEnableifskippedFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEnableifskippedFromFfi(handle) : null;
+
 void smokeEnableifskippedReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnableifskippedReleaseHandle(handle);
+
 // End of EnableIfSkipped "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/enable_tags_in_dart.dart
@@ -1,22 +1,33 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class EnableTagsInDart {
+
+abstract class EnableTagsInDart implements Finalizable {
+
   factory EnableTagsInDart(
     void Function() enableTaggedLambda,
     void Function() enableTaggedListLambda,
+
   ) => EnableTagsInDart$Lambdas(
     enableTaggedLambda,
     enableTaggedListLambda,
+
   );
 
+
   void enableTagged();
+
   void enableTaggedList();
 }
+
+
 // EnableTagsInDart "private" section, not exported.
+
 final _smokeEnabletagsindartRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -37,12 +48,17 @@ final _smokeEnabletagsindartGetTypeId = __lib.catchArgumentError(() => __lib.nat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_EnableTagsInDart_get_type_id'));
+
+
+
 class EnableTagsInDart$Lambdas implements EnableTagsInDart {
   void Function() enableTaggedLambda;
   void Function() enableTaggedListLambda;
+
   EnableTagsInDart$Lambdas(
     this.enableTaggedLambda,
     this.enableTaggedListLambda,
+
   );
 
   @override
@@ -52,7 +68,9 @@ class EnableTagsInDart$Lambdas implements EnableTagsInDart {
   void enableTaggedList() =>
     enableTaggedListLambda();
 }
+
 class EnableTagsInDart$Impl extends __lib.NativeBase implements EnableTagsInDart {
+
   EnableTagsInDart$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -60,15 +78,22 @@ class EnableTagsInDart$Impl extends __lib.NativeBase implements EnableTagsInDart
     final _enableTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_EnableTagsInDart_enableTagged'));
     final _handle = this.handle;
     _enableTaggedFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   @override
   void enableTaggedList() {
     final _enableTaggedListFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_EnableTagsInDart_enableTaggedList'));
     final _handle = this.handle;
     _enableTaggedListFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 int _smokeEnabletagsindartenableTaggedStatic(Object _obj) {
+
   try {
     (_obj as EnableTagsInDart).enableTagged();
   } finally {
@@ -76,14 +101,18 @@ int _smokeEnabletagsindartenableTaggedStatic(Object _obj) {
   return 0;
 }
 int _smokeEnabletagsindartenableTaggedListStatic(Object _obj) {
+
   try {
     (_obj as EnableTagsInDart).enableTaggedList();
   } finally {
   }
   return 0;
 }
+
+
 Pointer<Void> smokeEnabletagsindartToFfi(EnableTagsInDart value) {
   if (value is __lib.NativeBase) return _smokeEnabletagsindartCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeEnabletagsindartCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -91,15 +120,19 @@ Pointer<Void> smokeEnabletagsindartToFfi(EnableTagsInDart value) {
     Pointer.fromFunction<Uint8 Function(Handle)>(_smokeEnabletagsindartenableTaggedStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle)>(_smokeEnabletagsindartenableTaggedListStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 EnableTagsInDart smokeEnabletagsindartFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is EnableTagsInDart) return instance;
+
   final _typeIdHandle = _smokeEnabletagsindartGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeEnabletagsindartCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -108,12 +141,19 @@ EnableTagsInDart smokeEnabletagsindartFromFfi(Pointer<Void> handle) {
   _smokeEnabletagsindartRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeEnabletagsindartReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeEnabletagsindartReleaseHandle(handle);
+
 Pointer<Void> smokeEnabletagsindartToFfiNullable(EnableTagsInDart? value) =>
   value != null ? smokeEnabletagsindartToFfi(value) : Pointer<Void>.fromAddress(0);
+
 EnableTagsInDart? smokeEnabletagsindartFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeEnabletagsindartFromFfi(handle) : null;
+
 void smokeEnabletagsindartReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnabletagsindartReleaseHandle(handle);
+
 // End of EnableTagsInDart "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,7 +7,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/skip_proxy.dart';
-abstract class InheritFromSkipped implements SkipProxy {
+
+abstract class InheritFromSkipped implements SkipProxy, Finalizable {
+
   factory InheritFromSkipped(
     String Function(String) notInJavaLambda,
     bool Function(bool) notInSwiftLambda,
@@ -23,7 +27,10 @@ abstract class InheritFromSkipped implements SkipProxy {
   );
 
 }
+
+
 // InheritFromSkipped "private" section, not exported.
+
 final _smokeInheritfromskippedRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -44,6 +51,7 @@ final _smokeInheritfromskippedGetTypeId = __lib.catchArgumentError(() => __lib.n
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InheritFromSkipped_get_type_id'));
+
 class InheritFromSkipped$Lambdas implements InheritFromSkipped {
   String Function(String) notInJavaLambda;
   bool Function(bool) notInSwiftLambda;
@@ -51,6 +59,7 @@ class InheritFromSkipped$Lambdas implements InheritFromSkipped {
   void Function(String) skippedInJavaSetLambda;
   bool Function() isSkippedInSwiftGetLambda;
   void Function(bool) isSkippedInSwiftSetLambda;
+
   InheritFromSkipped$Lambdas(
     this.notInJavaLambda,
     this.notInSwiftLambda,
@@ -75,7 +84,9 @@ class InheritFromSkipped$Lambdas implements InheritFromSkipped {
   @override
   set isSkippedInSwift(bool value) => isSkippedInSwiftSetLambda(value);
 }
+
 class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSkipped {
+
   InheritFromSkipped$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -89,8 +100,11 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool notInSwift(bool input) {
     final _notInSwiftFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_notInSwift__Boolean'));
@@ -102,8 +116,11 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   String get skippedInJava {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInJava_get'));
     final _handle = this.handle;
@@ -112,15 +129,22 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set skippedInJava(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   bool get isSkippedInSwift {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
     final _handle = this.handle;
@@ -129,16 +153,25 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set isSkippedInSwift(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeInheritfromskippednotInJavaStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -159,10 +192,12 @@ int _smokeInheritfromskippednotInSwiftStatic(Object _obj, int input, Pointer<Uin
   }
   return 0;
 }
+
 int _smokeInheritfromskippedskippedInJavaGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as InheritFromSkipped).skippedInJava);
   return 0;
 }
+
 int _smokeInheritfromskippedskippedInJavaSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as InheritFromSkipped).skippedInJava =
@@ -176,6 +211,7 @@ int _smokeInheritfromskippedisSkippedInSwiftGetStatic(Object _obj, Pointer<Uint8
   _result.value = booleanToFfi((_obj as InheritFromSkipped).isSkippedInSwift);
   return 0;
 }
+
 int _smokeInheritfromskippedisSkippedInSwiftSetStatic(Object _obj, int _value) {
   try {
     (_obj as InheritFromSkipped).isSkippedInSwift =
@@ -185,8 +221,10 @@ int _smokeInheritfromskippedisSkippedInSwiftSetStatic(Object _obj, int _value) {
   }
   return 0;
 }
+
 Pointer<Void> smokeInheritfromskippedToFfi(InheritFromSkipped value) {
   if (value is __lib.NativeBase) return _smokeInheritfromskippedCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeInheritfromskippedCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -198,15 +236,19 @@ Pointer<Void> smokeInheritfromskippedToFfi(InheritFromSkipped value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Uint8>)>(_smokeInheritfromskippedisSkippedInSwiftGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeInheritfromskippedisSkippedInSwiftSetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 InheritFromSkipped smokeInheritfromskippedFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InheritFromSkipped) return instance;
+
   final _typeIdHandle = _smokeInheritfromskippedGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeInheritfromskippedCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -215,12 +257,19 @@ InheritFromSkipped smokeInheritfromskippedFromFfi(Pointer<Void> handle) {
   _smokeInheritfromskippedRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInheritfromskippedReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInheritfromskippedReleaseHandle(handle);
+
 Pointer<Void> smokeInheritfromskippedToFfiNullable(InheritFromSkipped? value) =>
   value != null ? smokeInheritfromskippedToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InheritFromSkipped? smokeInheritfromskippedFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInheritfromskippedFromFfi(handle) : null;
+
 void smokeInheritfromskippedReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInheritfromskippedReleaseHandle(handle);
+
 // End of InheritFromSkipped "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enable_parameters.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enable_parameters.dart
@@ -1,12 +1,20 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class SkipEnableParameters {
+
+abstract class SkipEnableParameters implements Finalizable {
+
+
   void doSomething(String input);
 }
+
+
 // SkipEnableParameters "private" section, not exported.
+
 final _smokeSkipenableparametersRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -19,8 +27,13 @@ final _smokeSkipenableparametersReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipEnableParameters_release_handle'));
+
+
+
 class SkipEnableParameters$Impl extends __lib.NativeBase implements SkipEnableParameters {
+
   SkipEnableParameters$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void doSomething(String input) {
     final _doSomethingFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipEnableParameters_doSomething__String'));
@@ -28,26 +41,39 @@ class SkipEnableParameters$Impl extends __lib.NativeBase implements SkipEnablePa
     final _handle = this.handle;
     _doSomethingFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
     stringReleaseFfiHandle(_inputHandle);
+
   }
+
+
 }
+
 Pointer<Void> smokeSkipenableparametersToFfi(SkipEnableParameters value) =>
   _smokeSkipenableparametersCopyHandle((value as __lib.NativeBase).handle);
+
 SkipEnableParameters smokeSkipenableparametersFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipEnableParameters) return instance;
+
   final _copiedHandle = _smokeSkipenableparametersCopyHandle(handle);
   final result = SkipEnableParameters$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSkipenableparametersRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSkipenableparametersReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSkipenableparametersReleaseHandle(handle);
+
 Pointer<Void> smokeSkipenableparametersToFfiNullable(SkipEnableParameters? value) =>
   value != null ? smokeSkipenableparametersToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SkipEnableParameters? smokeSkipenableparametersFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkipenableparametersFromFfi(handle) : null;
+
 void smokeSkipenableparametersReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipenableparametersReleaseHandle(handle);
+
 // End of SkipEnableParameters "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -1,18 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class SkipFunctions {
+
+abstract class SkipFunctions implements Finalizable {
+
 
   static String notInJava(String input) => $prototype.notInJava(input);
+
   static bool notInSwift(bool input) => $prototype.notInSwift(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = SkipFunctions$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // SkipFunctions "private" section, not exported.
+
 final _smokeSkipfunctionsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -25,9 +34,14 @@ final _smokeSkipfunctionsReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipFunctions_release_handle'));
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
+
   SkipFunctions$Impl(Pointer<Void> handle) : super(handle);
 
   String notInJava(String input) {
@@ -39,8 +53,11 @@ class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   bool notInSwift(bool input) {
     final _notInSwiftFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Int32, Uint8), int Function(int, int)>('library_smoke_SkipFunctions_notInSwift__Boolean'));
     final _inputHandle = booleanToFfi(input);
@@ -50,27 +67,41 @@ class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
 }
+
 Pointer<Void> smokeSkipfunctionsToFfi(SkipFunctions value) =>
   _smokeSkipfunctionsCopyHandle((value as __lib.NativeBase).handle);
+
 SkipFunctions smokeSkipfunctionsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipFunctions) return instance;
+
   final _copiedHandle = _smokeSkipfunctionsCopyHandle(handle);
   final result = SkipFunctions$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSkipfunctionsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSkipfunctionsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSkipfunctionsReleaseHandle(handle);
+
 Pointer<Void> smokeSkipfunctionsToFfiNullable(SkipFunctions? value) =>
   value != null ? smokeSkipfunctionsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SkipFunctions? smokeSkipfunctionsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkipfunctionsFromFfi(handle) : null;
+
 void smokeSkipfunctionsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipfunctionsReleaseHandle(handle);
+
 // End of SkipFunctions "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,7 +7,9 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/inherit_from_skipped.dart';
-abstract class SkipProxy {
+
+abstract class SkipProxy implements Finalizable {
+
   factory SkipProxy(
     String Function(String) notInJavaLambda,
     bool Function(bool) notInSwiftLambda,
@@ -22,14 +26,21 @@ abstract class SkipProxy {
     isSkippedInSwiftSetLambda
   );
 
+
   String notInJava(String input);
+
   bool notInSwift(bool input);
   String get skippedInJava;
   set skippedInJava(String value);
+
   bool get isSkippedInSwift;
   set isSkippedInSwift(bool value);
+
 }
+
+
 // SkipProxy "private" section, not exported.
+
 final _smokeSkipproxyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -50,6 +61,9 @@ final _smokeSkipproxyGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipProxy_get_type_id'));
+
+
+
 class SkipProxy$Lambdas implements SkipProxy {
   String Function(String) notInJavaLambda;
   bool Function(bool) notInSwiftLambda;
@@ -57,6 +71,7 @@ class SkipProxy$Lambdas implements SkipProxy {
   void Function(String) skippedInJavaSetLambda;
   bool Function() isSkippedInSwiftGetLambda;
   void Function(bool) isSkippedInSwiftSetLambda;
+
   SkipProxy$Lambdas(
     this.notInJavaLambda,
     this.notInSwiftLambda,
@@ -81,7 +96,9 @@ class SkipProxy$Lambdas implements SkipProxy {
   @override
   set isSkippedInSwift(bool value) => isSkippedInSwiftSetLambda(value);
 }
+
 class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
+
   SkipProxy$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -95,8 +112,11 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   bool notInSwift(bool input) {
     final _notInSwiftFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32, Uint8), int Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_notInSwift__Boolean'));
@@ -108,8 +128,11 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   String get skippedInJava {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInJava_get'));
     final _handle = this.handle;
@@ -118,15 +141,22 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set skippedInJava(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_SkipProxy_skippedInJava_set__String'));
     final _valueHandle = stringToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
   bool get isSkippedInSwift {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Uint8 Function(Pointer<Void>, Int32), int Function(Pointer<Void>, int)>('library_smoke_SkipProxy_isSkippedInSwift_get'));
     final _handle = this.handle;
@@ -135,16 +165,25 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
   set isSkippedInSwift(bool value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Uint8), void Function(Pointer<Void>, int, int)>('library_smoke_SkipProxy_isSkippedInSwift_set__Boolean'));
     final _valueHandle = booleanToFfi(value);
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     booleanReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 int _smokeSkipproxynotInJavaStatic(Object _obj, Pointer<Void> input, Pointer<Pointer<Void>> _result) {
   String? _resultObject;
   try {
@@ -165,10 +204,12 @@ int _smokeSkipproxynotInSwiftStatic(Object _obj, int input, Pointer<Uint8> _resu
   }
   return 0;
 }
+
 int _smokeSkipproxyskippedInJavaGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as SkipProxy).skippedInJava);
   return 0;
 }
+
 int _smokeSkipproxyskippedInJavaSetStatic(Object _obj, Pointer<Void> _value) {
   try {
     (_obj as SkipProxy).skippedInJava =
@@ -182,6 +223,7 @@ int _smokeSkipproxyisSkippedInSwiftGetStatic(Object _obj, Pointer<Uint8> _result
   _result.value = booleanToFfi((_obj as SkipProxy).isSkippedInSwift);
   return 0;
 }
+
 int _smokeSkipproxyisSkippedInSwiftSetStatic(Object _obj, int _value) {
   try {
     (_obj as SkipProxy).isSkippedInSwift =
@@ -191,12 +233,15 @@ int _smokeSkipproxyisSkippedInSwiftSetStatic(Object _obj, int _value) {
   }
   return 0;
 }
+
 Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
   if (value is __lib.NativeBase) return _smokeSkipproxyCopyHandle((value as __lib.NativeBase).handle);
+
   final descendantResult = tryDescendantToFfi(value);
   if (descendantResult != null) {
     return descendantResult;
   }
+
   final result = _smokeSkipproxyCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
@@ -208,15 +253,19 @@ Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Uint8>)>(_smokeSkipproxyisSkippedInSwiftGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeSkipproxyisSkippedInSwiftSetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 SkipProxy smokeSkipproxyFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipProxy) return instance;
+
   final _typeIdHandle = _smokeSkipproxyGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeSkipproxyCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -225,16 +274,24 @@ SkipProxy smokeSkipproxyFromFfi(Pointer<Void> handle) {
   _smokeSkipproxyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSkipproxyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSkipproxyReleaseHandle(handle);
+
 Pointer<Void> smokeSkipproxyToFfiNullable(SkipProxy? value) =>
   value != null ? smokeSkipproxyToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SkipProxy? smokeSkipproxyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkipproxyFromFfi(handle) : null;
+
 void smokeSkipproxyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipproxyReleaseHandle(handle);
+
 Pointer<Void>? tryDescendantToFfi(SkipProxy value) {
   if (value is InheritFromSkipped) return smokeInheritfromskippedToFfi(value);
   return null;
 }
+
 // End of SkipProxy "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_setter.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_setter.dart
@@ -1,18 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class SkipSetter {
+
+abstract class SkipSetter implements Finalizable {
+
   factory SkipSetter(
     String Function() fooGetLambda
   ) => SkipSetter$Lambdas(
     fooGetLambda
   );
+
   String get foo;
+
 }
+
+
 // SkipSetter "private" section, not exported.
+
 final _smokeSkipsetterRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -33,16 +42,22 @@ final _smokeSkipsetterGetTypeId = __lib.catchArgumentError(() => __lib.nativeLib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipSetter_get_type_id'));
+
 class SkipSetter$Lambdas implements SkipSetter {
   String Function() fooGetLambda;
+
   SkipSetter$Lambdas(
     this.fooGetLambda
   );
+
   @override
   String get foo => fooGetLambda();
 }
+
 class SkipSetter$Impl extends __lib.NativeBase implements SkipSetter {
+
   SkipSetter$Impl(Pointer<Void> handle) : super(handle);
+
   String get foo {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_SkipSetter_foo_get'));
     final _handle = this.handle;
@@ -51,30 +66,43 @@ class SkipSetter$Impl extends __lib.NativeBase implements SkipSetter {
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
+
+
 }
+
+
 int _smokeSkipsetterfooGetStatic(Object _obj, Pointer<Pointer<Void>> _result) {
   _result.value = stringToFfi((_obj as SkipSetter).foo);
   return 0;
 }
+
 Pointer<Void> smokeSkipsetterToFfi(SkipSetter value) {
   if (value is __lib.NativeBase) return _smokeSkipsetterCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeSkipsetterCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeSkipsetterfooGetStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 SkipSetter smokeSkipsetterFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipSetter) return instance;
+
   final _typeIdHandle = _smokeSkipsetterGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeSkipsetterCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -83,12 +111,19 @@ SkipSetter smokeSkipsetterFromFfi(Pointer<Void> handle) {
   _smokeSkipsetterRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSkipsetterReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSkipsetterReleaseHandle(handle);
+
 Pointer<Void> smokeSkipsetterToFfiNullable(SkipSetter? value) =>
   value != null ? smokeSkipsetterToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SkipSetter? smokeSkipsetterFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkipsetterFromFfi(handle) : null;
+
 void smokeSkipsetterReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipsetterReleaseHandle(handle);
+
 // End of SkipSetter "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_in_dart.dart
@@ -1,19 +1,29 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class SkipTagsInDart {
+
+abstract class SkipTagsInDart implements Finalizable {
+
   factory SkipTagsInDart(
     void Function() dontSkipTaggedLambda,
+
   ) => SkipTagsInDart$Lambdas(
     dontSkipTaggedLambda,
+
   );
+
 
   void dontSkipTagged();
 }
+
+
 // SkipTagsInDart "private" section, not exported.
+
 final _smokeSkiptagsindartRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -34,17 +44,23 @@ final _smokeSkiptagsindartGetTypeId = __lib.catchArgumentError(() => __lib.nativ
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTagsInDart_get_type_id'));
+
+
 class SkipTagsInDart$Lambdas implements SkipTagsInDart {
   void Function() dontSkipTaggedLambda;
+
   SkipTagsInDart$Lambdas(
     this.dontSkipTaggedLambda,
+
   );
 
   @override
   void dontSkipTagged() =>
     dontSkipTaggedLambda();
 }
+
 class SkipTagsInDart$Impl extends __lib.NativeBase implements SkipTagsInDart {
+
   SkipTagsInDart$Impl(Pointer<Void> handle) : super(handle);
 
   @override
@@ -52,32 +68,44 @@ class SkipTagsInDart$Impl extends __lib.NativeBase implements SkipTagsInDart {
     final _dontSkipTaggedFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_SkipTagsInDart_dontSkipTagged'));
     final _handle = this.handle;
     _dontSkipTaggedFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 int _smokeSkiptagsindartdontSkipTaggedStatic(Object _obj) {
+
   try {
     (_obj as SkipTagsInDart).dontSkipTagged();
   } finally {
   }
   return 0;
 }
+
+
 Pointer<Void> smokeSkiptagsindartToFfi(SkipTagsInDart value) {
   if (value is __lib.NativeBase) return _smokeSkiptagsindartCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeSkiptagsindartCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle)>(_smokeSkiptagsindartdontSkipTaggedStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 SkipTagsInDart smokeSkiptagsindartFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipTagsInDart) return instance;
+
   final _typeIdHandle = _smokeSkiptagsindartGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeSkiptagsindartCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -86,12 +114,19 @@ SkipTagsInDart smokeSkiptagsindartFromFfi(Pointer<Void> handle) {
   _smokeSkiptagsindartRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSkiptagsindartReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSkiptagsindartReleaseHandle(handle);
+
 Pointer<Void> smokeSkiptagsindartToFfiNullable(SkipTagsInDart? value) =>
   value != null ? smokeSkiptagsindartToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SkipTagsInDart? smokeSkiptagsindartFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkiptagsindartFromFfi(handle) : null;
+
 void smokeSkiptagsindartReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkiptagsindartReleaseHandle(handle);
+
 // End of SkipTagsInDart "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_tags_only.dart
@@ -1,11 +1,17 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class SkipTagsOnly {
+
+abstract class SkipTagsOnly implements Finalizable {
 
 }
+
+
 // SkipTagsOnly "private" section, not exported.
+
 final _smokeSkiptagsonlyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -18,28 +24,42 @@ final _smokeSkiptagsonlyReleaseHandle = __lib.catchArgumentError(() => __lib.nat
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTagsOnly_release_handle'));
+
+
 class SkipTagsOnly$Impl extends __lib.NativeBase implements SkipTagsOnly {
+
   SkipTagsOnly$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeSkiptagsonlyToFfi(SkipTagsOnly value) =>
   _smokeSkiptagsonlyCopyHandle((value as __lib.NativeBase).handle);
+
 SkipTagsOnly smokeSkiptagsonlyFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipTagsOnly) return instance;
+
   final _copiedHandle = _smokeSkiptagsonlyCopyHandle(handle);
   final result = SkipTagsOnly$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSkiptagsonlyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSkiptagsonlyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSkiptagsonlyReleaseHandle(handle);
+
 Pointer<Void> smokeSkiptagsonlyToFfiNullable(SkipTagsOnly? value) =>
   value != null ? smokeSkiptagsonlyToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SkipTagsOnly? smokeSkiptagsonlyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkiptagsonlyFromFfi(handle) : null;
+
 void smokeSkiptagsonlyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkiptagsonlyReleaseHandle(handle);
+
 // End of SkipTagsOnly "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -1,16 +1,25 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class SkipTypes {
+
+abstract class SkipTypes implements Finalizable {
 
 }
+
+
 class SkipTypes_NotInJava {
   String fooField;
+
   SkipTypes_NotInJava(this.fooField);
 }
+
+
 // SkipTypes_NotInJava "private" section, not exported.
+
 final _smokeSkiptypesNotinjavaCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -23,12 +32,16 @@ final _smokeSkiptypesNotinjavaGetFieldfooField = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_get_field_fooField'));
+
+
+
 Pointer<Void> smokeSkiptypesNotinjavaToFfi(SkipTypes_NotInJava value) {
   final _fooFieldHandle = stringToFfi(value.fooField);
   final _result = _smokeSkiptypesNotinjavaCreateHandle(_fooFieldHandle);
   stringReleaseFfiHandle(_fooFieldHandle);
   return _result;
 }
+
 SkipTypes_NotInJava smokeSkiptypesNotinjavaFromFfi(Pointer<Void> handle) {
   final _fooFieldHandle = _smokeSkiptypesNotinjavaGetFieldfooField(handle);
   try {
@@ -39,8 +52,11 @@ SkipTypes_NotInJava smokeSkiptypesNotinjavaFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_fooFieldHandle);
   }
 }
+
 void smokeSkiptypesNotinjavaReleaseFfiHandle(Pointer<Void> handle) => _smokeSkiptypesNotinjavaReleaseHandle(handle);
+
 // Nullable SkipTypes_NotInJava
+
 final _smokeSkiptypesNotinjavaCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -53,6 +69,7 @@ final _smokeSkiptypesNotinjavaGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInJava_get_value_nullable'));
+
 Pointer<Void> smokeSkiptypesNotinjavaToFfiNullable(SkipTypes_NotInJava? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeSkiptypesNotinjavaToFfi(value);
@@ -60,6 +77,7 @@ Pointer<Void> smokeSkiptypesNotinjavaToFfiNullable(SkipTypes_NotInJava? value) {
   smokeSkiptypesNotinjavaReleaseFfiHandle(_handle);
   return result;
 }
+
 SkipTypes_NotInJava? smokeSkiptypesNotinjavaFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeSkiptypesNotinjavaGetValueNullable(handle);
@@ -67,14 +85,21 @@ SkipTypes_NotInJava? smokeSkiptypesNotinjavaFromFfiNullable(Pointer<Void> handle
   smokeSkiptypesNotinjavaReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeSkiptypesNotinjavaReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkiptypesNotinjavaReleaseHandleNullable(handle);
+
 // End of SkipTypes_NotInJava "private" section.
+
 class SkipTypes_NotInSwift {
   String fooField;
+
   SkipTypes_NotInSwift(this.fooField);
 }
+
+
 // SkipTypes_NotInSwift "private" section, not exported.
+
 final _smokeSkiptypesNotinswiftCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -87,12 +112,16 @@ final _smokeSkiptypesNotinswiftGetFieldfooField = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_get_field_fooField'));
+
+
+
 Pointer<Void> smokeSkiptypesNotinswiftToFfi(SkipTypes_NotInSwift value) {
   final _fooFieldHandle = stringToFfi(value.fooField);
   final _result = _smokeSkiptypesNotinswiftCreateHandle(_fooFieldHandle);
   stringReleaseFfiHandle(_fooFieldHandle);
   return _result;
 }
+
 SkipTypes_NotInSwift smokeSkiptypesNotinswiftFromFfi(Pointer<Void> handle) {
   final _fooFieldHandle = _smokeSkiptypesNotinswiftGetFieldfooField(handle);
   try {
@@ -103,8 +132,11 @@ SkipTypes_NotInSwift smokeSkiptypesNotinswiftFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_fooFieldHandle);
   }
 }
+
 void smokeSkiptypesNotinswiftReleaseFfiHandle(Pointer<Void> handle) => _smokeSkiptypesNotinswiftReleaseHandle(handle);
+
 // Nullable SkipTypes_NotInSwift
+
 final _smokeSkiptypesNotinswiftCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -117,6 +149,7 @@ final _smokeSkiptypesNotinswiftGetValueNullable = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_SkipTypes_NotInSwift_get_value_nullable'));
+
 Pointer<Void> smokeSkiptypesNotinswiftToFfiNullable(SkipTypes_NotInSwift? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeSkiptypesNotinswiftToFfi(value);
@@ -124,6 +157,7 @@ Pointer<Void> smokeSkiptypesNotinswiftToFfiNullable(SkipTypes_NotInSwift? value)
   smokeSkiptypesNotinswiftReleaseFfiHandle(_handle);
   return result;
 }
+
 SkipTypes_NotInSwift? smokeSkiptypesNotinswiftFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeSkiptypesNotinswiftGetValueNullable(handle);
@@ -131,10 +165,14 @@ SkipTypes_NotInSwift? smokeSkiptypesNotinswiftFromFfiNullable(Pointer<Void> hand
   smokeSkiptypesNotinswiftReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeSkiptypesNotinswiftReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkiptypesNotinswiftReleaseHandleNullable(handle);
+
 // End of SkipTypes_NotInSwift "private" section.
+
 // SkipTypes "private" section, not exported.
+
 final _smokeSkiptypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -147,28 +185,42 @@ final _smokeSkiptypesReleaseHandle = __lib.catchArgumentError(() => __lib.native
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_release_handle'));
+
+
 class SkipTypes$Impl extends __lib.NativeBase implements SkipTypes {
+
   SkipTypes$Impl(Pointer<Void> handle) : super(handle);
 
+
 }
+
 Pointer<Void> smokeSkiptypesToFfi(SkipTypes value) =>
   _smokeSkiptypesCopyHandle((value as __lib.NativeBase).handle);
+
 SkipTypes smokeSkiptypesFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is SkipTypes) return instance;
+
   final _copiedHandle = _smokeSkiptypesCopyHandle(handle);
   final result = SkipTypes$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeSkiptypesRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeSkiptypesReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeSkiptypesReleaseHandle(handle);
+
 Pointer<Void> smokeSkiptypesToFfiNullable(SkipTypes? value) =>
   value != null ? smokeSkiptypesToFfi(value) : Pointer<Void>.fromAddress(0);
+
 SkipTypes? smokeSkiptypesFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeSkiptypesFromFfi(handle) : null;
+
 void smokeSkiptypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkiptypesReleaseHandle(handle);
+
 // End of SkipTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -10,7 +10,7 @@ import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'package:meta/meta.dart';
 
-abstract class Structs {
+abstract class Structs implements Finalizable {
 
 
   static Structs_Point swapPointCoordinates(Structs_Point input) => $prototype.swapPointCoordinates(input);

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,17 +7,24 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
-abstract class ExternalClass {
+
+abstract class ExternalClass implements Finalizable {
+
   factory ExternalClass() => $prototype.$init();
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = ExternalClass$Impl(Pointer<Void>.fromAddress(0));
 }
+
 enum ExternalClass_ErrorEnum {
     none,
     crashed
 }
+
 // ExternalClass_ErrorEnum "private" section, not exported.
+
 int smokeExternalclassErrorenumToFfi(ExternalClass_ErrorEnum value) {
   switch (value) {
   case ExternalClass_ErrorEnum.none:
@@ -26,6 +35,7 @@ int smokeExternalclassErrorenumToFfi(ExternalClass_ErrorEnum value) {
     throw StateError("Invalid enum value $value for ExternalClass_ErrorEnum enum.");
   }
 }
+
 ExternalClass_ErrorEnum smokeExternalclassErrorenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -36,7 +46,9 @@ ExternalClass_ErrorEnum smokeExternalclassErrorenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for ExternalClass_ErrorEnum enum.");
   }
 }
+
 void smokeExternalclassErrorenumReleaseFfiHandle(int handle) {}
+
 final _smokeExternalclassErrorenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -49,6 +61,7 @@ final _smokeExternalclassErrorenumGetValueNullable = __lib.catchArgumentError(()
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_ErrorEnum_get_value_nullable'));
+
 Pointer<Void> smokeExternalclassErrorenumToFfiNullable(ExternalClass_ErrorEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeExternalclassErrorenumToFfi(value);
@@ -56,6 +69,7 @@ Pointer<Void> smokeExternalclassErrorenumToFfiNullable(ExternalClass_ErrorEnum? 
   smokeExternalclassErrorenumReleaseFfiHandle(_handle);
   return result;
 }
+
 ExternalClass_ErrorEnum? smokeExternalclassErrorenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeExternalclassErrorenumGetValueNullable(handle);
@@ -63,21 +77,30 @@ ExternalClass_ErrorEnum? smokeExternalclassErrorenumFromFfiNullable(Pointer<Void
   smokeExternalclassErrorenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeExternalclassErrorenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalclassErrorenumReleaseHandleNullable(handle);
+
 // End of ExternalClass_ErrorEnum "private" section.
 class ExternalClass_ConstructorExplodedException implements Exception {
   final ExternalClass_ErrorEnum error;
   ExternalClass_ConstructorExplodedException(this.error);
 }
-abstract class ExternalClass_InternalOne {
+abstract class ExternalClass_InternalOne implements Finalizable {
+
   factory ExternalClass_InternalOne() => $prototype.$init();
+
   factory ExternalClass_InternalOne.WithParameter(int value) => $prototype.WithParameter(value);
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = ExternalClass_InternalOne$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // ExternalClass_InternalOne "private" section, not exported.
+
 final _smokeExternalclassInternaloneRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -90,6 +113,8 @@ final _smokeExternalclassInternaloneReleaseHandle = __lib.catchArgumentError(() 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_InternalOne_release_handle'));
+
+
 final _$initsmokeExternalclassInternaloneCreateReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -106,6 +131,8 @@ final _$initsmokeExternalclassInternaloneCreateReturnHasError = __lib.catchArgum
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_InternalOne_create_return_has_error'));
+
+
 final _WithParametersmokeExternalclassInternaloneCreateUlongReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -122,24 +149,36 @@ final _WithParametersmokeExternalclassInternaloneCreateUlongReturnHasError = __l
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_InternalOne_create__ULong_return_has_error'));
+
+
 /// @nodoc
 @visibleForTesting
 class ExternalClass_InternalOne$Impl extends __lib.NativeBase implements ExternalClass_InternalOne {
+
   ExternalClass_InternalOne$Impl(Pointer<Void> handle) : super(handle);
+
+
   ExternalClass_InternalOne $init() {
     final _result_handle = _$init();
     final _result = ExternalClass_InternalOne$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeExternalclassInternaloneRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   ExternalClass_InternalOne WithParameter(int value) {
     final _result_handle = _WithParameter(value);
     final _result = ExternalClass_InternalOne$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeExternalclassInternaloneRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _$init() {
     final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ExternalClass_InternalOne_create'));
     final __callResultHandle = _$initFfi(__lib.LibraryContext.isolateId);
@@ -156,10 +195,12 @@ class ExternalClass_InternalOne$Impl extends __lib.NativeBase implements Externa
     _$initsmokeExternalclassInternaloneCreateReturnReleaseHandle(__callResultHandle);
     return __resultHandle;
   }
+
   static Pointer<Void> _WithParameter(int value) {
     final _WithParameterFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64), Pointer<Void> Function(int, int)>('library_smoke_ExternalClass_InternalOne_create__ULong'));
     final _valueHandle = (value);
     final __callResultHandle = _WithParameterFfi(__lib.LibraryContext.isolateId, _valueHandle);
+
     if (_WithParametersmokeExternalclassInternaloneCreateUlongReturnHasError(__callResultHandle) != 0) {
         final __errorHandle = _WithParametersmokeExternalclassInternaloneCreateUlongReturnGetError(__callResultHandle);
         _WithParametersmokeExternalclassInternaloneCreateUlongReturnReleaseHandle(__callResultHandle);
@@ -173,35 +214,51 @@ class ExternalClass_InternalOne$Impl extends __lib.NativeBase implements Externa
     _WithParametersmokeExternalclassInternaloneCreateUlongReturnReleaseHandle(__callResultHandle);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeExternalclassInternaloneToFfi(ExternalClass_InternalOne value) =>
   _smokeExternalclassInternaloneCopyHandle((value as __lib.NativeBase).handle);
+
 ExternalClass_InternalOne smokeExternalclassInternaloneFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExternalClass_InternalOne) return instance;
+
   final _copiedHandle = _smokeExternalclassInternaloneCopyHandle(handle);
   final result = ExternalClass_InternalOne$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeExternalclassInternaloneRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExternalclassInternaloneReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExternalclassInternaloneReleaseHandle(handle);
+
 Pointer<Void> smokeExternalclassInternaloneToFfiNullable(ExternalClass_InternalOne? value) =>
   value != null ? smokeExternalclassInternaloneToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExternalClass_InternalOne? smokeExternalclassInternaloneFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExternalclassInternaloneFromFfi(handle) : null;
+
 void smokeExternalclassInternaloneReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalclassInternaloneReleaseHandle(handle);
+
 // End of ExternalClass_InternalOne "private" section.
-abstract class ExternalClass_InternalTwo {
+abstract class ExternalClass_InternalTwo implements Finalizable {
+
   factory ExternalClass_InternalTwo() => $prototype.$init();
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = ExternalClass_InternalTwo$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // ExternalClass_InternalTwo "private" section, not exported.
+
 final _smokeExternalclassInternaltwoRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -214,6 +271,8 @@ final _smokeExternalclassInternaltwoReleaseHandle = __lib.catchArgumentError(() 
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_ExternalClass_InternalTwo_release_handle'));
+
+
 final _$initsmokeExternalclassInternaltwoCreateReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -230,17 +289,25 @@ final _$initsmokeExternalclassInternaltwoCreateReturnHasError = __lib.catchArgum
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_InternalTwo_create_return_has_error'));
+
+
 /// @nodoc
 @visibleForTesting
 class ExternalClass_InternalTwo$Impl extends __lib.NativeBase implements ExternalClass_InternalTwo {
+
   ExternalClass_InternalTwo$Impl(Pointer<Void> handle) : super(handle);
+
+
   ExternalClass_InternalTwo $init() {
     final _result_handle = _$init();
     final _result = ExternalClass_InternalTwo$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeExternalclassInternaltwoRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _$init() {
     final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ExternalClass_InternalTwo_create'));
     final __callResultHandle = _$initFfi(__lib.LibraryContext.isolateId);
@@ -257,29 +324,41 @@ class ExternalClass_InternalTwo$Impl extends __lib.NativeBase implements Externa
     _$initsmokeExternalclassInternaltwoCreateReturnReleaseHandle(__callResultHandle);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeExternalclassInternaltwoToFfi(ExternalClass_InternalTwo value) =>
   _smokeExternalclassInternaltwoCopyHandle((value as __lib.NativeBase).handle);
+
 ExternalClass_InternalTwo smokeExternalclassInternaltwoFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExternalClass_InternalTwo) return instance;
+
   final _copiedHandle = _smokeExternalclassInternaltwoCopyHandle(handle);
   final result = ExternalClass_InternalTwo$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeExternalclassInternaltwoRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExternalclassInternaltwoReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExternalclassInternaltwoReleaseHandle(handle);
+
 Pointer<Void> smokeExternalclassInternaltwoToFfiNullable(ExternalClass_InternalTwo? value) =>
   value != null ? smokeExternalclassInternaltwoToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExternalClass_InternalTwo? smokeExternalclassInternaltwoFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExternalclassInternaltwoFromFfi(handle) : null;
+
 void smokeExternalclassInternaltwoReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalclassInternaltwoReleaseHandle(handle);
+
 // End of ExternalClass_InternalTwo "private" section.
+
 // ExternalClass "private" section, not exported.
+
 final _smokeExternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -296,6 +375,8 @@ final _smokeExternalclassGetTypeId = __lib.catchArgumentError(() => __lib.native
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_ExternalClass_get_type_id'));
+
+
 final _$initsmokeExternalclassCreateReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
@@ -312,17 +393,25 @@ final _$initsmokeExternalclassCreateReturnHasError = __lib.catchArgumentError(()
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_ExternalClass_create_return_has_error'));
+
+
 /// @nodoc
 @visibleForTesting
 class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
+
   ExternalClass$Impl(Pointer<Void> handle) : super(handle);
+
+
   ExternalClass $init() {
     final _result_handle = _$init();
     final _result = ExternalClass$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeExternalclassRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   static Pointer<Void> _$init() {
     final _$initFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_ExternalClass_create'));
     final __callResultHandle = _$initFfi(__lib.LibraryContext.isolateId);
@@ -339,16 +428,22 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
     _$initsmokeExternalclassCreateReturnReleaseHandle(__callResultHandle);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeExternalclassToFfi(ExternalClass value) =>
   _smokeExternalclassCopyHandle((value as __lib.NativeBase).handle);
+
 ExternalClass smokeExternalclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is ExternalClass) return instance;
+
   final _typeIdHandle = _smokeExternalclassGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeExternalclassCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -357,12 +452,19 @@ ExternalClass smokeExternalclassFromFfi(Pointer<Void> handle) {
   _smokeExternalclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeExternalclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeExternalclassReleaseHandle(handle);
+
 Pointer<Void> smokeExternalclassToFfiNullable(ExternalClass? value) =>
   value != null ? smokeExternalclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 ExternalClass? smokeExternalclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeExternalclassFromFfi(handle) : null;
+
 void smokeExternalclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeExternalclassReleaseHandle(handle);
+
 // End of ExternalClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/dart/lib/src/smoke/type_defs.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -6,24 +8,40 @@ import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
 import 'package:library/src/smoke/type_collection.dart';
 import 'package:meta/meta.dart';
-abstract class TypeDefs {
+
+abstract class TypeDefs implements Finalizable {
+
+
   static double methodWithPrimitiveTypeDef(double input) => $prototype.methodWithPrimitiveTypeDef(input);
+
   static List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) => $prototype.methodWithComplexTypeDef(input);
+
   static double returnNestedIntTypeDef(double input) => $prototype.returnNestedIntTypeDef(input);
+
   static TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) => $prototype.returnTestStructTypeDef(input);
+
   static TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) => $prototype.returnNestedStructTypeDef(input);
+
   static TypeCollection_Point returnTypeDefPointFromTypeCollection(TypeCollection_Point input) => $prototype.returnTypeDefPointFromTypeCollection(input);
   List<double> get primitiveTypeProperty;
   set primitiveTypeProperty(List<double> value);
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = TypeDefs$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 class TypeDefs_StructHavingAliasFieldDefinedBelow {
   double field;
+
   TypeDefs_StructHavingAliasFieldDefinedBelow(this.field);
 }
+
+
 // TypeDefs_StructHavingAliasFieldDefinedBelow "private" section, not exported.
+
 final _smokeTypedefsStructhavingaliasfielddefinedbelowCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Double),
     Pointer<Void> Function(double)
@@ -36,11 +54,16 @@ final _smokeTypedefsStructhavingaliasfielddefinedbelowGetFieldfield = __lib.catc
     Double Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_field_field'));
+
+
+
 Pointer<Void> smokeTypedefsStructhavingaliasfielddefinedbelowToFfi(TypeDefs_StructHavingAliasFieldDefinedBelow value) {
   final _fieldHandle = (value.field);
   final _result = _smokeTypedefsStructhavingaliasfielddefinedbelowCreateHandle(_fieldHandle);
+  
   return _result;
 }
+
 TypeDefs_StructHavingAliasFieldDefinedBelow smokeTypedefsStructhavingaliasfielddefinedbelowFromFfi(Pointer<Void> handle) {
   final _fieldHandle = _smokeTypedefsStructhavingaliasfielddefinedbelowGetFieldfield(handle);
   try {
@@ -48,10 +71,14 @@ TypeDefs_StructHavingAliasFieldDefinedBelow smokeTypedefsStructhavingaliasfieldd
       (_fieldHandle)
     );
   } finally {
+    
   }
 }
+
 void smokeTypedefsStructhavingaliasfielddefinedbelowReleaseFfiHandle(Pointer<Void> handle) => _smokeTypedefsStructhavingaliasfielddefinedbelowReleaseHandle(handle);
+
 // Nullable TypeDefs_StructHavingAliasFieldDefinedBelow
+
 final _smokeTypedefsStructhavingaliasfielddefinedbelowCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -64,6 +91,7 @@ final _smokeTypedefsStructhavingaliasfielddefinedbelowGetValueNullable = __lib.c
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_StructHavingAliasFieldDefinedBelow_get_value_nullable'));
+
 Pointer<Void> smokeTypedefsStructhavingaliasfielddefinedbelowToFfiNullable(TypeDefs_StructHavingAliasFieldDefinedBelow? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeTypedefsStructhavingaliasfielddefinedbelowToFfi(value);
@@ -71,6 +99,7 @@ Pointer<Void> smokeTypedefsStructhavingaliasfielddefinedbelowToFfiNullable(TypeD
   smokeTypedefsStructhavingaliasfielddefinedbelowReleaseFfiHandle(_handle);
   return result;
 }
+
 TypeDefs_StructHavingAliasFieldDefinedBelow? smokeTypedefsStructhavingaliasfielddefinedbelowFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeTypedefsStructhavingaliasfielddefinedbelowGetValueNullable(handle);
@@ -78,14 +107,21 @@ TypeDefs_StructHavingAliasFieldDefinedBelow? smokeTypedefsStructhavingaliasfield
   smokeTypedefsStructhavingaliasfielddefinedbelowReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeTypedefsStructhavingaliasfielddefinedbelowReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeTypedefsStructhavingaliasfielddefinedbelowReleaseHandleNullable(handle);
+
 // End of TypeDefs_StructHavingAliasFieldDefinedBelow "private" section.
+
 class TypeDefs_TestStruct {
   String something;
+
   TypeDefs_TestStruct(this.something);
 }
+
+
 // TypeDefs_TestStruct "private" section, not exported.
+
 final _smokeTypedefsTeststructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -98,12 +134,16 @@ final _smokeTypedefsTeststructGetFieldsomething = __lib.catchArgumentError(() =>
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_get_field_something'));
+
+
+
 Pointer<Void> smokeTypedefsTeststructToFfi(TypeDefs_TestStruct value) {
   final _somethingHandle = stringToFfi(value.something);
   final _result = _smokeTypedefsTeststructCreateHandle(_somethingHandle);
   stringReleaseFfiHandle(_somethingHandle);
   return _result;
 }
+
 TypeDefs_TestStruct smokeTypedefsTeststructFromFfi(Pointer<Void> handle) {
   final _somethingHandle = _smokeTypedefsTeststructGetFieldsomething(handle);
   try {
@@ -114,8 +154,11 @@ TypeDefs_TestStruct smokeTypedefsTeststructFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_somethingHandle);
   }
 }
+
 void smokeTypedefsTeststructReleaseFfiHandle(Pointer<Void> handle) => _smokeTypedefsTeststructReleaseHandle(handle);
+
 // Nullable TypeDefs_TestStruct
+
 final _smokeTypedefsTeststructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -128,6 +171,7 @@ final _smokeTypedefsTeststructGetValueNullable = __lib.catchArgumentError(() => 
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_TypeDefs_TestStruct_get_value_nullable'));
+
 Pointer<Void> smokeTypedefsTeststructToFfiNullable(TypeDefs_TestStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeTypedefsTeststructToFfi(value);
@@ -135,6 +179,7 @@ Pointer<Void> smokeTypedefsTeststructToFfiNullable(TypeDefs_TestStruct? value) {
   smokeTypedefsTeststructReleaseFfiHandle(_handle);
   return result;
 }
+
 TypeDefs_TestStruct? smokeTypedefsTeststructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeTypedefsTeststructGetValueNullable(handle);
@@ -142,10 +187,14 @@ TypeDefs_TestStruct? smokeTypedefsTeststructFromFfiNullable(Pointer<Void> handle
   smokeTypedefsTeststructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeTypedefsTeststructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeTypedefsTeststructReleaseHandleNullable(handle);
+
 // End of TypeDefs_TestStruct "private" section.
+
 // TypeDefs "private" section, not exported.
+
 final _smokeTypedefsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -158,19 +207,34 @@ final _smokeTypedefsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeL
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_TypeDefs_release_handle'));
+
+
+
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
+
   TypeDefs$Impl(Pointer<Void> handle) : super(handle);
+
   double methodWithPrimitiveTypeDef(double input) {
     final _methodWithPrimitiveTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_methodWithPrimitiveTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _methodWithPrimitiveTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   List<TypeDefs_TestStruct> methodWithComplexTypeDef(List<TypeDefs_TestStruct> input) {
     final _methodWithComplexTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_methodWithComplexTypeDef__ListOf_smoke_TypeDefs_TestStruct'));
     final _inputHandle = foobarListofSmokeTypedefsTeststructToFfi(input);
@@ -180,17 +244,25 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       return foobarListofSmokeTypedefsTeststructFromFfi(__resultHandle);
     } finally {
       foobarListofSmokeTypedefsTeststructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   double returnNestedIntTypeDef(double input) {
     final _returnNestedIntTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32, Double), double Function(int, double)>('library_smoke_TypeDefs_returnNestedIntTypeDef__Double'));
     final _inputHandle = (input);
     final __resultHandle = _returnNestedIntTypeDefFfi(__lib.LibraryContext.isolateId, _inputHandle);
+
     try {
       return (__resultHandle);
     } finally {
+
+
     }
+
   }
+
   TypeDefs_TestStruct returnTestStructTypeDef(TypeDefs_TestStruct input) {
     final _returnTestStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTestStructTypeDef__TestStruct'));
     final _inputHandle = smokeTypedefsTeststructToFfi(input);
@@ -200,8 +272,11 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       return smokeTypedefsTeststructFromFfi(__resultHandle);
     } finally {
       smokeTypedefsTeststructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   TypeDefs_TestStruct returnNestedStructTypeDef(TypeDefs_TestStruct input) {
     final _returnNestedStructTypeDefFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnNestedStructTypeDef__TestStruct'));
     final _inputHandle = smokeTypedefsTeststructToFfi(input);
@@ -211,8 +286,11 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       return smokeTypedefsTeststructFromFfi(__resultHandle);
     } finally {
       smokeTypedefsTeststructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   TypeCollection_Point returnTypeDefPointFromTypeCollection(TypeCollection_Point input) {
     final _returnTypeDefPointFromTypeCollectionFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_TypeDefs_returnTypeDefPointFromTypeCollection__Point'));
     final _inputHandle = smokeTypecollectionPointToFfi(input);
@@ -222,8 +300,11 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       return smokeTypecollectionPointFromFfi(__resultHandle);
     } finally {
       smokeTypecollectionPointReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   List<double> get primitiveTypeProperty {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Pointer<Void>, Int32), Pointer<Void> Function(Pointer<Void>, int)>('library_smoke_TypeDefs_primitiveTypeProperty_get'));
@@ -233,8 +314,11 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
       return foobarListofDoubleFromFfi(__resultHandle);
     } finally {
       foobarListofDoubleReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   @override
   set primitiveTypeProperty(List<double> value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TypeDefs_primitiveTypeProperty_set__ListOf_Double'));
@@ -242,26 +326,40 @@ class TypeDefs$Impl extends __lib.NativeBase implements TypeDefs {
     final _handle = this.handle;
     _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
     foobarListofDoubleReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeTypedefsToFfi(TypeDefs value) =>
   _smokeTypedefsCopyHandle((value as __lib.NativeBase).handle);
+
 TypeDefs smokeTypedefsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is TypeDefs) return instance;
+
   final _copiedHandle = _smokeTypedefsCopyHandle(handle);
   final result = TypeDefs$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeTypedefsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeTypedefsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeTypedefsReleaseHandle(handle);
+
 Pointer<Void> smokeTypedefsToFfiNullable(TypeDefs? value) =>
   value != null ? smokeTypedefsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 TypeDefs? smokeTypedefsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeTypedefsFromFfi(handle) : null;
+
 void smokeTypedefsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeTypedefsReleaseHandle(handle);
+
 // End of TypeDefs "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_class.dart
@@ -1,12 +1,20 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
+
 /// @nodoc
-abstract class InternalClass {
+abstract class InternalClass implements Finalizable {
+
+
   void fooBar();
 }
+
+
 // InternalClass "private" section, not exported.
+
 final _smokeInternalclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -19,33 +27,51 @@ final _smokeInternalclassReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClass_release_handle'));
+
+
+
 class InternalClass$Impl extends __lib.NativeBase implements InternalClass {
+
   InternalClass$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClass_fooBar'));
     final _handle = this.handle;
     _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 Pointer<Void> smokeInternalclassToFfi(InternalClass value) =>
   _smokeInternalclassCopyHandle((value as __lib.NativeBase).handle);
+
 InternalClass smokeInternalclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClass) return instance;
+
   final _copiedHandle = _smokeInternalclassCopyHandle(handle);
   final result = InternalClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeInternalclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInternalclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInternalclassReleaseHandle(handle);
+
 Pointer<Void> smokeInternalclassToFfiNullable(InternalClass? value) =>
   value != null ? smokeInternalclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InternalClass? smokeInternalclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInternalclassFromFfi(handle) : null;
+
 void smokeInternalclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInternalclassReleaseHandle(handle);
+
 // End of InternalClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_class_with_functions.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_class_with_functions.dart
@@ -1,19 +1,30 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
+
 /// @nodoc
-abstract class InternalClassWithFunctions {
+abstract class InternalClassWithFunctions implements Finalizable {
+
   factory InternalClassWithFunctions.make() => $prototype.make();
+
   factory InternalClassWithFunctions.remake(String foo) => $prototype.remake(foo);
+
+
   void fooBar();
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = InternalClassWithFunctions$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // InternalClassWithFunctions "private" section, not exported.
+
 final _smokeInternalclasswithfunctionsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -26,35 +37,53 @@ final _smokeInternalclasswithfunctionsReleaseHandle = __lib.catchArgumentError((
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithFunctions_release_handle'));
+
+
+
+
+
 /// @nodoc
 @visibleForTesting
 class InternalClassWithFunctions$Impl extends __lib.NativeBase implements InternalClassWithFunctions {
+
   InternalClassWithFunctions$Impl(Pointer<Void> handle) : super(handle);
+
+
   InternalClassWithFunctions make() {
     final _result_handle = _make();
     final _result = InternalClassWithFunctions$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeInternalclasswithfunctionsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
+
   InternalClassWithFunctions remake(String foo) {
     final _result_handle = _remake(foo);
     final _result = InternalClassWithFunctions$Impl(_result_handle);
+
     __lib.cacheInstance(_result_handle, _result);
+
     _smokeInternalclasswithfunctionsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
+
   @override
   void fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalClassWithFunctions_fooBar'));
     final _handle = this.handle;
     _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
   static Pointer<Void> _make() {
     final _makeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithFunctions_make'));
     final __resultHandle = _makeFfi(__lib.LibraryContext.isolateId);
     return __resultHandle;
   }
+
   static Pointer<Void> _remake(String foo) {
     final _remakeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_InternalClassWithFunctions_make__String'));
     final _fooHandle = stringToFfi(foo);
@@ -62,25 +91,37 @@ class InternalClassWithFunctions$Impl extends __lib.NativeBase implements Intern
     stringReleaseFfiHandle(_fooHandle);
     return __resultHandle;
   }
+
+
 }
+
 Pointer<Void> smokeInternalclasswithfunctionsToFfi(InternalClassWithFunctions value) =>
   _smokeInternalclasswithfunctionsCopyHandle((value as __lib.NativeBase).handle);
+
 InternalClassWithFunctions smokeInternalclasswithfunctionsFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClassWithFunctions) return instance;
+
   final _copiedHandle = _smokeInternalclasswithfunctionsCopyHandle(handle);
   final result = InternalClassWithFunctions$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeInternalclasswithfunctionsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInternalclasswithfunctionsReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInternalclasswithfunctionsReleaseHandle(handle);
+
 Pointer<Void> smokeInternalclasswithfunctionsToFfiNullable(InternalClassWithFunctions? value) =>
   value != null ? smokeInternalclasswithfunctionsToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InternalClassWithFunctions? smokeInternalclasswithfunctionsFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInternalclasswithfunctionsFromFfi(handle) : null;
+
 void smokeInternalclasswithfunctionsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInternalclasswithfunctionsReleaseHandle(handle);
+
 // End of InternalClassWithFunctions "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_class_with_static_property.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_class_with_static_property.dart
@@ -1,18 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
+
 /// @nodoc
-abstract class InternalClassWithStaticProperty {
+abstract class InternalClassWithStaticProperty implements Finalizable {
+
   static String get fooBar => $prototype.fooBar;
   static set fooBar(String value) { $prototype.fooBar = value; }
+
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = InternalClassWithStaticProperty$Impl(Pointer<Void>.fromAddress(0));
 }
+
+
 // InternalClassWithStaticProperty "private" section, not exported.
+
 final _smokeInternalclasswithstaticpropertyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -25,10 +34,14 @@ final _smokeInternalclasswithstaticpropertyReleaseHandle = __lib.catchArgumentEr
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalClassWithStaticProperty_release_handle'));
+
+
 /// @nodoc
 @visibleForTesting
 class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements InternalClassWithStaticProperty {
+
   InternalClassWithStaticProperty$Impl(Pointer<Void> handle) : super(handle);
+
   String get fooBar {
     final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_InternalClassWithStaticProperty_fooBar_get'));
     final __resultHandle = _getFfi(__lib.LibraryContext.isolateId);
@@ -36,33 +49,50 @@ class InternalClassWithStaticProperty$Impl extends __lib.NativeBase implements I
       return stringFromFfi(__resultHandle);
     } finally {
       stringReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
   set fooBar(String value) {
     final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>), void Function(int, Pointer<Void>)>('library_smoke_InternalClassWithStaticProperty_fooBar_set__String'));
     final _valueHandle = stringToFfi(value);
     _setFfi(__lib.LibraryContext.isolateId, _valueHandle);
     stringReleaseFfiHandle(_valueHandle);
+
   }
+
+
+
 }
+
 Pointer<Void> smokeInternalclasswithstaticpropertyToFfi(InternalClassWithStaticProperty value) =>
   _smokeInternalclasswithstaticpropertyCopyHandle((value as __lib.NativeBase).handle);
+
 InternalClassWithStaticProperty smokeInternalclasswithstaticpropertyFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalClassWithStaticProperty) return instance;
+
   final _copiedHandle = _smokeInternalclasswithstaticpropertyCopyHandle(handle);
   final result = InternalClassWithStaticProperty$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeInternalclasswithstaticpropertyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInternalclasswithstaticpropertyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInternalclasswithstaticpropertyReleaseHandle(handle);
+
 Pointer<Void> smokeInternalclasswithstaticpropertyToFfiNullable(InternalClassWithStaticProperty? value) =>
   value != null ? smokeInternalclasswithstaticpropertyToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InternalClassWithStaticProperty? smokeInternalclasswithstaticpropertyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInternalclasswithstaticpropertyFromFfi(handle) : null;
+
 void smokeInternalclasswithstaticpropertyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInternalclasswithstaticpropertyReleaseHandle(handle);
+
 // End of InternalClassWithStaticProperty "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_interface.dart
@@ -1,20 +1,31 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
 /// @nodoc
-abstract class InternalInterface {
+abstract class InternalInterface implements Finalizable {
   /// @nodoc
+
   factory InternalInterface(
     void Function() fooBarLambda,
+
   ) => InternalInterface$Lambdas(
     fooBarLambda,
+
   );
+
+
   void fooBar();
 }
+
+
 // InternalInterface "private" section, not exported.
+
 final _smokeInternalinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -35,48 +46,68 @@ final _smokeInternalinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.na
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_InternalInterface_get_type_id'));
+
+
 class InternalInterface$Lambdas implements InternalInterface {
   void Function() fooBarLambda;
+
   InternalInterface$Lambdas(
     this.fooBarLambda,
+
   );
+
   @override
   void fooBar() =>
     fooBarLambda();
 }
+
 class InternalInterface$Impl extends __lib.NativeBase implements InternalInterface {
+
   InternalInterface$Impl(Pointer<Void> handle) : super(handle);
+
   @override
   void fooBar() {
     final _fooBarFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_InternalInterface_fooBar'));
     final _handle = this.handle;
     _fooBarFfi(_handle, __lib.LibraryContext.isolateId);
+
   }
+
+
 }
+
 int _smokeInternalinterfacefooBarStatic(Object _obj) {
+
   try {
     (_obj as InternalInterface).fooBar();
   } finally {
   }
   return 0;
 }
+
+
 Pointer<Void> smokeInternalinterfaceToFfi(InternalInterface value) {
   if (value is __lib.NativeBase) return _smokeInternalinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokeInternalinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value,
     Pointer.fromFunction<Uint8 Function(Handle)>(_smokeInternalinterfacefooBarStatic, __lib.unknownError)
   );
+
   return result;
 }
+
 InternalInterface smokeInternalinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalInterface) return instance;
+
   final _typeIdHandle = _smokeInternalinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokeInternalinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -85,12 +116,19 @@ InternalInterface smokeInternalinterfaceFromFfi(Pointer<Void> handle) {
   _smokeInternalinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInternalinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInternalinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokeInternalinterfaceToFfiNullable(InternalInterface? value) =>
   value != null ? smokeInternalinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InternalInterface? smokeInternalinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInternalinterfaceFromFfi(handle) : null;
+
 void smokeInternalinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInternalinterfaceReleaseHandle(handle);
+
 // End of InternalInterface "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_property_only.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/internal_property_only.dart
@@ -1,10 +1,17 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
-abstract class InternalPropertyOnly {
+
+abstract class InternalPropertyOnly implements Finalizable {
+
 }
+
+
 // InternalPropertyOnly "private" section, not exported.
+
 final _smokeInternalpropertyonlyRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -17,27 +24,42 @@ final _smokeInternalpropertyonlyReleaseHandle = __lib.catchArgumentError(() => _
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_InternalPropertyOnly_release_handle'));
+
+
 class InternalPropertyOnly$Impl extends __lib.NativeBase implements InternalPropertyOnly {
+
   InternalPropertyOnly$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokeInternalpropertyonlyToFfi(InternalPropertyOnly value) =>
   _smokeInternalpropertyonlyCopyHandle((value as __lib.NativeBase).handle);
+
 InternalPropertyOnly smokeInternalpropertyonlyFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is InternalPropertyOnly) return instance;
+
   final _copiedHandle = _smokeInternalpropertyonlyCopyHandle(handle);
   final result = InternalPropertyOnly$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokeInternalpropertyonlyRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokeInternalpropertyonlyReleaseFfiHandle(Pointer<Void> handle) =>
   _smokeInternalpropertyonlyReleaseHandle(handle);
+
 Pointer<Void> smokeInternalpropertyonlyToFfiNullable(InternalPropertyOnly? value) =>
   value != null ? smokeInternalpropertyonlyToFfi(value) : Pointer<Void>.fromAddress(0);
+
 InternalPropertyOnly? smokeInternalpropertyonlyFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokeInternalpropertyonlyFromFfi(handle) : null;
+
 void smokeInternalpropertyonlyReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeInternalpropertyonlyReleaseHandle(handle);
+
 // End of InternalPropertyOnly "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_class_with_internal_attribute.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_class_with_internal_attribute.dart
@@ -6,7 +6,7 @@ import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 
 /// @nodoc
-abstract class OuterClassWithInternalAttribute {
+abstract class OuterClassWithInternalAttribute implements Finalizable {
 
 }
 
@@ -92,7 +92,7 @@ void smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseFfiHa
   _smokeOuterclasswithinternalattributeStructnestedininternalclassReleaseHandleNullable(handle);
 
 // End of OuterClassWithInternalAttribute_StructNestedInInternalClass "private" section.
-abstract class OuterClassWithInternalAttribute_ClassNestedInInternalClass {
+abstract class OuterClassWithInternalAttribute_ClassNestedInInternalClass implements Finalizable {
 
 }
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_class_with_internal_attribute.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_class_with_internal_attribute.dart
@@ -169,7 +169,7 @@ final _smokeOuterclasswithinternalattributeLambdanestedininternalclassCreateProx
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_OuterClassWithInternalAttribute_LambdaNestedInInternalClass_create_proxy'));
 
-class OuterClassWithInternalAttribute_LambdaNestedInInternalClass$Impl {
+class OuterClassWithInternalAttribute_LambdaNestedInInternalClass$Impl implements Finalizable {
   final Pointer<Void> handle;
   OuterClassWithInternalAttribute_LambdaNestedInInternalClass$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_struct_with_internal_attribute.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_struct_with_internal_attribute.dart
@@ -174,7 +174,7 @@ final _smokeOuterstructwithinternalattributeLambdanestedininternalstructCreatePr
     Pointer<Void> Function(int, int, Object, Pointer)
   >('library_smoke_OuterStructWithInternalAttribute_LambdaNestedInInternalStruct_create_proxy'));
 
-class OuterStructWithInternalAttribute_LambdaNestedInInternalStruct$Impl {
+class OuterStructWithInternalAttribute_LambdaNestedInInternalStruct$Impl implements Finalizable {
   final Pointer<Void> handle;
   OuterStructWithInternalAttribute_LambdaNestedInInternalStruct$Impl(this.handle);
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_struct_with_internal_attribute.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/outer_struct_with_internal_attribute.dart
@@ -97,7 +97,7 @@ void smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseFfi
   _smokeOuterstructwithinternalattributeStructnestedininternalstructReleaseHandleNullable(handle);
 
 // End of OuterStructWithInternalAttribute_StructNestedInInternalStruct "private" section.
-abstract class OuterStructWithInternalAttribute_ClassNestedInInternalStruct {
+abstract class OuterStructWithInternalAttribute_ClassNestedInInternalStruct implements Finalizable {
 
 }
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_class.dart
@@ -1,16 +1,23 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
 import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
-abstract class PublicClass {
+
+abstract class PublicClass implements Finalizable {
+
 }
+
 /// @nodoc
 enum PublicClass_InternalEnum {
     foo,
     bar
 }
+
 // PublicClass_InternalEnum "private" section, not exported.
+
 int smokePublicclassInternalenumToFfi(PublicClass_InternalEnum value) {
   switch (value) {
   case PublicClass_InternalEnum.foo:
@@ -21,6 +28,7 @@ int smokePublicclassInternalenumToFfi(PublicClass_InternalEnum value) {
     throw StateError("Invalid enum value $value for PublicClass_InternalEnum enum.");
   }
 }
+
 PublicClass_InternalEnum smokePublicclassInternalenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -31,7 +39,9 @@ PublicClass_InternalEnum smokePublicclassInternalenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for PublicClass_InternalEnum enum.");
   }
 }
+
 void smokePublicclassInternalenumReleaseFfiHandle(int handle) {}
+
 final _smokePublicclassInternalenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -44,6 +54,7 @@ final _smokePublicclassInternalenumGetValueNullable = __lib.catchArgumentError((
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalEnum_get_value_nullable'));
+
 Pointer<Void> smokePublicclassInternalenumToFfiNullable(PublicClass_InternalEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePublicclassInternalenumToFfi(value);
@@ -51,6 +62,7 @@ Pointer<Void> smokePublicclassInternalenumToFfiNullable(PublicClass_InternalEnum
   smokePublicclassInternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 PublicClass_InternalEnum? smokePublicclassInternalenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePublicclassInternalenumGetValueNullable(handle);
@@ -58,15 +70,22 @@ PublicClass_InternalEnum? smokePublicclassInternalenumFromFfiNullable(Pointer<Vo
   smokePublicclassInternalenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePublicclassInternalenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePublicclassInternalenumReleaseHandleNullable(handle);
+
 // End of PublicClass_InternalEnum "private" section.
 /// @nodoc
+
 class PublicClass_InternalStruct {
   String stringField;
+
   PublicClass_InternalStruct(this.stringField);
 }
+
+
 // PublicClass_InternalStruct "private" section, not exported.
+
 final _smokePublicclassInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -79,12 +98,16 @@ final _smokePublicclassInternalstructGetFieldstringField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_get_field_stringField'));
+
+
+
 Pointer<Void> smokePublicclassInternalstructToFfi(PublicClass_InternalStruct value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _result = _smokePublicclassInternalstructCreateHandle(_stringFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
   return _result;
 }
+
 PublicClass_InternalStruct smokePublicclassInternalstructFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokePublicclassInternalstructGetFieldstringField(handle);
   try {
@@ -95,8 +118,11 @@ PublicClass_InternalStruct smokePublicclassInternalstructFromFfi(Pointer<Void> h
     stringReleaseFfiHandle(_stringFieldHandle);
   }
 }
+
 void smokePublicclassInternalstructReleaseFfiHandle(Pointer<Void> handle) => _smokePublicclassInternalstructReleaseHandle(handle);
+
 // Nullable PublicClass_InternalStruct
+
 final _smokePublicclassInternalstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -109,6 +135,7 @@ final _smokePublicclassInternalstructGetValueNullable = __lib.catchArgumentError
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_InternalStruct_get_value_nullable'));
+
 Pointer<Void> smokePublicclassInternalstructToFfiNullable(PublicClass_InternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePublicclassInternalstructToFfi(value);
@@ -116,6 +143,7 @@ Pointer<Void> smokePublicclassInternalstructToFfiNullable(PublicClass_InternalSt
   smokePublicclassInternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 PublicClass_InternalStruct? smokePublicclassInternalstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePublicclassInternalstructGetValueNullable(handle);
@@ -123,15 +151,22 @@ PublicClass_InternalStruct? smokePublicclassInternalstructFromFfiNullable(Pointe
   smokePublicclassInternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePublicclassInternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePublicclassInternalstructReleaseHandleNullable(handle);
+
 // End of PublicClass_InternalStruct "private" section.
+
 class PublicClass_PublicStruct {
   /// @nodoc
   PublicClass_InternalStruct _internalField;
+
   PublicClass_PublicStruct(this._internalField);
 }
+
+
 // PublicClass_PublicStruct "private" section, not exported.
+
 final _smokePublicclassPublicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -144,12 +179,16 @@ final _smokePublicclassPublicstructGetFieldinternalField = __lib.catchArgumentEr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_get_field_internalField'));
+
+
+
 Pointer<Void> smokePublicclassPublicstructToFfi(PublicClass_PublicStruct value) {
   final _internalFieldHandle = smokePublicclassInternalstructToFfi(value._internalField);
   final _result = _smokePublicclassPublicstructCreateHandle(_internalFieldHandle);
   smokePublicclassInternalstructReleaseFfiHandle(_internalFieldHandle);
   return _result;
 }
+
 PublicClass_PublicStruct smokePublicclassPublicstructFromFfi(Pointer<Void> handle) {
   final _internalFieldHandle = _smokePublicclassPublicstructGetFieldinternalField(handle);
   try {
@@ -160,8 +199,11 @@ PublicClass_PublicStruct smokePublicclassPublicstructFromFfi(Pointer<Void> handl
     smokePublicclassInternalstructReleaseFfiHandle(_internalFieldHandle);
   }
 }
+
 void smokePublicclassPublicstructReleaseFfiHandle(Pointer<Void> handle) => _smokePublicclassPublicstructReleaseHandle(handle);
+
 // Nullable PublicClass_PublicStruct
+
 final _smokePublicclassPublicstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -174,6 +216,7 @@ final _smokePublicclassPublicstructGetValueNullable = __lib.catchArgumentError((
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStruct_get_value_nullable'));
+
 Pointer<Void> smokePublicclassPublicstructToFfiNullable(PublicClass_PublicStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePublicclassPublicstructToFfi(value);
@@ -181,6 +224,7 @@ Pointer<Void> smokePublicclassPublicstructToFfiNullable(PublicClass_PublicStruct
   smokePublicclassPublicstructReleaseFfiHandle(_handle);
   return result;
 }
+
 PublicClass_PublicStruct? smokePublicclassPublicstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePublicclassPublicstructGetValueNullable(handle);
@@ -188,18 +232,26 @@ PublicClass_PublicStruct? smokePublicclassPublicstructFromFfiNullable(Pointer<Vo
   smokePublicclassPublicstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePublicclassPublicstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePublicclassPublicstructReleaseHandleNullable(handle);
+
 // End of PublicClass_PublicStruct "private" section.
+
 class PublicClass_PublicStructWithInternalDefaults {
   /// @nodoc
   String _internalField;
+
   double publicField;
+
   PublicClass_PublicStructWithInternalDefaults._(this._internalField, this.publicField);
   PublicClass_PublicStructWithInternalDefaults(double publicField)
     : _internalField = "foo", publicField = publicField;
 }
+
+
 // PublicClass_PublicStructWithInternalDefaults "private" section, not exported.
+
 final _smokePublicclassPublicstructwithinternaldefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Float),
     Pointer<Void> Function(Pointer<Void>, double)
@@ -216,27 +268,36 @@ final _smokePublicclassPublicstructwithinternaldefaultsGetFieldpublicField = __l
     Float Function(Pointer<Void>),
     double Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_field_publicField'));
+
+
+
 Pointer<Void> smokePublicclassPublicstructwithinternaldefaultsToFfi(PublicClass_PublicStructWithInternalDefaults value) {
   final _internalFieldHandle = stringToFfi(value._internalField);
   final _publicFieldHandle = (value.publicField);
   final _result = _smokePublicclassPublicstructwithinternaldefaultsCreateHandle(_internalFieldHandle, _publicFieldHandle);
   stringReleaseFfiHandle(_internalFieldHandle);
+  
   return _result;
 }
+
 PublicClass_PublicStructWithInternalDefaults smokePublicclassPublicstructwithinternaldefaultsFromFfi(Pointer<Void> handle) {
   final _internalFieldHandle = _smokePublicclassPublicstructwithinternaldefaultsGetFieldinternalField(handle);
   final _publicFieldHandle = _smokePublicclassPublicstructwithinternaldefaultsGetFieldpublicField(handle);
   try {
     return PublicClass_PublicStructWithInternalDefaults._(
-      stringFromFfi(_internalFieldHandle),
+      stringFromFfi(_internalFieldHandle), 
       (_publicFieldHandle)
     );
   } finally {
     stringReleaseFfiHandle(_internalFieldHandle);
+    
   }
 }
+
 void smokePublicclassPublicstructwithinternaldefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokePublicclassPublicstructwithinternaldefaultsReleaseHandle(handle);
+
 // Nullable PublicClass_PublicStructWithInternalDefaults
+
 final _smokePublicclassPublicstructwithinternaldefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -249,6 +310,7 @@ final _smokePublicclassPublicstructwithinternaldefaultsGetValueNullable = __lib.
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicClass_PublicStructWithInternalDefaults_get_value_nullable'));
+
 Pointer<Void> smokePublicclassPublicstructwithinternaldefaultsToFfiNullable(PublicClass_PublicStructWithInternalDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePublicclassPublicstructwithinternaldefaultsToFfi(value);
@@ -256,6 +318,7 @@ Pointer<Void> smokePublicclassPublicstructwithinternaldefaultsToFfiNullable(Publ
   smokePublicclassPublicstructwithinternaldefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 PublicClass_PublicStructWithInternalDefaults? smokePublicclassPublicstructwithinternaldefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePublicclassPublicstructwithinternaldefaultsGetValueNullable(handle);
@@ -263,10 +326,14 @@ PublicClass_PublicStructWithInternalDefaults? smokePublicclassPublicstructwithin
   smokePublicclassPublicstructwithinternaldefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePublicclassPublicstructwithinternaldefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePublicclassPublicstructwithinternaldefaultsReleaseHandleNullable(handle);
+
 // End of PublicClass_PublicStructWithInternalDefaults "private" section.
+
 // PublicClass "private" section, not exported.
+
 final _smokePublicclassRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -279,27 +346,42 @@ final _smokePublicclassReleaseHandle = __lib.catchArgumentError(() => __lib.nati
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PublicClass_release_handle'));
+
+
 class PublicClass$Impl extends __lib.NativeBase implements PublicClass {
+
   PublicClass$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
 Pointer<Void> smokePublicclassToFfi(PublicClass value) =>
   _smokePublicclassCopyHandle((value as __lib.NativeBase).handle);
+
 PublicClass smokePublicclassFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PublicClass) return instance;
+
   final _copiedHandle = _smokePublicclassCopyHandle(handle);
   final result = PublicClass$Impl(_copiedHandle);
   __lib.cacheInstance(_copiedHandle, result);
   _smokePublicclassRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePublicclassReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePublicclassReleaseHandle(handle);
+
 Pointer<Void> smokePublicclassToFfiNullable(PublicClass? value) =>
   value != null ? smokePublicclassToFfi(value) : Pointer<Void>.fromAddress(0);
+
 PublicClass? smokePublicclassFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePublicclassFromFfi(handle) : null;
+
 void smokePublicclassReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePublicclassReleaseHandle(handle);
+
 // End of PublicClass "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_interface.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_interface.dart
@@ -1,3 +1,5 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/_native_base.dart' as __lib;
@@ -5,14 +7,22 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/_type_repository.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/smoke/public_class.dart';
-abstract class PublicInterface {
+
+abstract class PublicInterface implements Finalizable {
+
 }
+
 /// @nodoc
+
 class PublicInterface_InternalStruct {
   PublicClass_InternalStruct fieldOfInternalType;
+
   PublicInterface_InternalStruct(this.fieldOfInternalType);
 }
+
+
 // PublicInterface_InternalStruct "private" section, not exported.
+
 final _smokePublicinterfaceInternalstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -25,12 +35,16 @@ final _smokePublicinterfaceInternalstructGetFieldfieldOfInternalType = __lib.cat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_get_field_fieldOfInternalType'));
+
+
+
 Pointer<Void> smokePublicinterfaceInternalstructToFfi(PublicInterface_InternalStruct value) {
   final _fieldOfInternalTypeHandle = smokePublicclassInternalstructToFfi(value.fieldOfInternalType);
   final _result = _smokePublicinterfaceInternalstructCreateHandle(_fieldOfInternalTypeHandle);
   smokePublicclassInternalstructReleaseFfiHandle(_fieldOfInternalTypeHandle);
   return _result;
 }
+
 PublicInterface_InternalStruct smokePublicinterfaceInternalstructFromFfi(Pointer<Void> handle) {
   final _fieldOfInternalTypeHandle = _smokePublicinterfaceInternalstructGetFieldfieldOfInternalType(handle);
   try {
@@ -41,8 +55,11 @@ PublicInterface_InternalStruct smokePublicinterfaceInternalstructFromFfi(Pointer
     smokePublicclassInternalstructReleaseFfiHandle(_fieldOfInternalTypeHandle);
   }
 }
+
 void smokePublicinterfaceInternalstructReleaseFfiHandle(Pointer<Void> handle) => _smokePublicinterfaceInternalstructReleaseHandle(handle);
+
 // Nullable PublicInterface_InternalStruct
+
 final _smokePublicinterfaceInternalstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -55,6 +72,7 @@ final _smokePublicinterfaceInternalstructGetValueNullable = __lib.catchArgumentE
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_InternalStruct_get_value_nullable'));
+
 Pointer<Void> smokePublicinterfaceInternalstructToFfiNullable(PublicInterface_InternalStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePublicinterfaceInternalstructToFfi(value);
@@ -62,6 +80,7 @@ Pointer<Void> smokePublicinterfaceInternalstructToFfiNullable(PublicInterface_In
   smokePublicinterfaceInternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 PublicInterface_InternalStruct? smokePublicinterfaceInternalstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePublicinterfaceInternalstructGetValueNullable(handle);
@@ -69,10 +88,14 @@ PublicInterface_InternalStruct? smokePublicinterfaceInternalstructFromFfiNullabl
   smokePublicinterfaceInternalstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePublicinterfaceInternalstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePublicinterfaceInternalstructReleaseHandleNullable(handle);
+
 // End of PublicInterface_InternalStruct "private" section.
+
 // PublicInterface "private" section, not exported.
+
 final _smokePublicinterfaceRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Void Function(Pointer<Void>, Int32, Handle),
     void Function(Pointer<Void>, int, Object)
@@ -93,25 +116,38 @@ final _smokePublicinterfaceGetTypeId = __lib.catchArgumentError(() => __lib.nati
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PublicInterface_get_type_id'));
+
+
 class PublicInterface$Impl extends __lib.NativeBase implements PublicInterface {
+
   PublicInterface$Impl(Pointer<Void> handle) : super(handle);
+
+
 }
+
+
+
 Pointer<Void> smokePublicinterfaceToFfi(PublicInterface value) {
   if (value is __lib.NativeBase) return _smokePublicinterfaceCopyHandle((value as __lib.NativeBase).handle);
+
   final result = _smokePublicinterfaceCreateProxy(
     __lib.getObjectToken(value),
     __lib.LibraryContext.isolateId,
     value
   );
+
   return result;
 }
+
 PublicInterface smokePublicinterfaceFromFfi(Pointer<Void> handle) {
   if (handle.address == 0) throw StateError("Expected non-null value.");
   final instance = __lib.getCachedInstance(handle);
   if (instance != null && instance is PublicInterface) return instance;
+
   final _typeIdHandle = _smokePublicinterfaceGetTypeId(handle);
   final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
   stringReleaseFfiHandle(_typeIdHandle);
+
   final _copiedHandle = _smokePublicinterfaceCopyHandle(handle);
   final result = factoryConstructor != null
     ? factoryConstructor(_copiedHandle)
@@ -120,12 +156,19 @@ PublicInterface smokePublicinterfaceFromFfi(Pointer<Void> handle) {
   _smokePublicinterfaceRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
   return result;
 }
+
 void smokePublicinterfaceReleaseFfiHandle(Pointer<Void> handle) =>
   _smokePublicinterfaceReleaseHandle(handle);
+
 Pointer<Void> smokePublicinterfaceToFfiNullable(PublicInterface? value) =>
   value != null ? smokePublicinterfaceToFfi(value) : Pointer<Void>.fromAddress(0);
+
 PublicInterface? smokePublicinterfaceFromFfiNullable(Pointer<Void> handle) =>
   handle.address != 0 ? smokePublicinterfaceFromFfi(handle) : null;
+
 void smokePublicinterfaceReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePublicinterfaceReleaseHandle(handle);
+
 // End of PublicInterface "private" section.
+
+


### PR DESCRIPTION
----- Motivation -----
If the generated class is not marked with 'Finalizable' interface,
then, when methods are invoked on its object, the object can be
garbage collected in the middle of method execution.
    
For instance let's take a look at the following example from functional
tests:
    
'AsyncClass().asyncVoid(false)'
    
1. AsyncClass object is created and its lifetime is tied with the native
    finalizer, which deletes shared_ptr (this.handle) that owns resources.
2. Then, inside 'asyncVoid(false)' we use only 'this.handle' member to
    pass the opaque handle to the native function. For garbage collector
    after the handle is passed 'this' object is no longer used by anybody.
    Therefore, it is not needed – can be finalized.
3. If the garbage collection kicks in before the native call, then the
    'AsyncClass' object is garbage collected, its finalizer is run and therefore,
    the resources on C++ side are deleted. It causes the segmentation fault.
    
We have a race condition between the garbage collection and execution
of native functions.
    
The consequences can be dramatic -- the finalizer registered for
the object may be executed before the native function call inside
the member methods. The finalizers delete C++ resources tied with
the object. This can lead to segmentation fault.

----- Solution -----
The 'Finalizable' interface is a viable solution proposed by Dart:FFI
documentation. It ensures, that 'this' object outlives the whole method
call -- it guarantees, that the native function call finishes before the
finalizer is run.