### PR TITLE
Dart: do not derive from classes annotated as 'visibleForTesting'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+ * Dart: removed inheritance from base types annotated as `visibleForTesting`. It caused linter warnings.
+
 ## 13.10.1
 Release date 2024-12-12
 ### Bug fixes:

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -272,8 +272,10 @@ feature(Defaults cpp android swift dart SOURCES
 )
 
 feature(Inheritance cpp android swift dart SOURCES
+    input/src/cpp/BaseClassWithStaticMethodsImpl.cpp
     input/src/cpp/ChildClassImpl.cpp
     input/src/cpp/ChildClassImpl.h
+    input/src/cpp/DerivedClassWithStaticMethodsImpl.cpp
     input/src/cpp/GrandchildClassImpl.cpp
     input/src/cpp/GrandchildClassImpl.h
     input/src/cpp/ListenerInheritance.cpp
@@ -281,6 +283,7 @@ feature(Inheritance cpp android swift dart SOURCES
     input/src/cpp/Inheritance.cpp
     input/src/cpp/CrossPackageInheritance.cpp
 
+    input/lime/DartVisibleForTestingInheritance.lime
     input/lime/Inheritance.lime
     input/lime/InheritanceNameClash.lime
     input/lime/ListenerInheritance.lime

--- a/functional-tests/functional/input/lime/DartVisibleForTestingInheritance.lime
+++ b/functional-tests/functional/input/lime/DartVisibleForTestingInheritance.lime
@@ -1,0 +1,42 @@
+# Copyright (C) 2016-2024 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Skip(Java) @Skip(Swift)
+open class BaseClassWithStaticMethods {
+    // A constructor, which creates the base class.
+    constructor create()
+
+    // A static function defined in the base class.
+    static fun getRandomInt(): Int
+
+    // A nonstatic function defined in the base class.
+    fun nonstaticGetInt(): Int
+}
+
+@Skip(Java) @Skip(Swift)
+open class DerivedClassWithStaticMethods : BaseClassWithStaticMethods {
+    // A constructor, which creates the derived class.
+    constructor create()
+
+    // A static function defined in the derived class.
+    static fun getRandomDouble(): Double
+
+    // A nonstatic function defined in the derived class.
+    fun nonstaticGetDouble(): Double
+}

--- a/functional-tests/functional/input/src/cpp/BaseClassWithStaticMethodsImpl.cpp
+++ b/functional-tests/functional/input/src/cpp/BaseClassWithStaticMethodsImpl.cpp
@@ -1,0 +1,44 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2024 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/BaseClassWithStaticMethods.h"
+
+namespace test
+{
+
+class BaseClassWithStaticMethodsImpl : public BaseClassWithStaticMethods {
+public:
+    BaseClassWithStaticMethodsImpl() = default;
+    ~BaseClassWithStaticMethodsImpl() override = default;
+
+    int nonstatic_get_int() override {
+        return 14;
+    }
+};
+
+int BaseClassWithStaticMethods::get_random_int() {
+    return 7;
+}
+
+std::shared_ptr<BaseClassWithStaticMethods> BaseClassWithStaticMethods::create() {
+    return std::make_shared<BaseClassWithStaticMethodsImpl>();
+}
+
+} // namespace test

--- a/functional-tests/functional/input/src/cpp/DerivedClassWithStaticMethodsImpl.cpp
+++ b/functional-tests/functional/input/src/cpp/DerivedClassWithStaticMethodsImpl.cpp
@@ -1,0 +1,48 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2024 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/DerivedClassWithStaticMethods.h"
+
+namespace test
+{
+
+class DerivedClassWithStaticMethodsImpl : public DerivedClassWithStaticMethods {
+public:
+    DerivedClassWithStaticMethodsImpl() = default;
+    ~DerivedClassWithStaticMethodsImpl() override = default;
+
+    int nonstatic_get_int() override {
+        return 21;
+    }
+
+    double nonstatic_get_double() override {
+        return 21.21;
+    }
+};
+
+double DerivedClassWithStaticMethods::get_random_double() {
+    return 77.77;
+}
+
+std::shared_ptr<DerivedClassWithStaticMethods> DerivedClassWithStaticMethods::create() {
+    return std::make_shared<DerivedClassWithStaticMethodsImpl>();
+}
+
+} // namespace test

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -97,7 +97,15 @@ final _{{resolveName "Ffi"}}GetTypeId = __lib.catchArgumentError(() => __lib.nat
 /// @nodoc
 @visibleForTesting
 {{/ifPredicate}}
-class {{resolveName}}$Impl extends {{#if this.parentClass}}{{resolveName this.parentClass}}$Impl{{/if}}{{!!
+class {{resolveName}}$Impl extends {{!!
+}}{{#if this.parentClass}}{{!!
+}}{{#unlessPredicate this.parentClass "hasStaticFunctions"}}{{!!
+}}{{resolveName this.parentClass}}$Impl{{!!
+}}{{/unless}}{{!!
+}}{{#ifPredicate this.parentClass "hasStaticFunctions"}}{{!!
+}}{{resolveName this.parentClass}}$HiddenImpl{{!!
+}}{{/ifPredicate}}{{!!
+}}{{/if}}{{!!
 }}{{#unless this.parentClass}}__lib.NativeBase{{/unless}} implements {{resolveName}} {
 
   {{resolveName}}$Impl(Pointer<Void> handle) : super(handle);
@@ -126,7 +134,18 @@ class {{resolveName}}$Impl extends {{#if this.parentClass}}{{resolveName this.pa
 {{/set}}{{/set}}
 {{#if attributes.equatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}{{!!
 }}{{#if attributes.pointerEquatable}}{{prefixPartial "dart/DartEqualityOperator" "  "}}{{/if}}
+}{{!!
+}}{{#if this.isOpen}}{{!!
+}}{{#ifPredicate "hasStaticFunctions"}}
+
+/// @nodoc
+class {{resolveName}}$HiddenImpl extends {{resolveName}}$Impl {
+
+  {{resolveName}}$HiddenImpl(Pointer<Void> handle) : super(handle);
+
 }
+{{/ifPredicate}}{{!!
+}}{{/if}}
 
 Pointer<Void> {{resolveName "Ffi"}}ToFfi({{resolveName}} value) =>
   _{{resolveName "Ffi"}}CopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
+++ b/gluecodium/src/test/resources/smoke/constructors/output/dart/lib/src/smoke/constructors.dart
@@ -274,6 +274,12 @@ class Constructors$Impl extends __lib.NativeBase implements Constructors {
 
 
 }
+/// @nodoc
+class Constructors$HiddenImpl extends Constructors$Impl {
+
+  Constructors$HiddenImpl(Pointer<Void> handle) : super(handle);
+
+}
 
 Pointer<Void> smokeConstructorsToFfi(Constructors value) =>
   _smokeConstructorsCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/input/DartVisibleForTestingInheritance.lime
+++ b/gluecodium/src/test/resources/smoke/inheritance/input/DartVisibleForTestingInheritance.lime
@@ -1,0 +1,35 @@
+# Copyright (C) 2016-2024 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+@Skip(Java) @Skip(Swift)
+open class BaseClassWithStaticMethods {
+    constructor create()
+
+    // A static function defined in the base class.
+    static fun getRandomInt(): Int
+}
+
+@Skip(Java) @Skip(Swift)
+open class DerivedClassWithStaticMethods : BaseClassWithStaticMethods {
+    // A constructor, which creates the derived class.
+    constructor create()
+
+    // A static function defined in the derived class.
+    static fun getRandomDouble(): Double
+}

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/_type_repository.dart
@@ -1,3 +1,6 @@
+
+
+import 'package:library/src/smoke/base_class_with_static_methods.dart';
 import 'package:library/src/smoke/child_class_from_class.dart';
 import 'package:library/src/smoke/child_class_from_interface.dart';
 import 'package:library/src/smoke/child_class_name_clash.dart';
@@ -6,6 +9,7 @@ import 'package:library/src/smoke/child_class_with_imports.dart';
 import 'package:library/src/smoke/child_class_with_lambda.dart';
 import 'package:library/src/smoke/child_interface.dart';
 import 'package:library/src/smoke/child_with_parent_class_references.dart';
+import 'package:library/src/smoke/derived_class_with_static_methods.dart';
 import 'package:library/src/smoke/grand_child_interface.dart';
 import 'package:library/src/smoke/interface_with_lambda.dart';
 import 'package:library/src/smoke/interface_with_overloads.dart';
@@ -16,23 +20,45 @@ import 'package:library/src/smoke/parent_class_with_imports.dart';
 import 'package:library/src/smoke/parent_interface.dart';
 import 'package:library/src/smoke/parent_interface_with_bool.dart';
 import 'package:library/src/smoke/parent_with_class_references.dart';
-final Map<String, Function> typeRepository = {
+
+final Map<String, Function> typeRepository = { 
+  "smoke_BaseClassWithStaticMethods": (handle) => BaseClassWithStaticMethods$Impl(handle),
+
   "smoke_ChildClassFromClass": (handle) => ChildClassFromClass$Impl(handle),
+
   "smoke_ChildClassFromInterface": (handle) => ChildClassFromInterface$Impl(handle),
+
   "smoke_ChildClassNameClash": (handle) => ChildClassNameClash$Impl(handle),
+
   "smoke_ChildClassWithBool": (handle) => ChildClassWithBool$Impl(handle),
+
   "smoke_ChildClassWithImports": (handle) => ChildClassWithImports$Impl(handle),
+
   "smoke_ChildClassWithLambda": (handle) => ChildClassWithLambda$Impl(handle),
+
   "smoke_ChildInterface": (handle) => ChildInterface$Impl(handle),
+
   "smoke_ChildWithParentClassReferences": (handle) => ChildWithParentClassReferences$Impl(handle),
+
+  "smoke_DerivedClassWithStaticMethods": (handle) => DerivedClassWithStaticMethods$Impl(handle),
+
   "smoke_GrandChildInterface": (handle) => GrandChildInterface$Impl(handle),
+
   "smoke_InterfaceWithLambda": (handle) => InterfaceWithLambda$Impl(handle),
+
   "smoke_InterfaceWithOverloads": (handle) => InterfaceWithOverloads$Impl(handle),
+
   "smoke_InternalChild": (handle) => InternalChild$Impl(handle),
+
   "smoke_InternalParent": (handle) => InternalParent$Impl(handle),
+
   "smoke_ParentClass": (handle) => ParentClass$Impl(handle),
+
   "smoke_ParentClassWithImports": (handle) => ParentClassWithImports$Impl(handle),
+
   "smoke_ParentInterface": (handle) => ParentInterface$Impl(handle),
+
   "smoke_ParentInterfaceWithBool": (handle) => ParentInterfaceWithBool$Impl(handle),
+
   "smoke_ParentWithClassReferences": (handle) => ParentWithClassReferences$Impl(handle),
  };

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/base_class_with_static_methods.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/base_class_with_static_methods.dart
@@ -81,6 +81,12 @@ class BaseClassWithStaticMethods$Impl extends __lib.NativeBase implements BaseCl
 
 
 }
+/// @nodoc
+class BaseClassWithStaticMethods$HiddenImpl extends BaseClassWithStaticMethods$Impl {
+
+  BaseClassWithStaticMethods$HiddenImpl(Pointer<Void> handle) : super(handle);
+
+}
 
 Pointer<Void> smokeBaseclasswithstaticmethodsToFfi(BaseClassWithStaticMethods value) =>
   _smokeBaseclasswithstaticmethodsCopyHandle((value as __lib.NativeBase).handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/base_class_with_static_methods.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/base_class_with_static_methods.dart
@@ -1,0 +1,120 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:meta/meta.dart';
+
+abstract class BaseClassWithStaticMethods implements Finalizable {
+
+  factory BaseClassWithStaticMethods() => $prototype.create();
+
+  /// A static function defined in the base class.
+  ///
+  static int getRandomInt() => $prototype.getRandomInt();
+
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = BaseClassWithStaticMethods$Impl(Pointer<Void>.fromAddress(0));
+}
+
+
+// BaseClassWithStaticMethods "private" section, not exported.
+
+final _smokeBaseclasswithstaticmethodsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_BaseClassWithStaticMethods_register_finalizer'));
+final _smokeBaseclasswithstaticmethodsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_BaseClassWithStaticMethods_copy_handle'));
+final _smokeBaseclasswithstaticmethodsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_BaseClassWithStaticMethods_release_handle'));
+final _smokeBaseclasswithstaticmethodsGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_BaseClassWithStaticMethods_get_type_id'));
+
+
+
+
+/// @nodoc
+@visibleForTesting
+class BaseClassWithStaticMethods$Impl extends __lib.NativeBase implements BaseClassWithStaticMethods {
+
+  BaseClassWithStaticMethods$Impl(Pointer<Void> handle) : super(handle);
+
+
+  BaseClassWithStaticMethods create() {
+    final _result_handle = _create();
+    final _result = BaseClassWithStaticMethods$Impl(_result_handle);
+
+    __lib.cacheInstance(_result_handle, _result);
+
+    _smokeBaseclasswithstaticmethodsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+
+  static Pointer<Void> _create() {
+    final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_BaseClassWithStaticMethods_create'));
+    final __resultHandle = _createFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
+  }
+
+  int getRandomInt() {
+    final _getRandomIntFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Int32 Function(Int32), int Function(int)>('library_smoke_BaseClassWithStaticMethods_getRandomInt'));
+    final __resultHandle = _getRandomIntFfi(__lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+
+}
+
+Pointer<Void> smokeBaseclasswithstaticmethodsToFfi(BaseClassWithStaticMethods value) =>
+  _smokeBaseclasswithstaticmethodsCopyHandle((value as __lib.NativeBase).handle);
+
+BaseClassWithStaticMethods smokeBaseclasswithstaticmethodsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is BaseClassWithStaticMethods) return instance;
+
+  final _typeIdHandle = _smokeBaseclasswithstaticmethodsGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+
+  final _copiedHandle = _smokeBaseclasswithstaticmethodsCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : BaseClassWithStaticMethods$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeBaseclasswithstaticmethodsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeBaseclasswithstaticmethodsReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeBaseclasswithstaticmethodsReleaseHandle(handle);
+
+Pointer<Void> smokeBaseclasswithstaticmethodsToFfiNullable(BaseClassWithStaticMethods? value) =>
+  value != null ? smokeBaseclasswithstaticmethodsToFfi(value) : Pointer<Void>.fromAddress(0);
+
+BaseClassWithStaticMethods? smokeBaseclasswithstaticmethodsFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeBaseclasswithstaticmethodsFromFfi(handle) : null;
+
+void smokeBaseclasswithstaticmethodsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeBaseclasswithstaticmethodsReleaseHandle(handle);
+
+// End of BaseClassWithStaticMethods "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/derived_class_with_static_methods.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/derived_class_with_static_methods.dart
@@ -1,0 +1,122 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/base_class_with_static_methods.dart';
+import 'package:meta/meta.dart';
+
+abstract class DerivedClassWithStaticMethods implements BaseClassWithStaticMethods, Finalizable {
+  /// A constructor, which creates the derived class.
+  ///
+  factory DerivedClassWithStaticMethods() => $prototype.create();
+
+  /// A static function defined in the derived class.
+  ///
+  static double getRandomDouble() => $prototype.getRandomDouble();
+
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = DerivedClassWithStaticMethods$Impl(Pointer<Void>.fromAddress(0));
+}
+
+
+// DerivedClassWithStaticMethods "private" section, not exported.
+
+final _smokeDerivedclasswithstaticmethodsRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_DerivedClassWithStaticMethods_register_finalizer'));
+final _smokeDerivedclasswithstaticmethodsCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DerivedClassWithStaticMethods_copy_handle'));
+final _smokeDerivedclasswithstaticmethodsReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_DerivedClassWithStaticMethods_release_handle'));
+final _smokeDerivedclasswithstaticmethodsGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_DerivedClassWithStaticMethods_get_type_id'));
+
+
+
+
+/// @nodoc
+@visibleForTesting
+class DerivedClassWithStaticMethods$Impl extends BaseClassWithStaticMethods$Impl implements DerivedClassWithStaticMethods {
+
+  DerivedClassWithStaticMethods$Impl(Pointer<Void> handle) : super(handle);
+
+
+  DerivedClassWithStaticMethods create() {
+    final _result_handle = _create();
+    final _result = DerivedClassWithStaticMethods$Impl(_result_handle);
+
+    __lib.cacheInstance(_result_handle, _result);
+
+    _smokeDerivedclasswithstaticmethodsRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+
+  static Pointer<Void> _create() {
+    final _createFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32), Pointer<Void> Function(int)>('library_smoke_DerivedClassWithStaticMethods_create'));
+    final __resultHandle = _createFfi(__lib.LibraryContext.isolateId);
+    return __resultHandle;
+  }
+
+  double getRandomDouble() {
+    final _getRandomDoubleFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Int32), double Function(int)>('library_smoke_DerivedClassWithStaticMethods_getRandomDouble'));
+    final __resultHandle = _getRandomDoubleFfi(__lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+
+}
+
+Pointer<Void> smokeDerivedclasswithstaticmethodsToFfi(DerivedClassWithStaticMethods value) =>
+  _smokeDerivedclasswithstaticmethodsCopyHandle((value as __lib.NativeBase).handle);
+
+DerivedClassWithStaticMethods smokeDerivedclasswithstaticmethodsFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is DerivedClassWithStaticMethods) return instance;
+
+  final _typeIdHandle = _smokeDerivedclasswithstaticmethodsGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+
+  final _copiedHandle = _smokeDerivedclasswithstaticmethodsCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : DerivedClassWithStaticMethods$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeDerivedclasswithstaticmethodsRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeDerivedclasswithstaticmethodsReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeDerivedclasswithstaticmethodsReleaseHandle(handle);
+
+Pointer<Void> smokeDerivedclasswithstaticmethodsToFfiNullable(DerivedClassWithStaticMethods? value) =>
+  value != null ? smokeDerivedclasswithstaticmethodsToFfi(value) : Pointer<Void>.fromAddress(0);
+
+DerivedClassWithStaticMethods? smokeDerivedclasswithstaticmethodsFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeDerivedclasswithstaticmethodsFromFfi(handle) : null;
+
+void smokeDerivedclasswithstaticmethodsReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeDerivedclasswithstaticmethodsReleaseHandle(handle);
+
+// End of DerivedClassWithStaticMethods "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/derived_class_with_static_methods.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/derived_class_with_static_methods.dart
@@ -48,7 +48,7 @@ final _smokeDerivedclasswithstaticmethodsGetTypeId = __lib.catchArgumentError(()
 
 /// @nodoc
 @visibleForTesting
-class DerivedClassWithStaticMethods$Impl extends BaseClassWithStaticMethods$Impl implements DerivedClassWithStaticMethods {
+class DerivedClassWithStaticMethods$Impl extends BaseClassWithStaticMethods$HiddenImpl implements DerivedClassWithStaticMethods {
 
   DerivedClassWithStaticMethods$Impl(Pointer<Void> handle) : super(handle);
 
@@ -81,6 +81,12 @@ class DerivedClassWithStaticMethods$Impl extends BaseClassWithStaticMethods$Impl
 
   }
 
+
+}
+/// @nodoc
+class DerivedClassWithStaticMethods$HiddenImpl extends DerivedClassWithStaticMethods$Impl {
+
+  DerivedClassWithStaticMethods$HiddenImpl(Pointer<Void> handle) : super(handle);
 
 }
 

--- a/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
+++ b/gluecodium/src/test/resources/smoke/throwing_constructors/output/dart/lib/src/smoke/external_class.dart
@@ -217,7 +217,6 @@ class ExternalClass_InternalOne$Impl extends __lib.NativeBase implements Externa
 
 
 }
-
 Pointer<Void> smokeExternalclassInternaloneToFfi(ExternalClass_InternalOne value) =>
   _smokeExternalclassInternaloneCopyHandle((value as __lib.NativeBase).handle);
 
@@ -327,7 +326,6 @@ class ExternalClass_InternalTwo$Impl extends __lib.NativeBase implements Externa
 
 
 }
-
 Pointer<Void> smokeExternalclassInternaltwoToFfi(ExternalClass_InternalTwo value) =>
   _smokeExternalclassInternaltwoCopyHandle((value as __lib.NativeBase).handle);
 
@@ -429,6 +427,12 @@ class ExternalClass$Impl extends __lib.NativeBase implements ExternalClass {
     return __resultHandle;
   }
 
+
+}
+/// @nodoc
+class ExternalClass$HiddenImpl extends ExternalClass$Impl {
+
+  ExternalClass$HiddenImpl(Pointer<Void> handle) : super(handle);
 
 }
 


### PR DESCRIPTION
----- Motivation -----
In order to allow users to mock static functions in classes
the 'prototype' approach was implemented in the past. It uses
prototype class to redirect static function calls.
    
A class with '$Impl' suffix is created as a prototype. It is
annotated as 'visibleForTesting' and exported from the library.
    
The user may provide its own implementation in tests and this
way redirect the calls to the mock (after setting it as prototype).
    
Sadly, when a class is derived from the class, which has static
methods, then its '$Impl' derives from the '$Impl' of base class.
This leads to linter warnings: 'invalid_use_of_visible_for_testing_member'.

----- Implemented solution -----    
This change introduces a new type called '$HiddenImpl', which is
defined only when the class is open and has static functions.
The '$HiddenImpl' is not exported and therefore, the user cannot use it
directly. Still, the user may use the old approach to redirect the calls
to mock.

The '$HiddenImpl' is derived from an ordinary '$Impl' and its usage does
not generate linter warnings when the '$Impl' of derived class uses it,
because '$HiddenImpl' is not annotated as 'visibleForTesting'.
    
The '$HiddenImpl' is used only to provide implementation of methods from
the base class.