### PR TITLE
C++: generate synchronous version of function only when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 ### Bug fixes:
+ * C++: removed generation of redundant synchronous version of function when `@Async` is used only for C++/Dart and Java/Swift are skipped.
  * LimeParser: introduced non-greedy parsing of new lines for ceratin sub-rules of `constant` rule to prevent meaningless error messages when invalid syntax is used after declaration of a constant.
  * Dart: fixed problem related to missing includes for `@Async` functions.
  * JNI: removed leak of JNI weak references in JniWrapperCache.

--- a/docs/async.md
+++ b/docs/async.md
@@ -56,6 +56,10 @@ class AsyncClass {
 }
 ```
 
+>**Note:** if the function or whole type is generated only for C++ and Dart
+> and other platforms are skipped via `@Skip(Java)` and `@Skip(Swift)` then
+> only asynchronous version of the method is generated.
+
 The first C++ overload is the same as without the `@Async` attribute. It still should be used for synchronous usages in
 Java, Swift, and C++ itself. The second overload is intended for the asynchronous use. This overload does not return any
 value. Instead:

--- a/functional-tests/functional/input/src/cpp/AsyncClass.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncClass.cpp
@@ -32,30 +32,23 @@ public:
     ~AsyncClassImpl() override = default;
 public:
     void async_void(std::function<void()> result_callback, const bool input) override;
-    void async_void(const bool input) override;
     void async_void_throws(
         std::function<void()> result_callback,
         std::function<void(AsyncErrorCode)> error_callback,
         const bool should_throw
     ) override;
-    std::error_code async_void_throws(const bool input) override;
     void async_int(std::function<void(int32_t)> result_callback, const bool input) override;
-    int32_t async_int(const bool input) override;
     void async_int_throws(
         std::function<void(int32_t)> result_callback,
         std::function<void(AsyncErrorCode)> error_callback,
         const bool should_throw
     ) override;
-    Return<int32_t, std::error_code> async_int_throws(const bool input) override;
 };
 
 void
 AsyncClassImpl::async_void(std::function<void()> result_callback, const bool) {
     result_callback();
 }
-
-void
-AsyncClassImpl::async_void(const bool) {}
 
 void
 AsyncClassImpl::async_void_throws(
@@ -70,16 +63,10 @@ AsyncClassImpl::async_void_throws(
     }
 }
 
-std::error_code
-AsyncClassImpl::async_void_throws(const bool) { return {}; }
-
 void
 AsyncClassImpl::async_int(std::function<void(int32_t)> result_callback, const bool) {
     result_callback(42);
 }
-
-int32_t
-AsyncClassImpl::async_int(const bool) { return 0; }
 
 void
 AsyncClassImpl::async_int_throws(
@@ -94,9 +81,6 @@ AsyncClassImpl::async_int_throws(
     }
 }
 
-Return<int32_t, std::error_code>
-AsyncClassImpl::async_int_throws(const bool) { return Return<int32_t, std::error_code>(0); }
-
 // Static functions
 
 std::shared_ptr<AsyncClass>
@@ -106,8 +90,5 @@ void
 AsyncClass::async_static(std::function<void()> result_callback, const bool) {
     result_callback();
 }
-
-void
-AsyncClass::async_static(const bool) {}
 
 }

--- a/functional-tests/functional/input/src/cpp/AsyncStruct.cpp
+++ b/functional-tests/functional/input/src/cpp/AsyncStruct.cpp
@@ -32,9 +32,6 @@ AsyncStruct::async_void(std::function<void()> result_callback, const bool) const
 }
 
 void
-AsyncStruct::async_void(const bool) const {}
-
-void
 AsyncStruct::async_void_throws(
     std::function<void()> result_callback,
     std::function<void(std::string)> error_callback,
@@ -47,16 +44,10 @@ AsyncStruct::async_void_throws(
     }
 }
 
-Return<void, std::string>
-AsyncStruct::async_void_throws(const bool) const { return Return<void, std::string>(false); }
-
 void
 AsyncStruct::async_int(std::function<void(int32_t)> result_callback, const bool) const {
     result_callback(42);
 }
-
-int32_t
-AsyncStruct::async_int(const bool) const { return 0; }
 
 void
 AsyncStruct::async_int_throws(
@@ -71,17 +62,11 @@ AsyncStruct::async_int_throws(
     }
 }
 
-Return<int32_t, std::string>
-AsyncStruct::async_int_throws(const bool) const { return Return<int32_t, std::string>(0); }
-
 // Static functions
 
 void
 AsyncStruct::async_static(std::function<void()> result_callback, const bool) {
     result_callback();
 }
-
-void
-AsyncStruct::async_static(const bool) {}
 
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/cpp/CppGeneratorPredicates.kt
@@ -137,7 +137,6 @@ internal class CppGeneratorPredicates(private val referenceMap: Map<String, Lime
                         typesUsedInTheClass.filterKeys { it != container }.values.flatten().contains(container.fullName)
                     }
                 },
-
             "asyncFunNeedsSynchronousVersion" to { limeFunction: Any ->
                 if (limeFunction !is LimeFunction) {
                     false
@@ -148,7 +147,10 @@ internal class CppGeneratorPredicates(private val referenceMap: Map<String, Lime
             },
         )
 
-    private fun isSkippedInPlatform(limeFunction: LimeFunction, platform: LimeAttributeType) : Boolean {
+    private fun isSkippedInPlatform(
+        limeFunction: LimeFunction,
+        platform: LimeAttributeType,
+    ): Boolean {
         if (limeFunction.attributes.have(platform, LimeAttributeValueType.SKIP)) {
             return true
         }

--- a/gluecodium/src/main/resources/templates/cpp/CppFunctions.mustache
+++ b/gluecodium/src/main/resources/templates/cpp/CppFunctions.mustache
@@ -20,6 +20,9 @@
   !}}
 {{#functions}}{{#if attributes.async}}{{#set self=this isAsyncHelper=true}}{{#self}}
 {{prefixPartial "cpp/CppFunctionSignature" "    "}};
-{{/self}}{{/set}}{{/if}}
-{{prefixPartial "cpp/CppFunctionSignature" "    "}};
+{{/self}}{{/set}}
+{{#ifPredicate "asyncFunNeedsSynchronousVersion"}}{{!!
+}}{{prefixPartial "cpp/CppFunctionSignature" "    "}};{{!!
+}}{{/ifPredicate}}{{/if}}{{!!
+}}{{#unless attributes.async}}{{prefixPartial "cpp/CppFunctionSignature" "    "}};{{/unless}}
 {{/functions}}

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncClass.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncClass.h
@@ -22,15 +22,15 @@ public:
 
 public:
     virtual void async_void( std::function<void()> _result_callback, const bool input ) = 0;
-    virtual void async_void( const bool input ) = 0;
+
     virtual void async_void_throws( std::function<void()> _result_callback, std::function<void(::smoke::AsyncErrorCode)> _error_callback, const bool input ) = 0;
-    virtual ::std::error_code async_void_throws( const bool input ) = 0;
+
     virtual void async_int( std::function<void(int32_t)> _result_callback, const bool input ) = 0;
-    virtual int32_t async_int( const bool input ) = 0;
+
     virtual void async_int_throws( std::function<void(int32_t)> _result_callback, std::function<void(::smoke::AsyncErrorCode)> _error_callback, const bool input ) = 0;
-    virtual ::gluecodium::Return< int32_t, ::std::error_code > async_int_throws( const bool input ) = 0;
+
     static void async_static( std::function<void()> _result_callback, const bool input );
-    static void async_static( const bool input );
+
 };
 
 

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncRenamed.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncRenamed.h
@@ -18,7 +18,7 @@ public:
 
 public:
     virtual void callDispose( std::function<void()> _result_callback ) = 0;
-    virtual void callDispose(  ) = 0;
+
 };
 
 

--- a/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncStruct.h
+++ b/gluecodium/src/test/resources/smoke/async/output/cpp/include/smoke/AsyncStruct.h
@@ -1,27 +1,36 @@
 // -------------------------------------------------------------------------------------------------
 //
+
 //
 // -------------------------------------------------------------------------------------------------
+
 #pragma once
+
 #include "gluecodium/ExportGluecodiumCpp.h"
 #include "gluecodium/Return.h"
 #include <cstdint>
 #include <functional>
 #include <string>
+
 namespace smoke {
 struct _GLUECODIUM_CPP_EXPORT AsyncStruct {
     ::std::string string_field;
+
     AsyncStruct( );
     explicit AsyncStruct( ::std::string string_field );
+
     void async_void( std::function<void()> _result_callback, const bool input ) const;
-    void async_void( const bool input ) const;
+
     void async_void_throws( std::function<void()> _result_callback, std::function<void(::std::string)> _error_callback, const bool input ) const;
-    ::gluecodium::Return< void, ::std::string > async_void_throws( const bool input ) const;
+
     void async_int( std::function<void(int32_t)> _result_callback, const bool input ) const;
-    int32_t async_int( const bool input ) const;
+
     void async_int_throws( std::function<void(int32_t)> _result_callback, std::function<void(::std::string)> _error_callback, const bool input ) const;
-    ::gluecodium::Return< int32_t, ::std::string > async_int_throws( const bool input ) const;
+
     static void async_static( std::function<void()> _result_callback, const bool input );
-    static void async_static( const bool input );
+
+
 };
+
+
 }


### PR DESCRIPTION
When `@Async` annotation is used then C++ generator
behaves differently. In the past it was generating
two versions of the same function in such a case:
synchronous and asynchronous.

However, if the user only wants to generate the code
for C++ and Dart, then the synchronous version of a
function is not needed -- nobody is going to use it.

This change adjusts mustache templates and predicates
used for C++ generator in order to avoid generating
redundant code.

Moreover, this PR adjusts smoke and functional tests
as well as the documentation.