### PR TITLE
Release version 13.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Gluecodium project Release Notes
 
-## Unreleased
+## 13.10.4
+Release date 2025-02-13
 ### Bug fixes:
  * Java: add missing documentation comment to NativeBase class, to avoid triggering warnings.
 

--- a/gluecodium/src/main/resources/version.properties
+++ b/gluecodium/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version = 13.10.3
+version = 13.10.4


### PR DESCRIPTION
Bug fixes:
 * Java: add missing documentation comment to NativeBase
             class to avoid triggering warnings.
