### PR TITLE
Release version 13.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Gluecodium project Release Notes
 
-## Unreleased
+## 13.10.3
+Release date 2025-02-12
 ### Bug fixes:
  * C++: removed generation of redundant synchronous version of function when `@Async` is used only for C++/Dart and Java/Swift are skipped.
  * LimeParser: introduced non-greedy parsing of new lines for ceratin sub-rules of `constant` rule to prevent meaningless error messages when invalid syntax is used after declaration of a constant.

--- a/gluecodium/src/main/resources/version.properties
+++ b/gluecodium/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version = 13.10.2
+version = 13.10.3


### PR DESCRIPTION
Bug fixes:
 * C++: removed generation of redundant synchronous version of function when `@Async` is used only for C++/Dart and Java/Swift are skipped.
 * LimeParser: introduced non-greedy parsing of new lines for ceratin sub-rules of `constant` rule to prevent meaningless error messages when invalid syntax is used after declaration of a constant.
 * Dart: fixed problem related to missing includes for `@Async` functions.
 * JNI: removed leak of JNI weak references in JniWrapperCache.