### PR TITLE
functional_tests: make LocalesTest.swift stable

### DIFF
--- a/functional-tests/functional/swift/Tests/LocalesTests.swift
+++ b/functional-tests/functional/swift/Tests/LocalesTests.swift
@@ -87,7 +87,7 @@ class LocalesTests: XCTestCase {
     }
 
     func testLocalesStructRoundTrip() {
-        let locale = Locale.current
+        let locale = Locale(identifier: Locale.current.identifier)
         let localesStruct = LocalesStruct(primaryLocale: locale, secondaryLocale: locale)
 
         let result = LocalesStruct.localesStructRoundTrip(input: localesStruct)


### PR DESCRIPTION
BCP 47 language tag takes precedence if present
when converting from C++ locale to Swift locale.

From 'BuiltinConversions.swift':

```
if let languageTagUnwrapped = languageTag {
    // BCP 47 language tag takes precedence if present.
    return Locale(identifier: languageTagUnwrapped)
}
```

In some cases in Swift a locale object constructed using 'Locale.current.identifier'
does not yield equality when compared with 'Locale.current' even though fields like
'identifier' are equal. The test was sometimes failing when run locally, because
hashes of objects were different.

This change creates the locale object, which is sent to C++ and received back as:
`Locale(identifier: Locale.current.identifier)`

This is done to ensure, that the hash of objects always matches.
