### PR TITLE
Dart: do not generate redundant import for external constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+ * Dart: removed generation of redundant import for constants declared with external types. The redundant import caused linter warnings.
+
 ## 13.10.1
 Release date 2024-12-12
 ### Bug fixes:

--- a/functional-tests/functional/input/lime/DartExternalTypes.lime
+++ b/functional-tests/functional/input/lime/DartExternalTypes.lime
@@ -93,3 +93,9 @@ struct VeryBoolean {
     value: Boolean
     constructor make(value: Boolean)
 }
+
+@Java(Skip) @Swift(Skip)
+struct ExternalDartConstants {
+    const Small: Rectangle = {0, 0, 1, 1}
+    const Big: Rectangle = {0, 0, 10, 10}
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartImportResolver.kt
@@ -50,7 +50,7 @@ internal class DartImportResolver(
                 resolveTypeImports(limeElement.type) + resolveConversionImports(limeElement) +
                     listOfNotNull(lazyListImport.takeIf { limeElement.attributes.have(LimeAttributeType.OPTIMIZED) })
             is LimeType -> resolveTypeImports(limeElement) + resolveConversionImports(limeElement)
-            is LimeConstant -> resolveTypeImports(limeElement.typeRef.type)
+            is LimeConstant -> resolveTypeImports(limeElement.typeRef.type, skipHelpers = true)
             is LimeValue -> resolveValueImports(limeElement)
             is LimeNamedElement -> listOf(createImport(limeElement))
             else -> emptyList()

--- a/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
+++ b/gluecodium/src/test/resources/smoke/external_types/input/DartExternalTypes.lime
@@ -89,3 +89,9 @@ struct DartExternalCtor {
     `field`: String
     constructor make(`field`: String)
 }
+
+@Java(Skip) @Swift(Skip)
+struct ExternalDartConstants {
+    const Small: Rectangle = {0, 0, 1, 1}
+    const Big: Rectangle = {0, 0, 10, 10}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_dart_constants.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_dart_constants.dart
@@ -1,0 +1,81 @@
+
+
+import 'dart:ffi';
+import 'dart:math' as math;
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/smoke/rectangle_int_.dart';
+
+
+class ExternalDartConstants {
+  static final math.Rectangle<int> small = math.Rectangle<int>(0, 0, 1, 1);
+
+  static final math.Rectangle<int> big = math.Rectangle<int>(0, 0, 10, 10);
+
+}
+
+
+// ExternalDartConstants "private" section, not exported.
+
+final _smokeExternaldartconstantsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(),
+    Pointer<Void> Function()
+  >('library_smoke_ExternalDartConstants_create_handle'));
+final _smokeExternaldartconstantsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalDartConstants_release_handle'));
+
+
+
+Pointer<Void> smokeExternaldartconstantsToFfi(ExternalDartConstants value) {
+  final _result = _smokeExternaldartconstantsCreateHandle();
+  return _result;
+}
+
+ExternalDartConstants smokeExternaldartconstantsFromFfi(Pointer<Void> handle) {
+  try {
+    return ExternalDartConstants(
+    );
+  } finally {
+  }
+}
+
+void smokeExternaldartconstantsReleaseFfiHandle(Pointer<Void> handle) => _smokeExternaldartconstantsReleaseHandle(handle);
+
+// Nullable ExternalDartConstants
+
+final _smokeExternaldartconstantsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalDartConstants_create_handle_nullable'));
+final _smokeExternaldartconstantsReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_ExternalDartConstants_release_handle_nullable'));
+final _smokeExternaldartconstantsGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_ExternalDartConstants_get_value_nullable'));
+
+Pointer<Void> smokeExternaldartconstantsToFfiNullable(ExternalDartConstants? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeExternaldartconstantsToFfi(value);
+  final result = _smokeExternaldartconstantsCreateHandleNullable(_handle);
+  smokeExternaldartconstantsReleaseFfiHandle(_handle);
+  return result;
+}
+
+ExternalDartConstants? smokeExternaldartconstantsFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeExternaldartconstantsGetValueNullable(handle);
+  final result = smokeExternaldartconstantsFromFfi(_handle);
+  smokeExternaldartconstantsReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeExternaldartconstantsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeExternaldartconstantsReleaseHandleNullable(handle);
+
+// End of ExternalDartConstants "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_dart_constants.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_dart_constants.dart
@@ -3,7 +3,6 @@
 import 'dart:ffi';
 import 'dart:math' as math;
 import 'package:library/src/_library_context.dart' as __lib;
-import 'package:library/src/smoke/rectangle_int_.dart';
 
 
 class ExternalDartConstants {


### PR DESCRIPTION
----- Motivation -----
The generator added redundant import when external type
was used to specify constants. This resulted in linter error
`unused_import`.

----- Content of the change -----
This change adjusts 'DartImportResolver' to import
only necessary file, when a type, which uses external
one is specified for constants.

First two commits shows the invalid behavior in smoke
and functional tests. The latter is used to ensure, that
the code builds when the redundant import is removed.

The third commit contains the actual fix (one-line).