### PR TITLE
JavaNameRules: remove dead code

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaNameRules.kt
@@ -24,7 +24,6 @@ import com.here.gluecodium.generator.common.NameRules
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType.NAME
 import com.here.gluecodium.model.lime.LimeElement
-import com.here.gluecodium.model.lime.LimeLambdaParameter
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeTypedElement
@@ -39,11 +38,6 @@ internal class JavaNameRules(nameRuleSet: NameRuleSet) : NameRules(nameRuleSet) 
     override fun getSetterName(limeElement: LimeTypedElement) =
         (limeElement as? LimeProperty)?.let { getPlatformName(it.setter) }
             ?: super.getSetterName(limeElement)
-
-    fun getName(
-        limeLambdaParameter: LimeLambdaParameter,
-        index: Int,
-    ) = limeLambdaParameter.attributes.get(JAVA, NAME) ?: "p$index"
 
     private fun getPlatformName(limeElement: LimeNamedElement?) = limeElement?.attributes?.get(JAVA, NAME)
 


### PR DESCRIPTION
The overload of 'getName()' function for 'LimeLambdaParameter' is not used anywhere.

Initially, it was used by 'JavaModelBuilder', but this class was removed in the past and it no longer exists.

Currently, the type 'LimeLambdaParameter' is not used in Java generator and its templates, because 'JavaLambda.mustache' utilizes 'LimeLambda.asFunction()', which converts the mentioned type via 'LimeLambdaParameter.asLimeParameter()'.

The indices of lambda parameters are encoded in the path and stored via 'AntlrLimeModelBuilder.exitLambda()'.
