### PR TITLE
Kotlin: validate 'nocache' attribute handling

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -500,7 +500,7 @@ feature(CrossPackageNameClash cpp android swift dart SOURCES
     input/lime/CrossPackageNameClashC.lime
 )
 
-feature(NoCache android swift dart SOURCES
+feature(NoCache android android-kotlin swift dart SOURCES
     input/src/cpp/NoCache.cpp
 
     input/lime/NoCache.lime

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/NoCacheTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/NoCacheTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import org.junit.Assert.assertFalse
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class NoCacheTest {
+
+    class NoCacheImpl : NoCacheInterface {
+        override fun foo() {}
+    }
+
+    @org.junit.Test
+    fun noCacheInterfaceFromCpp() {
+        val instance1: NoCacheInterface = NoCacheHelper.getNoCacheInterface()
+        val instance2: NoCacheInterface = NoCacheHelper.getNoCacheInterface()
+
+        val result: Boolean = instance1 === instance2
+
+        assertFalse(result)
+    }
+
+    @org.junit.Test
+    fun noCacheInterfaceFromKotlin() {
+        val instance: NoCacheInterface = NoCacheImpl()
+
+        val result: Boolean = NoCacheHelper.compareNoCacheInterface(instance, instance)
+
+        assertFalse(result)
+    }
+
+    @org.junit.Test
+    fun noCacheClassFromCpp() {
+        val instance1: NoCacheClass = NoCacheHelper.getNoCacheClass()
+        val instance2: NoCacheClass = NoCacheHelper.getNoCacheClass()
+
+        val result: Boolean = instance1 === instance2
+
+        assertFalse(result)
+    }
+
+}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -27,7 +27,7 @@
 
 {{>kotlin/KotlinContainerContents}}
 
-{{#constructors}}
+{{#set classElement=this}}{{#constructors}}
     constructor({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
@@ -37,7 +37,7 @@
         cacheThisInstance();
 {{/unless}}
     }
-{{/constructors}}
+{{/constructors}}{{/set}}
 
     /*
      * For internal use only.

--- a/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class NoCacheClass : NativeBase {
+
+
+    constructor() : this(make(), null as Any?) {
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+    external fun foo() : Unit
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun make() : Long
+    }
+}


### PR DESCRIPTION
This change:
- implements a minor bug-fix for handling of 'nocache' in KotlinClass.mustache
- adds a new functional tests and smoke tests for 'nocache' attribute