### PR TITLE
CI: use macos-13 runner

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -188,7 +188,7 @@ jobs:
 
   swift-mac:
     name: Swift on MacOS
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v2

--- a/functional-tests/scripts/build-swift-functional
+++ b/functional-tests/scripts/build-swift-functional
@@ -117,7 +117,7 @@ popd
 # Run SwiftLint if available
 if which swiftlint; then
     pushd functional/swift > /dev/null
-    swiftlint --path . > "${BUILD_DIR}/swiftlint.xml"
+    swiftlint . > "${BUILD_DIR}/swiftlint.xml"
     popd > /dev/null
 else
     echo "SwiftLint was not found, skip linting"


### PR DESCRIPTION
The job was using 'macos-12' runner, which has been deprecated. Its usage caused error and tests were
not executed.

This commit updates the workflow to use macos-13 image.