### PR TITLE
LimeParser: non-greedy parsing of new lines for ceratin constants

### DIFF
--- a/lime-loader/src/main/antlr/LimeParser.g4
+++ b/lime-loader/src/main/antlr/LimeParser.g4
@@ -242,15 +242,15 @@ positionalEnumeratorRef
 
 structInitializer
     : '{' NewLine* ((simpleId NewLine* '=' NewLine*)? literalConstant NewLine*
-      (',' NewLine* (simpleId NewLine* '=' NewLine*)? literalConstant NewLine*)*)? '}' NewLine*
+      (',' NewLine* (simpleId NewLine* '=' NewLine*)? literalConstant NewLine*)*)? '}' NewLine*?
     ;
 
 listInitializer
-    : '[' NewLine* (literalConstant NewLine* (',' NewLine* literalConstant NewLine*)*)? ']' NewLine*
+    : '[' NewLine* (literalConstant NewLine* (',' NewLine* literalConstant NewLine*)*)? ']' NewLine*?
     ;
 
 mapInitializer
-    : '[' NewLine* (keyValuePair NewLine* (',' NewLine* keyValuePair NewLine*)*)? ']' NewLine*
+    : '[' NewLine* (keyValuePair NewLine* (',' NewLine* keyValuePair NewLine*)*)? ']' NewLine*?
     ;
 
 keyValuePair


### PR DESCRIPTION
Certain sub-rules of 'constant' rule used greedy
matching of new lines at the end:
 - 'structInitializer'
 - 'listInitializer'
 - 'mapInitializer'

If the input LIME file contained invalid syntax
after such constant definition, then the parser
tried to apply greedy matching. It resulted in
meaningless error message e.g.:
 - `mismatched input '//' expecting NewLine`

This change adds the usage of 'Nongreedy Parser Subrules'
which prevent the greedy matching and meaningless error messages.