### PR TITLE
Kotlin: add support for static members in interfaces

### DIFF
--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
@@ -57,5 +57,7 @@ class AttributesInterfaceTest {
 
         AttributesInterface.someStaticProperty = "NEW VALUE OF PROPERTY"
         assertEquals(AttributesInterface.someStaticProperty, "NEW VALUE OF PROPERTY")
+
+        assertEquals(AttributesInterface.staticFunction(), "Some magic string!");
     }
 }

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
@@ -18,9 +18,8 @@
  */
 package com.here.android.test
 
-import org.junit.Assert.assertEquals
-
 import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -49,5 +48,14 @@ class AttributesInterfaceTest {
 
         val result = attributes.structAttribute
         assertEquals(structValue.value, result.value, delta)
+    }
+
+    @org.junit.Test
+    fun setGetStaticAttributes() {
+        assertEquals(AttributesInterface.LABEL, "SOME CONSTANT LABEL")
+        assertEquals(AttributesInterface.someStaticProperty, "MY STATIC PROPERTY")
+
+        AttributesInterface.someStaticProperty = "NEW VALUE OF PROPERTY"
+        assertEquals(AttributesInterface.someStaticProperty, "NEW VALUE OF PROPERTY")
     }
 }

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/AttributesInterfaceTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/AttributesInterfaceTest.java
@@ -56,4 +56,13 @@ public class AttributesInterfaceTest {
     assertNotNull(result);
     assertEquals(structValue.value, result.value);
   }
+
+  @Test
+  public void setGetStaticAttributes() {
+    assertEquals(AttributesInterface.LABEL, "SOME CONSTANT LABEL");
+    assertEquals(AttributesInterface.getSomeStaticProperty(), "MY STATIC PROPERTY");
+
+    AttributesInterface.setSomeStaticProperty("NEW VALUE OF PROPERTY");
+    assertEquals(AttributesInterface.getSomeStaticProperty(), "NEW VALUE OF PROPERTY");
+  }
 }

--- a/functional-tests/functional/input/lime/AttributesInterface.lime
+++ b/functional-tests/functional/input/lime/AttributesInterface.lime
@@ -27,4 +27,6 @@ interface AttributesInterface {
     const LABEL: String = "SOME CONSTANT LABEL"
 
     static property someStaticProperty: String
+
+    static fun staticFunction(): String
 }

--- a/functional-tests/functional/input/lime/AttributesInterface.lime
+++ b/functional-tests/functional/input/lime/AttributesInterface.lime
@@ -23,4 +23,8 @@ interface AttributesInterface {
     }
     property structAttribute: ExampleStruct { get set }
     property builtInTypeAttribute: UInt
+
+    const LABEL: String = "SOME CONSTANT LABEL"
+
+    static property someStaticProperty: String
 }

--- a/functional-tests/functional/input/src/cpp/AttributesInterfaceImpl.cpp
+++ b/functional-tests/functional/input/src/cpp/AttributesInterfaceImpl.cpp
@@ -32,6 +32,10 @@ void AttributesInterface::set_some_static_property( const ::std::string& value )
     s_some_static_property = value;
 }
 
+std::string AttributesInterface::static_function() {
+    return "Some magic string!";
+}
+
 AttributesInterfaceImpl::~AttributesInterfaceImpl( ) = default;
 
 uint32_t

--- a/functional-tests/functional/input/src/cpp/AttributesInterfaceImpl.cpp
+++ b/functional-tests/functional/input/src/cpp/AttributesInterfaceImpl.cpp
@@ -22,6 +22,16 @@
 
 namespace test
 {
+static std::string s_some_static_property = "MY STATIC PROPERTY";
+
+::std::string AttributesInterface::get_some_static_property() {
+    return s_some_static_property;
+}
+
+void AttributesInterface::set_some_static_property( const ::std::string& value ) {
+    s_some_static_property = value;
+}
+
 AttributesInterfaceImpl::~AttributesInterfaceImpl( ) = default;
 
 uint32_t

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -65,8 +65,6 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 
 {{#ifPredicate "needsCompanionObject"}}
     companion object {
-{{#constants}}{{prefixPartial "kotlin/KotlinConstant" "        "}}
-{{/constants}}
 {{#ifPredicate "needsDisposer"}}
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
 {{/ifPredicate}}
@@ -76,6 +74,17 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{prefixPartial "kotlin/KotlinFunction" "        "}}
 {{/if}}
 {{/functions}}
+{{/ifPredicate}}
+{{#ifPredicate "hasStaticProperties"}}
+{{#properties}}
+{{#if isStatic}}
+{{#if setter}}        @JvmStatic var{{/if}}{{!!
+}}{{#unless setter}}        @JvmStatic val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+            external get{{#setter}}
+            external set{{/setter}}
+{{/if}}
+{{/properties}}
 {{/ifPredicate}}
     }
 {{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -39,4 +39,45 @@ interface {{resolveName}} {{!!
         set{{/setter}}
 {{/unless}}
 {{/properties}}
+
+{{#ifPredicate "needsCompanionObject"}}
+    companion object {
+{{#constants}}{{prefixPartial "kotlin/KotlinConstant" "        "}}
+{{/constants}}
+{{#ifPredicate "hasStaticFunctions"}}
+{{#set isInterface=true interface=this}}
+{{#functions}}
+{{#if isStatic}}
+{{prefixPartial "kotlin/KotlinFunction" "        "}}{{prefixPartial "redirectToImpl" "    " skipFirstLine=true}}
+{{/if}}
+{{/functions}}
+{{/set}}
+{{/ifPredicate}}
+{{#ifPredicate "hasStaticProperties"}}
+{{#set isInterface=true interface=this}}
+{{#properties}}
+{{#set property=this}}
+{{#property}}
+{{#if isStatic}}
+{{#if setter}}        @JvmStatic var{{/if}}{{!!
+}}{{#unless setter}}        @JvmStatic val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+            get() = {{resolveName interface}}Impl.{{resolveName property}}{{#setter}}
+            set(value) {
+                {{resolveName interface}}Impl.{{resolveName property}} = value
+            }{{/setter}}
+{{/if}}
+{{/property}}
+{{/set}}
+{{/properties}}
+{{/set}}
+{{/ifPredicate}}
+    }
+{{/ifPredicate}}{{!!
+
+}}{{+redirectToImpl}} {
+        {{#unless returnType.isVoid}}return {{/unless}}{{resolveName interface}}Impl.{{resolveName}}({{!!
+        }}{{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}})
+    }
+{{/redirectToImpl}}
 }

--- a/gluecodium/src/test/resources/smoke/errors/input/Errors.lime
+++ b/gluecodium/src/test/resources/smoke/errors/input/Errors.lime
@@ -68,6 +68,8 @@ interface ErrorsInterface {
     static fun methodWithPayloadError() throws WithPayload
     static fun methodWithPayloadErrorAndReturnValue(): String throws WithPayload
 
+    const ERROR_MESSAGE: String = "Some error message constant"
+
     exception Internal(InternalError)
     exception External(ExternalErrors)
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -27,5 +27,17 @@ interface ErrorsInterface {
     fun methodWithExternalErrors() : Unit
     fun methodWithErrorsAndReturnValue() : String
 
+
+    companion object {
+        val ERROR_MESSAGE: String = "Some error message constant"
+        @JvmStatic fun methodWithPayloadError() : Unit {
+            ErrorsInterfaceImpl.methodWithPayloadError()
+        }
+
+        @JvmStatic fun methodWithPayloadErrorAndReturnValue() : String {
+            return ErrorsInterfaceImpl.methodWithPayloadErrorAndReturnValue()
+        }
+
+    }
 }
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
@@ -1,0 +1,31 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ErrorsInterfaceImpl : NativeBase, ErrorsInterface {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun methodWithErrors() : Unit
+    override external fun methodWithExternalErrors() : Unit
+    override external fun methodWithErrorsAndReturnValue() : String
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun methodWithPayloadError() : Unit
+        @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
+    }
+}

--- a/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/ErrorsInterface.java
+++ b/gluecodium/src/test/resources/smoke/errors/output/android/com/example/smoke/ErrorsInterface.java
@@ -8,6 +8,7 @@ package com.example.smoke;
 import android.support.annotation.NonNull;
 
 public interface ErrorsInterface {
+    public static final String ERROR_MESSAGE = "Some error message constant";
     public enum InternalError {
         ERROR_NONE(0),
         ERROR_FATAL(1);
@@ -64,21 +65,16 @@ public interface ErrorsInterface {
         public final ErrorsInterface.ExternalErrors error;
     }
 
-
     void methodWithErrors() throws ErrorsInterface.InternalException;
 
-
     void methodWithExternalErrors() throws ErrorsInterface.ExternalException;
-
 
     @NonNull
     String methodWithErrorsAndReturnValue() throws ErrorsInterface.InternalException;
 
-
     static void methodWithPayloadError() throws WithPayloadException {
         ErrorsInterfaceImpl.methodWithPayloadError();
     }
-
 
 
     @NonNull

--- a/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
+++ b/gluecodium/src/test/resources/smoke/errors/output/dart/lib/src/smoke/errors_interface.dart
@@ -24,6 +24,8 @@ abstract class ErrorsInterface implements Finalizable {
 
   );
 
+  static final String errorMessage = "Some error message constant";
+
 
   void methodWithErrors();
 

--- a/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
+++ b/gluecodium/src/test/resources/smoke/errors/output/swift/smoke/ErrorsInterface.swift
@@ -1,26 +1,43 @@
 //
+
 //
+
 import Foundation
+
 public protocol ErrorsInterface : AnyObject {
+
+
     typealias ExternalError = ExternalErrors
+
+
     func methodWithErrors() throws -> Void
+
     func methodWithExternalErrors() throws -> Void
+
     func methodWithErrorsAndReturnValue() throws -> String
+
     static func methodWithPayloadError() throws -> Void
+
     static func methodWithPayloadErrorAndReturnValue() throws -> String
 }
+
 internal class _ErrorsInterface: ErrorsInterface {
+
+    public static let errorMessage: String = "Some error message constant"
     let c_instance : _baseRef
+
     init(cErrorsInterface: _baseRef) {
         guard cErrorsInterface != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cErrorsInterface
     }
+
     deinit {
         smoke_ErrorsInterface_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_ErrorsInterface_release_handle(c_instance)
     }
+
     public func methodWithErrors() throws -> Void {
         let RESULT = smoke_ErrorsInterface_methodWithErrors(self.c_instance)
         if (!RESULT.has_value) {
@@ -55,31 +72,47 @@ internal class _ErrorsInterface: ErrorsInterface {
         let c_result_handle = RESULT.returned_value
         return moveFromCType(c_result_handle)
     }
+
 }
+
+
+
 public enum InternalError : UInt32, CaseIterable, Codable {
+
     case errorNone
+
     case errorFatal
 }
 public enum ExternalErrors : UInt32, CaseIterable, Codable {
+
     case none
+
     case boom
+
     case bust
 }
+
+
+
 @_cdecl("_CBridgeInitsmoke_ErrorsInterface")
 internal func _CBridgeInitsmoke_ErrorsInterface(handle: _baseRef) -> UnsafeMutableRawPointer {
     let reference = _ErrorsInterface(cErrorsInterface: handle)
     return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
 }
+
 internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder {
+
     guard let reference = ref else {
         return RefHolder(0)
     }
+
     if let instanceReference = reference as? NativeBase {
         let handle_copy = smoke_ErrorsInterface_copy_handle(instanceReference.c_handle)
         return owning
             ? RefHolder(ref: handle_copy, release: smoke_ErrorsInterface_release_handle)
             : RefHolder(handle_copy)
     }
+
     var functions = smoke_ErrorsInterface_FunctionTable()
     functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
     functions.release = {swift_class_pointer in
@@ -87,9 +120,13 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             Unmanaged<AnyObject>.fromOpaque(swift_class).release()
         }
     }
+
+
     functions.smoke_ErrorsInterface_methodWithErrors = {(swift_class_pointer) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ErrorsInterface
-        do {
+
+        do { 
             try swift_class.methodWithErrors()
             return smoke_ErrorsInterface_methodWithErrors_result(has_value: true, error_value: 0)
         } catch let error as InternalError {
@@ -98,9 +135,12 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             fatalError("Unexpected error: \(error)")
         }
     }
+
     functions.smoke_ErrorsInterface_methodWithExternalErrors = {(swift_class_pointer) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ErrorsInterface
-        do {
+
+        do { 
             try swift_class.methodWithExternalErrors()
             return smoke_ErrorsInterface_methodWithExternalErrors_result(has_value: true, error_value: 0)
         } catch let error as ErrorsInterface.ExternalError {
@@ -109,9 +149,12 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
             fatalError("Unexpected error: \(error)")
         }
     }
+
     functions.smoke_ErrorsInterface_methodWithErrorsAndReturnValue = {(swift_class_pointer) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! ErrorsInterface
-        do {
+
+        do { 
             let call_result = try swift_class.methodWithErrorsAndReturnValue()
             let result_handle = copyToCType(call_result).ref
             return smoke_ErrorsInterface_methodWithErrorsAndReturnValue_result(has_value: true, .init(returned_value: result_handle))
@@ -124,6 +167,7 @@ internal func getRef(_ ref: ErrorsInterface?, owning: Bool = true) -> RefHolder 
     let proxy = smoke_ErrorsInterface_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_ErrorsInterface_release_handle) : RefHolder(proxy)
 }
+
 extension _ErrorsInterface: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -144,6 +188,7 @@ internal func ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
+
 internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterface {
     if let swift_pointer = smoke_ErrorsInterface_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? ErrorsInterface {
@@ -162,6 +207,7 @@ internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterfa
     }
     fatalError("Failed to initialize Swift object")
 }
+
 internal func ErrorsInterface_copyFromCType(_ handle: _baseRef) -> ErrorsInterface? {
     guard handle != 0 else {
         return nil
@@ -174,36 +220,44 @@ internal func ErrorsInterface_moveFromCType(_ handle: _baseRef) -> ErrorsInterfa
     }
     return ErrorsInterface_moveFromCType(handle) as ErrorsInterface
 }
+
 internal func copyToCType(_ swiftClass: ErrorsInterface) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: ErrorsInterface) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: ErrorsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: ErrorsInterface?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftEnum: InternalError) -> PrimitiveHolder<UInt32> {
     return PrimitiveHolder(swiftEnum.rawValue)
 }
 internal func moveToCType(_ swiftEnum: InternalError) -> PrimitiveHolder<UInt32> {
     return copyToCType(swiftEnum)
 }
+
 internal func copyToCType(_ swiftEnum: InternalError?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
 internal func moveToCType(_ swiftEnum: InternalError?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
+
 internal func copyFromCType(_ cValue: UInt32) -> InternalError {
     return InternalError(rawValue: cValue)!
 }
 internal func moveFromCType(_ cValue: UInt32) -> InternalError {
     return copyFromCType(cValue)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> InternalError? {
     guard handle != 0 else {
         return nil
@@ -222,18 +276,21 @@ internal func copyToCType(_ swiftEnum: ExternalErrors) -> PrimitiveHolder<UInt32
 internal func moveToCType(_ swiftEnum: ExternalErrors) -> PrimitiveHolder<UInt32> {
     return copyToCType(swiftEnum)
 }
+
 internal func copyToCType(_ swiftEnum: ExternalErrors?) -> RefHolder {
     return copyToCType(swiftEnum?.rawValue)
 }
 internal func moveToCType(_ swiftEnum: ExternalErrors?) -> RefHolder {
     return moveToCType(swiftEnum?.rawValue)
 }
+
 internal func copyFromCType(_ cValue: UInt32) -> ExternalErrors {
     return ExternalErrors(rawValue: cValue)!
 }
 internal func moveFromCType(_ cValue: UInt32) -> ExternalErrors {
     return copyFromCType(cValue)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> ExternalErrors? {
     guard handle != 0 else {
         return nil
@@ -246,6 +303,8 @@ internal func moveFromCType(_ handle: _baseRef) -> ExternalErrors? {
     }
     return copyFromCType(handle)
 }
+
+
 extension InternalError : Error {
 }
 extension ExternalErrors : Error {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStatic.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStatic.kt
@@ -1,0 +1,29 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface InterfaceWithStatic {
+
+    fun regularFunction() : String
+
+    var regularProperty: String
+        get
+        set
+
+    companion object {
+        @JvmStatic fun staticFunction() : String {
+            return InterfaceWithStaticImpl.staticFunction()
+        }
+
+        @JvmStatic var staticProperty: String
+            get() = InterfaceWithStaticImpl.staticProperty
+            set(value) {
+                InterfaceWithStaticImpl.staticProperty = value
+            }
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class InterfaceWithStaticImpl : NativeBase, InterfaceWithStatic {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun regularFunction() : String
+
+    override var regularProperty: String
+        external get
+        external set
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun staticFunction() : String
+        @JvmStatic var staticProperty: String
+            external get
+            external set
+    }
+}


### PR DESCRIPTION
This change:
 - adds support for constants, static functions and static properties in case of interfaces
 - adjusts old smoke tests and adds new ones
 - adds a new functional test to confirm that the new
   functionality works as expected