### PR TITLE
functional_tests: do not depend on local time zone in Swift tests

### DIFF
--- a/functional-tests/functional/swift/Tests/DatesTests.swift
+++ b/functional-tests/functional/swift/Tests/DatesTests.swift
@@ -120,10 +120,14 @@ class DatesTests: XCTestCase {
     }
 
     func testDateDefaultsCet() {
+        let utcTimeZone = TimeZone(identifier: "UTC")
+        XCTAssertNotNil(utcTimeZone)
+
         let date = DateDefaults().dateTime
         let dateComponents =
-            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+            Calendar.current.dateComponents(in: utcTimeZone!, from: date)
 
+        // Date was specified in UTC+2 as: "2022-02-04T11:15:17+02:00"
         XCTAssertEqual(2022, dateComponents.year!)
         XCTAssertEqual(2, dateComponents.month!)
         XCTAssertEqual(4, dateComponents.day!)
@@ -133,10 +137,14 @@ class DatesTests: XCTestCase {
     }
 
     func testDateDefaultsUtc() {
+        let utcTimeZone = TimeZone(identifier: "UTC")
+        XCTAssertNotNil(utcTimeZone)
+
         let date = DateDefaults().dateTimeUtc
         let dateComponents =
-            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+            Calendar.current.dateComponents(in: utcTimeZone!, from: date)
 
+        // Date was specified in UTC as: "2022-02-04T09:15:17Z"
         XCTAssertEqual(2022, dateComponents.year!)
         XCTAssertEqual(2, dateComponents.month!)
         XCTAssertEqual(4, dateComponents.day!)
@@ -146,10 +154,14 @@ class DatesTests: XCTestCase {
     }
 
     func testDateDefaultsBeforeEpoch() {
+        let utcTimeZone = TimeZone(identifier: "UTC")
+        XCTAssertNotNil(utcTimeZone)
+
         let date = DateDefaults().beforeEpoch
         let dateComponents =
-            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+            Calendar.current.dateComponents(in: utcTimeZone!, from: date)
 
+        // Date was specified in UTC as: "1922-02-04T09:15:17Z"
         XCTAssertEqual(1922, dateComponents.year!)
         XCTAssertEqual(2, dateComponents.month!)
         XCTAssertEqual(4, dateComponents.day!)
@@ -159,10 +171,14 @@ class DatesTests: XCTestCase {
     }
 
     func testDateDefaultsCpp() {
+        let utcTimeZone = TimeZone(identifier: "UTC")
+        XCTAssertNotNil(utcTimeZone)
+
         let date = DateDefaults.getCppDefaults().dateTimeUtc
         let dateComponents =
-            Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+            Calendar.current.dateComponents(in: utcTimeZone!, from: date)
 
+        // Date was specified in UTC as: "2022-02-04T09:15:17Z"
         XCTAssertEqual(2022, dateComponents.year!)
         XCTAssertEqual(2, dateComponents.month!)
         XCTAssertEqual(4, dateComponents.day!)


### PR DESCRIPTION
In 'DatesTests.swift' we expected numeric values of date fields
that were hardcoded for UTC time zone.

However, when 'Calendar.current.dateComponents()'
without specified TimeZone was used, then we received
numeric values that were specific for a local time zone of
the runner of tests.

This change makes the test stable and removes the
implicit dependency to the local time zone.

Since this commit the test passes even when run on a machine,
which uses different default time zone.
