### PR TITLE
Remove explicit dependency of JniGenerator on JavaGenerator

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -159,6 +159,11 @@ internal class JavaGenerator : Generator {
                 platformAttribute = JAVA,
                 limeReferenceMap = jniFilteredModel.referenceMap,
                 nameRules = javaNameRules,
+                externalNameRules =
+                    mapOf(
+                        "getPackageFromImportString" to JavaNameRules.Companion::getPackageFromImportString,
+                        "getClassNamesFromImportString" to JavaNameRules.Companion::getClassNamesFromImportString,
+                    ),
                 signatureResolver = signatureResolver,
                 basePackages = basePackages,
                 internalPackages = internalPackage,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -159,6 +159,7 @@ internal class JavaGenerator : Generator {
                 platformAttribute = JAVA,
                 limeReferenceMap = jniFilteredModel.referenceMap,
                 javaNameRules = javaNameRules,
+                signatureResolver = signatureResolver,
                 basePackages = basePackages,
                 internalPackages = internalPackage,
                 internalNamespace = internalNamespace,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -155,6 +155,7 @@ internal class JavaGenerator : Generator {
         val descendantInterfaces = LimeTypeHelper.collectDescendantInterfaces(jniFilteredModel.topElements)
         val jniTemplates =
             JniTemplates(
+                generatorName = GENERATOR_NAME,
                 limeReferenceMap = jniFilteredModel.referenceMap,
                 javaNameRules = javaNameRules,
                 basePackages = basePackages,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -156,6 +156,7 @@ internal class JavaGenerator : Generator {
         val jniTemplates =
             JniTemplates(
                 generatorName = GENERATOR_NAME,
+                platformAttribute = JAVA,
                 limeReferenceMap = jniFilteredModel.referenceMap,
                 javaNameRules = javaNameRules,
                 basePackages = basePackages,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGenerator.kt
@@ -158,7 +158,7 @@ internal class JavaGenerator : Generator {
                 generatorName = GENERATOR_NAME,
                 platformAttribute = JAVA,
                 limeReferenceMap = jniFilteredModel.referenceMap,
-                javaNameRules = javaNameRules,
+                nameRules = javaNameRules,
                 signatureResolver = signatureResolver,
                 basePackages = basePackages,
                 internalPackages = internalPackage,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniFileNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniFileNameRules.kt
@@ -19,7 +19,6 @@
 
 package com.here.gluecodium.generator.jni
 
-import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.NAME_NAME
 import com.here.gluecodium.model.lime.LimeInterface
@@ -42,8 +41,8 @@ internal class JniFileNameRules(
         val externalName = limeElement.external?.getFor(platformAttribute)?.get(NAME_NAME)
         return when {
             externalName != null -> {
-                val packageNames = JavaNameRules.getPackageFromImportString(externalName)
-                val classNames = JavaNameRules.getClassNamesFromImportString(externalName)
+                val packageNames = nameResolver.getPackageFromImportString(externalName)
+                val classNames = nameResolver.getClassNamesFromImportString(externalName)
                 (packageNames + classNames).joinToString("_")
             }
             else -> getElementFileNamePrefix(limeElement)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniFileNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniFileNameRules.kt
@@ -20,13 +20,18 @@
 package com.here.gluecodium.generator.jni
 
 import com.here.gluecodium.generator.java.JavaNameRules
+import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.NAME_NAME
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeNamedElement
 import java.io.File
 
-internal class JniFileNameRules(generatorName: String, private val nameResolver: JniNameResolver) {
+internal class JniFileNameRules(
+    generatorName: String,
+    private val platformAttribute: LimeAttributeType,
+    private val nameResolver: JniNameResolver,
+) {
     private val jniPathPrefix = generatorName + File.separator + "jni" + File.separator
 
     fun getHeaderFilePath(fileName: String) = "$jniPathPrefix$fileName.h"
@@ -34,7 +39,7 @@ internal class JniFileNameRules(generatorName: String, private val nameResolver:
     fun getImplementationFilePath(fileName: String) = "$jniPathPrefix$fileName.cpp"
 
     fun getConversionFileName(limeElement: LimeNamedElement): String {
-        val externalName = limeElement.external?.java?.get(NAME_NAME)
+        val externalName = limeElement.external?.getFor(platformAttribute)?.get(NAME_NAME)
         return when {
             externalName != null -> {
                 val packageNames = JavaNameRules.getPackageFromImportString(externalName)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -97,7 +97,7 @@ internal class JniGeneratorPredicates(
 
                 fun(limeEnumeration: Any): Boolean {
                     if (limeEnumeration !is LimeEnumeration) return false
-                    val descriptor = limeEnumeration.external?.java ?: return false
+                    val descriptor = limeEnumeration.external?.getFor(platformAttribute) ?: return false
                     return !descriptor.containsKey(CONVERTER_NAME)
                 },
             "needsRefSuffix" to { limeTypeRef: Any ->

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -21,11 +21,10 @@ package com.here.gluecodium.generator.jni
 
 import com.here.gluecodium.common.LimeModelSkipPredicates
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.generator.cpp.CppSignatureResolver
-import com.here.gluecodium.generator.java.JavaNameRules
-import com.here.gluecodium.generator.java.JavaSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeBasicType
@@ -51,12 +50,11 @@ import com.here.gluecodium.model.lime.LimeTypeRef
  */
 internal class JniGeneratorPredicates(
     private val limeReferenceMap: Map<String, LimeElement>,
-    javaNameRules: JavaNameRules,
+    private val platformSignatureResolver: PlatformSignatureResolver,
     cppNameRules: CppNameRules,
     cppNameResolver: CppNameResolver,
     private val activeTags: Set<String>,
 ) {
-    private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules, activeTags)
     private val cppSignatureResolver = CppSignatureResolver(limeReferenceMap, cppNameRules)
     private val overloadedLambdas = collectOverloadedLambdas()
 
@@ -93,7 +91,7 @@ internal class JniGeneratorPredicates(
                     return typeId.isNumericType || typeId == VOID || typeId == BOOLEAN
                 },
             "isOverloaded" to { limeFunction: Any ->
-                limeFunction is LimeFunction && javaSignatureResolver.isOverloadedInBindings(limeFunction)
+                limeFunction is LimeFunction && platformSignatureResolver.isOverloadedInBindings(limeFunction)
             },
             "needsOrdinalConversion" to
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -26,7 +26,6 @@ import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.generator.cpp.CppSignatureResolver
 import com.here.gluecodium.model.lime.LimeAttributeType
-import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.BOOLEAN
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId.VOID
@@ -51,6 +50,7 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 internal class JniGeneratorPredicates(
     private val limeReferenceMap: Map<String, LimeElement>,
     private val platformSignatureResolver: PlatformSignatureResolver,
+    private val platformAttribute: LimeAttributeType,
     cppNameRules: CppNameRules,
     cppNameResolver: CppNameResolver,
     private val activeTags: Set<String>,
@@ -113,7 +113,7 @@ internal class JniGeneratorPredicates(
         )
 
     fun shouldRetain(limeElement: LimeNamedElement) =
-        LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, JAVA, limeReferenceMap)
+        LimeModelSkipPredicates.shouldRetainCheckParent(limeElement, activeTags, platformAttribute, limeReferenceMap)
 
     private fun collectOverloadedLambdas(): Set<String> {
         val lambdas = limeReferenceMap.values.filterIsInstance<LimeLambda>()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniNameResolver.kt
@@ -23,7 +23,6 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.NameResolver
 import com.here.gluecodium.generator.common.NameRules
 import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
-import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.model.lime.LimeAttributeType.CACHED
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeType.OPTIMIZED
@@ -49,7 +48,11 @@ internal class JniNameResolver(
     limeReferenceMap: Map<String, LimeElement>,
     private val basePackages: List<String>,
     private val nameRules: NameRules,
+    externalNameRules: Map<String, (String) -> List<String>>,
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
+    val getPackageFromImportString = externalNameRules["getPackageFromImportString"]!!
+    val getClassNamesFromImportString = externalNameRules["getClassNamesFromImportString"]!!
+
     override fun resolveName(element: Any): String =
         when (element) {
             is String -> createJavaTypePath(element)
@@ -109,10 +112,7 @@ internal class JniNameResolver(
         }
 
     private fun createJavaTypePath(importString: String) =
-        createJavaTypePath(
-            JavaNameRules.getPackageFromImportString(importString),
-            JavaNameRules.getClassNamesFromImportString(importString),
-        )
+        createJavaTypePath(getPackageFromImportString(importString), getClassNamesFromImportString(importString))
 
     private fun createJavaTypePath(
         packageNames: List<String>,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.common.OptimizedListsCollector
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.generator.cpp.CppFullNameResolver
 import com.here.gluecodium.generator.cpp.CppIncludeResolver
@@ -30,7 +31,6 @@ import com.here.gluecodium.generator.cpp.CppNameCache
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.generator.java.JavaNameRules
-import com.here.gluecodium.generator.java.JavaSignatureResolver
 import com.here.gluecodium.generator.jni.JniGeneratorPredicates.Companion.hasThrowingFunctions
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributes
@@ -51,6 +51,7 @@ internal class JniTemplates(
     private val platformAttribute: LimeAttributeType,
     private val limeReferenceMap: Map<String, LimeElement>,
     javaNameRules: JavaNameRules,
+    signatureResolver: PlatformSignatureResolver,
     private val basePackages: List<String>,
     internalPackages: List<String>,
     private val internalNamespace: List<String>,
@@ -72,11 +73,10 @@ internal class JniTemplates(
             "C++ FQN" to CppFullNameResolver(nameCache),
         )
 
-    private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules, activeTags)
     private val generatorPredicates =
         JniGeneratorPredicates(
             limeReferenceMap = limeReferenceMap,
-            platformSignatureResolver = javaSignatureResolver,
+            platformSignatureResolver = signatureResolver,
             platformAttribute = platformAttribute,
             cppNameRules = nameCache.nameRules,
             cppNameResolver = cppNameResolver,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -61,7 +61,7 @@ internal class JniTemplates(
     activeTags: Set<String>,
     private val descendantInterfaces: Map<String, List<LimeInterface>>,
 ) {
-    private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, nameRules, externalNameRules)
+    private val jniNameResolver = JniNameResolver(platformAttribute, limeReferenceMap, basePackages, nameRules, externalNameRules)
     private val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
     private val fileNameRules = JniFileNameRules(generatorName, platformAttribute, jniNameResolver)
     private val fullInternalPackages = basePackages + internalPackages

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -73,7 +73,14 @@ internal class JniTemplates(
 
     private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules, activeTags)
     private val generatorPredicates =
-        JniGeneratorPredicates(limeReferenceMap, javaSignatureResolver, nameCache.nameRules, cppNameResolver, activeTags)
+        JniGeneratorPredicates(
+            limeReferenceMap = limeReferenceMap,
+            platformSignatureResolver = javaSignatureResolver,
+            platformAttribute = LimeAttributeType.JAVA,
+            cppNameRules = nameCache.nameRules,
+            cppNameResolver = cppNameResolver,
+            activeTags = activeTags,
+        )
 
     private val cppIncludeResolver = CppIncludeResolver(limeReferenceMap, cppNameRules, internalNamespace)
     private val jniIncludeResolver = JniIncludeResolver(fileNameRules, descendantInterfaces)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -31,6 +31,7 @@ import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
 import com.here.gluecodium.generator.java.JavaGenerator
 import com.here.gluecodium.generator.java.JavaNameRules
+import com.here.gluecodium.generator.java.JavaSignatureResolver
 import com.here.gluecodium.generator.jni.JniGeneratorPredicates.Companion.hasThrowingFunctions
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributes
@@ -69,8 +70,10 @@ internal class JniTemplates(
             "C++" to cppNameResolver,
             "C++ FQN" to CppFullNameResolver(nameCache),
         )
+
+    private val javaSignatureResolver = JavaSignatureResolver(limeReferenceMap, javaNameRules, activeTags)
     private val generatorPredicates =
-        JniGeneratorPredicates(limeReferenceMap, javaNameRules, nameCache.nameRules, cppNameResolver, activeTags)
+        JniGeneratorPredicates(limeReferenceMap, javaSignatureResolver, nameCache.nameRules, cppNameResolver, activeTags)
 
     private val cppIncludeResolver = CppIncludeResolver(limeReferenceMap, cppNameRules, internalNamespace)
     private val jniIncludeResolver = JniIncludeResolver(fileNameRules, descendantInterfaces)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -48,6 +48,7 @@ import com.here.gluecodium.model.lime.LimeType
 
 internal class JniTemplates(
     generatorName: String,
+    private val platformAttribute: LimeAttributeType,
     private val limeReferenceMap: Map<String, LimeElement>,
     javaNameRules: JavaNameRules,
     private val basePackages: List<String>,
@@ -76,7 +77,7 @@ internal class JniTemplates(
         JniGeneratorPredicates(
             limeReferenceMap = limeReferenceMap,
             platformSignatureResolver = javaSignatureResolver,
-            platformAttribute = LimeAttributeType.JAVA,
+            platformAttribute = platformAttribute,
             cppNameRules = nameCache.nameRules,
             cppNameResolver = cppNameResolver,
             activeTags = activeTags,
@@ -244,7 +245,7 @@ internal class JniTemplates(
 
         mustacheData["includes"] = listOf(selfInclude) +
             limeStruct.fields.filter {
-                CommonGeneratorPredicates.needsImportsForSkippedField(it, LimeAttributeType.JAVA, limeReferenceMap)
+                CommonGeneratorPredicates.needsImportsForSkippedField(it, platformAttribute, limeReferenceMap)
             }.flatMap { cppIncludeResolver.resolveElementImports(it.typeRef) }
         val implFile =
             GeneratedFile(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -51,6 +51,7 @@ internal class JniTemplates(
     private val platformAttribute: LimeAttributeType,
     private val limeReferenceMap: Map<String, LimeElement>,
     nameRules: NameRules,
+    externalNameRules: Map<String, (String) -> List<String>>,
     signatureResolver: PlatformSignatureResolver,
     private val basePackages: List<String>,
     internalPackages: List<String>,
@@ -60,7 +61,7 @@ internal class JniTemplates(
     activeTags: Set<String>,
     private val descendantInterfaces: Map<String, List<LimeInterface>>,
 ) {
-    private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, nameRules)
+    private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, nameRules, externalNameRules)
     private val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
     private val fileNameRules = JniFileNameRules(generatorName, platformAttribute, jniNameResolver)
     private val fullInternalPackages = basePackages + internalPackages

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.generator.jni
 import com.here.gluecodium.generator.common.CommonGeneratorPredicates
 import com.here.gluecodium.generator.common.GeneratedFile
 import com.here.gluecodium.generator.common.Include
+import com.here.gluecodium.generator.common.NameRules
 import com.here.gluecodium.generator.common.OptimizedListsCollector
 import com.here.gluecodium.generator.common.PlatformSignatureResolver
 import com.here.gluecodium.generator.common.templates.TemplateEngine
@@ -30,7 +31,6 @@ import com.here.gluecodium.generator.cpp.CppIncludeResolver
 import com.here.gluecodium.generator.cpp.CppNameCache
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
-import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.generator.jni.JniGeneratorPredicates.Companion.hasThrowingFunctions
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributes
@@ -50,7 +50,7 @@ internal class JniTemplates(
     generatorName: String,
     private val platformAttribute: LimeAttributeType,
     private val limeReferenceMap: Map<String, LimeElement>,
-    javaNameRules: JavaNameRules,
+    nameRules: NameRules,
     signatureResolver: PlatformSignatureResolver,
     private val basePackages: List<String>,
     internalPackages: List<String>,
@@ -60,7 +60,7 @@ internal class JniTemplates(
     activeTags: Set<String>,
     private val descendantInterfaces: Map<String, List<LimeInterface>>,
 ) {
-    private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, javaNameRules)
+    private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, nameRules)
     private val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
     private val fileNameRules = JniFileNameRules(generatorName, jniNameResolver)
     private val fullInternalPackages = basePackages + internalPackages

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -29,7 +29,6 @@ import com.here.gluecodium.generator.cpp.CppIncludeResolver
 import com.here.gluecodium.generator.cpp.CppNameCache
 import com.here.gluecodium.generator.cpp.CppNameResolver
 import com.here.gluecodium.generator.cpp.CppNameRules
-import com.here.gluecodium.generator.java.JavaGenerator
 import com.here.gluecodium.generator.java.JavaNameRules
 import com.here.gluecodium.generator.java.JavaSignatureResolver
 import com.here.gluecodium.generator.jni.JniGeneratorPredicates.Companion.hasThrowingFunctions
@@ -48,6 +47,7 @@ import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
 
 internal class JniTemplates(
+    generatorName: String,
     private val limeReferenceMap: Map<String, LimeElement>,
     javaNameRules: JavaNameRules,
     private val basePackages: List<String>,
@@ -60,7 +60,7 @@ internal class JniTemplates(
 ) {
     private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, javaNameRules)
     private val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
-    private val fileNameRules = JniFileNameRules(JavaGenerator.GENERATOR_NAME, jniNameResolver)
+    private val fileNameRules = JniFileNameRules(generatorName, jniNameResolver)
     private val fullInternalPackages = basePackages + internalPackages
     private val nameResolvers =
         mapOf(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -62,7 +62,7 @@ internal class JniTemplates(
 ) {
     private val jniNameResolver = JniNameResolver(limeReferenceMap, basePackages, nameRules)
     private val cppNameResolver = CppNameResolver(limeReferenceMap, internalNamespace, nameCache)
-    private val fileNameRules = JniFileNameRules(generatorName, jniNameResolver)
+    private val fileNameRules = JniFileNameRules(generatorName, platformAttribute, jniNameResolver)
     private val fullInternalPackages = basePackages + internalPackages
     private val nameResolvers =
         mapOf(

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
@@ -33,6 +33,15 @@ class LimeExternalDescriptor private constructor(
     val dart
         get() = descriptors[DART_TAG]
 
+    fun getFor(target: LimeAttributeType) =
+        when (target) {
+            LimeAttributeType.CPP -> cpp
+            LimeAttributeType.JAVA -> java
+            LimeAttributeType.SWIFT -> swift
+            LimeAttributeType.DART -> dart
+            else -> throw IllegalArgumentException("LimeExternalDescriptor.getFor(): Unknown target language: $target")
+        }
+
     operator fun plus(other: LimeExternalDescriptor) = LimeExternalDescriptor(descriptors + other.descriptors)
 
     override fun toString() =


### PR DESCRIPTION
------ Motivation ------

Types defined in `generator/jni` were tightly coupled with types from
`generator/java`.

There are more languages than Java, that could use JNI in the future.
Therefore, removing the explicit dependencies could be beneficial
by avoiding changes in JNI code and making this layer future-proof.

------ Solution ------

Removed the explicit dependencies on types and functions related to
`generator/java` from `generator/jni` by injecting them via constructors.