### PR TITLE
Implement boilerplate code required to support Kotlin generator

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -116,6 +116,61 @@ jobs:
           ./scripts/build-android-namerules --publish
         working-directory: functional-tests
 
+  android-kotlin:
+    name: Android-Kotlin
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            !*gluecodium*
+            !*lime-*
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Install GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: 8
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v1.7
+        with:
+          cmake-version: '3.19.3'
+      - name: Install ninja
+        run: sudo apt install -y ninja-build
+      - name: Install Android SDK
+        run: |
+          ANDROID_API_LEVEL=android-28
+          ANDROID_BUILD_TOOLS_VERSION=28.0.3
+          ANDROID_HOME=${HOME}/android-sdk-linux
+          PATH=${PATH}:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/cmdline-tools/latest/bin
+          mkdir -p "${ANDROID_HOME}/cmdline-tools"
+          wget -q "https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip" -O android-sdk-tools.zip
+          unzip -q android-sdk-tools.zip -d ${ANDROID_HOME}/cmdline-tools
+          mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest"
+          mkdir -p ~/.android
+          touch ~/.android/repositories.cfg
+          yes | sdkmanager --licenses
+          yes | sdkmanager "platforms;${ANDROID_API_LEVEL}" > /dev/null
+          yes | sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}" > /dev/null
+      - name: Build and run functional tests
+        run: |
+          export ANDROID_HOME=${HOME}/android-sdk-linux
+          export ANDROID_SDK_ROOT=${ANDROID_HOME}
+          export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools
+          ./scripts/build-android-kotlin-functional --publish --hostOnly
+        working-directory: functional-tests
+      - name: Clean build dir
+        run: ./scripts/clean
+        working-directory: functional-tests
+
   swift:
     name: Swift on Linux
     runs-on: ubuntu-20.04

--- a/cmake/modules/gluecodium/gluecodium/AddGenerateCommand.cmake
+++ b/cmake/modules/gluecodium/gluecodium/AddGenerateCommand.cmake
@@ -34,7 +34,7 @@ The general form of the command is::
   gluecodium_add_generate_command(
     <target>                        # The target to add custom build rules for.
     [GENERATORS <generator> ...]    # The list of source code generators.
-                                    # Known value are: cpp, swift, android, dart
+                                    # Known value are: cpp, swift, android, android-kotlin, dart
                                     # Usually at least two generators needs to be defined
                                     # the one for native code and another for platform,
                                     # for example android;cpp or swift;cpp

--- a/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
@@ -104,6 +104,31 @@ _gluecodium_define_target_property(
 )
 
 _gluecodium_define_target_property(
+  GLUECODIUM_KOTLIN_PACKAGE
+  BRIEF_DOCS "The base Kotlin package to use for generated Kotlin sources"
+  FULL_DOCS
+    "The base Kotlin package to use for generated Kotlin sources, for example \"com.my_company\"."
+    "This property is initialized by the value of the GLUECODIUM_KOTLIN_PACKAGE_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
+_gluecodium_define_target_property(
+  GLUECODIUM_KOTLIN_INTERNAL_PACKAGE
+  BRIEF_DOCS "The package to use for internal Kotlin code"
+  FULL_DOCS
+    "The subpackage to use for internal Kotlin code. This value is appended with separator '.' to a value passed with GLUECODIUM_KOTLIN_PACKAGE"
+    "This property is initialized by the value of the GLUECODIUM_KOTLIN_INTERNAL_PACKAGE_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
+_gluecodium_define_target_property(
+  GLUECODIUM_KOTLIN_NAMERULES
+  BRIEF_DOCS "The path to a file with name rules for Kotlin"
+  FULL_DOCS
+    "The path to a file with name rules for Kotlin."
+    ${_gluecodium_namerules_doc}
+    "This property is initialized by the value of the GLUECODIUM_KOTLIN_NAMERULES_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
+_gluecodium_define_target_property(
   GLUECODIUM_COPYRIGHT_HEADER
   BRIEF_DOCS "The path to file with copyright to add in generated source files"
   FULL_DOCS

--- a/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
+++ b/cmake/modules/gluecodium/gluecodium/TargetIncludeDirectories.cmake
@@ -74,6 +74,11 @@ function(gluecodium_get_target_include_directories _target)
                   "$<BUILD_INTERFACE:${_output_${_source_set_lower}_dir}/android/jni>")
     endif()
 
+    if(android-kotlin IN_LIST _generators)
+      list(APPEND _result_list_public
+                  "$<BUILD_INTERFACE:${_output_${_source_set_lower}_dir}/android-kotlin/jni>")
+    endif()
+
     if(dart IN_LIST _generators)
       list(APPEND _result_list_public
                   "$<BUILD_INTERFACE:${_output_${_source_set_lower}_dir}/dart/ffi>")
@@ -85,7 +90,7 @@ function(gluecodium_get_target_include_directories _target)
 
   endforeach()
 
-  if(android IN_LIST _generators)
+  if((android IN_LIST _generators) OR (android-kotlin IN_LIST _generators))
     # If we're not crosscompiling, we need to manually add JNI includes.
     if(NOT CMAKE_CROSSCOMPILING)
       find_package(JNI REQUIRED)

--- a/cmake/modules/gluecodium/gluecodium/details/InitVariablesWithUnitedFilePaths.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/InitVariablesWithUnitedFilePaths.cmake
@@ -26,6 +26,8 @@ macro(gluecodium_init_variables_with_united_file_paths name_suffix)
     set(GLUECODIUM_GENERATED_cpp_${_source_group} cpp/${name_suffix}_${_source_group}_glue.cpp)
     set(GLUECODIUM_GENERATED_jni_${_source_group}
         android/${name_suffix}_${_source_group}_jniglue.cpp)
+    set(GLUECODIUM_GENERATED_jni_kotlin_${_source_group}
+        android-kotlin/${name_suffix}_${_source_group}_jniglue.cpp)
     set(GLUECODIUM_GENERATED_cbridge_${_source_group}
         cbridge/${name_suffix}_${_source_group}_cglue.cpp)
     set(GLUECODIUM_GENERATED_cbridge_header_${_source_group}

--- a/cmake/modules/gluecodium/gluecodium/details/ListGeneratedFiles.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/ListGeneratedFiles.cmake
@@ -59,6 +59,10 @@ function(gluecodium_list_generated_files _target)
       list(APPEND _android_generated_files "${_unity_dir}/${GLUECODIUM_GENERATED_jni_${_group}}")
     endif()
 
+    if(android-kotlin IN_LIST _generators)
+      list(APPEND _android_kotlin_generated_files "${_unity_dir}/${GLUECODIUM_GENERATED_jni_kotlin_${_group}}")
+    endif()
+
     if(swift IN_LIST _generators)
       list(APPEND _cbridge_generated_files
                   "${_unity_dir}/${GLUECODIUM_GENERATED_cbridge_${_group}}")
@@ -76,11 +80,12 @@ function(gluecodium_list_generated_files _target)
     set(${_args_OUTPUT_ALL}
         ${_cpp_generated_files} ${_android_generated_files} ${_cbridge_generated_files}
         ${_cbridge_headers_generated_files} ${_swift_generated_files} ${_dart_generated_files}
+        ${_android_kotlin_generated_files}
         PARENT_SCOPE)
   endif()
 
   if(_args_OUTPUT_CPP)
-    set(${_args_OUTPUT_CPP} ${_cpp_generated_files} ${_android_generated_files}
+    set(${_args_OUTPUT_CPP} ${_cpp_generated_files} ${_android_generated_files} ${_android_kotlin_generated_files}
                             ${_cbridge_generated_files} ${_dart_generated_files} PARENT_SCOPE)
   endif()
 

--- a/cmake/modules/gluecodium/gluecodium/details/ReadRequiredProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/ReadRequiredProperties.cmake
@@ -67,6 +67,14 @@ function(gluecodium_read_required_properties _target)
     endif()
   endforeach()
 
+  if((android IN_LIST _gluecodium_generators) AND (android-kotlin IN_LIST _gluecodium_generators))
+    message(
+      FATAL_ERROR
+      "Both 'android' and 'android-kotlin' specified in list of generators. This may cause symbols clash for JNI bindings!"
+      " Currently, specifying only one of them is supported."
+    )
+  endif()
+
   if(_args_SOURCE_SETS)
     set(${_args_SOURCE_SETS} ${_gluecodium_source_sets} PARENT_SCOPE)
   endif()

--- a/cmake/modules/gluecodium/gluecodium/details/ReadRequiredProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/ReadRequiredProperties.cmake
@@ -41,7 +41,7 @@ function(gluecodium_read_required_properties _target)
     message(FATAL_ERROR "Specified target '${_target}' doesn't exist")
   endif()
 
-  set(GLUECODIUM_SUPPORTED_GENERATORS cpp android swift dart)
+  set(GLUECODIUM_SUPPORTED_GENERATORS cpp android android-kotlin swift dart)
 
   function(_read_required_property result _target property_name)
     get_target_property(_property_value ${_target} ${property_name})

--- a/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
@@ -140,6 +140,8 @@ function(_prepare_gluecodium_config_file file_path)
   _append_list_paths_option(input GLUECODIUM_LIME_SOURCES)
   _append_list_paths_option(auxinput GLUECODIUM_LIME_SOURCES_AUX)
 
+  _append_option(kotlinpackage GLUECODIUM_KOTLIN_PACKAGE)
+  _append_option(kotlinintpackage GLUECODIUM_KOTLIN_INTERNAL_PACKAGE)
   _append_option(javapackage GLUECODIUM_JAVA_PACKAGE)
   _append_option(intpackage GLUECODIUM_JAVA_INTERNAL_PACKAGE)
   _append_option(javanonnullannotation GLUECODIUM_JAVA_NONNULL_ANNOTATION)
@@ -153,6 +155,7 @@ function(_prepare_gluecodium_config_file file_path)
   _append_path_option(copyright GLUECODIUM_COPYRIGHT_HEADER)
   _append_path_option(cppnamerules GLUECODIUM_CPP_NAMERULES)
   _append_path_option(javanamerules GLUECODIUM_JAVA_NAMERULES)
+  _append_path_option(kotlinnamerules GLUECODIUM_KOTLIN_NAMERULES)
   _append_path_option(swiftnamerules GLUECODIUM_SWIFT_NAMERULES)
   _append_path_option(dartnamerules GLUECODIUM_DART_NAMERULES)
 
@@ -249,6 +252,12 @@ function(_collect_all_files_in_single_compilation_units)
     # Include all conversion headers first, so all later generic conversions relying on
     # specialization have all these defined
     _include_all(jni "android/jni/*_Conversion.h" "android/jni/*.cpp")
+  endif()
+
+  if(android-kotlin IN_LIST GLUECODIUM_GENERATORS)
+      # Include all conversion headers first, so all later generic conversions relying on
+      # specialization have all these defined
+      _include_all(jni_kotlin "android-kotlin/jni/*_Conversion.h" "android-kotlin/jni/*.cpp")
   endif()
 
   if(swift IN_LIST GLUECODIUM_GENERATORS)

--- a/functional-tests/build.gradle
+++ b/functional-tests/build.gradle
@@ -24,7 +24,19 @@ ext {
     minSdkVersion = 24
     cmakeVersion = '3.19.0+'
 
-    buildRoot = "${rootProject.projectDir}/build-android"
+    isAndroidKotlinBuild = {
+        return project.hasProperty("android-kotlin")
+    }
+
+    getAndroidBuildVariant = {
+        if (isAndroidKotlinBuild()) {
+            return "android-kotlin"
+        } else {
+            return "android"
+        }
+    }
+
+    buildRoot = "${rootProject.projectDir}/build-${getAndroidBuildVariant()}"
     buildNativeRoot = "${buildRoot}/cpp"
     generatedDir = "${buildRoot}/generated"
 

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -74,7 +74,7 @@ function(feature feature_name)
     set(FUNCTIONAL_LIME_SOURCES "${FUNCTIONAL_LIME_SOURCES};${lime_sources}" PARENT_SCOPE)
 endfunction()
 
-feature(Strings cpp android swift dart SOURCES
+feature(Strings cpp android android-kotlin swift dart SOURCES
     input/src/cpp/StaticStringMethods.cpp
     input/src/cpp/StringsWithCstring.cpp
     input/src/cpp/CppRefReturnType.cpp
@@ -99,7 +99,7 @@ feature(Blob cpp android swift dart SOURCES
     input/lime/StaticByteArrayMethods.lime
 )
 
-feature(BuiltinTypes cpp android swift dart SOURCES
+feature(BuiltinTypes cpp android android-kotlin swift dart SOURCES
     input/src/cpp/StaticBooleanMethods.cpp
     input/src/cpp/StaticFloatDoubleMethods.cpp
     input/src/cpp/StaticIntMethods.cpp
@@ -109,7 +109,7 @@ feature(BuiltinTypes cpp android swift dart SOURCES
     input/lime/StaticIntMethods.lime
 )
 
-feature(Classes cpp android swift dart SOURCES
+feature(Classes cpp android android-kotlin swift dart SOURCES
     input/src/cpp/Instances.h
     input/src/cpp/Instances.cpp
     input/src/cpp/InstancesFactory.cpp
@@ -117,7 +117,7 @@ feature(Classes cpp android swift dart SOURCES
     input/lime/Instances.lime
 )
 
-feature(Interfaces cpp android swift dart SOURCES
+feature(Interfaces cpp android android-kotlin swift dart SOURCES
     input/src/cpp/Interfaces.h
     input/src/cpp/Interfaces.cpp
     input/src/cpp/InterfacesFactory.cpp
@@ -165,7 +165,7 @@ feature(TypeDefs cpp android swift dart SOURCES
     input/lime/StaticTypedef.lime
 )
 
-feature(Enums cpp android swift dart SOURCES
+feature(Enums cpp android android-kotlin swift dart SOURCES
     input/src/cpp/Enums.cpp
     input/src/cpp/EnumsTypeCollection.cpp
 
@@ -175,7 +175,7 @@ feature(Enums cpp android swift dart SOURCES
     input/lime/EnumsTypeCollection.lime
 )
 
-feature(Properties cpp android swift dart SOURCES
+feature(Properties cpp android android-kotlin swift dart SOURCES
     input/src/cpp/AttributesInterfaceImpl.h
     input/src/cpp/AttributesInterfaceImpl.cpp
     input/src/cpp/AttributesInterfaceFactory.cpp
@@ -382,7 +382,7 @@ feature(Dates cpp android swift dart SOURCES
     input/lime/DateDefaults.lime
 )
 
-feature(Durations cpp android swift dart SOURCES
+feature(Durations cpp android android-kotlin swift dart SOURCES
     input/src/cpp/Durations.cpp
 
     input/lime/Durations.lime
@@ -443,7 +443,7 @@ feature(Nesting cpp android swift dart SOURCES
     input/lime/NestedInheritance.lime
 )
 
-feature(Lambdas cpp android swift dart SOURCES
+feature(Lambdas cpp android android-kotlin swift dart SOURCES
     input/lime/Lambdas.lime
 
     input/src/cpp/Lambdas.cpp
@@ -537,6 +537,8 @@ set_target_properties(functional_bindings PROPERTIES
     GLUECODIUM_JAVA_INTERNAL_PACKAGE lorem.ipsum
     GLUECODIUM_JAVA_NONNULL_ANNOTATION androidx.annotation.NonNull
     GLUECODIUM_JAVA_NULLABLE_ANNOTATION androidx.annotation.Nullable
+    GLUECODIUM_KOTLIN_PACKAGE com.here.android
+    GLUECODIUM_KOTLIN_INTERNAL_PACKAGE lorem.ipsum
     GLUECODIUM_CPP_INTERNAL_NAMESPACE "lorem_ipsum::test"
     GLUECODIUM_CBRIDGE_INTERNAL_PREFIX "libfunctional_"
     GLUECODIUM_DART_LIBRARY_NAME "functional"

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/RobolectricApplication.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/RobolectricApplication.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.android
+
+import android.annotation.SuppressLint
+import android.app.Application
+import android.util.Log
+import com.here.android.lorem.ipsum.NativeBase
+import com.here.gluecodium.test.functional.BuildConfig
+import org.powermock.reflect.Whitebox
+import org.robolectric.shadows.ShadowLog
+import java.io.File
+
+class RobolectricApplication : Application() {
+    private val TAG: String = RobolectricApplication::class.java.getSimpleName()
+
+    override fun onCreate() {
+        super.onCreate()
+
+        if (isFirstTime) {
+            isFirstTime = false
+
+            loadNativeLibraries();
+            Runtime.getRuntime().addShutdownHook(Thread{
+                try {
+                    Whitebox.invokeMethod(NativeBase::class.java, "cleanUpQueue")
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            })
+        }
+    }
+
+    /**
+     * Separate method to load libraries in case you want to subclass and can't load in onCreate().
+     */
+    @SuppressLint("UnsafeDynamicallyLoadedCode")
+    private fun loadNativeLibraries() {
+        val appLibraryPath: java.io.File = java.io.File(BuildConfig.NATIVE_LIB_HOST_DIR)
+
+        Log.d(TAG, "loadNativeLibraries: Using app library path: " + appLibraryPath)
+
+        val files = appLibraryPath.listFiles {
+            dir, name -> name.contains(".so") || name.endsWith(".dylib")
+        }
+
+        for (sharedObject in files)  {
+            Log.i(TAG, "loadNativeLibraries: Loading app library '" + sharedObject.getName() + "'...")
+            System.load(sharedObject.getAbsolutePath())
+        }
+    }
+
+    companion object {
+        private var isFirstTime: Boolean = true
+
+        init {
+            ShadowLog.stream = System.out // Android logcat output.
+        }
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import org.junit.Assert.assertEquals
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class AttributesInterfaceTest {
+    private val delta = 0.00000001
+    private val attributes: AttributesInterface = AttributesInterfaceFactory.createAttributesInterface()
+
+    @org.junit.Test
+    fun setGetBuiltInTypeAttribute() {
+        val value: Long = 42
+        attributes.builtInTypeAttribute = value
+
+        val result: Long = attributes.builtInTypeAttribute
+        assertEquals(value, result)
+    }
+
+    @org.junit.Test
+    fun setGetStructAttribute() {
+        val structValue = AttributesInterface.ExampleStruct()
+        structValue.value = 2.71
+
+        attributes.structAttribute = structValue
+
+        val result = attributes.structAttribute
+        assertEquals(structValue.value, result.value, delta)
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class AttributesTest {
+    private val deltaDouble = 0.00000001
+    private val deltaFloat = 0.00000001f
+    private val attributes: Attributes = Attributes()
+
+    @org.junit.Test
+    fun setGetBuiltInTypeAttribute() {
+        attributes.builtInTypeAttribute = 42L
+        assertEquals(42L, attributes.builtInTypeAttribute)
+    }
+
+    @org.junit.Test
+    fun getReadonlyAttribute() {
+        assertEquals(3.14f, attributes.readonlyAttribute, deltaFloat)
+    }
+
+    @org.junit.Test
+    fun setGetStructAttribute() {
+        val expectedStruct = Attributes.ExampleStruct(2.71, listOf())
+        attributes.structAttribute = expectedStruct
+
+        val result = attributes.structAttribute
+        assertEquals(expectedStruct.value, result.value, deltaDouble)
+        assertEquals(expectedStruct.intValue, result.intValue)
+    }
+
+
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/DurationsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/DurationsTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.lorem.ipsum.time.Duration
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class DurationsTest {
+
+    @org.junit.Test
+    fun durationSecondsRoundTrip() {
+        val duration: Duration = Duration.ofSeconds(42)
+        val result: Duration = DurationSeconds.increaseDuration(duration)
+
+        assertEquals(43, result.getSeconds())
+        assertEquals(0, result.getNano())
+    }
+
+    @org.junit.Test
+    fun durationSecondsRoundTripRoundedDown() {
+        val duration: Duration = Duration.ofMillis(42042)
+
+        val result: Duration = DurationSeconds.increaseDuration(duration)
+
+        assertEquals(43, result.getSeconds())
+        assertEquals(0, result.getNano())
+    }
+
+    @org.junit.Test
+    fun durationSecondsRoundTripRoundedUp() {
+        val duration: Duration = Duration.ofMillis(42840)
+
+        val result: Duration = DurationSeconds.increaseDuration(duration)
+
+        assertEquals(44, result.getSeconds())
+        assertEquals(0, result.getNano())
+    }
+
+    @org.junit.Test
+    fun nullableDurationSecondsRoundTrip() {
+        val duration: Duration = Duration.ofSeconds(42)
+
+        val result: Duration? = DurationSeconds.increaseDurationMaybe(duration)
+
+        assertEquals(43L, result?.getSeconds())
+        assertEquals(0, result?.getNano())
+    }
+
+    @org.junit.Test
+    fun nullableDurationSecondsRoundTripNull() {
+        val result: Duration? = DurationSeconds.increaseDurationMaybe(null)
+
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun durationSecondsStructRoundTrip() {
+        val struct: DurationSeconds.DurationStruct =
+            DurationSeconds.DurationStruct(Duration.ofSeconds(42))
+
+        val result: DurationSeconds.DurationStruct = DurationSeconds.durationStructRoundTrip(struct)
+
+        assertEquals(42, result.durationField.getSeconds())
+        assertEquals(0, result.durationField.getNano())
+    }
+
+    @org.junit.Test
+    fun durationMillisecondsRoundTrip() {
+        val duration: Duration = Duration.ofMillis(42042)
+
+        val result: Duration = DurationMilliseconds.increaseDuration(duration)
+
+        assertEquals(43, result.getSeconds())
+        assertEquals(42000000, result.getNano())
+    }
+
+    @org.junit.Test
+    fun durationMillisecondsRoundTripRoundedDown() {
+        val duration: Duration = Duration.ofNanos(42042071000L)
+
+        val result: Duration = DurationMilliseconds.increaseDuration(duration)
+
+        assertEquals(43, result.getSeconds())
+        assertEquals(42000000, result.getNano())
+    }
+
+    @org.junit.Test
+    fun durationMillisecondsRoundTripRoundedUp() {
+        val duration: Duration = Duration.ofNanos(42042710000L)
+
+        val result: Duration = DurationMilliseconds.increaseDuration(duration)
+
+        assertEquals(43, result.getSeconds())
+        assertEquals(43000000, result.getNano())
+    }
+
+    @org.junit.Test
+    fun nullableDurationMillisecondsRoundTrip() {
+        val duration: Duration = Duration.ofMillis(42042)
+
+        val result: Duration? = DurationMilliseconds.increaseDurationMaybe(duration)
+
+        assertEquals(43L, result?.getSeconds())
+        assertEquals(42000000, result?.getNano())
+    }
+
+    @org.junit.Test
+    fun nullableDurationMillisecondsRoundTripNull() {
+        val result: Duration? = DurationMilliseconds.increaseDurationMaybe(null)
+
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun durationMillisecondsStructRoundTrip() {
+        val struct: DurationMilliseconds.DurationStruct =
+            DurationMilliseconds.DurationStruct(Duration.ofMillis(42042))
+
+        val result: DurationMilliseconds.DurationStruct =
+            DurationMilliseconds.durationStructRoundTrip(struct)
+
+        assertEquals(42, result.durationField.getSeconds())
+        assertEquals(42000000, result.durationField.getNano())
+    }
+
+    @org.junit.Test
+    fun durationCallOverloadedFunction() {
+        val result: String = DurationOverloads.durationFunction(Duration.ofSeconds(42))
+
+        assertEquals("duration overload", result)
+    }
+
+    @org.junit.Test
+    fun durationDefaults() {
+        val javaDefaults: DurationDefaults = DurationDefaults()
+        val cppDefaults: DurationDefaults = DurationDefaults.getCppDefaults()
+
+        assertEquals(cppDefaults.dayz, javaDefaults.dayz)
+        assertEquals(cppDefaults.hourz, javaDefaults.hourz)
+        assertEquals(cppDefaults.minutez, javaDefaults.minutez)
+        assertEquals(cppDefaults.secondz, javaDefaults.secondz)
+        assertEquals(cppDefaults.milliz, javaDefaults.milliz)
+        assertEquals(cppDefaults.microz, javaDefaults.microz)
+        assertEquals(cppDefaults.nanoz, javaDefaults.nanoz)
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/EnumsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/EnumsTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class EnumsTest {
+    @org.junit.Test
+    fun flipEnumTC() {
+        val errorEnum: InternalErrorTypeCollection = InternalErrorTypeCollection.ERROR_FATAL
+        assertEquals(
+            InternalErrorTypeCollection.ERROR_NONE,
+            EnumsTypeCollectionMethods.flipEnumValue(errorEnum)
+        )
+    }
+
+    @org.junit.Test
+    fun flipEnum() {
+        val errorEnum: Enums.InternalError = Enums.InternalError.ERROR_FATAL
+        assertEquals(Enums.InternalError.ERROR_NONE, Enums.flipEnumValue(errorEnum))
+    }
+
+    @org.junit.Test
+    fun extractEnumFromStruct() {
+        val errorStruct = Enums.ErrorStruct()
+        errorStruct.type = Enums.InternalError.ERROR_NONE
+        assertEquals(Enums.InternalError.ERROR_FATAL, Enums.extractEnumFromStruct(errorStruct))
+    }
+
+    @org.junit.Test
+    fun extractEnumFromStructTC() {
+        val errorStruct: ErrorStructTypeCollection = ErrorStructTypeCollection()
+        errorStruct.type = InternalErrorTypeCollection.ERROR_NONE
+        assertEquals(
+            InternalErrorTypeCollection.ERROR_FATAL,
+            EnumsTypeCollectionMethods.extractEnumFromStruct(errorStruct)
+        )
+    }
+
+    @org.junit.Test
+    fun createStructWithEnumInside() {
+        val message: String = "myMessage"
+        val result: Enums.ErrorStruct =
+            Enums.createStructWithEnumInside(Enums.InternalError.ERROR_FATAL, message)
+
+        assertEquals(Enums.InternalError.ERROR_NONE, result.type)
+        assertEquals(message, result.message)
+    }
+
+    @org.junit.Test
+    fun createStructWithEnumInsideTC() {
+        val message: String = "myMessage"
+        val result: ErrorStructTypeCollection =
+            EnumsTypeCollectionMethods.createStructWithEnumInside(
+                InternalErrorTypeCollection.ERROR_FATAL, message
+            )
+
+        assertEquals(InternalErrorTypeCollection.ERROR_NONE, result.type)
+        assertEquals(message, result.message)
+    }
+
+    @org.junit.Test
+    fun compareAliasInJava() {
+        assertEquals(EnumWithAlias.ONE, EnumWithAlias.FIRST)
+    }
+
+    @org.junit.Test
+    fun compareDoubleAliasInJava() {
+        assertEquals(EnumWithAlias.ONE, EnumWithAlias.THE_BEST)
+    }
+
+    @org.junit.Test
+    fun compareAliasFromCpp() {
+        val value: EnumWithAlias = UseEnumWithAlias.getFirst()
+
+        assertEquals(EnumWithAlias.ONE, value)
+    }
+
+    @org.junit.Test
+    fun compareAliasToTargetCpp() {
+        val value: EnumWithAlias = EnumWithAlias.FIRST
+
+        val result: Boolean = UseEnumWithAlias.compareToOne(value)
+
+        assertTrue(result)
+    }
+
+    @org.junit.Test
+    fun compareAliasToAliasCpp() {
+        val value: EnumWithAlias = EnumWithAlias.FIRST
+
+        val result: Boolean = UseEnumWithAlias.compareToFirst(value)
+
+        assertTrue(result)
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InstancesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InstancesTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class InstancesTest {
+    @org.junit.Test
+    fun setSameTypeInstances() {
+        val instanceOne: SimpleInstantiableOne = InstancesFactory.createSimpleInstantiableOne()
+        val instanceTwo: SimpleInstantiableOne = InstancesFactory.createSimpleInstantiableOne()
+        val nestedInstanceOne: NestedInstantiableOne = InstancesFactory.createNestedInstantiableOne()
+        instanceOne.setStringValue(INSTANCE_ONE_STRING)
+        instanceTwo.setStringValue(INSTANCE_TWO_STRING)
+
+        nestedInstanceOne.setSameTypeInstances(instanceOne, instanceTwo)
+
+        val resultOne: SimpleInstantiableOne = nestedInstanceOne.getInstanceOne()
+        val resultTwo: SimpleInstantiableOne = nestedInstanceOne.getInstanceTwo()
+        assertEquals(INSTANCE_ONE_STRING, resultOne.getStringValue())
+        assertEquals(INSTANCE_TWO_STRING, resultTwo.getStringValue())
+    }
+
+    @org.junit.Test
+    fun setSameTypeInstances_identicalInstances() {
+        val instanceOne: SimpleInstantiableOne = InstancesFactory.createSimpleInstantiableOne()
+        val nestedInstanceOne: NestedInstantiableOne = InstancesFactory.createNestedInstantiableOne()
+        instanceOne.setStringValue(INSTANCE_ONE_STRING)
+
+        nestedInstanceOne.setSameTypeInstances(instanceOne, instanceOne)
+
+        val resultOne: SimpleInstantiableOne = nestedInstanceOne.getInstanceOne()
+        val resultTwo: SimpleInstantiableOne = nestedInstanceOne.getInstanceTwo()
+        assertEquals(INSTANCE_ONE_STRING, resultOne.getStringValue())
+        assertEquals(INSTANCE_ONE_STRING, resultTwo.getStringValue())
+    }
+
+    @org.junit.Test
+    fun setMultipleTypeInstances() {
+        val simpleInstanceOne: SimpleInstantiableOne = InstancesFactory.createSimpleInstantiableOne()
+        val otherInstanceOne: SimpleInstantiableOne = InstancesFactory.createSimpleInstantiableOne()
+        val simpleInstanceTwo: SimpleInstantiableTwo = InstancesFactory.createSimpleInstantiableTwo()
+        val nested: NestedInstantiableOne = InstancesFactory.createNestedInstantiableOne()
+        val nestedInstantiableTwo: NestedInstantiableTwo = InstancesFactory.createNestedInstantiableTwo()
+        simpleInstanceOne.setStringValue(INSTANCE_ONE_STRING)
+        simpleInstanceTwo.setStringValue(INSTANCE_TWO_STRING)
+        otherInstanceOne.setStringValue(INSTANCE_OTHER_STRING)
+        nested.setSameTypeInstances(simpleInstanceOne, otherInstanceOne)
+
+        nestedInstantiableTwo.setMultipleTypeInstances(simpleInstanceOne, simpleInstanceTwo, nested)
+
+        assertEquals(INSTANCE_ONE_STRING, nestedInstantiableTwo.getInstantiableOne().getStringValue())
+        assertEquals(INSTANCE_TWO_STRING, nestedInstantiableTwo.getInstantiableTwo().getStringValue())
+        val nestedInstantiable: NestedInstantiableOne = nestedInstantiableTwo.getNestedInstantiable()
+        assertEquals(INSTANCE_ONE_STRING, nestedInstantiable.getInstanceOne().getStringValue())
+        assertEquals(INSTANCE_OTHER_STRING, nestedInstantiable.getInstanceTwo().getStringValue())
+    }
+
+    @org.junit.Test
+    fun setSelfInstantiable() {
+        val simpleOne: SimpleInstantiableOne = InstancesFactory.createSimpleInstantiableOne()
+        simpleOne.setStringValue(INSTANCE_ONE_STRING)
+
+        val simpleTwo: SimpleInstantiableTwo = InstancesFactory.createSimpleInstantiableTwo()
+        simpleTwo.setStringValue(INSTANCE_TWO_STRING)
+
+        val nestedOne: NestedInstantiableOne = InstancesFactory.createNestedInstantiableOne()
+        val nestedTwo: NestedInstantiableTwo = InstancesFactory.createNestedInstantiableTwo()
+        nestedTwo.setMultipleTypeInstances(simpleOne, simpleTwo, nestedOne)
+        nestedTwo.setSelfInstantiable(nestedTwo)
+
+        val selfInstantiable: NestedInstantiableTwo = nestedTwo.getSelfInstantiable()
+        assertEquals(INSTANCE_ONE_STRING, selfInstantiable.getInstantiableOne().getStringValue())
+        assertEquals(INSTANCE_TWO_STRING, selfInstantiable.getInstantiableTwo().getStringValue())
+    }
+
+    companion object {
+        private const val INSTANCE_ONE_STRING: String = "simpleInstanceOne"
+        private const val INSTANCE_TWO_STRING: String = "simpleInstanceTwo"
+        private const val INSTANCE_OTHER_STRING: String = "simpleInstanceOther"
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InterfacesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InterfacesTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class InterfacesTest {
+
+    @org.junit.Test
+    fun setSameTypeInterfaces() {
+        val instanceOne: SimpleInterfaceOne = InterfacesFactory.createSimpleInterfaceOne()
+        instanceOne.setStringValue(INSTANCE_ONE_STRING)
+
+        val instanceTwo: SimpleInterfaceOne = InterfacesFactory.createSimpleInterfaceOne()
+        instanceTwo.setStringValue(INSTANCE_TWO_STRING)
+
+        val nestedInterfaceOne: NestedInterfaceOne = InterfacesFactory.createNestedInterfaceOne()
+        nestedInterfaceOne.setSameTypeInterfaces(instanceOne, instanceTwo)
+
+        val resultOne: SimpleInterfaceOne = nestedInterfaceOne.getInterfaceOne()
+        val resultTwo: SimpleInterfaceOne = nestedInterfaceOne.getInterfaceTwo()
+        assertEquals(INSTANCE_ONE_STRING, resultOne.getStringValue())
+        assertEquals(INSTANCE_TWO_STRING, resultTwo.getStringValue())
+    }
+
+    @org.junit.Test
+    fun setSameTypeInterfaces_identicalInterface() {
+        val instanceOne: SimpleInterfaceOne = InterfacesFactory.createSimpleInterfaceOne()
+        instanceOne.setStringValue(INSTANCE_ONE_STRING)
+
+        val nestedInterfaceOne: NestedInterfaceOne = InterfacesFactory.createNestedInterfaceOne()
+        nestedInterfaceOne.setSameTypeInterfaces(instanceOne, instanceOne)
+
+        val resultOne: SimpleInterfaceOne = nestedInterfaceOne.getInterfaceOne()
+        val resultTwo: SimpleInterfaceOne = nestedInterfaceOne.getInterfaceTwo()
+        assertEquals(INSTANCE_ONE_STRING, resultOne.getStringValue())
+        assertEquals(INSTANCE_ONE_STRING, resultTwo.getStringValue())
+    }
+
+    @org.junit.Test
+    fun setMultipleTypeInterface() {
+        val simpleInterfaceOne: SimpleInterfaceOne = InterfacesFactory.createSimpleInterfaceOne()
+        val otherInterfaceOne: SimpleInterfaceOne = InterfacesFactory.createSimpleInterfaceOne()
+        val simpleInterfaceTwo: SimpleInterfaceTwo = InterfacesFactory.createSimpleInterfaceTwo()
+        val nested: NestedInterfaceOne = InterfacesFactory.createNestedInterfaceOne()
+        val nestedInterfaceTwo: NestedInterfaceTwo = InterfacesFactory.createNestedInterfaceTwo()
+        simpleInterfaceOne.setStringValue(INSTANCE_ONE_STRING)
+        simpleInterfaceTwo.setStringValue(INSTANCE_TWO_STRING)
+        otherInterfaceOne.setStringValue(INSTANCE_OTHER_STRING)
+        nested.setSameTypeInterfaces(simpleInterfaceOne, otherInterfaceOne)
+
+        nestedInterfaceTwo.setMultipleTypeInterfaces(simpleInterfaceOne, simpleInterfaceTwo, nested)
+
+        assertEquals(INSTANCE_ONE_STRING, nestedInterfaceTwo.getInterfaceOne().getStringValue())
+        assertEquals(INSTANCE_TWO_STRING, nestedInterfaceTwo.getInterfaceTwo().getStringValue())
+
+        val nestedInterface: NestedInterfaceOne = nestedInterfaceTwo.getNestedInterface()
+        assertEquals(INSTANCE_ONE_STRING, nestedInterface.getInterfaceOne().getStringValue())
+        assertEquals(INSTANCE_OTHER_STRING, nestedInterface.getInterfaceTwo().getStringValue())
+    }
+
+    companion object {
+        private val INSTANCE_ONE_STRING: String = "simpleInterfaceOne"
+        private val INSTANCE_TWO_STRING: String = "simpleInterfaceTwo"
+        private val INSTANCE_OTHER_STRING: String = "simpleInstanceOther"
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/LambdasTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/LambdasTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class LambdasTest {
+
+    @org.junit.Test
+    fun callCppLambdaInJava() {
+        val result: String = Lambdas.getConcatenator(">.<").apply("foo", "bar")
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun callJavaLambdaInCpp() {
+        val delimiter: String = ">.<"
+        val result: String =
+            Lambdas.concatenate("foo", "bar", { s1: String, s2: String -> s1 + delimiter + s2 })
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun capturingRoundtrip() {
+        val concatenator: Lambdas.Concatenator = Lambdas.Concatenator { s1: String, s2: String -> s1 + s2 }
+        val tricatenator: Lambdas.Tricatenator = Lambdas.composeConcatenators(concatenator, concatenator)
+        val result: String = tricatenator.apply("foo", ">.<", "bar")
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun callConcatenateList() {
+        val strings: List<String> = mutableListOf<String>("foo", ">.<", "bar")
+        val concatenator: Lambdas.Concatenator = Lambdas.Concatenator { s1: String, s2: String -> s1 + s2 }
+        val concatenators: List<Lambdas.Concatenator> =
+            java.util.Arrays.asList<Lambdas.Concatenator>(concatenator, concatenator)
+        val result: String = Lambdas.concatenateList(strings, concatenators)
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun callCppLambdaInStructInJava() {
+        val result: String = Lambdas.getConcatenatorInStruct(">.<").concatenator.apply("foo", "bar")
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun callJavaLambdaInStructInCpp() {
+        val delimiter: String = ">.<"
+        val holder: Lambdas.LambdaHolder =
+            Lambdas.LambdaHolder({ s1: String, s2: String -> s1 + delimiter + s2 })
+        val result: String = Lambdas.concatenateInStruct("foo", "bar", holder)
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun callNullableCppLambdaInJava() {
+        val result: String? = Lambdas.getConcatenatorOrNull(">.<")?.apply("foo", "bar")
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun getNullCppLambdaInJava() {
+        val result: Lambdas.Concatenator? = Lambdas.getConcatenatorOrNull(null)
+
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun callNullableJavaLambdaInCpp() {
+        val delimiter: String = ">.<"
+        val result: String? =
+            Lambdas.concatenateOrNot("foo", "bar", { s1: String, s2: String -> s1 + delimiter + s2 })
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun callNullableJavaLambdaInCppWithNull() {
+        val result: String? = Lambdas.concatenateOrNot("foo", "bar", null)
+
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun setGetLambdaProperty() {
+        Lambdas.realConcatenator = Lambdas.getConcatenator(">.<")
+        val result: String = Lambdas.realConcatenator.apply("foo", "bar")
+
+        assertEquals("foo>.<bar", result)
+    }
+
+    @org.junit.Test
+    fun callCppNullableLambdaInJavaWithValue() {
+        val result: StandaloneProducer? = Lambdas.getNullableConfuser().apply("foo")
+
+        assertEquals("foo", result?.apply())
+    }
+
+    @org.junit.Test
+    fun callCppNullableLambdaInJavaWithNull() {
+        val result: StandaloneProducer? = Lambdas.getNullableConfuser().apply(null)
+
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun callJavaNullableLambdaInCppWithValue() {
+        val confuser: Lambdas.NullableConfuser = Lambdas.NullableConfuser { s1: String? ->
+            if (s1 != null) {
+                StandaloneProducer { s1 }
+            } else null
+        }
+        val result: StandaloneProducer? = Lambdas.applyNullableConfuser(confuser, "foo")
+
+        assertEquals("foo", result?.apply())
+    }
+
+    @org.junit.Test
+    fun callJavaNullableLambdaInCppWithNull() {
+        val confuser: Lambdas.NullableConfuser = Lambdas.NullableConfuser { s1: String? ->
+            if (s1 != null) {
+                StandaloneProducer { s1 }
+            } else null
+        }
+        val result: StandaloneProducer? = Lambdas.applyNullableConfuser(confuser, null)
+
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun callJavaOverloadedLambdaInCpp() {
+        val lambda: OverloadedLambda = OverloadedLambda { value: Int -> value.toString() }
+        val result: String = CallOverloadedLambda.invokeOverloadedLambda(lambda, 42)
+
+        assertEquals("42", result)
+    }
+
+    @org.junit.Test
+    fun callJavaLambdaFromCppForLambdaDefinedInStruct() {
+        val callback: StructWithLambda.LambdaCallback = StructWithLambda.LambdaCallback { arg: String? -> arg }
+        val result: String? = StructWithLambda.invokeCallback(callback)
+
+        assertEquals("some callback argument", result)
+    }
+
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticBooleanMethodsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticBooleanMethodsTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class StaticBooleanMethodsTest {
+    @org.junit.Test
+    fun returnInvertedBoolean_True() {
+        assertFalse(StaticBooleanMethods.returnInvertedBoolean(true))
+    }
+
+    @org.junit.Test
+    fun returnInvertedBoolean_booleanAndReturnsFalse() {
+        assertFalse(StaticBooleanMethods.returnAndBoolean(true, false))
+    }
+
+    @org.junit.Test
+    fun returnInvertedBoolean_booleanAndReturnsTrue() {
+        assertTrue(StaticBooleanMethods.returnAndBoolean(true, true))
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticFloatDoubleMethodsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticFloatDoubleMethodsTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class StaticFloatDoubleMethodsTest {
+    private val deltaFloat = 0.0000000001f
+    private val deltaDouble = 0.0000000001
+
+    @org.junit.Test
+    fun returnIncrementedFloat_simpleCase() {
+        assertEquals(2.5f, StaticFloatDoubleMethods.returnIncrementedFloat(1.5f), deltaFloat)
+    }
+
+    @org.junit.Test
+    fun sumTwoFloats_simpleCase() {
+        assertEquals(5.0f, StaticFloatDoubleMethods.sumTwoFloats(1.5f, 3.5f), deltaFloat)
+    }
+
+    @org.junit.Test
+    fun returnFloat_notANumber() {
+        assertTrue(StaticFloatDoubleMethods.returnFloat(Float.NaN).isNaN())
+    }
+
+    @org.junit.Test
+    fun returnFloat_maxValue() {
+        assertEquals(Float.MAX_VALUE, StaticFloatDoubleMethods.returnFloat(Float.MAX_VALUE), deltaFloat)
+    }
+
+    @org.junit.Test
+    fun returnFloat_minValue() {
+        assertEquals(Float.MIN_VALUE, StaticFloatDoubleMethods.returnFloat(Float.MIN_VALUE), deltaFloat)
+    }
+
+    @org.junit.Test
+    fun returnIncrementedDouble_simpleCase() {
+        assertEquals(2.5, StaticFloatDoubleMethods.returnIncrementedDouble(1.5), deltaDouble)
+    }
+
+    @org.junit.Test
+    fun sumTwoDoubles() {
+        assertEquals(5.0, StaticFloatDoubleMethods.sumTwoDoubles(1.5, 3.5), deltaDouble)
+    }
+
+    @org.junit.Test
+    fun nanDoubleValue() {
+        assertTrue(StaticFloatDoubleMethods.returnDouble(Double.NaN).isNaN())
+    }
+
+    @org.junit.Test
+    fun maxDoubleValue() {
+        assertEquals(Double.MAX_VALUE, StaticFloatDoubleMethods.returnDouble(Double.MAX_VALUE), deltaDouble)
+    }
+
+    @org.junit.Test
+    fun minDoubleValue() {
+        assertEquals(Double.MIN_VALUE, StaticFloatDoubleMethods.returnDouble(Double.MIN_VALUE), deltaDouble)
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticIntMethodsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticIntMethodsTest.kt
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class StaticIntMethodsTest {
+    @org.junit.Test
+    fun returnNextNumberInt8() {
+        // Arrange, act
+        val actual: Byte = StaticIntMethods.returnNextNumberInt8(115.toByte())
+
+        // Assert
+        assertEquals(116, actual.toInt())
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersInt8() {
+        // Arrange
+        val firstByte: Byte = 50
+        val secondByte: Byte = 60
+
+        // Act
+        val actual: Byte = StaticIntMethods.sumTwoNumbersInt8(firstByte, secondByte)
+
+        // Assert
+        assertEquals(firstByte + secondByte, actual.toInt())
+    }
+
+    @org.junit.Test
+    fun returnPrimeInt8() {
+        // Arrange, act, assert
+        assertEquals(2.toByte(), StaticIntMethods.returnPrimeInt8())
+    }
+
+    @org.junit.Test
+    fun returnNextNumberUint8() {
+        // Arrange
+        val number: Short = 200
+        val expected: Short = 201
+
+        // Act
+        val actual: Short = StaticIntMethods.returnNextNumberUint8(number)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersUint8() {
+        // Arrange
+        val firstNumber: Short = 160
+        val secondNumber: Short = 80
+        val expected: Short = (firstNumber + secondNumber).toShort()
+
+        // Act
+        val actual: Short = StaticIntMethods.sumTwoNumbersUint8(firstNumber, secondNumber)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun returnPrimeUint8() {
+        // Arrange, act, assert
+        assertEquals(131.toShort(), StaticIntMethods.returnPrimeUint8())
+    }
+
+    @org.junit.Test
+    fun returnNextNumberInt16() {
+        // Arrange
+        val number: Short = 2000
+        val expected: Short = 2001
+
+        // Act
+        val actual: Short = StaticIntMethods.returnNextNumberInt16(number)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersInt16() {
+        // Arrange
+        val firstNumber: Short = 1600
+        val secondNumber: Short = 800
+        val expected: Long = (firstNumber + secondNumber).toLong()
+
+        // Act
+        val actual: Short = StaticIntMethods.sumTwoNumbersInt16(firstNumber, secondNumber)
+
+        // Assert
+        assertEquals(expected, actual.toLong())
+    }
+
+    @org.junit.Test
+    fun returnPrimeInt16() {
+        // Arrange, act, assert
+        assertEquals(257.toShort(), StaticIntMethods.returnPrimeInt16())
+    }
+
+    @org.junit.Test
+    fun returnNextNumberUint16() {
+        // Arrange
+        val number: Int = 40000
+        val expected: Int = 40001
+
+        // Act
+        val actual: Int = StaticIntMethods.returnNextNumberUint16(number)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersUint16() {
+        // Arrange
+        val firstNumber: Int = 16000
+        val secondNumber: Int = 8000
+        val expected: Int = firstNumber + secondNumber
+
+        // Act
+        val actual: Int = StaticIntMethods.sumTwoNumbersUint16(firstNumber, secondNumber)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun returnPrimeUint16() {
+        // Arrange, act, assert
+        assertEquals(32771, StaticIntMethods.returnPrimeUint16())
+    }
+
+    @org.junit.Test
+    fun returnNextNumberInt32() {
+        // Arrange
+        val number: Int = 80000
+        val expected: Int = 80001
+
+        // Act
+        val actual: Int = StaticIntMethods.returnNextNumberInt32(number)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersInt32() {
+        // Arrange
+        val firstNumber: Int = 160000
+        val secondNumber: Int = 80000
+        val expected: Long = (firstNumber + secondNumber).toLong()
+
+        // Act
+        val actual: Int = StaticIntMethods.sumTwoNumbersInt32(firstNumber, secondNumber)
+
+        // Assert
+        assertEquals(expected, actual.toLong())
+    }
+
+    @org.junit.Test
+    fun returnPrimeInt32() {
+        // Arrange, act, assert
+        assertEquals(65537, StaticIntMethods.returnPrimeInt32())
+    }
+
+    @org.junit.Test
+    fun returnNextNumberUint32() {
+        // Arrange
+        val number: Long = 2000000000
+        val expected: Long = 2000000001
+
+        // Act
+        val actual: Long = StaticIntMethods.returnNextNumberUint32(number)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersUint32() {
+        // Arrange
+        val firstNumber: Long = 2000000000
+        val secondNumber: Long = 2000000001
+        val expected: Long = firstNumber + secondNumber
+
+        // Act
+        val actual: Long = StaticIntMethods.sumTwoNumbersUint32(firstNumber, secondNumber)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun returnPrimeUint32() {
+        // Arrange, act, assert
+        assertEquals(2147483659L, StaticIntMethods.returnPrimeUint32())
+    }
+
+    @org.junit.Test
+    fun returnNextNumberInt64() {
+        // Arrange
+        val number: Long = 5000000000L
+        val expected: Long = 5000000001L
+
+        // Act
+        val actual: Long = StaticIntMethods.returnNextNumberInt64(number)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersInt64() {
+        // Arrange
+        val firstNumber: Long = 5000000000L
+        val secondNumber: Long = 7000000000L
+        val expected: Long = firstNumber + secondNumber
+
+        // Act
+        val actual: Long = StaticIntMethods.sumTwoNumbersInt64(firstNumber, secondNumber)
+
+        // Assert
+        assertEquals(expected, actual)
+    }
+
+    @org.junit.Test
+    fun returnPrimeInt64() {
+        // Arrange, act, assert
+        assertEquals(4294967311L, StaticIntMethods.returnPrimeInt64())
+    }
+
+    @org.junit.Test
+    fun returnNextNumberUint64() {
+        // Arrange
+        val number: Long = 5000000000L
+
+        // Act
+        val actual: Long = StaticIntMethods.returnNextNumberUint64(number)
+
+        // Assert
+        assertEquals(5000000001L, actual)
+    }
+
+    @org.junit.Test
+    fun sumTwoNumbersUint64() {
+        // Arrange
+        val firstNumber: Long = 5000000000L
+        val secondNumber: Long = 7000000000L
+
+        // Act
+        val actual: Long = StaticIntMethods.sumTwoNumbersUint64(firstNumber, secondNumber)
+
+        // Assert
+        assertEquals(firstNumber + secondNumber, actual)
+    }
+
+    @org.junit.Test
+    fun returnPrimeUint64() {
+        // Arrange, act, assert
+        assertEquals(4294967311L, StaticIntMethods.returnPrimeUint64())
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticStringMethodsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/StaticStringMethodsTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class StaticStringMethodsTest {
+    @org.junit.Test
+    fun returnInputString() {
+        // Arrange
+        val inputString: String = "Foo"
+
+        // Act
+        val returnedString: String = StaticStringMethods.returnInputString(inputString)
+
+        // Assert
+        assertEquals(inputString, returnedString)
+    }
+
+    @org.junit.Test
+    fun concatenateStrings() {
+        // Arrange
+        val inputString1: String = "Hello"
+        val inputString2: String = "World"
+
+        // Act
+        val returnedString: String = StaticStringMethods.concatenateStrings(inputString1, inputString2)
+
+        // Assert
+        assertEquals(inputString1 + inputString2, returnedString)
+    }
+
+    @org.junit.Test
+    fun returnHelloString() {
+        // Arrange, act
+        val returnedString: String = StaticStringMethods.returnHelloString()
+
+        // Assert
+        assertEquals("hello", returnedString)
+    }
+
+    @org.junit.Test
+    fun returnEmpty() {
+        // Arrange, act
+        val returnedString: String = StaticStringMethods.returnEmpty()
+
+        // Assert
+        assertTrue(returnedString.isEmpty())
+    }
+
+    @org.junit.Test
+    fun stringRef() {
+        val result: String = CppRefReturnType.stringRef()
+
+        assertEquals("nonsense", result)
+    }
+}

--- a/functional-tests/functional/build.gradle
+++ b/functional-tests/functional/build.gradle
@@ -18,12 +18,13 @@
  */
 
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 project.buildDir = "${rootProject.buildDir}"
 
 def getCMakeCommonParameters() {
     return ['-Wno-dev',
-        '-DGLUECODIUM_GENERATORS_DEFAULT=android;cpp',
+        "-DGLUECODIUM_GENERATORS_DEFAULT=${rootProject.getAndroidBuildVariant()};cpp",
         "-DGLUECODIUM_BASE_OUTPUT_DIR_DEFAULT=${rootProject.generatedDir}",
         "-DGLUECODIUM_VERSION_DEFAULT=${rootProject.useGluecodiumVersion()}",
         '-DGLUECODIUM_ENABLE_INTERNAL_DEBUG_CHECKS_DEFAULT=ON']
@@ -61,23 +62,45 @@ android {
     }
 
     sourceSets {
-        main {
-            manifest.srcFile "${project.projectDir}/input/src/android/AndroidManifest.xml"
+        if (rootProject.isAndroidKotlinBuild()) {
+            main {
+                manifest.srcFile "${project.projectDir}/input/src/android/AndroidManifest.xml"
 
-            java.srcDirs += [
-                "${project.projectDir}/input/src/android/java",
-                "${rootProject.generatedDir}/functional_bindings/android-cpp/common/android",
-                "${rootProject.generatedDir}/functional_bindings/android-cpp/main/android"]
-        }
+                kotlin.srcDirs += [
+                        "${project.projectDir}/input/src/android-kotlin/kotlin",
+                        "${rootProject.generatedDir}/functional_bindings/android-kotlin-cpp/common/android-kotlin",
+                        "${rootProject.generatedDir}/functional_bindings/android-kotlin-cpp/main/android-kotlin"]
+            }
 
-        test {
-            java.srcDirs += ["${project.projectDir}/android/src/test/java"]
+            test {
+                kotlin.srcDirs += ["${project.projectDir}/android-kotlin/src/test/kotlin"]
+            }
+        } else {
+            main {
+                manifest.srcFile "${project.projectDir}/input/src/android/AndroidManifest.xml"
+
+                java.srcDirs += [
+                        "${project.projectDir}/input/src/android/java",
+                        "${rootProject.generatedDir}/functional_bindings/android-cpp/common/android",
+                        "${rootProject.generatedDir}/functional_bindings/android-cpp/main/android"]
+            }
+
+            test {
+                java.srcDirs += ["${project.projectDir}/android/src/test/java"]
+            }
         }
     }
 
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+    if (rootProject.isAndroidKotlinBuild()) {
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_17
+            targetCompatibility JavaVersion.VERSION_17
+        }
+    } else {
+        compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
     }
 
     testOptions {

--- a/functional-tests/functional/input/lime/StringsWithCstring.lime
+++ b/functional-tests/functional/input/lime/StringsWithCstring.lime
@@ -19,7 +19,7 @@ package test
 
 class StringsWithCstring {
     // Method that takes a C string as input and returns an std::string it as output.
-    @Skip(Java, Swift, Dart)
+    @Skip(Java, Swift, Dart, Kotlin)
     @Cpp("return_input_string")
     static fun returnInputStringType(inputString: @Cpp(Type="char*") String): String
     // Method that takes a C string as input and returns an std::string it as output.

--- a/functional-tests/scripts/build-android-kotlin-functional
+++ b/functional-tests/scripts/build-android-kotlin-functional
@@ -1,0 +1,97 @@
+#!/bin/bash -e
+#
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+. "${SCRIPT_DIR}/inc.functions"
+
+USAGE=$(cat <<EOF
+$0 [options]
+    --publish                 Build and publish Gluecodium locally and use it for code generation
+    --buildGluecodium         Build and use local Gluecodium version
+    --gluecodiumPath [PATH]   Implies --buildGluecodium, path to local gluecodium (default: ${GLUECODIUM_PATH})
+    --debug                   Build with debug symbols
+    --docs                    Generate docs of tests
+    --hostOnly                Only build host architecture
+    --help                    Print this message
+EOF
+)
+
+CMAKE_BUILD_TYPE=
+BUILD_LOCAL_GLUECODIUM=false
+GENERATE_DOCS=false
+HOST_ONLY=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --publish)
+            publish_local
+            shift
+            ;;
+        --buildGluecodium)
+            BUILD_LOCAL_GLUECODIUM=true
+            shift
+            ;;
+        --gluecodiumPath)
+            BUILD_LOCAL_GLUECODIUM=true
+            GLUECODIUM_PATH="$2"
+            shift 2
+            ;;
+        --debug)
+            CMAKE_BUILD_TYPE="-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+            shift
+            ;;
+        --docs)
+            GENERATE_DOCS=true
+            shift
+            ;;
+        --hostOnly)
+            HOST_ONLY=true
+            shift
+            ;;
+        --help|*)
+            echo "$USAGE"
+            exit 0
+            ;;
+    esac
+done
+
+if [[ "$BUILD_LOCAL_GLUECODIUM" = "true" ]]; then
+    export GLUECODIUM_PATH
+fi
+
+# Sanity checks
+[ $ANDROID_HOME ] || die "ANDROID_HOME environment variable is mandatory"
+
+GLUECODIUM_VERSION="${GLUECODIUM_VERSION:-+}"
+BUILD_DIR_PREFIX="${PWD}/build-android-kotlin-"
+ANDROID_DIR="${PWD}/functional/android-kotlin"
+DIST_ANDROID_DIR="${PWD}/dist/android-kotlin"
+DOCS_DIR="${DIST_ANDROID_DIR}/docs"
+INSTALL_AAR_DIR="${ANDROID_DIR}/app/libs/"
+TMP_DIR=$(mktemp -d)
+
+if $HOST_ONLY; then
+    ./gradlew functional:testRelease -Pandroid-kotlin -PhostOnly -PgluecodiumVersion=${GLUECODIUM_VERSION}
+else
+    ./gradlew functional:testRelease -Pandroid-kotlin -PgluecodiumVersion=${GLUECODIUM_VERSION}
+fi
+
+if [ "$GENERATE_DOCS" = true ]; then
+    ./gradlew generateJavadoc
+fi

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -68,6 +68,13 @@ object OptionReader {
                 true,
                 "Java package name to append to 'javapackage' for internal types.",
             )
+            addOption("kotlinpackage", true, "Kotlin package name")
+            addOption(
+                "kotlinintpackage",
+                "kotlin-internal-package",
+                true,
+                "Kotlin package name to append to 'kotlinpackage' for internal types.",
+            )
             addOption("help", false, "Shows this help and exits.")
             addOption("version", false, "Prints version info and exits.")
             addOption(
@@ -147,6 +154,7 @@ object OptionReader {
             addOption("javanamerules", true, "Java name rules property file.")
             addOption("swiftnamerules", true, "Swift name rules property file.")
             addOption("dartnamerules", true, "Dart name rules property file.")
+            addOption("kotlinnamerules", true, "Kotlin name rules property file.")
         }
 
     @Throws(OptionReaderException::class)
@@ -203,6 +211,9 @@ object OptionReader {
         generatorOptions.javaNullableAnnotation = parseAnnotation(getStringValue("javanullableannotation"))
         generatorOptions.javaInternalPackages = getStringValue("intpackage")?.split(".") ?: emptyList()
 
+        generatorOptions.kotlinPackages = getStringValue("kotlinpackage")?.split(".") ?: emptyList()
+        generatorOptions.kotlinInternalPackages = getStringValue("kotlinintpackage")?.split(".") ?: emptyList()
+
         generatorOptions.cppRootNamespace = getStringValue("cppnamespace")?.split(".") ?: emptyList()
         generatorOptions.cppInternalNamespace = getStringValue("intnamespace")?.split(".") ?: emptyList()
         getStringValue("cppexport")?.let { generatorOptions.cppExport = it }
@@ -222,6 +233,8 @@ object OptionReader {
             readConfigFile(getStringValue("swiftnamerules"), generatorOptions.swiftNameRules)
         generatorOptions.dartNameRules =
             readConfigFile(getStringValue("dartnamerules"), generatorOptions.dartNameRules)
+        generatorOptions.kotlinNameRules =
+            readConfigFile(getStringValue("kotlinnamerules"), generatorOptions.kotlinNameRules)
 
         generatorOptions.copyrightHeaderContents = getStringValue("copyright")?.let { File(it).readText() }
         getStringListValue("tag")?.let { generatorOptions.tags = CaseInsensitiveSet(it) }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
@@ -27,6 +27,8 @@ data class GeneratorOptions(
     var werror: Set<String> = emptySet(),
     var javaPackages: List<String> = listOf(),
     var javaInternalPackages: List<String> = listOf(),
+    var kotlinPackages: List<String> = listOf(),
+    var kotlinInternalPackages: List<String> = listOf(),
     var javaNullableAnnotation: Pair<String, List<String>>? = null,
     var javaNonNullAnnotation: Pair<String, List<String>>? = null,
     var copyrightHeaderContents: String? = null,
@@ -49,6 +51,11 @@ data class GeneratorOptions(
         ConfigurationProperties.fromResource(
             Gluecodium::class.java,
             "/namerules/java.properties",
+        ),
+    var kotlinNameRules: Configuration =
+        ConfigurationProperties.fromResource(
+            Gluecodium::class.java,
+            "/namerules/kotlin.properties",
         ),
     var swiftNameRules: Configuration =
         ConfigurationProperties.fromResource(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinCommentsProcessor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.generator.common.CommentsProcessor
+import com.here.gluecodium.generator.java.JavaDocProcessor.Companion.flexmarkOptions
+import com.here.gluecodium.model.lime.LimeElement
+import com.vladsch.flexmark.ast.LinkRef
+import com.vladsch.flexmark.html.HtmlRenderer
+
+internal class KotlinCommentsProcessor(private val referenceMap: Map<String, LimeElement>, private val werror: Boolean = true) :
+    CommentsProcessor(HtmlRenderer.builder(flexmarkOptions).build(), werror, flexmarkOptions) {
+    override fun processLink(
+        linkNode: LinkRef,
+        linkReference: String,
+        limeFullName: String,
+    ) {
+        // TODO: implement me!
+        linkNode.firstChild?.unlink()
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGenerator.kt
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.common.LimeModelFilter
+import com.here.gluecodium.common.LimeModelSkipPredicates
+import com.here.gluecodium.generator.common.GeneratedFile
+import com.here.gluecodium.generator.common.Generator
+import com.here.gluecodium.generator.common.GeneratorOptions
+import com.here.gluecodium.generator.common.nameRuleSetFromConfig
+import com.here.gluecodium.generator.common.templates.TemplateEngine
+import com.here.gluecodium.generator.cpp.CppNameCache
+import com.here.gluecodium.generator.cpp.CppNameRules
+import com.here.gluecodium.generator.jni.JniTemplates
+import com.here.gluecodium.model.lime.LimeAttributeType.KOTLIN
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.CONVERTER_NAME
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.NAME_NAME
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypeAlias
+import com.here.gluecodium.model.lime.LimeTypeHelper
+import com.here.gluecodium.validator.LimeOverloadsValidator
+import java.io.File
+import java.util.logging.Logger
+
+internal class KotlinGenerator : Generator {
+    private lateinit var basePackages: List<String>
+    private lateinit var internalPackage: List<String>
+    private lateinit var internalPackageList: List<String>
+    private lateinit var internalNamespace: List<String>
+    private lateinit var rootNamespace: List<String>
+    private lateinit var cppNameRules: CppNameRules
+    private lateinit var kotlinNameRules: KotlinNameRules
+    private lateinit var activeTags: Set<String>
+
+    override val shortName = GENERATOR_NAME
+
+    override fun initialize(options: GeneratorOptions) {
+        basePackages = options.kotlinPackages.ifEmpty { listOf("com", "example") }
+        internalPackage = options.kotlinInternalPackages
+        internalPackageList = basePackages + internalPackage
+        internalNamespace = options.cppInternalNamespace
+        rootNamespace = options.cppRootNamespace
+        cppNameRules = CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
+        kotlinNameRules = KotlinNameRules(nameRuleSetFromConfig(options.kotlinNameRules))
+        activeTags = options.tags
+    }
+
+    override fun generate(limeModel: LimeModel): List<GeneratedFile> {
+        val limeLogger = LimeLogger(logger, limeModel.fileNameMap)
+        val cachingNameResolver = CppNameCache(rootNamespace, limeModel.referenceMap, cppNameRules)
+
+        val jniFilteredModel =
+            LimeModelFilter
+                .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, KOTLIN, retainFunctionsAndFields = true) }
+
+        val kotlinFilteredModel =
+            LimeModelFilter
+                .filter(limeModel) { LimeModelSkipPredicates.shouldRetainElement(it, activeTags, KOTLIN, retainFunctionsAndFields = false) }
+
+        val signatureResolver = KotlinSignatureResolver(limeModel.referenceMap, kotlinNameRules, activeTags)
+        val overloadsValidator = LimeOverloadsValidator(signatureResolver, limeLogger, validateCustomConstructors = true)
+        val validationResult = overloadsValidator.validate(jniFilteredModel.referenceMap.values)
+        if (!validationResult) {
+            throw GluecodiumExecutionException("Validation errors found, see log for details.")
+        }
+
+        val commentsProcessor = KotlinCommentsProcessor(kotlinFilteredModel.referenceMap)
+
+        val nameResolver =
+            KotlinNameResolver(
+                limeReferenceMap = limeModel.referenceMap,
+                kotlinNameRules = kotlinNameRules,
+                limeLogger = limeLogger,
+                commentsProcessor = commentsProcessor,
+                signatureResolver = signatureResolver,
+                basePackages = basePackages,
+            )
+
+        val importResolver =
+            KotlinImportResolver(
+                limeReferenceMap = limeModel.referenceMap,
+                nameResolver = nameResolver,
+                internalPackage = internalPackageList,
+            )
+
+        val importCollector =
+            KotlinImportCollector(importResolver) {
+                LimeModelSkipPredicates.shouldRetainCheckParent(it, activeTags, KOTLIN, limeModel.referenceMap)
+            }
+
+        val resultFiles =
+            kotlinFilteredModel.topElements
+                .flatMap { generateKotlinFiles(it, nameResolver, importResolver, importCollector) }
+                .toMutableList()
+
+        val nativeBasePath = (listOf(GENERATOR_NAME) + internalPackageList).joinToString("/")
+        resultFiles +=
+            GeneratedFile(
+                TemplateEngine.render("kotlin/KotlinNativeBase", internalPackageList),
+                "$nativeBasePath/NativeBase.kt",
+                GeneratedFile.SourceSet.COMMON,
+            )
+
+        resultFiles +=
+            GeneratedFile(
+                TemplateEngine.render("kotlin/KotlinDuration", internalPackageList),
+                "$nativeBasePath/time/Duration.kt",
+                GeneratedFile.SourceSet.COMMON,
+            )
+
+        val descendantInterfaces = LimeTypeHelper.collectDescendantInterfaces(jniFilteredModel.topElements)
+        val jniTemplates =
+            JniTemplates(
+                generatorName = GENERATOR_NAME,
+                platformAttribute = KOTLIN,
+                limeReferenceMap = jniFilteredModel.referenceMap,
+                nameRules = kotlinNameRules,
+                externalNameRules =
+                    mapOf(
+                        "getPackageFromImportString" to KotlinNameRules.Companion::getPackageFromImportString,
+                        "getClassNamesFromImportString" to KotlinNameRules.Companion::getClassNamesFromImportString,
+                    ),
+                signatureResolver = signatureResolver,
+                basePackages = basePackages,
+                internalPackages = internalPackage,
+                internalNamespace = internalNamespace,
+                cppNameRules = cppNameRules,
+                nameCache = cachingNameResolver,
+                activeTags = activeTags,
+                descendantInterfaces = descendantInterfaces,
+            )
+        for (fileName in UTILS_FILES) {
+            resultFiles += jniTemplates.generateConversionUtilsHeaderFile(fileName)
+            resultFiles += jniTemplates.generateConversionUtilsImplementationFile(fileName)
+        }
+        for (fileName in UTILS_FILES_HEADER_ONLY) {
+            resultFiles += jniTemplates.generateConversionUtilsHeaderFile(fileName)
+        }
+
+        val allTypes = jniFilteredModel.topElements.flatMap { LimeTypeHelper.getAllTypes(it) }
+        resultFiles += allTypes.flatMap { jniTemplates.generateFiles(it) } +
+            jniTemplates.generateConversionFiles(allTypes)
+
+        if (commentsProcessor.hasError) {
+            throw GluecodiumExecutionException("Validation errors found, see log for details.")
+        }
+
+        return resultFiles
+    }
+
+    private fun generateKotlinFiles(
+        limeElement: LimeNamedElement,
+        nameResolver: KotlinNameResolver,
+        importResolver: KotlinImportResolver,
+        importCollector: KotlinImportCollector,
+    ): List<GeneratedFile> {
+        if (limeElement.external?.kotlin?.get(NAME_NAME) != null &&
+            limeElement.external?.kotlin?.get(CONVERTER_NAME) == null
+        ) {
+            return emptyList()
+        }
+
+        val contentTemplateName = selectTemplate(limeElement)
+        val packages = (basePackages + limeElement.path.head).map { KotlinNameResolver.normalizePackageName(it) }
+        val imports = importCollector.collectImports(limeElement).filterNot { KotlinNameRules.getPackageFromImportString(it) == packages }
+
+        val templateData =
+            mutableMapOf(
+                "model" to limeElement,
+                "contentTemplate" to contentTemplateName,
+                "package" to packages,
+                "imports" to imports.distinct().sorted(),
+            )
+
+        val nameResolvers = mapOf("" to nameResolver)
+
+        val mainContent =
+            TemplateEngine.render("kotlin/KotlinFile", templateData, nameResolvers, KotlinGeneratorPredicates.predicates)
+        val name = nameResolver.resolveName(limeElement)
+        val mainFileName = (listOf(GENERATOR_NAME) + packages + "$name.kt").joinToString(File.separator)
+        val mainFile = GeneratedFile(mainContent, mainFileName)
+
+        if (limeElement !is LimeInterface && limeElement !is LimeLambda) {
+            return listOf(mainFile)
+        }
+
+        val implImports =
+            when (limeElement) {
+                is LimeInterface -> importCollector.collectImplImports(limeElement, imports)
+                else -> imports
+            } + importResolver.nativeBaseImport
+        templateData["imports"] = implImports.distinct().sorted()
+        templateData["contentTemplate"] = "kotlin/KotlinImplClass"
+
+        val implContent =
+            TemplateEngine.render("kotlin/KotlinFile", templateData, nameResolvers, KotlinGeneratorPredicates.predicates)
+        val implFileName = (listOf(GENERATOR_NAME) + packages + "${name}Impl.kt").joinToString(File.separator)
+        val implFile = GeneratedFile(implContent, implFileName)
+
+        return listOf(mainFile, implFile)
+    }
+
+    private fun selectTemplate(limeElement: LimeNamedElement) =
+        when (limeElement) {
+            is LimeClass -> "kotlin/KotlinClass"
+            is LimeInterface -> "kotlin/KotlinInterface"
+            is LimeStruct -> "kotlin/KotlinStruct"
+            is LimeEnumeration -> "kotlin/KotlinEnumeration"
+            is LimeException -> "kotlin/KotlinException"
+            is LimeLambda -> "kotlin/KotlinLambda"
+            is LimeTypeAlias -> "kotlin/KotlinTypeAlias"
+            else -> throw GluecodiumExecutionException("Unsupported top-level element: " + limeElement::class.java.name)
+        }
+
+    companion object {
+        internal const val GENERATOR_NAME = "android-kotlin"
+
+        private val logger = Logger.getLogger(KotlinGenerator::class.java.name)
+
+        private val UTILS_FILES =
+            listOf(
+                "CppProxyBase",
+                "FieldAccessMethods",
+                "JniBase",
+                "JniCallbackErrorChecking",
+                "JniCppConversionUtils",
+                "JniJavaContainers",
+                "BoxingConversionUtils",
+                "JniClassCache",
+                "JniNativeHandle",
+                "JniWrapperCache",
+                "JniExceptionThrower",
+                "JniReference",
+                "JniThrowNewException",
+            )
+        private val UTILS_FILES_HEADER_ONLY =
+            listOf("JniCallJavaMethod", "ArrayConversionUtils", "JniTemplateMetainfo", "JniTypeId")
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+
+internal object KotlinGeneratorPredicates {
+    val predicates =
+        mapOf(
+            "hasStaticFunctions" to this::hasStaticFunctions,
+            "needsDisposer" to this::needsDisposer,
+            "needsCompanionObject" to this::needsCompanionObject,
+            "hasConstants" to this::hasConstants,
+            "hasStaticProperties" to this::hasStaticProperties,
+        )
+
+    private fun hasStaticFunctions(element: Any) =
+        when (element) {
+            is LimeContainer -> element.functions.any { it.isStatic }
+            else -> false
+        }
+
+    private fun hasConstants(element: Any) =
+        when (element) {
+            is LimeContainer -> element.constants.isNotEmpty()
+            else -> false
+        }
+
+    private fun needsDisposer(element: Any) =
+        when (element) {
+            is LimeClass -> element.parentClass == null
+            is LimeInterface -> true
+            is LimeLambda -> true
+            else -> false
+        }
+
+    private fun hasStaticProperties(element: Any) =
+        when (element) {
+            is LimeContainerWithInheritance -> element.properties.any { it.isStatic }
+            else -> false
+        }
+
+    private fun needsCompanionObject(element: Any) =
+        hasStaticFunctions(element) || hasConstants(element) || needsDisposer(element) || hasStaticProperties(element)
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportCollector.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.generator.common.ImportsCollector
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeConstant
+import com.here.gluecodium.model.lime.LimeContainer
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+
+internal class KotlinImportCollector(
+    private val importsResolver: KotlinImportResolver,
+    private val retainPredicate: (LimeNamedElement) -> Boolean,
+) : ImportsCollector<String> {
+    override fun collectImports(limeElement: LimeNamedElement): List<String> {
+        if (!retainPredicate(limeElement)) return emptyList()
+
+        val nestedImports =
+            when (limeElement) {
+                is LimeStruct ->
+                    collectContainerImports(limeElement) + limeElement.fields.flatMap { collectImports(it) }
+                is LimeContainer -> collectContainerImports(limeElement)
+                is LimeFunction -> collectFunctionImports(limeElement)
+                is LimeLambda -> collectFunctionImports(limeElement.asFunction())
+                is LimeConstant -> importsResolver.resolveElementImports(limeElement.value)
+                is LimeField ->
+                    limeElement.defaultValue?.let { importsResolver.resolveElementImports(it) } ?: emptyList()
+                else -> emptyList()
+            }
+        return importsResolver.resolveElementImports(limeElement) + nestedImports
+    }
+
+    fun collectImplImports(
+        limeInterface: LimeInterface,
+        defImports: List<String>,
+    ): List<String> {
+        if (limeInterface.parents.isEmpty()) return defImports
+        val parentImports =
+            limeInterface.parents.mapNotNull { importsResolver.createTopElementImport(it.type.actualType) }
+        return defImports - parentImports.toSet() +
+            (limeInterface.inheritedFunctions + limeInterface.inheritedProperties).flatMap { collectImports(it) }
+    }
+
+    private fun collectContainerImports(limeContainer: LimeContainer): List<String> {
+        val nestedElements =
+            limeContainer.functions + limeContainer.properties + limeContainer.structs +
+                limeContainer.classes + limeContainer.interfaces + limeContainer.exceptions + limeContainer.lambdas +
+                limeContainer.constants
+        val inheritedElements =
+            when {
+                limeContainer !is LimeContainerWithInheritance -> emptyList()
+                (limeContainer is LimeClass && limeContainer.parentInterfaces.isNotEmpty()) ||
+                    (limeContainer is LimeInterface && limeContainer.path.hasParent) ->
+                    limeContainer.inheritedFunctions + limeContainer.inheritedProperties
+                else -> emptyList()
+            }
+        return (nestedElements + inheritedElements).flatMap { collectImports(it) }
+    }
+
+    private fun collectFunctionImports(limeFunction: LimeFunction): List<String> {
+        return limeFunction.parameters.flatMap { importsResolver.resolveElementImports(it) }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportResolver.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.generator.common.ImportsResolver
+import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeConstant
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeDirectTypeRef
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeException
+import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeList
+import com.here.gluecodium.model.lime.LimeMap
+import com.here.gluecodium.model.lime.LimeParameter
+import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeSet
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeValue
+
+internal class KotlinImportResolver(
+    private val limeReferenceMap: Map<String, LimeElement>,
+    private val nameResolver: KotlinNameResolver,
+    internalPackage: List<String>,
+) : ImportsResolver<String> {
+    val nativeBaseImport = (internalPackage + listOf("NativeBase")).joinToString(".")
+    private val durationImport = (internalPackage + listOf("time", "Duration")).joinToString(".")
+
+    override fun resolveElementImports(limeElement: LimeElement): List<String> =
+        when (limeElement) {
+            is LimeContainerWithInheritance -> resolveClassInterfaceImports(limeElement)
+            is LimeStruct -> resolveStructImports(limeElement)
+            is LimeFunction -> resolveFunctionImports(limeElement)
+            is LimeLambda -> resolveLambdaImports(limeElement)
+            is LimeConstant -> resolveTypeRefImports(limeElement.typeRef)
+            is LimeField -> resolveTypeRefImports(limeElement.typeRef)
+            is LimeParameter -> resolveTypeRefImports(limeElement.typeRef)
+            is LimeProperty -> resolveTypeRefImports(limeElement.typeRef)
+            is LimeException -> resolveTypeRefImports(limeElement.errorType)
+            is LimeValue -> resolveValueImports(limeElement)
+            else -> emptyList()
+        }
+
+    private fun resolveClassInterfaceImports(limeContainer: LimeContainerWithInheritance): List<String> {
+        val parentImports = limeContainer.parents.flatMap { resolveTypeRefImports(it) }.toMutableList()
+        if ((limeContainer is LimeClass && limeContainer.parentClass == null) ||
+            (limeContainer is LimeInterface && limeContainer.path.hasParent)
+        ) {
+            parentImports.add(nativeBaseImport)
+        }
+        return parentImports
+    }
+
+    private fun resolveLambdaImports(limeLambda: LimeLambda): List<String> =
+        resolveFunctionImports(limeLambda.asFunction()) +
+            listOfNotNull(nativeBaseImport.takeIf { limeLambda.path.hasParent })
+
+    private fun resolveStructImports(limeStruct: LimeStruct): List<String> = emptyList()
+
+    private fun resolveValueImports(limeValue: LimeValue?): List<String> =
+        when (limeValue) {
+            is LimeValue.KeyValuePair ->
+                resolveValueImports(limeValue.key) + resolveValueImports(limeValue.value)
+            is LimeValue.InitializerList ->
+                limeValue.values.flatMap { resolveValueImports(it) }
+            is LimeValue.StructInitializer -> limeValue.values.flatMap { resolveValueImports(it) }
+            is LimeValue.Constant -> resolveTypeRefImports(limeValue.valueRef.typeRef)
+            else -> emptyList()
+        }
+
+    private fun resolveTypeRefImports(limeTypeRef: LimeTypeRef?): List<String> {
+        val limeType = limeTypeRef?.type?.actualType ?: return emptyList()
+
+        return when {
+            limeType.external?.kotlin != null -> emptyList()
+            limeType is LimeBasicType -> listOfNotNull(resolveBasicTypeImport(limeType.typeId))
+            limeType is LimeList -> resolveTypeRefImports(limeType.elementType)
+            limeType is LimeSet -> resolveTypeRefImports(limeType.elementType)
+            limeType is LimeMap -> resolveTypeRefImports(limeType.keyType) + resolveTypeRefImports(limeType.valueType)
+            else -> listOfNotNull(createTopElementImport(limeType))
+        }
+    }
+
+    fun createTopElementImport(limeType: LimeType): String? {
+        val topElement =
+            generateSequence(limeType) {
+                limeReferenceMap[it.path.parent.toString()] as? LimeType
+            }.last()
+
+        val packages = nameResolver.resolvePackageNames(topElement)
+        val elementName = listOf(nameResolver.resolveName(topElement))
+        val importParts = packages + elementName
+
+        if (importParts.isEmpty()) {
+            return null
+        }
+
+        return (packages + elementName).joinToString(separator = ".")
+    }
+
+    private fun resolveFunctionImports(limeFunction: LimeFunction): List<String> {
+        val returnTypeImports = resolveTypeRefImports(limeFunction.returnType.typeRef)
+        val exceptionImports =
+            limeFunction.exception?.let { resolveTypeRefImports(LimeDirectTypeRef(it)) }
+        return returnTypeImports + (exceptionImports ?: emptyList())
+    }
+
+    private fun resolveBasicTypeImport(typeId: TypeId): String? =
+        when (typeId) {
+            TypeId.DATE -> "${JAVA_UTIL_PACKAGE}.Date"
+            TypeId.DURATION -> durationImport
+            TypeId.LOCALE -> "${JAVA_UTIL_PACKAGE}.Locale"
+            else -> null
+        }
+
+    companion object {
+        private const val JAVA_UTIL_PACKAGE = "java.util"
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.generator.common.CommentsProcessor
+import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.generator.common.ReferenceMapBasedResolver
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.FUNCTION_NAME
+import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+import com.here.gluecodium.model.lime.LimeComment
+import com.here.gluecodium.model.lime.LimeDirectTypeRef
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.NAME_NAME
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeGenericType
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeList
+import com.here.gluecodium.model.lime.LimeMap
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeReturnType
+import com.here.gluecodium.model.lime.LimeSet
+import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeValue
+
+internal class KotlinNameResolver(
+    limeReferenceMap: Map<String, LimeElement>,
+    private val kotlinNameRules: KotlinNameRules,
+    private val limeLogger: LimeLogger,
+    private val commentsProcessor: CommentsProcessor,
+    private val signatureResolver: KotlinSignatureResolver,
+    private val basePackages: List<String>,
+) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
+    private val kotlinValueResolver = KotlinValueResolver(this)
+
+    override fun resolveName(element: Any): String =
+        when (element) {
+            is LimeComment -> resolveComment(element)
+            is LimeValue -> resolveValue(element)
+            is LimeType -> resolveTypeName(element)
+            is LimeTypeRef -> resolveTypeRef(element)
+            is LimeReturnType -> resolveTypeRef(element.typeRef)
+            is LimeFunction -> resolveFunctionName(element)
+            is LimeNamedElement -> kotlinNameRules.getName(element)
+            else -> throw GluecodiumExecutionException("Unsupported element type ${element.javaClass.name}")
+        }
+
+    override fun resolveReferenceName(element: Any) =
+        when (element) {
+            is LimeTypeRef -> resolveTypeRef(element)
+            is LimeType -> resolveTypeRef(LimeDirectTypeRef(element))
+            else -> null
+        }
+
+    private fun resolveComment(limeComment: LimeComment): String {
+        // TODO: implement me!
+        return ""
+    }
+
+    private fun resolveValue(limeValue: LimeValue): String {
+        return kotlinValueResolver.resolveValue(limeValue)
+    }
+
+    private fun resolveTypeName(limeType: LimeType) =
+        when (val actualType = limeType.actualType) {
+            is LimeBasicType -> resolveBasicType(actualType.typeId)
+            else -> kotlinNameRules.getName(actualType)
+        }
+
+    private fun resolveBasicType(typeId: TypeId) =
+        when (typeId) {
+            TypeId.VOID -> "Unit"
+            TypeId.INT8 -> "Byte"
+            TypeId.UINT8, TypeId.INT16 -> "Short"
+            TypeId.UINT16, TypeId.INT32 -> "Int"
+            TypeId.UINT32, TypeId.INT64, TypeId.UINT64 -> "Long"
+            TypeId.BOOLEAN -> "Boolean"
+            TypeId.FLOAT -> "Float"
+            TypeId.DOUBLE -> "Double"
+            TypeId.STRING -> "String"
+            TypeId.BLOB -> "ByteArray"
+            TypeId.DATE -> "Date"
+            TypeId.DURATION -> "Duration"
+            TypeId.LOCALE -> "Locale"
+        }
+
+    private fun resolveTypeRef(limeTypeRef: LimeTypeRef): String {
+        val limeType = limeTypeRef.type.actualType
+        val externalName = limeType.external?.kotlin?.get(NAME_NAME)
+
+        val typeString =
+            when {
+                externalName != null -> externalName
+                limeType is LimeGenericType -> resolveGenericTypeRef(limeType)
+                limeType !is LimeBasicType -> resolveNestedNames(limeType).joinToString(".")
+                else -> resolveBasicType(limeType.typeId)
+            }
+
+        val suffix = if (limeTypeRef.isNullable) "?" else ""
+        return typeString + suffix
+    }
+
+    private fun resolveGenericTypeRef(limeType: LimeGenericType) =
+        when (limeType) {
+            is LimeList -> "List<${resolveTypeRef(limeType.elementType)}>"
+            is LimeSet -> "Set<${resolveTypeRef(limeType.elementType)}>"
+            is LimeMap -> "Map<${resolveTypeRef(limeType.keyType)}, ${resolveTypeRef(limeType.valueType)}>"
+            else -> throw GluecodiumExecutionException("Unsupported element type ${limeType.javaClass.name}")
+        }
+
+    private fun resolveNestedNames(limeElement: LimeNamedElement): List<String> {
+        val elementName = kotlinNameRules.getName(limeElement)
+        val parentElement = if (limeElement.path.hasParent) getParentElement(limeElement) else null
+        return when {
+            parentElement != null -> resolveNestedNames(parentElement) + elementName
+            else -> listOf(elementName)
+        }
+    }
+
+    private fun resolveFunctionName(limeFunction: LimeFunction): String {
+        return when (val parentElement = getParentElement(limeFunction)) {
+            is LimeLambda -> parentElement.attributes.get(LimeAttributeType.KOTLIN, FUNCTION_NAME) ?: "apply"
+            else -> kotlinNameRules.getName(limeFunction)
+        }
+    }
+
+    fun resolvePackageNames(limeElement: LimeNamedElement) = (basePackages + limeElement.path.head).map { normalizePackageName(it) }
+
+    companion object {
+        fun normalizePackageName(name: String) = name.replace("_", "")
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameRules.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameRules.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.generator.common.NameRuleSet
+import com.here.gluecodium.generator.common.NameRules
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType.NAME
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeTypedElement
+
+class KotlinNameRules(nameRuleSet: NameRuleSet) : NameRules(nameRuleSet) {
+    override fun getName(limeElement: LimeElement) = getPlatformName(limeElement as? LimeNamedElement) ?: super.getName(limeElement)
+
+    override fun getGetterName(limeElement: LimeTypedElement) =
+        (limeElement as? LimeProperty)?.let { getPlatformName(it.getter) }
+            ?: super.getGetterName(limeElement)
+
+    override fun getSetterName(limeElement: LimeTypedElement) =
+        (limeElement as? LimeProperty)?.let { getPlatformName(it.setter) }
+            ?: super.getSetterName(limeElement)
+
+    private fun getPlatformName(limeElement: LimeNamedElement?) = limeElement?.attributes?.get(LimeAttributeType.KOTLIN, NAME)
+
+    companion object {
+        fun getPackageFromImportString(importString: String) = importString.split('.').takeWhile { it.first().isLowerCase() }
+
+        fun getClassNamesFromImportString(importString: String) = importString.split('.').dropWhile { it.first().isLowerCase() }
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinSignatureResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinSignatureResolver.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.generator.common.PlatformSignatureResolver
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeTypeRef
+
+internal class KotlinSignatureResolver(
+    limeReferenceMap: Map<String, LimeElement>,
+    nameRules: KotlinNameRules,
+    activeTags: Set<String>,
+) : PlatformSignatureResolver(limeReferenceMap, LimeAttributeType.KOTLIN, nameRules, activeTags) {
+    override fun getArrayName(elementType: LimeTypeRef) = TYPE_ERASED_ARRAY
+
+    override fun getMapName(
+        keyType: LimeTypeRef,
+        valueType: LimeTypeRef,
+    ) = TYPE_ERASED_MAP
+
+    override fun getSetName(elementType: LimeTypeRef) = TYPE_ERASED_SET
+
+    companion object {
+        private const val TYPE_ERASED_ARRAY = "List<>"
+        private const val TYPE_ERASED_MAP = "Map<>"
+        private const val TYPE_ERASED_SET = "Set<>"
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinValueResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinValueResolver.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.generator.kotlin
+
+import com.here.gluecodium.cli.GluecodiumExecutionException
+import com.here.gluecodium.model.lime.LimeBasicType
+import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+import com.here.gluecodium.model.lime.LimeEnumerator
+import com.here.gluecodium.model.lime.LimeList
+import com.here.gluecodium.model.lime.LimeMap
+import com.here.gluecodium.model.lime.LimeSet
+import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypeHelper
+import com.here.gluecodium.model.lime.LimeValue
+import com.here.gluecodium.model.lime.LimeValue.Duration.TimeUnit
+
+internal class KotlinValueResolver(private val nameResolver: KotlinNameResolver) {
+    fun resolveValue(limeValue: LimeValue): String =
+        when (limeValue) {
+            is LimeValue.Literal -> mapLiteralValue(limeValue)
+            is LimeValue.Constant -> resolveConstantValue(limeValue)
+            is LimeValue.Special -> mapSpecialValue(limeValue)
+            is LimeValue.Null -> "null"
+            is LimeValue.InitializerList -> mapInitializerList(limeValue)
+            is LimeValue.StructInitializer -> mapStructInitializer(limeValue)
+            is LimeValue.KeyValuePair -> "${resolveValue(limeValue.key)} to ${resolveValue(limeValue.value)}"
+            is LimeValue.Duration -> mapDurationValue(limeValue)
+        }
+
+    private fun mapLiteralValue(limeValue: LimeValue.Literal): String {
+        val limeType = limeValue.typeRef.type.actualType
+        if (limeType !is LimeBasicType) return limeType.toString()
+
+        return when (limeType.typeId) {
+            TypeId.FLOAT -> "${limeValue}f"
+            TypeId.UINT32, TypeId.UINT64, TypeId.INT64 -> "${limeValue}L"
+            TypeId.DATE -> {
+                val epochSeconds = LimeTypeHelper.dateLiteralEpochSeconds(limeValue.value)?.let { it * 1000 }
+                "Date(${epochSeconds}L)"
+            }
+            TypeId.LOCALE -> {
+                val localeTag = LimeTypeHelper.normalizeLocaleTag(limeValue.value)
+                "Locale.forLanguageTag(\"$localeTag\")"
+            }
+            else -> limeValue.toString()
+        }
+    }
+
+    private fun resolveConstantValue(limeValue: LimeValue.Constant): String {
+        return when (val limeElement = limeValue.valueRef.element) {
+            is LimeEnumerator -> {
+                val typeName = nameResolver.resolveReferenceName(limeValue.typeRef.type.actualType)
+                val elementName = nameResolver.resolveName(limeElement)
+                "$typeName.$elementName"
+            }
+            else -> nameResolver.resolveName(limeValue.valueRef.element)
+        }
+    }
+
+    private fun mapInitializerList(limeValue: LimeValue.InitializerList): String {
+        val limeType = limeValue.typeRef.type.actualType
+        if (limeType is LimeBasicType && limeType.typeId == TypeId.BLOB) {
+            val values = limeValue.values.joinToString(", ") { "${resolveValue(it)}.toByte()" }
+            return "byteArrayOf( $values )"
+        }
+
+        return when (limeType) {
+            is LimeList -> {
+                val values = limeValue.values.joinToString(", ") { resolveValue(it) }
+                "listOf($values)"
+            }
+
+            is LimeSet -> {
+                val values = limeValue.values.joinToString(", ") { resolveValue(it) }
+                "setOf($values)"
+            }
+
+            is LimeMap -> {
+                val values = limeValue.values.joinToString(".") { resolveValue(it) }
+                "mapOf($values)"
+            }
+
+            else -> throw GluecodiumExecutionException("Unsupported type ${limeType.javaClass.name} for initializer list")
+        }
+    }
+
+    private fun mapStructInitializer(limeValue: LimeValue.StructInitializer): String {
+        val actualType = limeValue.typeRef.type.actualType
+        if (actualType !is LimeStruct) {
+            throw GluecodiumExecutionException("Unsupported type ${actualType.javaClass.name} for struct initializer")
+        }
+        val values = limeValue.values.joinToString(", ") { resolveValue(it) }
+        return "${nameResolver.resolveReferenceName(actualType)}($values)"
+    }
+
+    private fun mapSpecialValue(limeValue: LimeValue.Special): String {
+        val prefix =
+            when ((limeValue.typeRef.type as LimeBasicType).typeId) {
+                TypeId.FLOAT -> "Float"
+                else -> "Double"
+            }
+        val value =
+            when (limeValue.value) {
+                LimeValue.Special.ValueId.NAN -> "NaN"
+                LimeValue.Special.ValueId.INFINITY -> "POSITIVE_INFINITY"
+                LimeValue.Special.ValueId.NEGATIVE_INFINITY -> "NEGATIVE_INFINITY"
+            }
+        return "$prefix.$value"
+    }
+
+    private fun mapDurationValue(limeValue: LimeValue.Duration): String {
+        val factoryMethod =
+            when (limeValue.timeUnit) {
+                TimeUnit.DAY -> "ofDays"
+                TimeUnit.HOUR -> "ofHours"
+                TimeUnit.MINUTE -> "ofMinutes"
+                TimeUnit.SECOND -> "ofSeconds"
+                TimeUnit.MILLISECOND -> "ofMillis"
+                TimeUnit.MICROSECOND, TimeUnit.NANOSECOND -> "ofNanos"
+            }
+        val valueSuffix =
+            when (limeValue.timeUnit) {
+                TimeUnit.MICROSECOND -> "000L"
+                else -> "L"
+            }
+        return "Duration.$factoryMethod(${limeValue.value}$valueSuffix)"
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/package-info.java
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/package-info.java
@@ -1,0 +1,12 @@
+/**
+ * Generates Kotlin code.
+ *
+ * <h1>Input</h1>
+ *
+ * Language independent LIME model
+ *
+ * <h1>Output</h1>
+ *
+ * List of generated files
+ */
+package com.here.gluecodium.generator.kotlin;

--- a/gluecodium/src/main/resources/META-INF/services/com.here.gluecodium.generator.common.Generator
+++ b/gluecodium/src/main/resources/META-INF/services/com.here.gluecodium.generator.common.Generator
@@ -2,3 +2,4 @@ com.here.gluecodium.generator.cpp.CppGenerator
 com.here.gluecodium.generator.java.JavaGenerator
 com.here.gluecodium.generator.swift.SwiftGenerator
 com.here.gluecodium.generator.dart.DartGenerator
+com.here.gluecodium.generator.kotlin.KotlinGenerator

--- a/gluecodium/src/main/resources/namerules/kotlin.properties
+++ b/gluecodium/src/main/resources/namerules/kotlin.properties
@@ -1,0 +1,15 @@
+field=lowerCamelCase
+parameter=lowerCamelCase
+constant=UPPER_SNAKE_CASE
+enumerator=UPPER_SNAKE_CASE
+method=lowerCamelCase
+setter=lowerCamelCase
+setter.prefix=set
+getter=lowerCamelCase
+getter.prefix=get
+getter.prefix.boolean=is
+property.prefix.boolean=is
+property=lowerCamelCase
+type=UpperCamelCase
+error=UpperCamelCase
+error.suffix=Exception

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -1,0 +1,117 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if this.isOpen}}open {{/if}}class {{resolveName}} : {{!!
+}}{{#if this.parentClass}}{{resolveName this.parentClass "" "ref"}}{{/if}}{{!!
+}}{{#unless this.parentClass}}NativeBase{{/unless}}{{!!
+}}{{#if this.parentInterfaces}}, {{#this.parentInterfaces}}{{!!
+}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/this.parentInterfaces}}{{/if}} {
+
+{{>kotlin/KotlinContainerContents}}
+
+{{#constructors}}
+    constructor({{!!
+}}{{#parameters}}{{!!
+}}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/parameters}}){{!!
+}} : this({{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}), null as Any?) {
+{{#unless classElement.attributes.nocache}}
+        cacheThisInstance();
+{{/unless}}
+    }
+{{/constructors}}
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : {{!!
+}}{{#unlessPredicate "needsDisposer"}}super(nativeHandle, tag){{/unlessPredicate}}{{!!
+}}{{#ifPredicate "needsDisposer"}}super(nativeHandle, { disposeNativeHandle(it) }){{/ifPredicate}} {}
+
+{{#if constructors}}{{#unless this.attributes.nocache}}
+    private external fun cacheThisInstance()
+{{/unless}}{{/if}}
+
+{{#functions}}
+{{#unless isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "    "}}
+{{/unless}}
+{{/functions}}
+
+{{#properties}}
+{{#unless isStatic}}
+{{#if setter}}    var{{/if}}{{!!
+}}{{#unless setter}}    val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+        external get{{#setter}}
+        external set{{/setter}}
+{{/unless}}
+{{/properties}}
+
+{{#if this.parentInterfaces}}{{#set override=true classElement=this}}
+{{#classElement.interfaceInheritedFunctions}}
+{{#unless isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "    "}}
+{{/unless}}
+{{/classElement.interfaceInheritedFunctions}}
+{{#classElement.interfaceInheritedProperties}}
+{{#unless isStatic}}
+{{#if setter}}    override var{{/if}}{{!!
+}}{{#unless setter}}    override val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+        external get{{#setter}}
+        external set{{/setter}}
+{{/unless}}
+{{/classElement.interfaceInheritedProperties}}
+{{/set}}{{/if}}
+
+{{#ifPredicate "needsCompanionObject"}}
+    companion object {
+{{#constants}}{{prefixPartial "kotlin/KotlinConstant" "        "}}
+{{/constants}}
+{{#ifPredicate "needsDisposer"}}
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+{{/ifPredicate}}
+{{#ifPredicate "hasStaticFunctions"}}
+{{#functions}}
+{{#if isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "        "}}
+{{/if}}
+{{/functions}}
+{{/ifPredicate}}
+{{#ifPredicate "hasStaticProperties"}}
+{{#properties}}
+{{#if isStatic}}
+{{#if setter}}        @JvmStatic var{{/if}}{{!!
+}}{{#unless setter}}        @JvmStatic val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+            external get{{#setter}}
+            external set{{/setter}}
+{{/if}}
+{{/properties}}
+{{/ifPredicate}}
+    }
+{{/ifPredicate}}
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
@@ -1,0 +1,21 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+val {{resolveName}}: {{resolveName typeRef}} = {{resolveName value}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinContainerContents.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinContainerContents.mustache
@@ -1,0 +1,34 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#enumerations}}{{prefixPartial "kotlin/KotlinEnumeration" "    "}}
+{{/enumerations}}
+{{#exceptions}}{{prefixPartial "kotlin/KotlinException" "    "}}
+{{/exceptions}}
+{{#structs}}{{prefixPartial "kotlin/KotlinStruct" "    "}}
+{{/structs}}
+{{#classes}}{{prefixPartial "kotlin/KotlinClass" "    "}}
+{{/classes}}
+{{#interfaces}}{{prefixPartial "kotlin/KotlinInterface" "    "}}
+{{/interfaces}}
+{{#lambdas}}{{prefixPartial "kotlin/KotlinLambda" "    "}}
+{{/lambdas}}
+{{#each interfaces lambdas}}{{prefixPartial "kotlin/KotlinImplClass" "    "}}
+{{/each}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinDuration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinDuration.mustache
@@ -1,0 +1,376 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package {{join this delimiter="."}}.time
+
+/**
+ * Represents duration in time (both positive and negative).
+ * <p>
+ *     The duration is represented as number of seconds (see {@link #getSeconds()})
+ *     and number of nanoseconds in a second (see {@link #getNano()}).
+ * <p>
+ *     Duration can be created from various units of time by calling on of
+ *     {@code of*} methods. The {@code to*} family of methods convert duration
+ *     to a value expressed in desired unit of time.
+ */
+public class Duration private constructor(private var mSeconds: Long, private var mNanos: Int) : Comparable<Duration> {
+
+    /**
+     *
+     * @return The nanoseconds component of this duration.
+     */
+    public fun getNano(): Int {
+        return mNanos;
+    }
+
+    /**
+     *
+     * @return The seconds component of this duration.
+     */
+    public fun getSeconds(): Long {
+        return mSeconds;
+    }
+
+    /**
+     * Converts this duration to nanoseconds.
+     *
+     * @return Total number of nanoseconds in this duration.
+     * @throws ArithmeticException if the resulting value cannot be represented
+     *                             by {@code long} type.
+     */
+    public fun toNanos(): Long {
+        return exactAdd(exactMultiply(mSeconds, NANOS_PER_SECOND), mNanos.toLong());
+    }
+
+    /**
+     * Gets the nanoseconds part of this duration. Equals to {@link #getNano()}.
+     *
+     * @return The nanoseconds part of this duration, value from 0 to 999999999.
+     */
+    public fun toNanosPart(): Int {
+        return mNanos;
+    }
+
+    /**
+     * Converts this duration to milliseconds. Any data past milliseconds precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 999999 nanoseconds will still be converted to 0 milliseconds.
+     *
+     * @return Total number of milliseconds in this duration.
+     * @throws ArithmeticException if the resulting value cannot be represented
+     *                             by {@code long} type.
+     */
+    public fun toMillis(): Long {
+        return exactAdd(exactMultiply(mSeconds, MILLIS_PER_SECOND), (mNanos / NANOS_PER_MILLIS).toLong());
+    }
+
+    /**
+     * Gets the milliseconds part of this duration.
+     *
+     * @return The milliseconds part of this duration.
+     */
+    public fun toMillisPart(): Int {
+        return mNanos / NANOS_PER_MILLIS;
+    }
+
+    /**
+     * Converts this duration to seconds. Any data past seconds precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 999 milliseconds will still be converted to 0 seconds.
+     *
+     * @return Total number of seconds in this duration.
+     */
+    public fun toSeconds(): Long {
+        return mSeconds;
+    }
+
+    /**
+     * Gets the seconds part of this duration.
+     *
+     * @return The seconds part of this duration, value from 0 to 59.
+     */
+    public fun toSecondsPart(): Int {
+        return (mSeconds % 60).toInt();
+    }
+
+    /**
+     * Converts this duration to minutes. Any data past minute precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 59 seconds and 999 milliseconds will still be converted to 0 minutes.
+     *
+     * @return Total number of minutes in this duration.
+     */
+    public fun toMinutes(): Long {
+        return mSeconds / 60;
+    }
+
+    /**
+     * Gets the minutes part of this duration.
+     *
+     * @return The minutes part of this duration, value from 0 to 59.
+     */
+    public fun toMinutesPart(): Int {
+        return (toMinutes() % 60).toInt();
+    }
+
+    /**
+     *
+     * Converts this duration to hours. Any data past hour precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 59 minutes and 59 seconds will still be converted to 0 hours.
+     *
+     * @return The number of full hours in this duration.
+     */
+    public fun toHours(): Long {
+        return toMinutes() / 60;
+    }
+
+    /**
+     * Gets the hours part of this duration.
+     *
+     * @return The hours part of this duration, value from 0 to 23.
+     */
+    public fun toHoursPart(): Int {
+        return (toHours() % 24).toInt();
+    }
+
+    /**
+     * Converts this duration to days. Any data past day precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 23 hours 59 minutes and 59 seconds will still be converted to 0 days.
+     * Day is always assumed to be 24 hours.
+     *
+     * @return The number of full days in this duration.
+     */
+    public fun toDays(): Long {
+        return toHours() / 24;
+    }
+
+    /**
+     * Same as {@link #toDays()}.
+     *
+     * @return The number of full days in this duration.
+     */
+    public fun toDaysPart(): Long {
+        return toDays();
+    }
+
+    public override fun compareTo(duration: Duration): Int {
+        var result: Int = 0;
+        if (mSeconds < duration.mSeconds) {
+            result = -1;
+        } else if (mSeconds > duration.mSeconds) {
+            result = 1;
+        }
+        if (result == 0) {
+            if (mNanos < duration.mNanos) {
+                result = -1;
+            } else if (mNanos > duration.mNanos) {
+                result = 1;
+            }
+        }
+        return result;
+    }
+
+    public override fun equals(o: Any?): Boolean {
+        if (this === o) {
+            return true;
+        }
+
+        if (o === null || (this::class != o::class)) {
+            return false;
+        }
+
+        var duration: Duration = o as Duration
+        return mSeconds == duration.mSeconds && mNanos == duration.mNanos;
+    }
+
+    override public fun hashCode(): Int {
+        return java.util.Objects.hash(mSeconds, mNanos);
+    }
+
+    companion object {
+        private val NANOS_PER_SECOND: Long = 1000000000;
+        private val NANOS_PER_MILLIS: Int = 1000000;
+        private val MILLIS_PER_SECOND: Long = 1000;
+
+        @JvmStatic
+        private fun exactAdd(v1: Long, v2: Long): Long {
+            if (v2 < 0 && v1 < (Long.MIN_VALUE - v2)) {
+                throw ArithmeticException("Integer underflow");
+            } else if (v2 > 0 && v1 > (Long.MAX_VALUE - v2)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            return v1 + v2;
+        }
+
+        @JvmStatic
+        private fun exactMultiply(v1: Long, v2: Long): Long {
+            if ((v2 == -1L && v1 == Long.MIN_VALUE) || (v1 == -1L && v2 == Long.MIN_VALUE)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            if (v2 > 0 && v1 > (Long.MAX_VALUE / v2)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            if (v2 > 0 && v1 < (Long.MIN_VALUE / v2)) {
+                throw ArithmeticException("Integer underflow");
+            }
+            if (v2 < -1 && v1 > (Long.MIN_VALUE / v2)) {
+                throw ArithmeticException("Integer underflow");
+            }
+            if (v2 < -1 && v1 < (Long.MAX_VALUE / v2)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            return v1 * v2;
+        }
+
+        @JvmStatic
+        private fun divFloor(x: Long, y: Long): Long {
+            var result = x / y;
+            if ((x xor y) < 0 && ((result * y) != x)) {
+                result--;
+            }
+            return result;
+        }
+
+        @JvmStatic
+        private fun modFloor(x: Long, y: Long): Long {
+            var result = x % y;
+            if ((x xor y) < 0 && result != 0L) {
+                result += y;
+            }
+            return result;
+        }
+
+        /**
+         * Creates a duration representing specified number of days.
+         * A Day is assumed to always be 24 hours.
+         *
+         * @param days The number of days.
+         * @return The Duration representing the specified number of days.
+         * @throws ArithmeticException if the input is outside the range possible to
+         *                             represent by a Duration
+         */
+        @JvmStatic
+        public fun ofDays(days: Long): Duration {
+            return ofHours(exactMultiply(days, 24));
+        }
+
+        /**
+         * Creates a duration representing specified number of hours.
+         * An hour is assumed to always be 60 minutes.
+         *
+         * @param hours The number of hours.
+         * @return The Duration representing the specified number of hours.
+         * @throws ArithmeticException if the input is outside the range possible to
+         *                             represent by a Duration
+         */
+        @JvmStatic
+        public fun ofHours(hours: Long): Duration {
+            return ofMinutes(exactMultiply(hours, 60));
+        }
+
+        /**
+         * Creates a duration representing specified number of hours.
+         * A minute is assumed to always be 60 seconds.
+         *
+         * @param minutes The number of minutes.
+         * @return The Duration representing the specified number of minutes.
+         * @throws ArithmeticException if the input is outside the range possible to
+         *                             represent by a Duration
+         */
+        @JvmStatic
+        public fun ofMinutes(minutes: Long): Duration {
+            return ofSeconds(exactMultiply(minutes, 60));
+        }
+
+        /**
+         * Creates a duration representing specified number of seconds.
+         *
+         * @param seconds The number of seconds.
+         * @return The Duration representing the specified number of seconds.
+         */
+        @JvmStatic
+        public fun ofSeconds(seconds: Long): Duration {
+            return Duration(seconds, 0);
+        }
+
+        /**
+         * Creates a duration representing specified number of seconds and an adjustment in nanoseconds.
+         *
+         * @param seconds The number of seconds.
+         * @param nanoAdjustment The nanosecond adjustment to the number of seconds.
+         * @return The Duration representing the specified number of seconds, adjusted.
+         */
+        @JvmStatic
+        public fun ofSeconds(seconds: Long, nanoAdjustment: Long): Duration {
+            var secs = exactAdd(seconds, divFloor(nanoAdjustment, NANOS_PER_SECOND));
+            var nanos = modFloor(nanoAdjustment, NANOS_PER_SECOND).toInt();
+            return Duration(secs, nanos);
+        }
+
+        /**
+         * Creates a duration representing specified number of milliseconds.
+         *
+         * @param milliseconds The number of milliseconds.
+         * @return The Duration representing the specified number of milliseconds.
+         */
+        @JvmStatic
+        public fun ofMillis(milliseconds: Long): Duration {
+            return ofNanos(milliseconds * NANOS_PER_MILLIS);
+        }
+
+        /**
+         * Creates a duration representing specified number of nanoseconds.
+         *
+         * @param nanoseconds The number of nanoseconds.
+         * @return The Duration representing the specified number of nanoseconds.
+         */
+        @JvmStatic
+        public fun ofNanos(nanoseconds: Long): Duration {
+            var secs = nanoseconds / NANOS_PER_SECOND;
+            var nanos = (nanoseconds % NANOS_PER_SECOND).toInt();
+            if (nanos < 0) {
+                nanos += NANOS_PER_SECOND.toInt();
+                secs--;
+            }
+            return Duration(secs, nanos);
+        }
+    }
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
@@ -1,0 +1,31 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+enum class {{resolveName}}(private val value: Int) {
+{{joinPartial uniqueEnumerators "kotlin/KotlinEnumerator" ",
+"}}{{#if uniqueEnumerators}};{{/if}}{{#if aliasEnumerators}}
+
+    companion object {
+    {{#set enumeration=this}}{{joinPartial aliasEnumerators "kotlin/KotlinEnumerator" "
+    "}}{{/set}}
+    }
+{{/if}}
+
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
@@ -1,0 +1,23 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if isAlias}}    val {{resolveName}}{{!!
+}} = {{resolveName value}}{{/if}}{{!!
+}}{{#unless isAlias}}    {{resolveName}}({{resolveName value}}){{/unless}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
@@ -1,0 +1,22 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+class {{resolveName}}(val error: {{resolveName errorType}}) : Exception(error.toString())
+

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFile.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFile.mustache
@@ -1,0 +1,34 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+/*
+{{#if copyrightHeader}}{{prefix copyrightHeader " * "}}{{/if}}
+ *
+ */
+
+package {{#package}}{{this}}{{#if iter.hasNext}}.{{/if}}{{/package}}
+
+{{#imports}}
+import {{this}}
+{{/imports}}
+
+{{#model}}
+{{include contentTemplate}}
+{{/model}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
@@ -1,0 +1,27 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
+}}{{#unless isInterface}}external {{/unless}}fun {{resolveName}}({{!!
+}}{{#parameters}}{{!!
+}}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/parameters}}) : {{!!
+}}{{#unless this.isConstructor}}{{resolveName returnType}}{{/unless}}{{!!
+}}{{#if this.isConstructor}}Long{{/if}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -1,0 +1,82 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+class {{resolveName}}Impl : NativeBase, {{resolveName}} {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+{{#set override=true classElement=this}}
+{{#functions}}
+{{#unless isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "    "}}
+{{/unless}}
+{{/functions}}
+{{/set}}
+
+{{#properties}}
+{{#unless isStatic}}
+{{#if setter}}    override var{{/if}}{{!!
+}}{{#unless setter}}    override val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+        external get{{#setter}}
+        external set{{/setter}}
+{{/unless}}
+{{/properties}}
+
+{{#if this.parentInterfaces}}{{#set override=true classElement=this}}
+{{#classElement.interfaceInheritedFunctions}}
+{{#unless isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "    "}}
+{{/unless}}
+{{/classElement.interfaceInheritedFunctions}}
+{{#classElement.interfaceInheritedProperties}}
+{{#unless isStatic}}
+{{#if setter}}    override var{{/if}}{{!!
+}}{{#unless setter}}    override val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+        external get{{#setter}}
+        external set{{/setter}}
+{{/unless}}
+{{/classElement.interfaceInheritedProperties}}
+{{/set}}{{/if}}
+
+{{#ifPredicate "needsCompanionObject"}}
+    companion object {
+{{#constants}}{{prefixPartial "kotlin/KotlinConstant" "        "}}
+{{/constants}}
+{{#ifPredicate "needsDisposer"}}
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+{{/ifPredicate}}
+{{#ifPredicate "hasStaticFunctions"}}
+{{#functions}}
+{{#if isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "        "}}
+{{/if}}
+{{/functions}}
+{{/ifPredicate}}
+    }
+{{/ifPredicate}}
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -1,0 +1,42 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+interface {{resolveName}} {{!!
+}}{{#if this.parents}}extends {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
+{{>kotlin/KotlinContainerContents}}
+
+{{#set isInterface=true classElement=this}}
+{{#functions}}
+{{#unless isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "    "}}
+{{/unless}}
+{{/functions}}
+{{/set}}
+
+{{#properties}}
+{{#unless isStatic}}
+{{#if setter}}    var{{/if}}{{!!
+}}{{#unless setter}}    val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+        get{{#setter}}
+        set{{/setter}}
+{{/unless}}
+{{/properties}}
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
@@ -1,0 +1,27 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+fun interface {{resolveName}} {
+{{#set isInterface=true noAttributes=true}}{{!!
+}}{{#asFunction}}
+{{prefixPartial "kotlin/KotlinFunction" "    "}}
+{{/asFunction}}{{!!
+}}{{/set}}
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinNativeBase.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinNativeBase.mustache
@@ -1,0 +1,122 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package {{join this delimiter="."}};
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/*
+ * <p>Internal base class for public non-POD objects to manage the lifecycle of underlying C++ objects.
+ * While the class is public for technical reasons, but should be considered <b>internal</b> and not
+ * part of the public API and thus not used directly.
+ *
+ * <p>Kotlin classes which wrap C++ objects inherit from NativeBase to
+ * <ol>
+ * <li>reference the C++ object</li>
+ * <li>manage the lifecycle of C++ object</li>
+ * </ol>
+ *
+ * <p>Cleanup of C++ objects is done automatically as long as there are new subclasses of NativeBase
+ * created. Currently there is no explicit way to destroy the underlying C++ object of a Kotlin
+ * wrapper. This is intentional because normally no manual cleanup is necessary. Additionally the
+ * client of the Kotlin wrapper would need additional knowledge of the underlying implementation to
+ * be able to decide whether or not cleanup is necessary. It is not clear for the client which
+ * object needs cleanup and which doesn't if all objects have auto-generated cleanup functions.
+ * So instead API designers should manually define methods if resource cleanup is necessary.
+ */
+public abstract class NativeBase {
+    private val nativeHandle: Long
+
+    constructor(nativeHandle: Long, disposer: (Long) -> Unit) {
+        this.nativeHandle = nativeHandle
+        REFERENCES.add(DisposableReference(this, nativeHandle, disposer));
+    }
+
+    private class DisposableReference: PhantomReference<NativeBase> {
+        private val nativePointer: Long
+        private val disposer: (Long) -> Unit
+
+        constructor(disposable: NativeBase, nativePointer: Long, disposer: (Long) -> Unit) : super(disposable, REFERENCE_QUEUE) {
+            this.nativePointer = nativePointer
+            this.disposer = disposer
+
+            cleanUpQueue();
+        }
+
+        fun dispose() {
+            REFERENCES.remove(this);
+            disposer(nativePointer);
+        }
+    }
+
+    companion object {
+        private val LOGGER = Logger.getLogger(NativeBase::class.java.name);
+
+        // The set is to keep DisposableReference itself from being garbage-collected.
+        // The set is backed by ConcurrentHashMap to make it thread-safe.
+        private val REFERENCES: MutableSet<Reference<*>> =
+            Collections.newSetFromMap(ConcurrentHashMap<Reference<*>, Boolean>());
+
+        private val REFERENCE_QUEUE = ReferenceQueue<NativeBase>();
+
+        @JvmStatic
+        private fun cleanUpQueue() {
+            var reference: Reference<*>? = REFERENCE_QUEUE.poll()
+
+            while (reference != null) {
+                reference.clear()
+
+                try {
+                    (reference as DisposableReference).dispose()
+                } catch (t: Throwable) {
+                    LOGGER.log(Level.SEVERE, "Error cleaning up after reference.", t);
+                }
+
+                reference = REFERENCE_QUEUE.poll()
+            }
+        }
+    }
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
@@ -1,0 +1,51 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+class {{resolveName}}({{!!
+}}{{#fields}}{{!!
+}}var {{resolveName}}: {{resolveName typeRef}}{{#if defaultValue}} = {{resolveName defaultValue}}{{/if}}{{!!
+}}{{#if iter.hasNext}},
+    {{/if}}{{!!
+}}{{/fields}}) {
+
+{{>kotlin/KotlinContainerContents}}
+
+{{#functions}}
+{{#unless isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "    "}}
+{{/unless}}
+{{/functions}}
+
+{{#ifPredicate "needsCompanionObject"}}
+    companion object {
+{{#constants}}{{prefixPartial "kotlin/KotlinConstant" "        "}}
+{{/constants}}
+{{#ifPredicate "hasStaticFunctions"}}
+{{#functions}}
+{{#if isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "        "}}
+{{/if}}
+{{/functions}}
+{{/ifPredicate}}
+    }
+{{/ifPredicate}}
+
+}
+

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinTypeAlias.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinTypeAlias.mustache
@@ -1,0 +1,21 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+typealias {{resolveName}} = {{resolveName typeRef}}

--- a/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
@@ -170,6 +170,32 @@ class OptionReaderTest {
         assertTrue(options!!.second.dartDisableFinalizableMarker)
     }
 
+    @Test
+    @Throws(OptionReaderException::class)
+    fun kotlinpackageOptionIsRecognised() {
+        // Arrange
+        val toRead = prepareToRead("-kotlinpackage", TEST_KOTLIN_PACKAGE_LIST)
+
+        // Act
+        val options = OptionReader.read(toRead)
+
+        // Assert
+        assertEquals(listOf(TEST_KOTLIN_PACKAGE_LIST), options!!.second.kotlinPackages)
+    }
+
+    @Test
+    @Throws(OptionReaderException::class)
+    fun kotlinintpackageOptionIsRecognised() {
+        // Arrange
+        val toRead = prepareToRead("-kotlinintpackage", TEST_KOTLIN_PACKAGE_LIST)
+
+        // Act
+        val options = OptionReader.read(toRead)
+
+        // Assert
+        assertEquals(listOf(TEST_KOTLIN_PACKAGE_LIST), options!!.second.kotlinInternalPackages)
+    }
+
     private fun prepareToRead(
         optionName: String,
         optionValue: String,
@@ -181,5 +207,6 @@ class OptionReaderTest {
         private const val TEST_OUTPUT = "./outputFile"
         private const val TEST_GENERATORS = "java,cpp"
         private const val TEST_JAVA_PACKAGE_LIST = "some_package"
+        private const val TEST_KOTLIN_PACKAGE_LIST = "another_package"
     }
 }

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/NativeBase.kt
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/NativeBase.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.example;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/*
+ * <p>Internal base class for public non-POD objects to manage the lifecycle of underlying C++ objects.
+ * While the class is public for technical reasons, but should be considered <b>internal</b> and not
+ * part of the public API and thus not used directly.
+ *
+ * <p>Kotlin classes which wrap C++ objects inherit from NativeBase to
+ * <ol>
+ * <li>reference the C++ object</li>
+ * <li>manage the lifecycle of C++ object</li>
+ * </ol>
+ *
+ * <p>Cleanup of C++ objects is done automatically as long as there are new subclasses of NativeBase
+ * created. Currently there is no explicit way to destroy the underlying C++ object of a Kotlin
+ * wrapper. This is intentional because normally no manual cleanup is necessary. Additionally the
+ * client of the Kotlin wrapper would need additional knowledge of the underlying implementation to
+ * be able to decide whether or not cleanup is necessary. It is not clear for the client which
+ * object needs cleanup and which doesn't if all objects have auto-generated cleanup functions.
+ * So instead API designers should manually define methods if resource cleanup is necessary.
+ */
+public abstract class NativeBase {
+    private val nativeHandle: Long
+
+    constructor(nativeHandle: Long, disposer: (Long) -> Unit) {
+        this.nativeHandle = nativeHandle
+        REFERENCES.add(DisposableReference(this, nativeHandle, disposer));
+    }
+
+    private class DisposableReference: PhantomReference<NativeBase> {
+        private val nativePointer: Long
+        private val disposer: (Long) -> Unit
+
+        constructor(disposable: NativeBase, nativePointer: Long, disposer: (Long) -> Unit) : super(disposable, REFERENCE_QUEUE) {
+            this.nativePointer = nativePointer
+            this.disposer = disposer
+
+            cleanUpQueue();
+        }
+
+        fun dispose() {
+            REFERENCES.remove(this);
+            disposer(nativePointer);
+        }
+    }
+
+    companion object {
+        private val LOGGER = Logger.getLogger(NativeBase::class.java.name);
+
+        // The set is to keep DisposableReference itself from being garbage-collected.
+        // The set is backed by ConcurrentHashMap to make it thread-safe.
+        private val REFERENCES: MutableSet<Reference<*>> =
+            Collections.newSetFromMap(ConcurrentHashMap<Reference<*>, Boolean>());
+
+        private val REFERENCE_QUEUE = ReferenceQueue<NativeBase>();
+
+        @JvmStatic
+        private fun cleanUpQueue() {
+            var reference: Reference<*>? = REFERENCE_QUEUE.poll()
+
+            while (reference != null) {
+                reference.clear()
+
+                try {
+                    (reference as DisposableReference).dispose()
+                } catch (t: Throwable) {
+                    LOGGER.log(Level.SEVERE, "Error cleaning up after reference.", t);
+                }
+
+                reference = REFERENCE_QUEUE.poll()
+            }
+        }
+    }
+}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
@@ -1,0 +1,41 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class BasicTypes : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun stringFunction(input: String) : String
+        @JvmStatic external fun boolFunction(input: Boolean) : Boolean
+        @JvmStatic external fun floatFunction(input: Float) : Float
+        @JvmStatic external fun doubleFunction(input: Double) : Double
+        @JvmStatic external fun byteFunction(input: Byte) : Byte
+        @JvmStatic external fun shortFunction(input: Short) : Short
+        @JvmStatic external fun intFunction(input: Int) : Int
+        @JvmStatic external fun longFunction(input: Long) : Long
+        @JvmStatic external fun ubyteFunction(input: Short) : Short
+        @JvmStatic external fun ushortFunction(input: Int) : Int
+        @JvmStatic external fun uintFunction(input: Long) : Long
+        @JvmStatic external fun ulongFunction(input: Long) : Long
+    }
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CollectionConstants : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+    companion object {
+        val LIST_CONSTANT: List<String> = listOf("foo", "bar")
+        val SET_CONSTANT: Set<String> = setOf("foo", "bar")
+        val MAP_CONSTANT: Map<String, String> = mapOf("foo" to "bar")
+        val MIXED_CONSTANT: Map<List<String>, Set<String>> = mapOf(listOf("foo") to setOf("bar"))
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
@@ -1,0 +1,29 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class Constants() {
+
+    enum class StateEnum(private val value: Int) {
+        OFF(0),
+        ON(1);
+    }
+
+
+    companion object {
+        val BOOL_CONSTANT: Boolean = true
+        val INT_CONSTANT: Int = -11
+        val UINT_CONSTANT: Long = 4294967295L
+        val FLOAT_CONSTANT: Float = 2.71f
+        val DOUBLE_CONSTANT: Double = -3.14
+        val STRING_CONSTANT: String = "Foo bar"
+        val ENUM_CONSTANT: Constants.StateEnum = Constants.StateEnum.ON
+    }
+
+}
+
+

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
@@ -1,0 +1,40 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ConstantsInterface : NativeBase {
+
+    enum class StateEnum(private val value: Int) {
+        OFF(0),
+        ON(1);
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+    companion object {
+        val BOOL_CONSTANT: Boolean = true
+        val INT_CONSTANT: Int = -11
+        val UINT_CONSTANT: Long = 4294967295L
+        val FLOAT_CONSTANT: Float = 2.71f
+        val DOUBLE_CONSTANT: Double = -3.14
+        val STRING_CONSTANT: String = "Foo bar"
+        val ENUM_CONSTANT: ConstantsInterface.StateEnum = ConstantsInterface.StateEnum.ON
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
@@ -1,0 +1,49 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class StructConstants : NativeBase {
+
+    class SomeStruct(var stringField: String,
+        var floatField: Float) {
+
+
+
+
+    }
+
+
+    class NestingStruct(var structField: StructConstants.SomeStruct) {
+
+
+
+
+    }
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        val STRUCT_CONSTANT: StructConstants.SomeStruct = StructConstants.SomeStruct("bar Buzz", 1.41f)
+        val NESTING_STRUCT_CONSTANT: StructConstants.NestingStruct = StructConstants.NestingStruct(StructConstants.SomeStruct("nonsense", -2.82f))
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/constructors/input/Constructors.lime
+++ b/gluecodium/src/test/resources/smoke/constructors/input/Constructors.lime
@@ -44,8 +44,10 @@ open class Constructors {
 
 class ChildConstructors : Constructors {
     @Java(Name = "createNoArgsChild")
+    @Kotlin(Name = "createNoArgsChild")
     constructor create()
     @Java(Name = "createCopyFromParent")
+    @Kotlin(Name = "createCopyFromParent")
     constructor create(other: Constructors)
 }
 

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
@@ -1,0 +1,37 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class ChildConstructors : Constructors {
+
+
+    constructor() : this(createNoArgsChild(), null as Any?) {
+        cacheThisInstance();
+    }
+    constructor(other: Constructors) : this(createCopyFromParent(other), null as Any?) {
+        cacheThisInstance();
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, tag) {}
+
+    private external fun cacheThisInstance()
+
+
+
+
+    companion object {
+        @JvmStatic external fun createNoArgsChild() : Long
+        @JvmStatic external fun createCopyFromParent(other: Constructors) : Long
+    }
+}

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -1,0 +1,62 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+open class Constructors : NativeBase {
+
+    enum class ErrorEnum(private val value: Int) {
+        NONE(0),
+        CRASHED(1);
+    }
+    class ConstructorExplodedException(val error: Constructors.ErrorEnum) : Exception(error.toString())
+
+
+
+    constructor() : this(create(), null as Any?) {
+        cacheThisInstance();
+    }
+    constructor(other: Constructors) : this(create(other), null as Any?) {
+        cacheThisInstance();
+    }
+    constructor(foo: String, bar: Long) : this(create(foo, bar), null as Any?) {
+        cacheThisInstance();
+    }
+    constructor(input: String) : this(create(input), null as Any?) {
+        cacheThisInstance();
+    }
+    constructor(input: List<Double>) : this(create(input), null as Any?) {
+        cacheThisInstance();
+    }
+    constructor(input: Long) : this(create(input), null as Any?) {
+        cacheThisInstance();
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    private external fun cacheThisInstance()
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun create() : Long
+        @JvmStatic external fun create(other: Constructors) : Long
+        @JvmStatic external fun create(foo: String, bar: Long) : Long
+        @JvmStatic external fun create(input: String) : Long
+        @JvmStatic external fun create(input: List<Double>) : Long
+        @JvmStatic external fun create(input: Long) : Long
+    }
+}

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/BlobDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/BlobDefaults.kt
@@ -1,0 +1,17 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class BlobDefaults(var emptyList: ByteArray = byteArrayOf(  ),
+    var deadBeef: ByteArray = byteArrayOf( 222.toByte(), 173.toByte(), 190.toByte(), 239.toByte() )) {
+
+
+
+
+}
+
+

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
@@ -1,0 +1,91 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class DefaultValues : NativeBase {
+
+    class StructWithDefaults(var intField: Int = 42,
+        var uintField: Long = 4294967295L,
+        var floatField: Float = 3.14f,
+        var doubleField: Double = -1.4142,
+        var boolField: Boolean = true,
+        var stringField: String = "\\Jonny \"Magic\" Smith\n") {
+
+
+
+
+    }
+
+
+    class NullableStructWithDefaults(var intField: Int? = null,
+        var uintField: Long? = null,
+        var floatField: Float? = null,
+        var boolField: Boolean? = null,
+        var stringField: String? = null) {
+
+
+
+
+    }
+
+
+    class StructWithSpecialDefaults(var floatNanField: Float = Float.NaN,
+        var floatInfinityField: Float = Float.POSITIVE_INFINITY,
+        var floatNegativeInfinityField: Float = Float.NEGATIVE_INFINITY,
+        var doubleNanField: Double = Double.NaN,
+        var doubleInfinityField: Double = Double.POSITIVE_INFINITY,
+        var doubleNegativeInfinityField: Double = Double.NEGATIVE_INFINITY) {
+
+
+
+
+    }
+
+
+    class StructWithEmptyDefaults(var intsField: List<Int> = listOf(),
+        var floatsField: List<Float> = listOf(),
+        var mapField: Map<Long, String> = mapOf(),
+        var structField: DefaultValues.StructWithDefaults = DefaultValues.StructWithDefaults(),
+        var setTypeField: Set<String> = setOf()) {
+
+
+
+
+    }
+
+
+    class StructWithTypedefDefaults(var longField: Long = 42L,
+        var boolField: Boolean = true,
+        var stringField: String = "\\Jonny \"Magic\" Smith\n") {
+
+
+
+
+    }
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun processStructWithDefaults(input: DefaultValues.StructWithDefaults) : DefaultValues.StructWithDefaults
+    }
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationDefaults.kt
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.time.Duration
+
+class DurationDefaults(var dayz: Duration = Duration.ofDays(28L),
+    var hourz: Duration = Duration.ofHours(22L),
+    var minutez: Duration = Duration.ofMinutes(45L),
+    var secondz: Duration = Duration.ofSeconds(42L),
+    var milliz: Duration = Duration.ofMillis(500L),
+    var microz: Duration = Duration.ofNanos(665000L),
+    var nanoz: Duration = Duration.ofNanos(314635L)) {
+
+
+
+
+}
+
+

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
@@ -1,0 +1,44 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import com.example.time.Duration
+
+class DurationMilliseconds : NativeBase {
+
+    class DurationStruct(var durationField: Duration) {
+
+
+
+
+    }
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+    external fun durationFunction(input: Duration) : Duration
+    external fun nullableDurationFunction(input: Duration?) : Duration?
+
+    var durationProperty: Duration
+        external get
+        external set
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
@@ -1,0 +1,44 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import com.example.time.Duration
+
+class DurationSeconds : NativeBase {
+
+    class DurationStruct(var durationField: Duration) {
+
+
+
+
+    }
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+    external fun durationFunction(input: Duration) : Duration
+    external fun nullableDurationFunction(input: Duration?) : Duration?
+
+    var durationProperty: Duration
+        external get
+        external set
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/time/Duration.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/time/Duration.kt
@@ -1,0 +1,356 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.example.time
+
+/**
+ * Represents duration in time (both positive and negative).
+ * <p>
+ *     The duration is represented as number of seconds (see {@link #getSeconds()})
+ *     and number of nanoseconds in a second (see {@link #getNano()}).
+ * <p>
+ *     Duration can be created from various units of time by calling on of
+ *     {@code of*} methods. The {@code to*} family of methods convert duration
+ *     to a value expressed in desired unit of time.
+ */
+public class Duration private constructor(private var mSeconds: Long, private var mNanos: Int) : Comparable<Duration> {
+
+    /**
+     *
+     * @return The nanoseconds component of this duration.
+     */
+    public fun getNano(): Int {
+        return mNanos;
+    }
+
+    /**
+     *
+     * @return The seconds component of this duration.
+     */
+    public fun getSeconds(): Long {
+        return mSeconds;
+    }
+
+    /**
+     * Converts this duration to nanoseconds.
+     *
+     * @return Total number of nanoseconds in this duration.
+     * @throws ArithmeticException if the resulting value cannot be represented
+     *                             by {@code long} type.
+     */
+    public fun toNanos(): Long {
+        return exactAdd(exactMultiply(mSeconds, NANOS_PER_SECOND), mNanos.toLong());
+    }
+
+    /**
+     * Gets the nanoseconds part of this duration. Equals to {@link #getNano()}.
+     *
+     * @return The nanoseconds part of this duration, value from 0 to 999999999.
+     */
+    public fun toNanosPart(): Int {
+        return mNanos;
+    }
+
+    /**
+     * Converts this duration to milliseconds. Any data past milliseconds precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 999999 nanoseconds will still be converted to 0 milliseconds.
+     *
+     * @return Total number of milliseconds in this duration.
+     * @throws ArithmeticException if the resulting value cannot be represented
+     *                             by {@code long} type.
+     */
+    public fun toMillis(): Long {
+        return exactAdd(exactMultiply(mSeconds, MILLIS_PER_SECOND), (mNanos / NANOS_PER_MILLIS).toLong());
+    }
+
+    /**
+     * Gets the milliseconds part of this duration.
+     *
+     * @return The milliseconds part of this duration.
+     */
+    public fun toMillisPart(): Int {
+        return mNanos / NANOS_PER_MILLIS;
+    }
+
+    /**
+     * Converts this duration to seconds. Any data past seconds precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 999 milliseconds will still be converted to 0 seconds.
+     *
+     * @return Total number of seconds in this duration.
+     */
+    public fun toSeconds(): Long {
+        return mSeconds;
+    }
+
+    /**
+     * Gets the seconds part of this duration.
+     *
+     * @return The seconds part of this duration, value from 0 to 59.
+     */
+    public fun toSecondsPart(): Int {
+        return (mSeconds % 60).toInt();
+    }
+
+    /**
+     * Converts this duration to minutes. Any data past minute precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 59 seconds and 999 milliseconds will still be converted to 0 minutes.
+     *
+     * @return Total number of minutes in this duration.
+     */
+    public fun toMinutes(): Long {
+        return mSeconds / 60;
+    }
+
+    /**
+     * Gets the minutes part of this duration.
+     *
+     * @return The minutes part of this duration, value from 0 to 59.
+     */
+    public fun toMinutesPart(): Int {
+        return (toMinutes() % 60).toInt();
+    }
+
+    /**
+     *
+     * Converts this duration to hours. Any data past hour precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 59 minutes and 59 seconds will still be converted to 0 hours.
+     *
+     * @return The number of full hours in this duration.
+     */
+    public fun toHours(): Long {
+        return toMinutes() / 60;
+    }
+
+    /**
+     * Gets the hours part of this duration.
+     *
+     * @return The hours part of this duration, value from 0 to 23.
+     */
+    public fun toHoursPart(): Int {
+        return (toHours() % 24).toInt();
+    }
+
+    /**
+     * Converts this duration to days. Any data past day precision is
+     * simply discarded. There is no mathematical rounding, so a duration
+     * of 23 hours 59 minutes and 59 seconds will still be converted to 0 days.
+     * Day is always assumed to be 24 hours.
+     *
+     * @return The number of full days in this duration.
+     */
+    public fun toDays(): Long {
+        return toHours() / 24;
+    }
+
+    /**
+     * Same as {@link #toDays()}.
+     *
+     * @return The number of full days in this duration.
+     */
+    public fun toDaysPart(): Long {
+        return toDays();
+    }
+
+    public override fun compareTo(duration: Duration): Int {
+        var result: Int = 0;
+        if (mSeconds < duration.mSeconds) {
+            result = -1;
+        } else if (mSeconds > duration.mSeconds) {
+            result = 1;
+        }
+        if (result == 0) {
+            if (mNanos < duration.mNanos) {
+                result = -1;
+            } else if (mNanos > duration.mNanos) {
+                result = 1;
+            }
+        }
+        return result;
+    }
+
+    public override fun equals(o: Any?): Boolean {
+        if (this === o) {
+            return true;
+        }
+
+        if (o === null || (this::class != o::class)) {
+            return false;
+        }
+
+        var duration: Duration = o as Duration
+        return mSeconds == duration.mSeconds && mNanos == duration.mNanos;
+    }
+
+    override public fun hashCode(): Int {
+        return java.util.Objects.hash(mSeconds, mNanos);
+    }
+
+    companion object {
+        private val NANOS_PER_SECOND: Long = 1000000000;
+        private val NANOS_PER_MILLIS: Int = 1000000;
+        private val MILLIS_PER_SECOND: Long = 1000;
+
+        @JvmStatic
+        private fun exactAdd(v1: Long, v2: Long): Long {
+            if (v2 < 0 && v1 < (Long.MIN_VALUE - v2)) {
+                throw ArithmeticException("Integer underflow");
+            } else if (v2 > 0 && v1 > (Long.MAX_VALUE - v2)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            return v1 + v2;
+        }
+
+        @JvmStatic
+        private fun exactMultiply(v1: Long, v2: Long): Long {
+            if ((v2 == -1L && v1 == Long.MIN_VALUE) || (v1 == -1L && v2 == Long.MIN_VALUE)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            if (v2 > 0 && v1 > (Long.MAX_VALUE / v2)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            if (v2 > 0 && v1 < (Long.MIN_VALUE / v2)) {
+                throw ArithmeticException("Integer underflow");
+            }
+            if (v2 < -1 && v1 > (Long.MIN_VALUE / v2)) {
+                throw ArithmeticException("Integer underflow");
+            }
+            if (v2 < -1 && v1 < (Long.MAX_VALUE / v2)) {
+                throw ArithmeticException("Integer overflow");
+            }
+            return v1 * v2;
+        }
+
+        @JvmStatic
+        private fun divFloor(x: Long, y: Long): Long {
+            var result = x / y;
+            if ((x xor y) < 0 && ((result * y) != x)) {
+                result--;
+            }
+            return result;
+        }
+
+        @JvmStatic
+        private fun modFloor(x: Long, y: Long): Long {
+            var result = x % y;
+            if ((x xor y) < 0 && result != 0L) {
+                result += y;
+            }
+            return result;
+        }
+
+        /**
+         * Creates a duration representing specified number of days.
+         * A Day is assumed to always be 24 hours.
+         *
+         * @param days The number of days.
+         * @return The Duration representing the specified number of days.
+         * @throws ArithmeticException if the input is outside the range possible to
+         *                             represent by a Duration
+         */
+        @JvmStatic
+        public fun ofDays(days: Long): Duration {
+            return ofHours(exactMultiply(days, 24));
+        }
+
+        /**
+         * Creates a duration representing specified number of hours.
+         * An hour is assumed to always be 60 minutes.
+         *
+         * @param hours The number of hours.
+         * @return The Duration representing the specified number of hours.
+         * @throws ArithmeticException if the input is outside the range possible to
+         *                             represent by a Duration
+         */
+        @JvmStatic
+        public fun ofHours(hours: Long): Duration {
+            return ofMinutes(exactMultiply(hours, 60));
+        }
+
+        /**
+         * Creates a duration representing specified number of hours.
+         * A minute is assumed to always be 60 seconds.
+         *
+         * @param minutes The number of minutes.
+         * @return The Duration representing the specified number of minutes.
+         * @throws ArithmeticException if the input is outside the range possible to
+         *                             represent by a Duration
+         */
+        @JvmStatic
+        public fun ofMinutes(minutes: Long): Duration {
+            return ofSeconds(exactMultiply(minutes, 60));
+        }
+
+        /**
+         * Creates a duration representing specified number of seconds.
+         *
+         * @param seconds The number of seconds.
+         * @return The Duration representing the specified number of seconds.
+         */
+        @JvmStatic
+        public fun ofSeconds(seconds: Long): Duration {
+            return Duration(seconds, 0);
+        }
+
+        /**
+         * Creates a duration representing specified number of seconds and an adjustment in nanoseconds.
+         *
+         * @param seconds The number of seconds.
+         * @param nanoAdjustment The nanosecond adjustment to the number of seconds.
+         * @return The Duration representing the specified number of seconds, adjusted.
+         */
+        @JvmStatic
+        public fun ofSeconds(seconds: Long, nanoAdjustment: Long): Duration {
+            var secs = exactAdd(seconds, divFloor(nanoAdjustment, NANOS_PER_SECOND));
+            var nanos = modFloor(nanoAdjustment, NANOS_PER_SECOND).toInt();
+            return Duration(secs, nanos);
+        }
+
+        /**
+         * Creates a duration representing specified number of milliseconds.
+         *
+         * @param milliseconds The number of milliseconds.
+         * @return The Duration representing the specified number of milliseconds.
+         */
+        @JvmStatic
+        public fun ofMillis(milliseconds: Long): Duration {
+            return ofNanos(milliseconds * NANOS_PER_MILLIS);
+        }
+
+        /**
+         * Creates a duration representing specified number of nanoseconds.
+         *
+         * @param nanoseconds The number of nanoseconds.
+         * @return The Duration representing the specified number of nanoseconds.
+         */
+        @JvmStatic
+        public fun ofNanos(nanoseconds: Long): Duration {
+            var secs = nanoseconds / NANOS_PER_SECOND;
+            var nanos = (nanoseconds % NANOS_PER_SECOND).toInt();
+            if (nanos < 0) {
+                nanos += NANOS_PER_SECOND.toInt();
+                secs--;
+            }
+            return Duration(secs, nanos);
+        }
+    }
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumOptionSet.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumOptionSet.kt
@@ -1,0 +1,13 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+enum class EnumOptionSet(private val value: Int) {
+    ONE(1),
+    TWO(2),
+    THREE(4);
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
@@ -1,0 +1,19 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+enum class EnumWithAlias(private val value: Int) {
+    ONE(2),
+    TWO(3),
+    THREE(4);
+
+    companion object {
+        val FIRST = EnumWithAlias.ONE
+        val THE_BEST = EnumWithAlias.FIRST
+    }
+
+}

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -1,0 +1,50 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class Errors : NativeBase {
+
+    enum class InternalErrorCode(private val value: Int) {
+        ERROR_NONE(0),
+        ERROR_FATAL(1);
+    }
+    enum class ExternalErrors(private val value: Int) {
+        NONE(0),
+        BOOM(1),
+        BUST(2);
+    }
+    class InternalException(val error: Errors.InternalErrorCode) : Exception(error.toString())
+
+
+    class ExternalException(val error: Errors.ExternalErrors) : Exception(error.toString())
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun methodWithErrors() : Unit
+        @JvmStatic external fun methodWithExternalErrors() : Unit
+        @JvmStatic external fun methodWithErrorsAndReturnValue() : String
+        @JvmStatic external fun methodWithPayloadError() : Unit
+        @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
+    }
+}

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -1,0 +1,31 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface ErrorsInterface {
+    enum class InternalError(private val value: Int) {
+        ERROR_NONE(0),
+        ERROR_FATAL(1);
+    }
+    enum class ExternalErrors(private val value: Int) {
+        NONE(0),
+        BOOM(1),
+        BUST(2);
+    }
+    class InternalException(val error: ErrorsInterface.InternalError) : Exception(error.toString())
+
+
+    class ExternalException(val error: ErrorsInterface.ExternalErrors) : Exception(error.toString())
+
+
+
+    fun methodWithErrors() : Unit
+    fun methodWithExternalErrors() : Unit
+    fun methodWithErrorsAndReturnValue() : String
+
+}
+

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class SomeTypeCollection() {
+
+    enum class SomeTypeCollectionError(private val value: Int) {
+        ERROR_A(0),
+        ERROR_B(1);
+    }
+    class SomeException(val error: SomeTypeCollection.SomeTypeCollectionError) : Exception(error.toString())
+
+
+
+
+
+}
+
+

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/WithPayloadException.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/WithPayloadException.kt
@@ -1,0 +1,11 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class WithPayloadException(val error: Payload) : Exception(error.toString())
+
+

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
@@ -1,0 +1,70 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class Properties : NativeBase {
+
+    enum class InternalErrorCode(private val value: Int) {
+        ERROR_NONE(0),
+        ERROR_FATAL(999);
+    }
+    class ExampleStruct(var value: Double) {
+
+
+
+
+    }
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    var builtInTypeProperty: Long
+        external get
+        external set
+    val readonlyProperty: Float
+        external get
+    var structProperty: Properties.ExampleStruct
+        external get
+        external set
+    var arrayProperty: List<String>
+        external get
+        external set
+    var complexTypeProperty: Properties.InternalErrorCode
+        external get
+        external set
+    var byteBufferProperty: ByteArray
+        external get
+        external set
+    var instanceProperty: PropertiesInterface
+        external get
+        external set
+    var isBooleanProperty: Boolean
+        external get
+        external set
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic var staticProperty: String
+            external get
+            external set
+        @JvmStatic val staticReadonlyProperty: Properties.ExampleStruct
+            external get
+    }
+}

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -30,6 +30,10 @@ spotless {
         endWithNewline()
     }
     kotlin {
+        target project.fileTree(project.projectDir) {
+            include '**/*.kt'
+            exclude '**/build', '**/test/resources'
+        }
         ktlint("1.1.0")
         licenseHeaderFile rootProject.file('config/spotless/here_java.license')
     }

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -25,6 +25,7 @@ import com.here.gluecodium.antlr.LimedocParser
 import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeAttributeType.DART
 import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
+import com.here.gluecodium.model.lime.LimeAttributeType.KOTLIN
 import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeAttributes
@@ -65,7 +66,7 @@ internal object AntlrLimeConverter {
             attributes.addAttribute(LimeAttributeType.INTERNAL)
         }
 
-        listOf(JAVA, SWIFT, DART).forEach {
+        listOf(JAVA, SWIFT, DART, KOTLIN).forEach {
             if (parentAttributes.have(it, LimeAttributeValueType.INTERNAL)) {
                 attributes.addAttribute(it, LimeAttributeValueType.INTERNAL)
             }
@@ -207,6 +208,7 @@ internal object AntlrLimeConverter {
             "Immutable" -> LimeAttributeType.IMMUTABLE
             "Internal" -> LimeAttributeType.INTERNAL
             "Java" -> LimeAttributeType.JAVA
+            "Kotlin" -> LimeAttributeType.KOTLIN
             "NoCache" -> LimeAttributeType.NO_CACHE
             "Optimized" -> LimeAttributeType.OPTIMIZED
             "Overloaded" -> LimeAttributeType.OVERLOADED

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeType.kt
@@ -27,6 +27,7 @@ enum class LimeAttributeType(
 ) {
     CPP("Cpp", LimeAttributeValueType.NAME),
     JAVA("Java", LimeAttributeValueType.NAME),
+    KOTLIN("KOTLIN", LimeAttributeValueType.NAME),
     SWIFT("Swift", LimeAttributeValueType.NAME),
     DART("Dart", LimeAttributeValueType.NAME),
     ASYNC("Async"),

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeExternalDescriptor.kt
@@ -32,11 +32,14 @@ class LimeExternalDescriptor private constructor(
         get() = descriptors[SWIFT_TAG]
     val dart
         get() = descriptors[DART_TAG]
+    val kotlin
+        get() = descriptors[KOTLIN_TAG]
 
     fun getFor(target: LimeAttributeType) =
         when (target) {
             LimeAttributeType.CPP -> cpp
             LimeAttributeType.JAVA -> java
+            LimeAttributeType.KOTLIN -> kotlin
             LimeAttributeType.SWIFT -> swift
             LimeAttributeType.DART -> dart
             else -> throw IllegalArgumentException("LimeExternalDescriptor.getFor(): Unknown target language: $target")
@@ -67,6 +70,7 @@ class LimeExternalDescriptor private constructor(
     companion object {
         const val CPP_TAG = "cpp"
         const val JAVA_TAG = "java"
+        const val KOTLIN_TAG = "kotlin"
         const val SWIFT_TAG = "swift"
         const val DART_TAG = "dart"
 


### PR DESCRIPTION
This change is intended to bring the boilerplate code, which is required
to support generation of the new output language: Kotlin.

The CLI interface has been extended by the new Kotlin-specific parameters:
  - `kotlinpackage` - Kotlin package name
  - `kotlinintpackage` - Kotlin package name to append to `kotlinpackage` for internal types
  - `kotlinnamerules` - Kotlin name rules property file

CMake scripts have been adjusted to allow the users to generate the code for Kotlin and properly
build it. Moreover, CMake parameters, which correspond to new CLI options have been added as well:
 - `GLUECODIUM_KOTLIN_PACKAGE`
 - `GLUECODIUM_KOTLIN_INTERNAL_PACKAGE`
 - `GLUECODIUM_KOTLIN_NAMERULES`

The required classes for Kotlin have been created in `gluecodium/generator/` directory.
Furthermore, new mustache templates were added to generate Kotlin files.

To provide some basic level of validation new smoke and functional tests were created.
The CI workflow file for functional tests has been also adjusted to execute the tests on CI.