### PR TITLE
Dart: do not generate `default` clause for enumerations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+ * Dart: removed generation of redundant `default` clause in exhaustive switch-cases for enumerations. The redundant `default` caused linter warnings.
+
 ## 13.10.1
 Release date 2024-12-12
 ### Bug fixes:

--- a/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartEnumeration.mustache
@@ -49,9 +49,11 @@ int {{resolveName "Ffi"}}ToFfi({{resolveName this "" "ref"}} value{{#if external
 {{#set parent=this}}{{#uniqueEnumerators}}
   case {{resolveName parent "" "ref"}}{{#if external.dart.converter}}Internal{{/if}}.{{resolveName}}:
     return {{value}};
-{{/uniqueEnumerators}}{{/set}}
+{{/uniqueEnumerators}}{{/set}}{{!!
+}}{{#if aliasEnumerators}}
   default:
     throw StateError("Invalid enum value $value for {{resolveName}} enum.");
+{{/if}}
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
+++ b/gluecodium/src/test/resources/smoke/attributes/output/dart/lib/src/smoke/attributes_enum.dart
@@ -1,19 +1,23 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
 @OnEnumeration
 enum AttributesEnum {
     @OnEnumerator
     nope
 }
+
 // AttributesEnum "private" section, not exported.
+
 int smokeAttributesenumToFfi(AttributesEnum value) {
   switch (value) {
   case AttributesEnum.nope:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for AttributesEnum enum.");
   }
 }
+
 AttributesEnum smokeAttributesenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -22,7 +26,9 @@ AttributesEnum smokeAttributesenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for AttributesEnum enum.");
   }
 }
+
 void smokeAttributesenumReleaseFfiHandle(int handle) {}
+
 final _smokeAttributesenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -35,6 +41,7 @@ final _smokeAttributesenumGetValueNullable = __lib.catchArgumentError(() => __li
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_AttributesEnum_get_value_nullable'));
+
 Pointer<Void> smokeAttributesenumToFfiNullable(AttributesEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeAttributesenumToFfi(value);
@@ -42,6 +49,7 @@ Pointer<Void> smokeAttributesenumToFfiNullable(AttributesEnum? value) {
   smokeAttributesenumReleaseFfiHandle(_handle);
   return result;
 }
+
 AttributesEnum? smokeAttributesenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeAttributesenumGetValueNullable(handle);
@@ -49,6 +57,10 @@ AttributesEnum? smokeAttributesenumFromFfiNullable(Pointer<Void> handle) {
   smokeAttributesenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeAttributesenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAttributesenumReleaseHandleNullable(handle);
+
 // End of AttributesEnum "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -122,8 +122,6 @@ int smokeCommentsSomeenumToFfi(Comments_SomeEnum value) {
     return 0;
   case Comments_SomeEnum.useful:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Comments_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments_interface.dart
@@ -108,8 +108,6 @@ int smokeCommentsinterfaceSomeenumToFfi(CommentsInterface_SomeEnum value) {
     return 0;
   case CommentsInterface_SomeEnum.useful:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for CommentsInterface_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments.dart
@@ -73,8 +73,6 @@ int smokeDeprecationcommentsSomeenumToFfi(DeprecationComments_SomeEnum value) {
   switch (value) {
   case DeprecationComments_SomeEnum.useless:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for DeprecationComments_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/deprecation_comments_only.dart
@@ -51,8 +51,6 @@ int smokeDeprecationcommentsonlySomeenumToFfi(DeprecationCommentsOnly_SomeEnum v
   switch (value) {
   case DeprecationCommentsOnly_SomeEnum.useless:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for DeprecationCommentsOnly_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments.dart
@@ -53,8 +53,6 @@ int smokeExcludedcommentsSomeenumToFfi(ExcludedComments_SomeEnum value) {
   switch (value) {
   case ExcludedComments_SomeEnum.useless:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for ExcludedComments_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/excluded_comments_only.dart
@@ -37,8 +37,6 @@ int smokeExcludedcommentsonlySomeenumToFfi(ExcludedCommentsOnly_SomeEnum value) 
   switch (value) {
   case ExcludedCommentsOnly_SomeEnum.useless:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for ExcludedCommentsOnly_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/platform_comments.dart
@@ -42,8 +42,6 @@ int smokePlatformcommentsSomeenumToFfi(PlatformComments_SomeEnum value) {
     return 0;
   case PlatformComments_SomeEnum.useful:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for PlatformComments_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants.dart
@@ -1,29 +1,42 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
+
 class Constants {
   static final bool boolConstant = true;
+
   static final int intConstant = -11;
+
   static final int uintConstant = 4294967295;
+
   static final double floatConstant = 2.71;
+
   static final double doubleConstant = -3.14;
+
   static final String stringConstant = "Foo bar";
+
   static final Constants_StateEnum enumConstant = Constants_StateEnum.on;
+
 }
+
 enum Constants_StateEnum {
     off,
     on
 }
+
 // Constants_StateEnum "private" section, not exported.
+
 int smokeConstantsStateenumToFfi(Constants_StateEnum value) {
   switch (value) {
   case Constants_StateEnum.off:
     return 0;
   case Constants_StateEnum.on:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Constants_StateEnum enum.");
   }
 }
+
 Constants_StateEnum smokeConstantsStateenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -34,7 +47,9 @@ Constants_StateEnum smokeConstantsStateenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Constants_StateEnum enum.");
   }
 }
+
 void smokeConstantsStateenumReleaseFfiHandle(int handle) {}
+
 final _smokeConstantsStateenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -47,6 +62,7 @@ final _smokeConstantsStateenumGetValueNullable = __lib.catchArgumentError(() => 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Constants_StateEnum_get_value_nullable'));
+
 Pointer<Void> smokeConstantsStateenumToFfiNullable(Constants_StateEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeConstantsStateenumToFfi(value);
@@ -54,6 +70,7 @@ Pointer<Void> smokeConstantsStateenumToFfiNullable(Constants_StateEnum? value) {
   smokeConstantsStateenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Constants_StateEnum? smokeConstantsStateenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeConstantsStateenumGetValueNullable(handle);
@@ -61,10 +78,14 @@ Constants_StateEnum? smokeConstantsStateenumFromFfiNullable(Pointer<Void> handle
   smokeConstantsStateenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeConstantsStateenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeConstantsStateenumReleaseHandleNullable(handle);
+
 // End of Constants_StateEnum "private" section.
+
 // Constants "private" section, not exported.
+
 final _smokeConstantsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -73,10 +94,14 @@ final _smokeConstantsReleaseHandle = __lib.catchArgumentError(() => __lib.native
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Constants_release_handle'));
+
+
+
 Pointer<Void> smokeConstantsToFfi(Constants value) {
   final _result = _smokeConstantsCreateHandle();
   return _result;
 }
+
 Constants smokeConstantsFromFfi(Pointer<Void> handle) {
   try {
     return Constants(
@@ -84,8 +109,11 @@ Constants smokeConstantsFromFfi(Pointer<Void> handle) {
   } finally {
   }
 }
+
 void smokeConstantsReleaseFfiHandle(Pointer<Void> handle) => _smokeConstantsReleaseHandle(handle);
+
 // Nullable Constants
+
 final _smokeConstantsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -98,6 +126,7 @@ final _smokeConstantsGetValueNullable = __lib.catchArgumentError(() => __lib.nat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Constants_get_value_nullable'));
+
 Pointer<Void> smokeConstantsToFfiNullable(Constants? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeConstantsToFfi(value);
@@ -105,6 +134,7 @@ Pointer<Void> smokeConstantsToFfiNullable(Constants? value) {
   smokeConstantsReleaseFfiHandle(_handle);
   return result;
 }
+
 Constants? smokeConstantsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeConstantsGetValueNullable(handle);
@@ -112,6 +142,10 @@ Constants? smokeConstantsFromFfiNullable(Pointer<Void> handle) {
   smokeConstantsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeConstantsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeConstantsReleaseHandleNullable(handle);
+
 // End of Constants "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
+++ b/gluecodium/src/test/resources/smoke/constants/output/dart/lib/src/smoke/constants_interface.dart
@@ -36,8 +36,6 @@ int smokeConstantsinterfaceStateenumToFfi(ConstantsInterface_StateEnum value) {
     return 0;
   case ConstantsInterface_StateEnum.on:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for ConstantsInterface_StateEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -42,8 +42,6 @@ int smokeConstructorsErrorenumToFfi(Constructors_ErrorEnum value) {
     return 0;
   case Constructors_ErrorEnum.crashed:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Constructors_ErrorEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/dart/lib/src/smoke/alphabet.dart
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/dart/lib/src/smoke/alphabet.dart
@@ -1,11 +1,16 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
 enum Alphabet {
     a,
     b,
     c
 }
+
 // Alphabet "private" section, not exported.
+
 int smokeAlphabetToFfi(Alphabet value) {
   switch (value) {
   case Alphabet.a:
@@ -14,10 +19,9 @@ int smokeAlphabetToFfi(Alphabet value) {
     return 1;
   case Alphabet.c:
     return 2;
-  default:
-    throw StateError("Invalid enum value $value for Alphabet enum.");
   }
 }
+
 Alphabet smokeAlphabetFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -30,7 +34,9 @@ Alphabet smokeAlphabetFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Alphabet enum.");
   }
 }
+
 void smokeAlphabetReleaseFfiHandle(int handle) {}
+
 final _smokeAlphabetCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -43,6 +49,7 @@ final _smokeAlphabetGetValueNullable = __lib.catchArgumentError(() => __lib.nati
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Alphabet_get_value_nullable'));
+
 Pointer<Void> smokeAlphabetToFfiNullable(Alphabet? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeAlphabetToFfi(value);
@@ -50,6 +57,7 @@ Pointer<Void> smokeAlphabetToFfiNullable(Alphabet? value) {
   smokeAlphabetReleaseFfiHandle(_handle);
   return result;
 }
+
 Alphabet? smokeAlphabetFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeAlphabetGetValueNullable(handle);
@@ -57,6 +65,10 @@ Alphabet? smokeAlphabetFromFfiNullable(Pointer<Void> handle) {
   smokeAlphabetReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeAlphabetReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeAlphabetReleaseHandleNullable(handle);
+
 // End of Alphabet "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enum_starts_with_one.dart
@@ -1,20 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
 enum EnumStartsWithOne {
     first,
     second
 }
+
 // EnumStartsWithOne "private" section, not exported.
+
 int smokeEnumstartswithoneToFfi(EnumStartsWithOne value) {
   switch (value) {
   case EnumStartsWithOne.first:
     return 1;
   case EnumStartsWithOne.second:
     return 2;
-  default:
-    throw StateError("Invalid enum value $value for EnumStartsWithOne enum.");
   }
 }
+
 EnumStartsWithOne smokeEnumstartswithoneFromFfi(int handle) {
   switch (handle) {
   case 1:
@@ -25,7 +29,9 @@ EnumStartsWithOne smokeEnumstartswithoneFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for EnumStartsWithOne enum.");
   }
 }
+
 void smokeEnumstartswithoneReleaseFfiHandle(int handle) {}
+
 final _smokeEnumstartswithoneCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -38,6 +44,7 @@ final _smokeEnumstartswithoneGetValueNullable = __lib.catchArgumentError(() => _
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_EnumStartsWithOne_get_value_nullable'));
+
 Pointer<Void> smokeEnumstartswithoneToFfiNullable(EnumStartsWithOne? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEnumstartswithoneToFfi(value);
@@ -45,6 +52,7 @@ Pointer<Void> smokeEnumstartswithoneToFfiNullable(EnumStartsWithOne? value) {
   smokeEnumstartswithoneReleaseFfiHandle(_handle);
   return result;
 }
+
 EnumStartsWithOne? smokeEnumstartswithoneFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEnumstartswithoneGetValueNullable(handle);
@@ -52,6 +60,10 @@ EnumStartsWithOne? smokeEnumstartswithoneFromFfiNullable(Pointer<Void> handle) {
   smokeEnumstartswithoneReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEnumstartswithoneReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEnumstartswithoneReleaseHandleNullable(handle);
+
 // End of EnumStartsWithOne "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/enums/output/dart/lib/src/smoke/enums.dart
@@ -36,8 +36,6 @@ int smokeEnumsSimpleenumToFfi(Enums_SimpleEnum value) {
     return 0;
   case Enums_SimpleEnum.second:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Enums_SimpleEnum enum.");
   }
 }
 
@@ -100,8 +98,6 @@ int smokeEnumsInternalerrorcodeToFfi(Enums_InternalErrorCode value) {
     return 0;
   case Enums_InternalErrorCode.errorFatal:
     return 999;
-  default:
-    throw StateError("Invalid enum value $value for Enums_InternalErrorCode enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
+++ b/gluecodium/src/test/resources/smoke/equatable/output/dart/lib/src/smoke/equatable.dart
@@ -1,25 +1,31 @@
+
+
 import 'dart:ffi';
 import 'package:collection/collection.dart';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:library/src/generic_types__conversion.dart';
+
+
 class Equatable {
 }
+
 enum Equatable_SomeEnum {
     foo,
     bar
 }
+
 // Equatable_SomeEnum "private" section, not exported.
+
 int smokeEquatableSomeenumToFfi(Equatable_SomeEnum value) {
   switch (value) {
   case Equatable_SomeEnum.foo:
     return 0;
   case Equatable_SomeEnum.bar:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Equatable_SomeEnum enum.");
   }
 }
+
 Equatable_SomeEnum smokeEquatableSomeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -30,7 +36,9 @@ Equatable_SomeEnum smokeEquatableSomeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Equatable_SomeEnum enum.");
   }
 }
+
 void smokeEquatableSomeenumReleaseFfiHandle(int handle) {}
+
 final _smokeEquatableSomeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -43,6 +51,7 @@ final _smokeEquatableSomeenumGetValueNullable = __lib.catchArgumentError(() => _
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Equatable_SomeEnum_get_value_nullable'));
+
 Pointer<Void> smokeEquatableSomeenumToFfiNullable(Equatable_SomeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEquatableSomeenumToFfi(value);
@@ -50,6 +59,7 @@ Pointer<Void> smokeEquatableSomeenumToFfiNullable(Equatable_SomeEnum? value) {
   smokeEquatableSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 Equatable_SomeEnum? smokeEquatableSomeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEquatableSomeenumGetValueNullable(handle);
@@ -57,20 +67,33 @@ Equatable_SomeEnum? smokeEquatableSomeenumFromFfiNullable(Pointer<Void> handle) 
   smokeEquatableSomeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEquatableSomeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEquatableSomeenumReleaseHandleNullable(handle);
+
 // End of Equatable_SomeEnum "private" section.
+
 class Equatable_EquatableStruct {
   bool boolField;
+
   int intField;
+
   int longField;
+
   double floatField;
+
   double doubleField;
+
   String stringField;
+
   Equatable_NestedEquatableStruct structField;
+
   Equatable_SomeEnum enumField;
+
   List<String> arrayField;
+
   Map<int, String> mapField;
+
   Equatable_EquatableStruct(this.boolField, this.intField, this.longField, this.floatField, this.doubleField, this.stringField, this.structField, this.enumField, this.arrayField, this.mapField);
   @override
   bool operator ==(Object other) {
@@ -88,6 +111,7 @@ class Equatable_EquatableStruct {
         DeepCollectionEquality().equals(arrayField, _other.arrayField) &&
         DeepCollectionEquality().equals(mapField, _other.mapField);
   }
+
   @override
   int get hashCode {
     int result = 7;
@@ -104,7 +128,10 @@ class Equatable_EquatableStruct {
     return result;
   }
 }
+
+
 // Equatable_EquatableStruct "private" section, not exported.
+
 final _smokeEquatableEquatablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint8, Int32, Int64, Float, Double, Pointer<Void>, Pointer<Void>, Uint32, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(int, int, int, double, double, Pointer<Void>, Pointer<Void>, int, Pointer<Void>, Pointer<Void>)
@@ -153,6 +180,9 @@ final _smokeEquatableEquatablestructGetFieldmapField = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_field_mapField'));
+
+
+
 Pointer<Void> smokeEquatableEquatablestructToFfi(Equatable_EquatableStruct value) {
   final _boolFieldHandle = booleanToFfi(value.boolField);
   final _intFieldHandle = (value.intField);
@@ -166,6 +196,10 @@ Pointer<Void> smokeEquatableEquatablestructToFfi(Equatable_EquatableStruct value
   final _mapFieldHandle = foobarMapofIntToStringToFfi(value.mapField);
   final _result = _smokeEquatableEquatablestructCreateHandle(_boolFieldHandle, _intFieldHandle, _longFieldHandle, _floatFieldHandle, _doubleFieldHandle, _stringFieldHandle, _structFieldHandle, _enumFieldHandle, _arrayFieldHandle, _mapFieldHandle);
   booleanReleaseFfiHandle(_boolFieldHandle);
+  
+  
+  
+  
   stringReleaseFfiHandle(_stringFieldHandle);
   smokeEquatableNestedequatablestructReleaseFfiHandle(_structFieldHandle);
   smokeEquatableSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -173,6 +207,7 @@ Pointer<Void> smokeEquatableEquatablestructToFfi(Equatable_EquatableStruct value
   foobarMapofIntToStringReleaseFfiHandle(_mapFieldHandle);
   return _result;
 }
+
 Equatable_EquatableStruct smokeEquatableEquatablestructFromFfi(Pointer<Void> handle) {
   final _boolFieldHandle = _smokeEquatableEquatablestructGetFieldboolField(handle);
   final _intFieldHandle = _smokeEquatableEquatablestructGetFieldintField(handle);
@@ -186,19 +221,23 @@ Equatable_EquatableStruct smokeEquatableEquatablestructFromFfi(Pointer<Void> han
   final _mapFieldHandle = _smokeEquatableEquatablestructGetFieldmapField(handle);
   try {
     return Equatable_EquatableStruct(
-      booleanFromFfi(_boolFieldHandle),
-      (_intFieldHandle),
-      (_longFieldHandle),
-      (_floatFieldHandle),
-      (_doubleFieldHandle),
-      stringFromFfi(_stringFieldHandle),
-      smokeEquatableNestedequatablestructFromFfi(_structFieldHandle),
-      smokeEquatableSomeenumFromFfi(_enumFieldHandle),
-      foobarListofStringFromFfi(_arrayFieldHandle),
+      booleanFromFfi(_boolFieldHandle), 
+      (_intFieldHandle), 
+      (_longFieldHandle), 
+      (_floatFieldHandle), 
+      (_doubleFieldHandle), 
+      stringFromFfi(_stringFieldHandle), 
+      smokeEquatableNestedequatablestructFromFfi(_structFieldHandle), 
+      smokeEquatableSomeenumFromFfi(_enumFieldHandle), 
+      foobarListofStringFromFfi(_arrayFieldHandle), 
       foobarMapofIntToStringFromFfi(_mapFieldHandle)
     );
   } finally {
     booleanReleaseFfiHandle(_boolFieldHandle);
+    
+    
+    
+    
     stringReleaseFfiHandle(_stringFieldHandle);
     smokeEquatableNestedequatablestructReleaseFfiHandle(_structFieldHandle);
     smokeEquatableSomeenumReleaseFfiHandle(_enumFieldHandle);
@@ -206,8 +245,11 @@ Equatable_EquatableStruct smokeEquatableEquatablestructFromFfi(Pointer<Void> han
     foobarMapofIntToStringReleaseFfiHandle(_mapFieldHandle);
   }
 }
+
 void smokeEquatableEquatablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeEquatableEquatablestructReleaseHandle(handle);
+
 // Nullable Equatable_EquatableStruct
+
 final _smokeEquatableEquatablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -220,6 +262,7 @@ final _smokeEquatableEquatablestructGetValueNullable = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableStruct_get_value_nullable'));
+
 Pointer<Void> smokeEquatableEquatablestructToFfiNullable(Equatable_EquatableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEquatableEquatablestructToFfi(value);
@@ -227,6 +270,7 @@ Pointer<Void> smokeEquatableEquatablestructToFfiNullable(Equatable_EquatableStru
   smokeEquatableEquatablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Equatable_EquatableStruct? smokeEquatableEquatablestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEquatableEquatablestructGetValueNullable(handle);
@@ -234,19 +278,31 @@ Equatable_EquatableStruct? smokeEquatableEquatablestructFromFfiNullable(Pointer<
   smokeEquatableEquatablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEquatableEquatablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEquatableEquatablestructReleaseHandleNullable(handle);
+
 // End of Equatable_EquatableStruct "private" section.
+
 class Equatable_EquatableNullableStruct {
   bool? boolField;
+
   int? intField;
+
   int? uintField;
+
   double? floatField;
+
   String? stringField;
+
   Equatable_NestedEquatableStruct? structField;
+
   Equatable_SomeEnum? enumField;
+
   List<String>? arrayField;
+
   Map<int, String>? mapField;
+
   Equatable_EquatableNullableStruct._(this.boolField, this.intField, this.uintField, this.floatField, this.stringField, this.structField, this.enumField, this.arrayField, this.mapField);
   Equatable_EquatableNullableStruct()
     : boolField = null, intField = null, uintField = null, floatField = null, stringField = null, structField = null, enumField = null, arrayField = null, mapField = null;
@@ -265,6 +321,7 @@ class Equatable_EquatableNullableStruct {
         DeepCollectionEquality().equals(arrayField, _other.arrayField) &&
         DeepCollectionEquality().equals(mapField, _other.mapField);
   }
+
   @override
   int get hashCode {
     int result = 7;
@@ -280,7 +337,10 @@ class Equatable_EquatableNullableStruct {
     return result;
   }
 }
+
+
 // Equatable_EquatableNullableStruct "private" section, not exported.
+
 final _smokeEquatableEquatablenullablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>, Pointer<Void>)
@@ -325,6 +385,9 @@ final _smokeEquatableEquatablenullablestructGetFieldmapField = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_field_mapField'));
+
+
+
 Pointer<Void> smokeEquatableEquatablenullablestructToFfi(Equatable_EquatableNullableStruct value) {
   final _boolFieldHandle = booleanToFfiNullable(value.boolField);
   final _intFieldHandle = intToFfiNullable(value.intField);
@@ -347,6 +410,7 @@ Pointer<Void> smokeEquatableEquatablenullablestructToFfi(Equatable_EquatableNull
   foobarMapofIntToStringReleaseFfiHandleNullable(_mapFieldHandle);
   return _result;
 }
+
 Equatable_EquatableNullableStruct smokeEquatableEquatablenullablestructFromFfi(Pointer<Void> handle) {
   final _boolFieldHandle = _smokeEquatableEquatablenullablestructGetFieldboolField(handle);
   final _intFieldHandle = _smokeEquatableEquatablenullablestructGetFieldintField(handle);
@@ -359,14 +423,14 @@ Equatable_EquatableNullableStruct smokeEquatableEquatablenullablestructFromFfi(P
   final _mapFieldHandle = _smokeEquatableEquatablenullablestructGetFieldmapField(handle);
   try {
     return Equatable_EquatableNullableStruct._(
-      booleanFromFfiNullable(_boolFieldHandle),
-      intFromFfiNullable(_intFieldHandle),
-      uShortFromFfiNullable(_uintFieldHandle),
-      floatFromFfiNullable(_floatFieldHandle),
-      stringFromFfiNullable(_stringFieldHandle),
-      smokeEquatableNestedequatablestructFromFfiNullable(_structFieldHandle),
-      smokeEquatableSomeenumFromFfiNullable(_enumFieldHandle),
-      foobarListofStringFromFfiNullable(_arrayFieldHandle),
+      booleanFromFfiNullable(_boolFieldHandle), 
+      intFromFfiNullable(_intFieldHandle), 
+      uShortFromFfiNullable(_uintFieldHandle), 
+      floatFromFfiNullable(_floatFieldHandle), 
+      stringFromFfiNullable(_stringFieldHandle), 
+      smokeEquatableNestedequatablestructFromFfiNullable(_structFieldHandle), 
+      smokeEquatableSomeenumFromFfiNullable(_enumFieldHandle), 
+      foobarListofStringFromFfiNullable(_arrayFieldHandle), 
       foobarMapofIntToStringFromFfiNullable(_mapFieldHandle)
     );
   } finally {
@@ -381,8 +445,11 @@ Equatable_EquatableNullableStruct smokeEquatableEquatablenullablestructFromFfi(P
     foobarMapofIntToStringReleaseFfiHandleNullable(_mapFieldHandle);
   }
 }
+
 void smokeEquatableEquatablenullablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeEquatableEquatablenullablestructReleaseHandle(handle);
+
 // Nullable Equatable_EquatableNullableStruct
+
 final _smokeEquatableEquatablenullablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -395,6 +462,7 @@ final _smokeEquatableEquatablenullablestructGetValueNullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_EquatableNullableStruct_get_value_nullable'));
+
 Pointer<Void> smokeEquatableEquatablenullablestructToFfiNullable(Equatable_EquatableNullableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEquatableEquatablenullablestructToFfi(value);
@@ -402,6 +470,7 @@ Pointer<Void> smokeEquatableEquatablenullablestructToFfiNullable(Equatable_Equat
   smokeEquatableEquatablenullablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Equatable_EquatableNullableStruct? smokeEquatableEquatablenullablestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEquatableEquatablenullablestructGetValueNullable(handle);
@@ -409,11 +478,15 @@ Equatable_EquatableNullableStruct? smokeEquatableEquatablenullablestructFromFfiN
   smokeEquatableEquatablenullablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEquatableEquatablenullablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEquatableEquatablenullablestructReleaseHandleNullable(handle);
+
 // End of Equatable_EquatableNullableStruct "private" section.
+
 class Equatable_NestedEquatableStruct {
   String fooField;
+
   Equatable_NestedEquatableStruct(this.fooField);
   @override
   bool operator ==(Object other) {
@@ -422,6 +495,7 @@ class Equatable_NestedEquatableStruct {
     Equatable_NestedEquatableStruct _other = other;
     return fooField == _other.fooField;
   }
+
   @override
   int get hashCode {
     int result = 7;
@@ -429,7 +503,10 @@ class Equatable_NestedEquatableStruct {
     return result;
   }
 }
+
+
 // Equatable_NestedEquatableStruct "private" section, not exported.
+
 final _smokeEquatableNestedequatablestructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -442,12 +519,16 @@ final _smokeEquatableNestedequatablestructGetFieldfooField = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_get_field_fooField'));
+
+
+
 Pointer<Void> smokeEquatableNestedequatablestructToFfi(Equatable_NestedEquatableStruct value) {
   final _fooFieldHandle = stringToFfi(value.fooField);
   final _result = _smokeEquatableNestedequatablestructCreateHandle(_fooFieldHandle);
   stringReleaseFfiHandle(_fooFieldHandle);
   return _result;
 }
+
 Equatable_NestedEquatableStruct smokeEquatableNestedequatablestructFromFfi(Pointer<Void> handle) {
   final _fooFieldHandle = _smokeEquatableNestedequatablestructGetFieldfooField(handle);
   try {
@@ -458,8 +539,11 @@ Equatable_NestedEquatableStruct smokeEquatableNestedequatablestructFromFfi(Point
     stringReleaseFfiHandle(_fooFieldHandle);
   }
 }
+
 void smokeEquatableNestedequatablestructReleaseFfiHandle(Pointer<Void> handle) => _smokeEquatableNestedequatablestructReleaseHandle(handle);
+
 // Nullable Equatable_NestedEquatableStruct
+
 final _smokeEquatableNestedequatablestructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -472,6 +556,7 @@ final _smokeEquatableNestedequatablestructGetValueNullable = __lib.catchArgument
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_NestedEquatableStruct_get_value_nullable'));
+
 Pointer<Void> smokeEquatableNestedequatablestructToFfiNullable(Equatable_NestedEquatableStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEquatableNestedequatablestructToFfi(value);
@@ -479,6 +564,7 @@ Pointer<Void> smokeEquatableNestedequatablestructToFfiNullable(Equatable_NestedE
   smokeEquatableNestedequatablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 Equatable_NestedEquatableStruct? smokeEquatableNestedequatablestructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEquatableNestedequatablestructGetValueNullable(handle);
@@ -486,10 +572,14 @@ Equatable_NestedEquatableStruct? smokeEquatableNestedequatablestructFromFfiNulla
   smokeEquatableNestedequatablestructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEquatableNestedequatablestructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEquatableNestedequatablestructReleaseHandleNullable(handle);
+
 // End of Equatable_NestedEquatableStruct "private" section.
+
 // Equatable "private" section, not exported.
+
 final _smokeEquatableCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -498,10 +588,14 @@ final _smokeEquatableReleaseHandle = __lib.catchArgumentError(() => __lib.native
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_Equatable_release_handle'));
+
+
+
 Pointer<Void> smokeEquatableToFfi(Equatable value) {
   final _result = _smokeEquatableCreateHandle();
   return _result;
 }
+
 Equatable smokeEquatableFromFfi(Pointer<Void> handle) {
   try {
     return Equatable(
@@ -509,8 +603,11 @@ Equatable smokeEquatableFromFfi(Pointer<Void> handle) {
   } finally {
   }
 }
+
 void smokeEquatableReleaseFfiHandle(Pointer<Void> handle) => _smokeEquatableReleaseHandle(handle);
+
 // Nullable Equatable
+
 final _smokeEquatableCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -523,6 +620,7 @@ final _smokeEquatableGetValueNullable = __lib.catchArgumentError(() => __lib.nat
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_Equatable_get_value_nullable'));
+
 Pointer<Void> smokeEquatableToFfiNullable(Equatable? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeEquatableToFfi(value);
@@ -530,6 +628,7 @@ Pointer<Void> smokeEquatableToFfiNullable(Equatable? value) {
   smokeEquatableReleaseFfiHandle(_handle);
   return result;
 }
+
 Equatable? smokeEquatableFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeEquatableGetValueNullable(handle);
@@ -537,6 +636,10 @@ Equatable? smokeEquatableFromFfiNullable(Pointer<Void> handle) {
   smokeEquatableReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeEquatableReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeEquatableReleaseHandleNullable(handle);
+
 // End of Equatable "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors.dart
@@ -40,8 +40,6 @@ int smokeErrorsInternalerrorcodeToFfi(Errors_InternalErrorCode value) {
     return 0;
   case Errors_InternalErrorCode.errorFatal:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Errors_InternalErrorCode enum.");
   }
 }
 
@@ -107,8 +105,6 @@ int smokeErrorsExternalerrorsToFfi(Errors_ExternalErrors value) {
     return 1;
   case Errors_ExternalErrors.bust:
     return 2;
-  default:
-    throw StateError("Invalid enum value $value for Errors_ExternalErrors enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -53,8 +53,6 @@ int smokeErrorsinterfaceInternalerrorToFfi(ErrorsInterface_InternalError value) 
     return 0;
   case ErrorsInterface_InternalError.errorFatal:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for ErrorsInterface_InternalError enum.");
   }
 }
 
@@ -120,8 +118,6 @@ int smokeErrorsinterfaceExternalerrorsToFfi(ErrorsInterface_ExternalErrors value
     return 1;
   case ErrorsInterface_ExternalErrors.bust:
     return 2;
-  default:
-    throw StateError("Invalid enum value $value for ErrorsInterface_ExternalErrors enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/dart/lib/src/package/types.dart
@@ -1,20 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
+
 class Types {
   static final Types_Enum Const = Types_Enum.naN;
+
 }
+
 enum Types_Enum {
     naN
 }
+
 // Types_Enum "private" section, not exported.
+
 int packageTypesEnumToFfi(Types_Enum value) {
   switch (value) {
   case Types_Enum.naN:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for Types_Enum enum.");
   }
 }
+
 Types_Enum packageTypesEnumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -23,7 +30,9 @@ Types_Enum packageTypesEnumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for Types_Enum enum.");
   }
 }
+
 void packageTypesEnumReleaseFfiHandle(int handle) {}
+
 final _packageTypesEnumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -36,6 +45,7 @@ final _packageTypesEnumGetValueNullable = __lib.catchArgumentError(() => __lib.n
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Types_Enum_get_value_nullable'));
+
 Pointer<Void> packageTypesEnumToFfiNullable(Types_Enum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = packageTypesEnumToFfi(value);
@@ -43,6 +53,7 @@ Pointer<Void> packageTypesEnumToFfiNullable(Types_Enum? value) {
   packageTypesEnumReleaseFfiHandle(_handle);
   return result;
 }
+
 Types_Enum? packageTypesEnumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _packageTypesEnumGetValueNullable(handle);
@@ -50,20 +61,27 @@ Types_Enum? packageTypesEnumFromFfiNullable(Pointer<Void> handle) {
   packageTypesEnumReleaseFfiHandle(_handle);
   return result;
 }
+
 void packageTypesEnumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _packageTypesEnumReleaseHandleNullable(handle);
+
 // End of Types_Enum "private" section.
 class Types_ExceptionException implements Exception {
   final Types_Enum error;
   Types_ExceptionException(this.error);
 }
+
 class Types_Struct {
   Types_Enum null;
+
   Types_Struct._(this.null);
   Types_Struct()
     : null = Types_Enum.naN;
 }
+
+
 // Types_Struct "private" section, not exported.
+
 final _packageTypesStructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -76,12 +94,16 @@ final _packageTypesStructGetFieldnull = __lib.catchArgumentError(() => __lib.nat
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_package_Types_Struct_get_field_null'));
+
+
+
 Pointer<Void> packageTypesStructToFfi(Types_Struct value) {
   final _nullHandle = packageTypesEnumToFfi(value.null);
   final _result = _packageTypesStructCreateHandle(_nullHandle);
   packageTypesEnumReleaseFfiHandle(_nullHandle);
   return _result;
 }
+
 Types_Struct packageTypesStructFromFfi(Pointer<Void> handle) {
   final _nullHandle = _packageTypesStructGetFieldnull(handle);
   try {
@@ -92,8 +114,11 @@ Types_Struct packageTypesStructFromFfi(Pointer<Void> handle) {
     packageTypesEnumReleaseFfiHandle(_nullHandle);
   }
 }
+
 void packageTypesStructReleaseFfiHandle(Pointer<Void> handle) => _packageTypesStructReleaseHandle(handle);
+
 // Nullable Types_Struct
+
 final _packageTypesStructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -106,6 +131,7 @@ final _packageTypesStructGetValueNullable = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Types_Struct_get_value_nullable'));
+
 Pointer<Void> packageTypesStructToFfiNullable(Types_Struct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = packageTypesStructToFfi(value);
@@ -113,6 +139,7 @@ Pointer<Void> packageTypesStructToFfiNullable(Types_Struct? value) {
   packageTypesStructReleaseFfiHandle(_handle);
   return result;
 }
+
 Types_Struct? packageTypesStructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _packageTypesStructGetValueNullable(handle);
@@ -120,10 +147,14 @@ Types_Struct? packageTypesStructFromFfiNullable(Pointer<Void> handle) {
   packageTypesStructReleaseFfiHandle(_handle);
   return result;
 }
+
 void packageTypesStructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _packageTypesStructReleaseHandleNullable(handle);
+
 // End of Types_Struct "private" section.
+
 // Types "private" section, not exported.
+
 final _packageTypesCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -132,10 +163,14 @@ final _packageTypesReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLi
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_package_Types_release_handle'));
+
+
+
 Pointer<Void> packageTypesToFfi(Types value) {
   final _result = _packageTypesCreateHandle();
   return _result;
 }
+
 Types packageTypesFromFfi(Pointer<Void> handle) {
   try {
     return Types(
@@ -143,8 +178,11 @@ Types packageTypesFromFfi(Pointer<Void> handle) {
   } finally {
   }
 }
+
 void packageTypesReleaseFfiHandle(Pointer<Void> handle) => _packageTypesReleaseHandle(handle);
+
 // Nullable Types
+
 final _packageTypesCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -157,6 +195,7 @@ final _packageTypesGetValueNullable = __lib.catchArgumentError(() => __lib.nativ
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_package_Types_get_value_nullable'));
+
 Pointer<Void> packageTypesToFfiNullable(Types? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = packageTypesToFfi(value);
@@ -164,6 +203,7 @@ Pointer<Void> packageTypesToFfiNullable(Types? value) {
   packageTypesReleaseFfiHandle(_handle);
   return result;
 }
+
 Types? packageTypesFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _packageTypesGetValueNullable(handle);
@@ -171,6 +211,10 @@ Types? packageTypesFromFfiNullable(Pointer<Void> handle) {
   packageTypesReleaseFfiHandle(_handle);
   return result;
 }
+
 void packageTypesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _packageTypesReleaseHandleNullable(handle);
+
 // End of Types "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/enums.dart
@@ -29,8 +29,6 @@ int smokeEnumsExternalenumToFfi(Enums_ExternalEnum value) {
     return 0;
   case Enums_ExternalEnum.barValue:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Enums_ExternalEnum enum.");
   }
 }
 
@@ -93,8 +91,6 @@ int smokeEnumsVeryexternalenumToFfi(Enums_VeryExternalEnum value) {
     return 0;
   case Enums_VeryExternalEnum.bar:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Enums_VeryExternalEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_class.dart
@@ -24,8 +24,6 @@ int smokeExternalclassSomeenumToFfi(ExternalClass_SomeEnum value) {
   switch (value) {
   case ExternalClass_SomeEnum.someValue:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for ExternalClass_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/external_interface.dart
@@ -33,8 +33,6 @@ int smokeExternalinterfaceSomeenumToFfi(ExternalInterface_SomeEnum value) {
   switch (value) {
   case ExternalInterface_SomeEnum.someValue:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for ExternalInterface_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/http_client_response_compression_state.dart
@@ -1,7 +1,12 @@
+
+
 import 'dart:ffi';
 import 'package:foo/bar.dart' as bar;
 import 'package:library/src/_library_context.dart' as __lib;
+
+
 // HttpClientResponseCompressionState "private" section, not exported.
+
 int smokeCompressionstateToFfi(bar.HttpClientResponseCompressionState value) {
   switch (value) {
   case bar.HttpClientResponseCompressionState.compressed:
@@ -10,10 +15,9 @@ int smokeCompressionstateToFfi(bar.HttpClientResponseCompressionState value) {
     return 1;
   case bar.HttpClientResponseCompressionState.notCompressed:
     return 2;
-  default:
-    throw StateError("Invalid enum value $value for HttpClientResponseCompressionState enum.");
   }
 }
+
 bar.HttpClientResponseCompressionState smokeCompressionstateFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -26,7 +30,9 @@ bar.HttpClientResponseCompressionState smokeCompressionstateFromFfi(int handle) 
     throw StateError("Invalid numeric value $handle for HttpClientResponseCompressionState enum.");
   }
 }
+
 void smokeCompressionstateReleaseFfiHandle(int handle) {}
+
 final _smokeCompressionstateCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -39,6 +45,7 @@ final _smokeCompressionstateGetValueNullable = __lib.catchArgumentError(() => __
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_CompressionState_get_value_nullable'));
+
 Pointer<Void> smokeCompressionstateToFfiNullable(bar.HttpClientResponseCompressionState? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeCompressionstateToFfi(value);
@@ -46,6 +53,7 @@ Pointer<Void> smokeCompressionstateToFfiNullable(bar.HttpClientResponseCompressi
   smokeCompressionstateReleaseFfiHandle(_handle);
   return result;
 }
+
 bar.HttpClientResponseCompressionState? smokeCompressionstateFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeCompressionstateGetValueNullable(handle);
@@ -53,6 +61,10 @@ bar.HttpClientResponseCompressionState? smokeCompressionstateFromFfiNullable(Poi
   smokeCompressionstateReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeCompressionstateReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeCompressionstateReleaseHandleNullable(handle);
+
 // End of HttpClientResponseCompressionState "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
+++ b/gluecodium/src/test/resources/smoke/external_types/output/dart/lib/src/smoke/string.dart
@@ -1,13 +1,18 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import '../season_converter.dart';
+
 enum StringInternal {
     winter,
     spring,
     summer,
     autumn
 }
+
 // String "private" section, not exported.
+
 int smokeDartseasonToFfi(String valueExternal) {
   final value = SeasonConverter.convertToInternal(valueExternal);
   switch (value) {
@@ -19,10 +24,9 @@ int smokeDartseasonToFfi(String valueExternal) {
     return 2;
   case StringInternal.autumn:
     return 3;
-  default:
-    throw StateError("Invalid enum value $value for String enum.");
   }
 }
+
 String smokeDartseasonFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -37,7 +41,9 @@ String smokeDartseasonFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for String enum.");
   }
 }
+
 void smokeDartseasonReleaseFfiHandle(int handle) {}
+
 final _smokeDartseasonCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -50,6 +56,7 @@ final _smokeDartseasonGetValueNullable = __lib.catchArgumentError(() => __lib.na
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_DartSeason_get_value_nullable'));
+
 Pointer<Void> smokeDartseasonToFfiNullable(String? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeDartseasonToFfi(value);
@@ -57,6 +64,7 @@ Pointer<Void> smokeDartseasonToFfiNullable(String? value) {
   smokeDartseasonReleaseFfiHandle(_handle);
   return result;
 }
+
 String? smokeDartseasonFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeDartseasonGetValueNullable(handle);
@@ -64,6 +72,10 @@ String? smokeDartseasonFromFfiNullable(Pointer<Void> handle) {
   smokeDartseasonReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeDartseasonReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeDartseasonReleaseHandleNullable(handle);
+
 // End of String "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_nullable_types.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_nullable_types.dart
@@ -1,5 +1,8 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
 
 class FieldConstructorsNullableTypes {
   FieldConstructorsNullableTypes_StructWithParameters? nullableField;
@@ -22,8 +25,6 @@ int smokeFieldconstructorsnullabletypesFoodtypeToFfi(FieldConstructorsNullableTy
     return 0;
   case FieldConstructorsNullableTypes_FoodType.fruits:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for FieldConstructorsNullableTypes_FoodType enum.");
   }
 }
 
@@ -226,3 +227,5 @@ void smokeFieldconstructorsnullabletypesReleaseFfiHandleNullable(Pointer<Void> h
   _smokeFieldconstructorsnullabletypesReleaseHandleNullable(handle);
 
 // End of FieldConstructorsNullableTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/dart/lib/src/smoke/generic_types_with_compound_types.dart
@@ -42,8 +42,6 @@ int smokeGenerictypeswithcompoundtypesSomeenumToFfi(GenericTypesWithCompoundType
     return 0;
   case GenericTypesWithCompoundTypes_SomeEnum.bar:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for GenericTypesWithCompoundTypes_SomeEnum enum.");
   }
 }
 
@@ -106,8 +104,6 @@ int smokeGenerictypeswithcompoundtypesExternalenumToFfi(GenericTypesWithCompound
     return 0;
   case GenericTypesWithCompoundTypes_ExternalEnum.off:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for GenericTypesWithCompoundTypes_ExternalEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listener_with_properties.dart
@@ -80,8 +80,6 @@ int smokeListenerwithpropertiesResultenumToFfi(ListenerWithProperties_ResultEnum
     return 0;
   case ListenerWithProperties_ResultEnum.result:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for ListenerWithProperties_ResultEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/listeners_with_return_values.dart
@@ -60,8 +60,6 @@ int smokeListenerswithreturnvaluesResultenumToFfi(ListenersWithReturnValues_Resu
     return 0;
   case ListenersWithReturnValues_ResultEnum.result:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for ListenersWithReturnValues_ResultEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/free_enum.dart
@@ -1,20 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
 enum FreeEnum {
     foo,
     bar
 }
+
 // FreeEnum "private" section, not exported.
+
 int smokeFreeenumToFfi(FreeEnum value) {
   switch (value) {
   case FreeEnum.foo:
     return 0;
   case FreeEnum.bar:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for FreeEnum enum.");
   }
 }
+
 FreeEnum smokeFreeenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -25,7 +29,9 @@ FreeEnum smokeFreeenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for FreeEnum enum.");
   }
 }
+
 void smokeFreeenumReleaseFfiHandle(int handle) {}
+
 final _smokeFreeenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -38,6 +44,7 @@ final _smokeFreeenumGetValueNullable = __lib.catchArgumentError(() => __lib.nati
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_FreeEnum_get_value_nullable'));
+
 Pointer<Void> smokeFreeenumToFfiNullable(FreeEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeFreeenumToFfi(value);
@@ -45,6 +52,7 @@ Pointer<Void> smokeFreeenumToFfiNullable(FreeEnum? value) {
   smokeFreeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 FreeEnum? smokeFreeenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeFreeenumGetValueNullable(handle);
@@ -52,6 +60,10 @@ FreeEnum? smokeFreeenumFromFfiNullable(Pointer<Void> handle) {
   smokeFreeenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeFreeenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFreeenumReleaseHandleNullable(handle);
+
 // End of FreeEnum "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/level_one.dart
@@ -33,8 +33,6 @@ int smokeLeveloneLeveltwoLevelthreeLevelfourenumToFfi(LevelOne_LevelTwo_LevelThr
   switch (value) {
   case LevelOne_LevelTwo_LevelThree_LevelFourEnum.none:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for LevelOne_LevelTwo_LevelThree_LevelFourEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_struct.dart
@@ -51,8 +51,6 @@ int smokeOuterstructInnerenumToFfi(OuterStruct_InnerEnum value) {
     return 0;
   case OuterStruct_InnerEnum.bar:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for OuterStruct_InnerEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
+++ b/gluecodium/src/test/resources/smoke/nullable/output/dart/lib/src/smoke/nullable.dart
@@ -75,8 +75,6 @@ int smokeNullableSomeenumToFfi(Nullable_SomeEnum value) {
     return 0;
   case Nullable_SomeEnum.off:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Nullable_SomeEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/dart/lib/src/smoke/wee_types.dart
@@ -1,21 +1,27 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
+
+
 class weeTypes {
 }
+
 enum weeTypes_werrEnum {
     WEE_ITEM
 }
+
 // weeTypes_werrEnum "private" section, not exported.
+
 int smokePlatformnamesBasicenumToFfi(weeTypes_werrEnum value) {
   switch (value) {
   case weeTypes_werrEnum.WEE_ITEM:
     return 0;
-  default:
-    throw StateError("Invalid enum value $value for weeTypes_werrEnum enum.");
   }
 }
+
 weeTypes_werrEnum smokePlatformnamesBasicenumFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -24,7 +30,9 @@ weeTypes_werrEnum smokePlatformnamesBasicenumFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for weeTypes_werrEnum enum.");
   }
 }
+
 void smokePlatformnamesBasicenumReleaseFfiHandle(int handle) {}
+
 final _smokePlatformnamesBasicenumCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -37,6 +45,7 @@ final _smokePlatformnamesBasicenumGetValueNullable = __lib.catchArgumentError(()
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicEnum_get_value_nullable'));
+
 Pointer<Void> smokePlatformnamesBasicenumToFfiNullable(weeTypes_werrEnum? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePlatformnamesBasicenumToFfi(value);
@@ -44,6 +53,7 @@ Pointer<Void> smokePlatformnamesBasicenumToFfiNullable(weeTypes_werrEnum? value)
   smokePlatformnamesBasicenumReleaseFfiHandle(_handle);
   return result;
 }
+
 weeTypes_werrEnum? smokePlatformnamesBasicenumFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePlatformnamesBasicenumGetValueNullable(handle);
@@ -51,18 +61,28 @@ weeTypes_werrEnum? smokePlatformnamesBasicenumFromFfiNullable(Pointer<Void> hand
   smokePlatformnamesBasicenumReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePlatformnamesBasicenumReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformnamesBasicenumReleaseHandleNullable(handle);
+
 // End of weeTypes_werrEnum "private" section.
+
+
 class weeTypes_weeStruct {
   String WEE_FIELD;
+
   weeTypes_weeStruct._(this.WEE_FIELD);
+
   factory weeTypes_weeStruct.WeeCreate(String WeeParameter) => $prototype.WeeCreate(WeeParameter);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = weeTypes_weeStruct$Impl();
 }
+
+
 // weeTypes_weeStruct "private" section, not exported.
+
 final _smokePlatformnamesBasicstructCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -75,6 +95,9 @@ final _smokePlatformnamesBasicstructGetFieldstringField = __lib.catchArgumentErr
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_get_field_stringField'));
+
+
+
 /// @nodoc
 @visibleForTesting
 class weeTypes_weeStruct$Impl {
@@ -87,15 +110,20 @@ class weeTypes_weeStruct$Impl {
       return smokePlatformnamesBasicstructFromFfi(__resultHandle);
     } finally {
       smokePlatformnamesBasicstructReleaseFfiHandle(__resultHandle);
+
     }
+
   }
+
 }
+
 Pointer<Void> smokePlatformnamesBasicstructToFfi(weeTypes_weeStruct value) {
   final _WEE_FIELDHandle = stringToFfi(value.WEE_FIELD);
   final _result = _smokePlatformnamesBasicstructCreateHandle(_WEE_FIELDHandle);
   stringReleaseFfiHandle(_WEE_FIELDHandle);
   return _result;
 }
+
 weeTypes_weeStruct smokePlatformnamesBasicstructFromFfi(Pointer<Void> handle) {
   final _WEE_FIELDHandle = _smokePlatformnamesBasicstructGetFieldstringField(handle);
   try {
@@ -106,8 +134,11 @@ weeTypes_weeStruct smokePlatformnamesBasicstructFromFfi(Pointer<Void> handle) {
     stringReleaseFfiHandle(_WEE_FIELDHandle);
   }
 }
+
 void smokePlatformnamesBasicstructReleaseFfiHandle(Pointer<Void> handle) => _smokePlatformnamesBasicstructReleaseHandle(handle);
+
 // Nullable weeTypes_weeStruct
+
 final _smokePlatformnamesBasicstructCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -120,6 +151,7 @@ final _smokePlatformnamesBasicstructGetValueNullable = __lib.catchArgumentError(
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_BasicStruct_get_value_nullable'));
+
 Pointer<Void> smokePlatformnamesBasicstructToFfiNullable(weeTypes_weeStruct? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePlatformnamesBasicstructToFfi(value);
@@ -127,6 +159,7 @@ Pointer<Void> smokePlatformnamesBasicstructToFfiNullable(weeTypes_weeStruct? val
   smokePlatformnamesBasicstructReleaseFfiHandle(_handle);
   return result;
 }
+
 weeTypes_weeStruct? smokePlatformnamesBasicstructFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePlatformnamesBasicstructGetValueNullable(handle);
@@ -134,10 +167,14 @@ weeTypes_weeStruct? smokePlatformnamesBasicstructFromFfiNullable(Pointer<Void> h
   smokePlatformnamesBasicstructReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePlatformnamesBasicstructReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformnamesBasicstructReleaseHandleNullable(handle);
+
 // End of weeTypes_weeStruct "private" section.
+
 // weeTypes "private" section, not exported.
+
 final _smokePlatformnamesCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(),
     Pointer<Void> Function()
@@ -146,10 +183,14 @@ final _smokePlatformnamesReleaseHandle = __lib.catchArgumentError(() => __lib.na
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_PlatformNames_release_handle'));
+
+
+
 Pointer<Void> smokePlatformnamesToFfi(weeTypes value) {
   final _result = _smokePlatformnamesCreateHandle();
   return _result;
 }
+
 weeTypes smokePlatformnamesFromFfi(Pointer<Void> handle) {
   try {
     return weeTypes(
@@ -157,8 +198,11 @@ weeTypes smokePlatformnamesFromFfi(Pointer<Void> handle) {
   } finally {
   }
 }
+
 void smokePlatformnamesReleaseFfiHandle(Pointer<Void> handle) => _smokePlatformnamesReleaseHandle(handle);
+
 // Nullable weeTypes
+
 final _smokePlatformnamesCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -171,6 +215,7 @@ final _smokePlatformnamesGetValueNullable = __lib.catchArgumentError(() => __lib
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_PlatformNames_get_value_nullable'));
+
 Pointer<Void> smokePlatformnamesToFfiNullable(weeTypes? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokePlatformnamesToFfi(value);
@@ -178,6 +223,7 @@ Pointer<Void> smokePlatformnamesToFfiNullable(weeTypes? value) {
   smokePlatformnamesReleaseFfiHandle(_handle);
   return result;
 }
+
 weeTypes? smokePlatformnamesFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokePlatformnamesGetValueNullable(handle);
@@ -185,6 +231,10 @@ weeTypes? smokePlatformnamesFromFfiNullable(Pointer<Void> handle) {
   smokePlatformnamesReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokePlatformnamesReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokePlatformnamesReleaseHandleNullable(handle);
+
 // End of weeTypes "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
+++ b/gluecodium/src/test/resources/smoke/properties/output/dart/lib/src/smoke/properties.dart
@@ -59,8 +59,6 @@ int smokePropertiesInternalerrorcodeToFfi(Properties_InternalErrorCode value) {
     return 0;
   case Properties_InternalErrorCode.errorFatal:
     return 999;
-  default:
-    throw StateError("Invalid enum value $value for Properties_InternalErrorCode enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_auto_tag.dart
@@ -1,20 +1,24 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
 enum SkipEnumeratorAutoTag {
     one,
     three
 }
+
 // SkipEnumeratorAutoTag "private" section, not exported.
+
 int smokeSkipenumeratorautotagToFfi(SkipEnumeratorAutoTag value) {
   switch (value) {
   case SkipEnumeratorAutoTag.one:
     return 0;
   case SkipEnumeratorAutoTag.three:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for SkipEnumeratorAutoTag enum.");
   }
 }
+
 SkipEnumeratorAutoTag smokeSkipenumeratorautotagFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -25,7 +29,9 @@ SkipEnumeratorAutoTag smokeSkipenumeratorautotagFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for SkipEnumeratorAutoTag enum.");
   }
 }
+
 void smokeSkipenumeratorautotagReleaseFfiHandle(int handle) {}
+
 final _smokeSkipenumeratorautotagCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -38,6 +44,7 @@ final _smokeSkipenumeratorautotagGetValueNullable = __lib.catchArgumentError(() 
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorAutoTag_get_value_nullable'));
+
 Pointer<Void> smokeSkipenumeratorautotagToFfiNullable(SkipEnumeratorAutoTag? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeSkipenumeratorautotagToFfi(value);
@@ -45,6 +52,7 @@ Pointer<Void> smokeSkipenumeratorautotagToFfiNullable(SkipEnumeratorAutoTag? val
   smokeSkipenumeratorautotagReleaseFfiHandle(_handle);
   return result;
 }
+
 SkipEnumeratorAutoTag? smokeSkipenumeratorautotagFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeSkipenumeratorautotagGetValueNullable(handle);
@@ -52,6 +60,10 @@ SkipEnumeratorAutoTag? smokeSkipenumeratorautotagFromFfiNullable(Pointer<Void> h
   smokeSkipenumeratorautotagReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeSkipenumeratorautotagReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipenumeratorautotagReleaseHandleNullable(handle);
+
 // End of SkipEnumeratorAutoTag "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_enumerator_explicit_tag.dart
@@ -1,11 +1,16 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
+
 enum SkipEnumeratorExplicitTag {
     zero,
     one,
     three
 }
+
 // SkipEnumeratorExplicitTag "private" section, not exported.
+
 int smokeSkipenumeratorexplicittagToFfi(SkipEnumeratorExplicitTag value) {
   switch (value) {
   case SkipEnumeratorExplicitTag.zero:
@@ -14,10 +19,9 @@ int smokeSkipenumeratorexplicittagToFfi(SkipEnumeratorExplicitTag value) {
     return 3;
   case SkipEnumeratorExplicitTag.three:
     return 4;
-  default:
-    throw StateError("Invalid enum value $value for SkipEnumeratorExplicitTag enum.");
   }
 }
+
 SkipEnumeratorExplicitTag smokeSkipenumeratorexplicittagFromFfi(int handle) {
   switch (handle) {
   case 0:
@@ -30,7 +34,9 @@ SkipEnumeratorExplicitTag smokeSkipenumeratorexplicittagFromFfi(int handle) {
     throw StateError("Invalid numeric value $handle for SkipEnumeratorExplicitTag enum.");
   }
 }
+
 void smokeSkipenumeratorexplicittagReleaseFfiHandle(int handle) {}
+
 final _smokeSkipenumeratorexplicittagCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Uint32),
     Pointer<Void> Function(int)
@@ -43,6 +49,7 @@ final _smokeSkipenumeratorexplicittagGetValueNullable = __lib.catchArgumentError
     Uint32 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_SkipEnumeratorExplicitTag_get_value_nullable'));
+
 Pointer<Void> smokeSkipenumeratorexplicittagToFfiNullable(SkipEnumeratorExplicitTag? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeSkipenumeratorexplicittagToFfi(value);
@@ -50,6 +57,7 @@ Pointer<Void> smokeSkipenumeratorexplicittagToFfiNullable(SkipEnumeratorExplicit
   smokeSkipenumeratorexplicittagReleaseFfiHandle(_handle);
   return result;
 }
+
 SkipEnumeratorExplicitTag? smokeSkipenumeratorexplicittagFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeSkipenumeratorexplicittagGetValueNullable(handle);
@@ -57,6 +65,10 @@ SkipEnumeratorExplicitTag? smokeSkipenumeratorexplicittagFromFfiNullable(Pointer
   smokeSkipenumeratorexplicittagReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeSkipenumeratorexplicittagReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeSkipenumeratorexplicittagReleaseHandleNullable(handle);
+
 // End of SkipEnumeratorExplicitTag "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -39,8 +39,6 @@ int smokeStructsFoobarToFfi(Structs_FooBar value) {
     return 0;
   case Structs_FooBar.bar:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for Structs_FooBar enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
@@ -31,8 +31,6 @@ int smokeExternalclassErrorenumToFfi(ExternalClass_ErrorEnum value) {
     return 0;
   case ExternalClass_ErrorEnum.crashed:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for ExternalClass_ErrorEnum enum.");
   }
 }
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_class.dart
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/dart/lib/src/smoke/public_class.dart
@@ -24,8 +24,6 @@ int smokePublicclassInternalenumToFfi(PublicClass_InternalEnum value) {
     return 0;
   case PublicClass_InternalEnum.bar:
     return 1;
-  default:
-    throw StateError("Invalid enum value $value for PublicClass_InternalEnum enum.");
   }
 }
 


### PR DESCRIPTION
----- Motivation -----
In the case of enumerations we match all the possible
matchable values in `case` clauses. Then, we generate
`default` clause, but the linter is able to see, that
this is a dead code.
    
In such case `unreachable_switch_default` warning is
raised by the linter.
    
----- Important -----
The above is true if we generate an authentic `enum` in Dart.
In the case when aliasing enumerators are needed, then
we generate an enum-like class. In such case `default` clause
is needed, because we operate on integers and compiler assumes,
that switch-case is not exhaustive.
    
----- Implemented solution -----
Removed generation of redundant `default` clause when we use
an authentic Dart `enum` to avoid linter warnings.