### PR TITLE
Dart: ignore internal warning related to visibleForTesting usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Bug fixes:
+ * Dart: disabled generation of `invalid_use_of_visible_for_testing_member` warning from the generated code for a hierarchy of classes.
  * Dart: removed generation of redundant import for constants declared with external types. The redundant import caused linter warnings.
  * Dart: removed generation of redundant `default` clause in exhaustive switch-cases for enumerations. The redundant `default` caused linter warnings.
 

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -97,6 +97,7 @@ final _{{resolveName "Ffi"}}GetTypeId = __lib.catchArgumentError(() => __lib.nat
 /// @nodoc
 @visibleForTesting
 {{/ifPredicate}}
+{{#if this.parentClass}}// ignore: invalid_use_of_visible_for_testing_member{{/if}}
 class {{resolveName}}$Impl extends {{#if this.parentClass}}{{resolveName this.parentClass}}$Impl{{/if}}{{!!
 }}{{#unless this.parentClass}}__lib.NativeBase{{/unless}} implements {{resolveName}} {
 

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_from_class.dart
@@ -36,6 +36,7 @@ final _smokeChildclassfromclassGetTypeId = __lib.catchArgumentError(() => __lib.
 
 
 
+// ignore: invalid_use_of_visible_for_testing_member
 class ChildClassFromClass$Impl extends ParentClass$Impl implements ChildClassFromClass {
 
   ChildClassFromClass$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
+++ b/gluecodium/src/test/resources/smoke/inheritance/output/dart/lib/src/smoke/child_class_with_imports.dart
@@ -33,6 +33,7 @@ final _smokeChildclasswithimportsGetTypeId = __lib.catchArgumentError(() => __li
   >('library_smoke_ChildClassWithImports_get_type_id'));
 
 
+// ignore: invalid_use_of_visible_for_testing_member
 class ChildClassWithImports$Impl extends ParentClassWithImports$Impl implements ChildClassWithImports {
 
   ChildClassWithImports$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/dart/lib/src/smoke/first_parent_is_class_class.dart
@@ -40,6 +40,7 @@ final _smokeFirstparentisclassclassGetTypeId = __lib.catchArgumentError(() => __
 
 
 
+// ignore: invalid_use_of_visible_for_testing_member
 class FirstParentIsClassClass$Impl extends ParentClass$Impl implements FirstParentIsClassClass {
 
   FirstParentIsClassClass$Impl(Pointer<Void> handle) : super(handle);

--- a/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
+++ b/gluecodium/src/test/resources/smoke/nesting/output/dart/lib/src/smoke/outer_class_with_inheritance.dart
@@ -38,6 +38,7 @@ final _smokeOuterclasswithinheritanceInnerclassReleaseHandle = __lib.catchArgume
 
 
 
+
 class OuterClassWithInheritance_InnerClass$Impl extends __lib.NativeBase implements OuterClassWithInheritance_InnerClass {
 
   OuterClassWithInheritance_InnerClass$Impl(Pointer<Void> handle) : super(handle);
@@ -242,6 +243,7 @@ final _smokeOuterclasswithinheritanceGetTypeId = __lib.catchArgumentError(() => 
 
 
 
+// ignore: invalid_use_of_visible_for_testing_member
 class OuterClassWithInheritance$Impl extends ParentClass$Impl implements OuterClassWithInheritance {
 
   OuterClassWithInheritance$Impl(Pointer<Void> handle) : super(handle);


### PR DESCRIPTION
----- Motivation -----
In order to allow users to mock static functions in classes the 'prototype'
approach was implemented in the past. It uses prototype class to redirect
static function calls.

A class with '$Impl' suffix is created as a prototype. It is annotated as
'visibleForTesting' and exported from the library.

The user may provide its own implementation in tests and this way redirect
the calls to the mock (after setting it as prototype).

Sadly, when a class is derived from the class, which has static methods, then
its '$Impl' derives from the '$Impl' of base class. This leads to linter warnings:
'invalid_use_of_visible_for_testing_member'.

----- Implemented solution -----
This change adds a comment, which disables linter warnings for derived '$Impl'
classes to remove the mentioned warnings from the generated code.