### PR TITLE
Dart: fix compilation error caused by missing includes for async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Bug fixes:
+ * Dart: fixed problem related to missing includes for `@Async` functions.
  * JNI: removed leak of JNI weak references in JniWrapperCache.
 
 ## 13.10.2

--- a/functional-tests/functional/dart/test/Async_test.dart
+++ b/functional-tests/functional/dart/test/Async_test.dart
@@ -19,7 +19,7 @@
 // -------------------------------------------------------------------------------------------------
 
 import "package:test/test.dart";
-import "package:functional/test.dart";
+import "package:functional/abc.dart";
 import "../test_suite.dart";
 
 final _testSuite = TestSuite("Async");

--- a/functional-tests/functional/input/lime/Async.lime
+++ b/functional-tests/functional/input/lime/Async.lime
@@ -15,7 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # License-Filename: LICENSE
 
-package test
+package abc
 
 @Skip(Java, Swift)
 enum AsyncErrorCode {

--- a/functional-tests/functional/input/src/cpp/AsyncClass.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncClass.cpp
@@ -18,11 +18,11 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/AsyncClass.h"
+#include "abc/AsyncClass.h"
 #include <memory>
 #include <string>
 
-namespace test
+namespace abc
 {
 using namespace lorem_ipsum::test;
 

--- a/functional-tests/functional/input/src/cpp/AsyncStruct.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncStruct.cpp
@@ -18,11 +18,11 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/AsyncStruct.h"
+#include "abc/AsyncStruct.h"
 #include <memory>
 #include <string>
 
-namespace test
+namespace abc
 {
 using namespace lorem_ipsum::test;
 

--- a/functional-tests/functional/input/src/cpp/AsyncWithSkips.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncWithSkips.cpp
@@ -18,11 +18,11 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/AsyncWithSkips.h"
+#include "abc/AsyncWithSkips.h"
 #include <memory>
 #include <string>
 
-namespace test
+namespace abc
 {
 
 void

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/ffi/FfiCppIncludeResolver.kt
@@ -26,6 +26,7 @@ import com.here.gluecodium.generator.common.Include
 import com.here.gluecodium.generator.cpp.CppIncludesCache
 import com.here.gluecodium.generator.cpp.CppLibraryIncludes
 import com.here.gluecodium.generator.cpp.CppNameRules
+import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeConstant
@@ -139,7 +140,7 @@ internal class FfiCppIncludeResolver(
         listOfNotNull(
             isolateContextInclude.takeIf { limeContainer.functions.isNotEmpty() || limeContainer.properties.isNotEmpty() },
             cppIncludesCache.typeRepositoryInclude.takeIf { CommonGeneratorPredicates.hasTypeRepository(limeContainer) },
-        )
+        ) + (if (limeContainer.functions.any { it.attributes.have(LimeAttributeType.ASYNC) }) proxyIncludes else emptyList())
 
     companion object {
         private val BOOL_INCLUDE = Include.createSystemInclude("stdbool.h")

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncClass.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncClass.cpp
@@ -1,8 +1,12 @@
+
 #include "ffi_smoke_AsyncClass.h"
+
 #include "ConversionBase.h"
 #include "InstanceCache.h"
 #include "FinalizerData.h"
+#include "CallbacksQueue.h"
 #include "IsolateContext.h"
+#include "ProxyCache.h"
 #include "smoke/AsyncClass.h"
 #include "smoke/AsyncErrorCode.h"
 #include <cstdint>
@@ -10,35 +14,47 @@
 #include <stdbool.h>
 #include <memory>
 #include <new>
+
 class smoke_AsyncClass_AsyncvoidResultlambda_Proxy {
 public:
     smoke_AsyncClass_AsyncvoidResultlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncClass_AsyncvoidResultlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncClass_AsyncvoidResultlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncClass_AsyncvoidResultlambda_Proxy(const smoke_AsyncClass_AsyncvoidResultlambda_Proxy&) = delete;
     smoke_AsyncClass_AsyncvoidResultlambda_Proxy& operator=(const smoke_AsyncClass_AsyncvoidResultlambda_Proxy&) = delete;
+
     void
     operator()() {
+        
+        
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -46,35 +62,47 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
 class smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy {
 public:
     smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncClass_AsyncvoidthrowsResultlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy(const smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy&) = delete;
     smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy& operator=(const smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy&) = delete;
+
     void
     operator()() {
+        
+        
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -82,36 +110,48 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
 class smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy {
 public:
     smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncClass_AsyncvoidthrowsErrorlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy(const smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy&) = delete;
     smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy& operator=(const smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy&) = delete;
+
     void
     operator()(const smoke::AsyncErrorCode p0) {
-        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, uint32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle),
+        
+        
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, uint32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle), 
             gluecodium::ffi::Conversion<smoke::AsyncErrorCode>::toFfi(p0)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -119,36 +159,48 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
 class smoke_AsyncClass_AsyncintResultlambda_Proxy {
 public:
     smoke_AsyncClass_AsyncintResultlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncClass_AsyncintResultlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncClass_AsyncintResultlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncClass_AsyncintResultlambda_Proxy(const smoke_AsyncClass_AsyncintResultlambda_Proxy&) = delete;
     smoke_AsyncClass_AsyncintResultlambda_Proxy& operator=(const smoke_AsyncClass_AsyncintResultlambda_Proxy&) = delete;
+
     void
     operator()(const int32_t p0) {
-        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, int32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle),
+        
+        
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, int32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle), 
             gluecodium::ffi::Conversion<int32_t>::toFfi(p0)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -156,36 +208,48 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
 class smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy {
 public:
     smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncClass_AsyncintthrowsResultlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy(const smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy&) = delete;
     smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy& operator=(const smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy&) = delete;
+
     void
     operator()(const int32_t p0) {
-        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, int32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle),
+        
+        
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, int32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle), 
             gluecodium::ffi::Conversion<int32_t>::toFfi(p0)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -193,36 +257,48 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
 class smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy {
 public:
     smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncClass_AsyncintthrowsErrorlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy(const smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy&) = delete;
     smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy& operator=(const smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy&) = delete;
+
     void
     operator()(const smoke::AsyncErrorCode p0) {
-        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, uint32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle),
+        
+        
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, uint32_t)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle), 
             gluecodium::ffi::Conversion<smoke::AsyncErrorCode>::toFfi(p0)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -230,35 +306,47 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
 class smoke_AsyncClass_AsyncstaticResultlambda_Proxy {
 public:
     smoke_AsyncClass_AsyncstaticResultlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncClass_AsyncstaticResultlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncClass_AsyncstaticResultlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncClass_AsyncstaticResultlambda_Proxy(const smoke_AsyncClass_AsyncstaticResultlambda_Proxy&) = delete;
     smoke_AsyncClass_AsyncstaticResultlambda_Proxy& operator=(const smoke_AsyncClass_AsyncstaticResultlambda_Proxy&) = delete;
+
     void
     operator()() {
+        
+        
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -266,9 +354,15 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
+
 void
 library_smoke_AsyncClass_asyncVoid__asyncVoid__resultLambda_Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle Resultlambda, bool input) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -277,6 +371,9 @@ library_smoke_AsyncClass_asyncVoid__asyncVoid__resultLambda_Boolean(FfiOpaqueHan
         gluecodium::ffi::Conversion<bool>::toCpp(input)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_asyncVoidThrows__asyncVoidThrows__resultLambda_asyncVoidThrows__errorLambda_Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle Resultlambda, FfiOpaqueHandle Errorlambda, bool input) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -286,6 +383,9 @@ library_smoke_AsyncClass_asyncVoidThrows__asyncVoidThrows__resultLambda_asyncVoi
         gluecodium::ffi::Conversion<bool>::toCpp(input)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_asyncInt__asyncInt__resultLambda_Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle Resultlambda, bool input) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -294,6 +394,9 @@ library_smoke_AsyncClass_asyncInt__asyncInt__resultLambda_Boolean(FfiOpaqueHandl
         gluecodium::ffi::Conversion<bool>::toCpp(input)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_asyncIntThrows__asyncIntThrows__resultLambda_asyncIntThrows__errorLambda_Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle Resultlambda, FfiOpaqueHandle Errorlambda, bool input) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -303,6 +406,9 @@ library_smoke_AsyncClass_asyncIntThrows__asyncIntThrows__resultLambda_asyncIntTh
         gluecodium::ffi::Conversion<bool>::toCpp(input)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_asyncStatic__asyncStatic__resultLambda_Boolean(int32_t _isolate_id, FfiOpaqueHandle Resultlambda, bool input) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -311,16 +417,35 @@ library_smoke_AsyncClass_asyncStatic__asyncStatic__resultLambda_Boolean(int32_t 
         gluecodium::ffi::Conversion<bool>::toCpp(input)
     );
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
 void
 library_smoke_AsyncClass_AsyncvoidResultlambda_call(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
     gluecodium::ffi::Conversion<::std::function<void()>>::toCpp(_self).operator()();
 }
+
+
+
 void
 library_smoke_AsyncClass_AsyncvoidthrowsResultlambda_call(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
     gluecodium::ffi::Conversion<::std::function<void()>>::toCpp(_self).operator()();
 }
+
+
+
 void
 library_smoke_AsyncClass_AsyncvoidthrowsErrorlambda_call__AsyncErrorCode(FfiOpaqueHandle _self, int32_t _isolate_id, uint32_t p0) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -328,6 +453,9 @@ library_smoke_AsyncClass_AsyncvoidthrowsErrorlambda_call__AsyncErrorCode(FfiOpaq
         gluecodium::ffi::Conversion<smoke::AsyncErrorCode>::toCpp(p0)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_AsyncintResultlambda_call__Int(FfiOpaqueHandle _self, int32_t _isolate_id, int32_t p0) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -335,6 +463,9 @@ library_smoke_AsyncClass_AsyncintResultlambda_call__Int(FfiOpaqueHandle _self, i
         gluecodium::ffi::Conversion<int32_t>::toCpp(p0)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_AsyncintthrowsResultlambda_call__Int(FfiOpaqueHandle _self, int32_t _isolate_id, int32_t p0) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -342,6 +473,9 @@ library_smoke_AsyncClass_AsyncintthrowsResultlambda_call__Int(FfiOpaqueHandle _s
         gluecodium::ffi::Conversion<int32_t>::toCpp(p0)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_AsyncintthrowsErrorlambda_call__AsyncErrorCode(FfiOpaqueHandle _self, int32_t _isolate_id, uint32_t p0) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -349,11 +483,19 @@ library_smoke_AsyncClass_AsyncintthrowsErrorlambda_call__AsyncErrorCode(FfiOpaqu
         gluecodium::ffi::Conversion<smoke::AsyncErrorCode>::toCpp(p0)
     );
 }
+
+
+
 void
 library_smoke_AsyncClass_AsyncstaticResultlambda_call(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
     gluecodium::ffi::Conversion<::std::function<void()>>::toCpp(_self).operator()();
 }
+
+
+
+
+
 // "Private" finalizer, not exposed to be callable from Dart.
 void
 library_smoke_AsyncClass_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
@@ -361,11 +503,13 @@ library_smoke_AsyncClass_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
     library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
     library_smoke_AsyncClass_release_handle(handle);
 }
+
 void
 library_smoke_AsyncClass_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
     FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_AsyncClass_finalizer};
     Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
 }
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_copy_handle(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(
@@ -374,10 +518,12 @@ library_smoke_AsyncClass_copy_handle(FfiOpaqueHandle handle) {
         )
     );
 }
+
 void
 library_smoke_AsyncClass_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::shared_ptr<smoke::AsyncClass>*>(handle);
 }
+
 void
 library_smoke_AsyncClass_AsyncvoidResultlambda_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<::std::function<void()>*>(handle);
@@ -406,97 +552,138 @@ void
 library_smoke_AsyncClass_AsyncstaticResultlambda_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<::std::function<void()>*>(handle);
 }
+
+
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_AsyncvoidResultlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncClass_AsyncvoidResultlambda_Proxy>(token, isolate_id, "smoke_AsyncClass_AsyncvoidResultlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncClass_AsyncvoidResultlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncClass_AsyncvoidResultlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void()>(
             std::bind(&smoke_AsyncClass_AsyncvoidResultlambda_Proxy::operator(), cached_proxy)
         )
     );
 }
+
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_AsyncvoidthrowsResultlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy>(token, isolate_id, "smoke_AsyncClass_AsyncvoidthrowsResultlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncClass_AsyncvoidthrowsResultlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void()>(
             std::bind(&smoke_AsyncClass_AsyncvoidthrowsResultlambda_Proxy::operator(), cached_proxy)
         )
     );
 }
+
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_AsyncvoidthrowsErrorlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy>(token, isolate_id, "smoke_AsyncClass_AsyncvoidthrowsErrorlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncClass_AsyncvoidthrowsErrorlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void(const smoke::AsyncErrorCode)>(
             std::bind(&smoke_AsyncClass_AsyncvoidthrowsErrorlambda_Proxy::operator(), cached_proxy, std::placeholders::_1)
         )
     );
 }
+
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_AsyncintResultlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncClass_AsyncintResultlambda_Proxy>(token, isolate_id, "smoke_AsyncClass_AsyncintResultlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncClass_AsyncintResultlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncClass_AsyncintResultlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void(const int32_t)>(
             std::bind(&smoke_AsyncClass_AsyncintResultlambda_Proxy::operator(), cached_proxy, std::placeholders::_1)
         )
     );
 }
+
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_AsyncintthrowsResultlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy>(token, isolate_id, "smoke_AsyncClass_AsyncintthrowsResultlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncClass_AsyncintthrowsResultlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void(const int32_t)>(
             std::bind(&smoke_AsyncClass_AsyncintthrowsResultlambda_Proxy::operator(), cached_proxy, std::placeholders::_1)
         )
     );
 }
+
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_AsyncintthrowsErrorlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy>(token, isolate_id, "smoke_AsyncClass_AsyncintthrowsErrorlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncClass_AsyncintthrowsErrorlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void(const smoke::AsyncErrorCode)>(
             std::bind(&smoke_AsyncClass_AsyncintthrowsErrorlambda_Proxy::operator(), cached_proxy, std::placeholders::_1)
         )
     );
 }
+
+
 FfiOpaqueHandle
 library_smoke_AsyncClass_AsyncstaticResultlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncClass_AsyncstaticResultlambda_Proxy>(token, isolate_id, "smoke_AsyncClass_AsyncstaticResultlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncClass_AsyncstaticResultlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncClass_AsyncstaticResultlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void()>(
             std::bind(&smoke_AsyncClass_AsyncstaticResultlambda_Proxy::operator(), cached_proxy)
         )
     );
 }
+
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncRenamed.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncRenamed.cpp
@@ -1,41 +1,57 @@
+
 #include "ffi_smoke_AsyncRenamed.h"
+
 #include "ConversionBase.h"
 #include "InstanceCache.h"
 #include "FinalizerData.h"
+#include "CallbacksQueue.h"
 #include "IsolateContext.h"
+#include "ProxyCache.h"
 #include "smoke/AsyncRenamed.h"
 #include <memory>
 #include <memory>
 #include <new>
+
 class smoke_AsyncRenamed_DisposeResultlambda_Proxy {
 public:
     smoke_AsyncRenamed_DisposeResultlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncRenamed_DisposeResultlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncRenamed_DisposeResultlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncRenamed_DisposeResultlambda_Proxy(const smoke_AsyncRenamed_DisposeResultlambda_Proxy&) = delete;
     smoke_AsyncRenamed_DisposeResultlambda_Proxy& operator=(const smoke_AsyncRenamed_DisposeResultlambda_Proxy&) = delete;
+
     void
     operator()() {
+        
+        
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -43,9 +59,15 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
+
 void
 library_smoke_AsyncRenamed_dispose__dispose__resultLambda(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle Resultlambda) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -53,11 +75,29 @@ library_smoke_AsyncRenamed_dispose__dispose__resultLambda(FfiOpaqueHandle _self,
         gluecodium::ffi::Conversion<std::function<void()>>::toCpp(Resultlambda)
     );
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
 void
 library_smoke_AsyncRenamed_DisposeResultlambda_call(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
     gluecodium::ffi::Conversion<::std::function<void()>>::toCpp(_self).operator()();
 }
+
+
+
+
+
 // "Private" finalizer, not exposed to be callable from Dart.
 void
 library_smoke_AsyncRenamed_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
@@ -65,11 +105,13 @@ library_smoke_AsyncRenamed_finalizer(FfiOpaqueHandle handle, int32_t isolate_id)
     library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
     library_smoke_AsyncRenamed_release_handle(handle);
 }
+
 void
 library_smoke_AsyncRenamed_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
     FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_AsyncRenamed_finalizer};
     Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
 }
+
 FfiOpaqueHandle
 library_smoke_AsyncRenamed_copy_handle(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(
@@ -78,27 +120,40 @@ library_smoke_AsyncRenamed_copy_handle(FfiOpaqueHandle handle) {
         )
     );
 }
+
 void
 library_smoke_AsyncRenamed_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::shared_ptr<smoke::AsyncRenamed>*>(handle);
 }
+
 void
 library_smoke_AsyncRenamed_DisposeResultlambda_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<::std::function<void()>*>(handle);
 }
+
+
+
 FfiOpaqueHandle
 library_smoke_AsyncRenamed_DisposeResultlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncRenamed_DisposeResultlambda_Proxy>(token, isolate_id, "smoke_AsyncRenamed_DisposeResultlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncRenamed_DisposeResultlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncRenamed_DisposeResultlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void()>(
             std::bind(&smoke_AsyncRenamed_DisposeResultlambda_Proxy::operator(), cached_proxy)
         )
     );
 }
+
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncWithSkips.cpp
+++ b/gluecodium/src/test/resources/smoke/async/output/dart/ffi/ffi_smoke_AsyncWithSkips.cpp
@@ -1,41 +1,57 @@
+
 #include "ffi_smoke_AsyncWithSkips.h"
+
 #include "ConversionBase.h"
 #include "InstanceCache.h"
 #include "FinalizerData.h"
+#include "CallbacksQueue.h"
 #include "IsolateContext.h"
+#include "ProxyCache.h"
 #include "smoke/AsyncWithSkips.h"
 #include <memory>
 #include <memory>
 #include <new>
+
 class smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy {
 public:
     smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0)
         : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0) {
     }
+
     ~smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_AsyncWithSkips_MakeSharedInstanceResultlambda");
+
         auto dart_persistent_handle_local = dart_persistent_handle;
         auto deleter = [dart_persistent_handle_local]() {
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy(const smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy&) = delete;
     smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy& operator=(const smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy&) = delete;
+
     void
     operator()() {
+        
+        
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle)
         ); });
     }
+
+
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -43,9 +59,15 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
+
 void
 library_smoke_AsyncWithSkips_makeSharedInstance__make_shared_instance__resultLambda(int32_t _isolate_id, FfiOpaqueHandle Resultlambda) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -53,11 +75,29 @@ library_smoke_AsyncWithSkips_makeSharedInstance__make_shared_instance__resultLam
         gluecodium::ffi::Conversion<std::function<void()>>::toCpp(Resultlambda)
     );
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
 void
 library_smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_call(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
     gluecodium::ffi::Conversion<::std::function<void()>>::toCpp(_self).operator()();
 }
+
+
+
+
+
 // "Private" finalizer, not exposed to be callable from Dart.
 void
 library_smoke_AsyncWithSkips_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
@@ -65,11 +105,13 @@ library_smoke_AsyncWithSkips_finalizer(FfiOpaqueHandle handle, int32_t isolate_i
     library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
     library_smoke_AsyncWithSkips_release_handle(handle);
 }
+
 void
 library_smoke_AsyncWithSkips_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
     FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_AsyncWithSkips_finalizer};
     Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
 }
+
 FfiOpaqueHandle
 library_smoke_AsyncWithSkips_copy_handle(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(
@@ -78,27 +120,40 @@ library_smoke_AsyncWithSkips_copy_handle(FfiOpaqueHandle handle) {
         )
     );
 }
+
 void
 library_smoke_AsyncWithSkips_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::shared_ptr<smoke::AsyncWithSkips>*>(handle);
 }
+
 void
 library_smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<::std::function<void()>*>(handle);
 }
+
+
+
 FfiOpaqueHandle
 library_smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0) {
+
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy>(token, isolate_id, "smoke_AsyncWithSkips_MakeSharedInstanceResultlambda");
     if (!cached_proxy) {
         cached_proxy = std::make_shared<smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy>(token, isolate_id, dart_handle, f0);
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_AsyncWithSkips_MakeSharedInstanceResultlambda", cached_proxy);
     }
+
+
     return reinterpret_cast<FfiOpaqueHandle>(
         new ::std::function<void()>(
             std::bind(&smoke_AsyncWithSkips_MakeSharedInstanceResultlambda_Proxy::operator(), cached_proxy)
         )
     );
 }
+
+
+
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
FfiCppIncludeResolver class was not resolving includes correctly,
because certain includes were missing. Sadly, the problem was not
visible because of the order of includes in unity file.

This change:
- adjusted functional tests to reproduce the compilation error caused by missing includes
- implemented fix in FfiCppIncludeResolver
- Adjusted smoke tests