### PR TITLE
Java: add missing documentation comment to NativeBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Bug fixes:
+ * Java: add missing documentation comment to NativeBase class, to avoid triggering warnings.
+
 ## 13.10.3
 Release date 2025-02-12
 ### Bug fixes:

--- a/gluecodium/src/main/resources/templates/java/NativeBase.mustache
+++ b/gluecodium/src/main/resources/templates/java/NativeBase.mustache
@@ -76,6 +76,11 @@ public abstract class NativeBase {
   private static final Set<Reference<?>> REFERENCES =
       Collections.newSetFromMap(new ConcurrentHashMap<Reference<?>, Boolean>());
 
+  /**
+   * Controls whether exceptions related to cleanup of C++ objects tied with Java objects
+   * are propagated to the user application.
+   * @hidden
+   */
   public static boolean propagateCleanupException = false;
 
   private static final ReferenceQueue<NativeBase> REFERENCE_QUEUE = new ReferenceQueue<>();

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/android/com/example/foo/bar/NativeBase.java
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/android/com/example/foo/bar/NativeBase.java
@@ -56,6 +56,11 @@ public abstract class NativeBase {
   private static final Set<Reference<?>> REFERENCES =
       Collections.newSetFromMap(new ConcurrentHashMap<Reference<?>, Boolean>());
 
+  /**
+   * Controls whether exceptions related to cleanup of C++ objects tied with Java objects
+   * are propagated to the user application.
+   * @hidden
+   */
   public static boolean propagateCleanupException = false;
 
   private static final ReferenceQueue<NativeBase> REFERENCE_QUEUE = new ReferenceQueue<>();


### PR DESCRIPTION
'propagateCleanupException' flag was added in the past to NativeBase class.
It allows controlling whether exceptions related to cleanup of C++ objects should
be propagated to client application. This is an internal flag for developers.

Sadly, the comment was not added for this flag -- this could
trigger compilation warnings (or errors depending on the flags).

This change adds the missing comment with `hidden` attribute.

