### PR TITLE
Kotlin: validate usage of 'Skip' and 'EnableIf'

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
@@ -22,7 +22,6 @@ package com.here.gluecodium.generator.kotlin
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
-import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
 
 internal object KotlinGeneratorPredicates {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
@@ -50,7 +50,6 @@ internal object KotlinGeneratorPredicates {
     private fun needsDisposer(element: Any) =
         when (element) {
             is LimeClass -> element.parentClass == null
-            is LimeInterface -> true
             is LimeLambda -> true
             else -> false
         }

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -47,12 +47,12 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{/properties}}
 
 {{#if this.parentInterfaces}}{{#set override=true classElement=this}}
-{{#classElement.interfaceInheritedFunctions}}
+{{#classElement.inheritedFunctions}}
 {{#unless isStatic}}
 {{prefixPartial "kotlin/KotlinFunction" "    "}}
 {{/unless}}
-{{/classElement.interfaceInheritedFunctions}}
-{{#classElement.interfaceInheritedProperties}}
+{{/classElement.inheritedFunctions}}
+{{#classElement.inheritedProperties}}
 {{#unless isStatic}}
 {{#if setter}}    override var{{/if}}{{!!
 }}{{#unless setter}}    override val{{/unless}}{{!!
@@ -60,7 +60,7 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
         external get{{#setter}}
         external set{{/setter}}
 {{/unless}}
-{{/classElement.interfaceInheritedProperties}}
+{{/classElement.inheritedProperties}}
 {{/set}}{{/if}}
 
 {{#ifPredicate "needsCompanionObject"}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -63,11 +63,8 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{/classElement.inheritedProperties}}
 {{/set}}{{/if}}
 
-{{#ifPredicate "needsCompanionObject"}}
     companion object {
-{{#ifPredicate "needsDisposer"}}
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
-{{/ifPredicate}}
 {{#ifPredicate "hasStaticFunctions"}}
 {{#functions}}
 {{#if isStatic}}
@@ -87,5 +84,4 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{/properties}}
 {{/ifPredicate}}
     }
-{{/ifPredicate}}
 }

--- a/gluecodium/src/test/resources/smoke/skip/input/EnableIfInPlatform.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/EnableIfInPlatform.lime
@@ -17,7 +17,7 @@
 
 package smoke
 
-@Skip(Swift, Dart)
+@Skip(Swift, Dart, Kotlin)
 interface EnableTagsInJava {
     @Java(EnableIf = "Lite")
     fun enableTagged()
@@ -27,7 +27,7 @@ interface EnableTagsInJava {
     fun enableTaggedList()
 }
 
-@Skip(Java, Dart)
+@Skip(Java, Dart, Kotlin)
 interface EnableTagsInSwift {
     @Swift(EnableIf = "Lite")
     fun enableTagged()
@@ -37,13 +37,23 @@ interface EnableTagsInSwift {
     fun enableTaggedList()
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Swift, Kotlin)
 interface EnableTagsInDart {
     @Dart(EnableIf = "Lite")
     fun enableTagged()
     @Dart(EnableIf = "Pro")
     fun dontEnableTagged()
     @Dart(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}
+
+@Skip(Swift, Dart, Java)
+interface EnableTagsInKotlin {
+    @Kotlin(EnableIf = "Lite")
+    fun enableTagged()
+    @Kotlin(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Kotlin(EnableIf = ["Lite", "Pro"])
     fun enableTaggedList()
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/Skip.lime
@@ -24,19 +24,21 @@ class SkipFunctions {
     static fun notInSwift(input: Boolean): Boolean
     @Dart(Skip)
     static fun notInDart(input: Float): Float
+    @Kotlin(Skip)
+    static fun notInKotlin(input: String): String
 }
 
 class ClassWithStructWithSkipLambdaInPlatform {
     struct SkipLambdaInPlatform {
         intField: Int
 
-        @Skip(Java, Dart, Swift)
+        @Skip(Java, Dart, Swift, Kotlin)
         lambda SomeLambda = () -> Int
 
-        @Skip(Java, Dart, Swift)
+        @Skip(Java, Dart, Swift, Kotlin)
         someLambda: SomeLambda
 
-        @Skip(Java, Dart, Swift)
+        @Skip(Java, Dart, Swift, Kotlin)
         fun useLambda(someLambda: SomeLambda): SomeLambda
     }
 }
@@ -54,8 +56,12 @@ class SkipTypes {
     struct NotInDart {
         fooField: String
     }
+    @Kotlin(Skip)
+    struct NotInKotlin {
+        fooField: String
+    }
 
-    @Dart(Skip) @Java(Skip) @Swift(Skip)
+    @Dart(Skip) @Java(Skip) @Swift(Skip) @Kotlin(Skip)
     fun useListInDart(): List<NotInDart>
 }
 
@@ -66,6 +72,8 @@ interface SkipProxy {
     fun notInSwift(input: Boolean): Boolean
     @Dart(Skip)
     fun notInDart(input: Float): Float
+    @Kotlin(Skip)
+    fun notInKotlin(input: Float): Float
 
     @Java(Skip)
     property skippedInJava: String
@@ -73,21 +81,23 @@ interface SkipProxy {
     property skippedInSwift: Boolean
     @Dart(Skip)
     property skippedInDart: Float
+    @Kotlin(Skip)
+    property skippedInKotlin: Float
 
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     property skippedEverywhere: SkippedEverywhere
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     property skippedEverywhereToo: SkippedEverywhereEnum
 }
 
-@Java(Skip) @Swift(Skip) @Dart(Skip)
+@Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
 struct SkippedEverywhere {
     nothingToSeeHere: String
 
     fun useMapInDart(foo: Map<Int, SkipTypes.NotInDart>)
 }
 
-@Java(Skip) @Swift(Skip) @Dart(Skip)
+@Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
 enum SkippedEverywhereEnum {
     nothingToSeeHere
 }
@@ -96,7 +106,7 @@ interface InheritFromSkipped: SkipProxy { }
 
 struct SkipFieldInPlatform {
     intField: Int
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     stringField: String
     boolField: Boolean
 }
@@ -104,7 +114,7 @@ struct SkipFieldInPlatform {
 @Immutable
 struct SkipFieldInPlatformImmutable {
     intField: Int
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     stringField: DummyStruct = {}
     boolField: Boolean
 }
@@ -116,7 +126,7 @@ struct DummyStruct {
 interface SkipSetter {
     property foo: String {
         get
-        @Java(Skip) @Swift(Skip) @Dart(Skip)
+        @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
         set
     }
 }

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipNameClash.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipNameClash.lime
@@ -23,6 +23,7 @@ struct SkipFieldConstructorsClash {
     @Swift(Skip)
     field constructor()
 
+    @Kotlin(Skip)
     @Swift(Skip)
     @Java(Skip)
     @Cpp(Skip)

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTags.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTags.lime
@@ -41,6 +41,8 @@ class SkipPlatforms {
     static fun notInSwift(input: Boolean): Boolean
     @Skip(Dart)
     static fun notInDart(input: Float): Float
+    @Skip(Kotlin)
+    static fun notInKotlin(input: Float): Float
 }
 
 class SkipMixed {
@@ -50,6 +52,8 @@ class SkipMixed {
     static fun notInSwift(input: Boolean): Boolean
     @Skip(Dart, Lite)
     static fun notInDart(input: Float): Float
+    @Skip(Kotlin, Lite)
+    static fun notInKotlin(input: Float): Float
 }
 
 struct SkipTypesTags {

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTagsInPlatform.lime
@@ -17,7 +17,7 @@
 
 package smoke
 
-@Skip(Swift, Dart)
+@Skip(Swift, Dart, Kotlin)
 interface SkipTagsInJava {
     @Java(Skip = "Lite")
     fun skipTagged()
@@ -27,7 +27,7 @@ interface SkipTagsInJava {
     fun skipTaggedList()
 }
 
-@Skip(Java, Dart)
+@Skip(Java, Dart, Kotlin)
 interface SkipTagsInSwift {
     @Swift(Skip = "Lite")
     fun skipTagged()
@@ -37,12 +37,22 @@ interface SkipTagsInSwift {
     fun skipTaggedList()
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Swift, Kotlin)
 interface SkipTagsInDart {
     @Dart(Skip = "Lite")
     fun skipTagged()
     @Dart(Skip = "Pro")
     fun dontSkipTagged()
     @Dart(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}
+
+@Skip(Swift, Dart, Java)
+interface SkipTagsInKotlin {
+    @Kotlin(Skip = "Lite")
+    fun skipTagged()
+    @Kotlin(Skip = "Pro")
+    fun dontSkipTagged()
+    @Kotlin(Skip = ["Lite", "Pro"])
     fun skipTaggedList()
 }

--- a/gluecodium/src/test/resources/smoke/skip/input/SkipTagsIncludes.lime
+++ b/gluecodium/src/test/resources/smoke/skip/input/SkipTagsIncludes.lime
@@ -28,6 +28,7 @@ struct SomeSkippedStruct {
     `field`: List<SomeSkippedEnum>
 }
 
+@Kotlin(Skip = "Pro")
 @Java(Skip = "Pro")
 @Swift(Skip = "Pro")
 class SomeSkippedClass {
@@ -38,5 +39,6 @@ class SkippedFunctionClass {
     @Java(Skip = "Lite")
     @Swift(Skip = "Lite")
     @Dart(Skip = "Lite")
+    @Kotlin(Skip = "Lite")
     fun doFoo(input: dont.smoke.DontSmokeEnum)
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
@@ -1,0 +1,38 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ClassWithStructWithSkipLambdaInPlatform : NativeBase {
+
+    class SkipLambdaInPlatform(var intField: Int) {
+
+
+
+
+    }
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
@@ -1,0 +1,37 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class EnableIfEnabled : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun enableIfUnquoted() : Unit
+        @JvmStatic external fun enableIfUnquotedList() : Unit
+        @JvmStatic external fun enableIfQuoted() : Unit
+        @JvmStatic external fun enableIfQuotedList() : Unit
+        @JvmStatic external fun enableIfTagged() : Unit
+        @JvmStatic external fun enableIfTaggedList() : Unit
+        @JvmStatic external fun enableIfMixedList() : Unit
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
@@ -1,0 +1,30 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class EnableIfSkipped : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableTagsInKotlin.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableTagsInKotlin.kt
@@ -1,0 +1,15 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface EnableTagsInKotlin {
+
+    fun enableTagged() : Unit
+    fun enableTaggedList() : Unit
+
+}
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
@@ -1,0 +1,38 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class InheritFromSkippedImpl : NativeBase, InheritFromSkipped {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    override external fun notInJava(input: String) : String
+    override external fun notInSwift(input: Boolean) : Boolean
+    override external fun notInDart(input: Float) : Float
+    override var skippedInJava: String
+        external get
+        external set
+    override var isSkippedInSwift: Boolean
+        external get
+        external set
+    override var skippedInDart: Float
+        external get
+        external set
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorAutoTag.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorAutoTag.kt
@@ -1,0 +1,12 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+enum class SkipEnumeratorAutoTag(private val value: Int) {
+    ONE(0),
+    THREE(1);
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorExplicitTag.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorExplicitTag.kt
@@ -1,0 +1,13 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+enum class SkipEnumeratorExplicitTag(private val value: Int) {
+    ZERO(0),
+    ONE(3),
+    THREE(4);
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipField.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipField.kt
@@ -1,0 +1,16 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class SkipField(var field: String) {
+
+
+
+
+}
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class SkipFunctions : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun notInJava(input: String) : String
+        @JvmStatic external fun notInSwift(input: Boolean) : Boolean
+        @JvmStatic external fun notInDart(input: Float) : Float
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipProxy.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipProxy.kt
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface SkipProxy {
+
+    fun notInJava(input: String) : String
+    fun notInSwift(input: Boolean) : Boolean
+    fun notInDart(input: Float) : Float
+
+    var skippedInJava: String
+        get
+        set
+    var isSkippedInSwift: Boolean
+        get
+        set
+    var skippedInDart: Float
+        get
+        set
+}
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipSetter.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipSetter.kt
@@ -1,0 +1,15 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface SkipSetter {
+
+
+    val foo: String
+        get
+}
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsInKotlin.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsInKotlin.kt
@@ -1,0 +1,14 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface SkipTagsInKotlin {
+
+    fun dontSkipTagged() : Unit
+
+}
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
@@ -1,0 +1,30 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class SkipTagsOnly : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
@@ -1,0 +1,54 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class SkipTypes : NativeBase {
+
+    class NotInJava(var fooField: String) {
+
+
+
+
+    }
+
+
+    class NotInSwift(var fooField: String) {
+
+
+
+
+    }
+
+
+    class NotInDart(var fooField: String) {
+
+
+
+
+    }
+
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import com.example.dont.smoke.DontSmokeEnum
+
+class SomeSkippedClass : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+    external fun doFoo() : DontSmokeEnum
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/InheritFromSkippedImpl.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/InheritFromSkippedImpl.java
@@ -1,8 +1,12 @@
 /*
+
  *
  */
+
 package com.example.smoke;
+
 import com.example.NativeBase;
+
 class InheritFromSkippedImpl extends NativeBase implements InheritFromSkipped {
     protected InheritFromSkippedImpl(final long nativeHandle, final Object dummy) {
         super(nativeHandle, new Disposer() {
@@ -12,17 +16,55 @@ class InheritFromSkippedImpl extends NativeBase implements InheritFromSkipped {
             }
         });
     }
+
     private static native void disposeNativeHandle(long nativeHandle);
+
+
+
+
+
     @Override
     public native boolean notInSwift(final boolean input);
+
+
+
     @Override
     public native float notInDart(final float input);
+
+
+
+    @Override
+    public native float notInKotlin(final float input);
+
+
+
     @Override
     public native boolean isSkippedInSwift();
+
+
+
     @Override
     public native void setSkippedInSwift(final boolean value);
+
+
+
     @Override
     public native float getSkippedInDart();
+
+
+
     @Override
     public native void setSkippedInDart(final float value);
+
+
+
+    @Override
+    public native float getSkippedInKotlin();
+
+
+
+    @Override
+    public native void setSkippedInKotlin(final float value);
+
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipFunctions.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipFunctions.java
@@ -1,9 +1,15 @@
 /*
+
  *
  */
+
 package com.example.smoke;
+
+import android.support.annotation.NonNull;
 import com.example.NativeBase;
+
 public final class SkipFunctions extends NativeBase {
+
     /**
      * For internal use only.
      * @hidden
@@ -18,7 +24,21 @@ public final class SkipFunctions extends NativeBase {
             }
         });
     }
+
     private static native void disposeNativeHandle(long nativeHandle);
+
+
+
     public static native boolean notInSwift(final boolean input);
+
+
     public static native float notInDart(final float input);
+
+
+    @NonNull
+    public static native String notInKotlin(@NonNull final String input);
+
+
+
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipProxy.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipProxy.java
@@ -1,12 +1,29 @@
 /*
+
  *
  */
+
 package com.example.smoke;
+
+
 public interface SkipProxy {
+
     boolean notInSwift(final boolean input);
+
     float notInDart(final float input);
+
+    float notInKotlin(final float input);
+
     boolean isSkippedInSwift();
+
     void setSkippedInSwift(final boolean value);
+
     float getSkippedInDart();
+
     void setSkippedInDart(final float value);
+
+    float getSkippedInKotlin();
+
+    void setSkippedInKotlin(final float value);
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTypes.java
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/com/example/smoke/SkipTypes.java
@@ -1,24 +1,48 @@
 /*
+
  *
  */
+
 package com.example.smoke;
+
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
+
 public final class SkipTypes extends NativeBase {
     public static final class NotInSwift {
         @NonNull
         public String fooField;
+
         public NotInSwift(@NonNull final String fooField) {
             this.fooField = fooField;
         }
+
+
     }
+
     public static final class NotInDart {
         @NonNull
         public String fooField;
+
         public NotInDart(@NonNull final String fooField) {
             this.fooField = fooField;
         }
+
+
     }
+
+    public static final class NotInKotlin {
+        @NonNull
+        public String fooField;
+
+        public NotInKotlin(@NonNull final String fooField) {
+            this.fooField = fooField;
+        }
+
+
+    }
+
+
     /**
      * For internal use only.
      * @hidden
@@ -33,5 +57,11 @@ public final class SkipTypes extends NativeBase {
             }
         });
     }
+
     private static native void disposeNativeHandle(long nativeHandle);
+
+
+
+
 }
+

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFunctions.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipFunctions.h
@@ -1,15 +1,25 @@
 /*
+
  *
  */
+
 #pragma once
+
 #include <jni.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 JNIEXPORT jboolean JNICALL
 Java_com_example_smoke_SkipFunctions_notInSwift(JNIEnv* _jenv, jobject _jinstance, jboolean jinput);
 JNIEXPORT jfloat JNICALL
 Java_com_example_smoke_SkipFunctions_notInDart(JNIEnv* _jenv, jobject _jinstance, jfloat jinput);
+JNIEXPORT jstring JNICALL
+Java_com_example_smoke_SkipFunctions_notInKotlin(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImpl.cpp
@@ -60,6 +60,29 @@ Java_com_example_smoke_SkipProxyImpl_notInDart(JNIEnv* _jenv, jobject _jinstance
     return _result;
 }
 
+jfloat
+Java_com_example_smoke_SkipProxyImpl_notInKotlin(JNIEnv* _jenv, jobject _jinstance, jfloat jinput)
+
+{
+
+
+
+    float input = jinput;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->not_in_kotlin(input);
+
+    return _result;
+}
+
 
 jboolean
 Java_com_example_smoke_SkipProxyImpl_isSkippedInSwift(JNIEnv* _jenv, jobject _jinstance)
@@ -146,6 +169,51 @@ Java_com_example_smoke_SkipProxyImpl_setSkippedInDart(JNIEnv* _jenv, jobject _ji
 
 
     (*pInstanceSharedPointer)->set_skipped_in_dart(value);
+
+}
+
+
+
+jfloat
+Java_com_example_smoke_SkipProxyImpl_getSkippedInKotlin(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_skipped_in_kotlin();
+
+    return _result;
+}
+
+
+
+void
+Java_com_example_smoke_SkipProxyImpl_setSkippedInKotlin(JNIEnv* _jenv, jobject _jinstance, jfloat jvalue)
+
+{
+
+
+
+    float value = jvalue;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SkipProxy>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->set_skipped_in_kotlin(value);
 
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/android/jni/com_example_smoke_SkipProxyImplCppProxy.cpp
@@ -54,6 +54,21 @@ com_example_smoke_SkipProxy_CppProxy::not_in_dart( const float ninput ) {
 
 }
 
+float
+com_example_smoke_SkipProxy_CppProxy::not_in_kotlin( const float ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jfloat jinput = ninput;
+    auto _result = callJavaMethod<jfloat>( "notInKotlin", "(F)F", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return _result;
+
+
+
+}
+
 
 ::std::string
 com_example_smoke_SkipProxy_CppProxy::get_skipped_in_java(  ) const {
@@ -126,6 +141,37 @@ com_example_smoke_SkipProxy_CppProxy::set_skipped_in_dart( const float nvalue ) 
     JNIEnv* jniEnv = getJniEnvironment( );
     jfloat jvalue = nvalue;
     callJavaMethod<void>( "setSkippedInDart", "(F)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+
+float
+com_example_smoke_SkipProxy_CppProxy::get_skipped_in_kotlin(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jfloat>( "getSkippedInKotlin", "()F", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return _result;
+
+
+
+}
+
+
+
+void
+com_example_smoke_SkipProxy_CppProxy::set_skipped_in_kotlin( const float nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jfloat jvalue = nvalue;
+    callJavaMethod<void>( "setSkippedInKotlin", "(F)V", jniEnv , jvalue);
 
     checkExceptionAndReportIfAny(jniEnv);
 

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipFunctions.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipFunctions.h
@@ -1,18 +1,36 @@
 //
+
 //
+
 #pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 #include "cbridge/include/BaseHandle.h"
 #include "cbridge/include/Export.h"
+
+
+
 _GLUECODIUM_C_EXPORT void smoke_SkipFunctions_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipFunctions_copy_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT const void* smoke_SkipFunctions_get_swift_object_from_wrapper_cache(_baseRef handle);
 _GLUECODIUM_C_EXPORT void smoke_SkipFunctions_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void smoke_SkipFunctions_remove_swift_object_from_wrapper_cache(_baseRef handle);
+
+
+
+
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipFunctions_notInJava(_baseRef input);
+
 _GLUECODIUM_C_EXPORT float smoke_SkipFunctions_notInDart(float input);
+
+_GLUECODIUM_C_EXPORT _baseRef smoke_SkipFunctions_notInKotlin(_baseRef input);
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipProxy.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/include/smoke/cbridge_SkipProxy.h
@@ -1,35 +1,73 @@
 //
+
 //
+
 #pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 #include "cbridge/include/BaseHandle.h"
 #include "cbridge/include/Export.h"
+
+
+
 _GLUECODIUM_C_EXPORT void smoke_SkipProxy_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_copy_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT const void* smoke_SkipProxy_get_swift_object_from_wrapper_cache(_baseRef handle);
 _GLUECODIUM_C_EXPORT void smoke_SkipProxy_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer);
 _GLUECODIUM_C_EXPORT void smoke_SkipProxy_remove_swift_object_from_wrapper_cache(_baseRef handle);
 _GLUECODIUM_C_EXPORT void* smoke_SkipProxy_get_typed(_baseRef handle);
+
 typedef struct {
     void* swift_pointer;
     void(*release)(void* swift_pointer);
     _baseRef(*smoke_SkipProxy_notInJava)(void* swift_pointer, _baseRef input);
     float(*smoke_SkipProxy_notInDart)(void* swift_pointer, float input);
+    float(*smoke_SkipProxy_notInKotlin)(void* swift_pointer, float input);
     _baseRef(*smoke_SkipProxy_skippedInJava_get)(void* swift_pointer);
     void(*smoke_SkipProxy_skippedInJava_set)(void* swift_pointer, _baseRef value);
     float(*smoke_SkipProxy_skippedInDart_get)(void* swift_pointer);
     void(*smoke_SkipProxy_skippedInDart_set)(void* swift_pointer, float value);
+    float(*smoke_SkipProxy_skippedInKotlin_get)(void* swift_pointer);
+    void(*smoke_SkipProxy_skippedInKotlin_set)(void* swift_pointer, float value);
 } smoke_SkipProxy_FunctionTable;
+
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_create_proxy(smoke_SkipProxy_FunctionTable functionTable);
 _GLUECODIUM_C_EXPORT const void* smoke_SkipProxy_get_swift_object_from_cache(_baseRef handle);
+
+
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_notInJava(_baseRef _instance, _baseRef input);
+
 _GLUECODIUM_C_EXPORT float smoke_SkipProxy_notInDart(_baseRef _instance, float input);
+
+_GLUECODIUM_C_EXPORT float smoke_SkipProxy_notInKotlin(_baseRef _instance, float input);
+
+
 _GLUECODIUM_C_EXPORT _baseRef smoke_SkipProxy_skippedInJava_get(_baseRef _instance);
+
+
 _GLUECODIUM_C_EXPORT void smoke_SkipProxy_skippedInJava_set(_baseRef _instance, _baseRef value);
+
+
+
 _GLUECODIUM_C_EXPORT float smoke_SkipProxy_skippedInDart_get(_baseRef _instance);
+
+
 _GLUECODIUM_C_EXPORT void smoke_SkipProxy_skippedInDart_set(_baseRef _instance, float value);
+
+
+
+_GLUECODIUM_C_EXPORT float smoke_SkipProxy_skippedInKotlin_get(_baseRef _instance);
+
+
+_GLUECODIUM_C_EXPORT void smoke_SkipProxy_skippedInKotlin_set(_baseRef _instance, float value);
+
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/cbridge/src/smoke/cbridge_SkipProxy.cpp
@@ -1,5 +1,7 @@
 //
+
 //
+
 #include "cbridge/include/smoke/cbridge_SkipProxy.h"
 #include "cbridge/include/StringHandle.h"
 #include "cbridge_internal/include/BaseHandleImpl.h"
@@ -11,30 +13,37 @@
 #include <memory>
 #include <new>
 #include <string>
+
 void smoke_SkipProxy_release_handle(_baseRef handle) {
     delete get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(handle);
 }
+
 _baseRef smoke_SkipProxy_copy_handle(_baseRef handle) {
     return handle
         ? reinterpret_cast<_baseRef>(checked_pointer_copy(*get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(handle)))
         : 0;
 }
+
 const void* smoke_SkipProxy_get_swift_object_from_wrapper_cache(_baseRef handle) {
     return handle
         ? ::gluecodium::get_wrapper_cache().get_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(handle)->get())
         : nullptr;
 }
+
 void smoke_SkipProxy_cache_swift_object_wrapper(_baseRef handle, const void* swift_pointer) {
     if (!handle) return;
     ::gluecodium::get_wrapper_cache().cache_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(handle)->get(), swift_pointer);
 }
+
 void smoke_SkipProxy_remove_swift_object_from_wrapper_cache(_baseRef handle) {
     if (!::gluecodium::WrapperCache::is_alive) return;
     ::gluecodium::get_wrapper_cache().remove_cached_wrapper(get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(handle)->get());
 }
+
 extern "C" {
 extern void* _CBridgeInitsmoke_SkipProxy(_baseRef handle);
 }
+
 namespace {
 struct smoke_SkipProxyRegisterInit {
     smoke_SkipProxyRegisterInit() {
@@ -42,40 +51,84 @@ struct smoke_SkipProxyRegisterInit {
     }
 } s_smoke_SkipProxy_register_init;
 }
+
 void* smoke_SkipProxy_get_typed(_baseRef handle) {
     const auto& real_type_id = ::gluecodium::get_type_repository().get_id(get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(handle)->get());
     auto init_function = get_init_repository().get_init(real_type_id);
     return init_function ? init_function(handle) : _CBridgeInitsmoke_SkipProxy(handle);
 }
+
+
+
+
 _baseRef smoke_SkipProxy_notInJava(_baseRef _instance, _baseRef input) {
     return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->not_in_java(Conversion<::std::string>::toCpp(input)));
 }
+
+
 float smoke_SkipProxy_notInDart(_baseRef _instance, float input) {
     return get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->not_in_dart(input);
 }
+
+
+float smoke_SkipProxy_notInKotlin(_baseRef _instance, float input) {
+    return get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->not_in_kotlin(input);
+}
+
+
+
 _baseRef smoke_SkipProxy_skippedInJava_get(_baseRef _instance) {
     return Conversion<::std::string>::toBaseRef(get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->get_skipped_in_java());
 }
+
+
+
 void smoke_SkipProxy_skippedInJava_set(_baseRef _instance, _baseRef value) {
     return get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->set_skipped_in_java(Conversion<::std::string>::toCpp(value));
 }
+
+
+
+
 float smoke_SkipProxy_skippedInDart_get(_baseRef _instance) {
     return get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->get_skipped_in_dart();
 }
+
+
+
 void smoke_SkipProxy_skippedInDart_set(_baseRef _instance, float value) {
     return get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->set_skipped_in_dart(value);
 }
+
+
+
+
+float smoke_SkipProxy_skippedInKotlin_get(_baseRef _instance) {
+    return get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->get_skipped_in_kotlin();
+}
+
+
+
+void smoke_SkipProxy_skippedInKotlin_set(_baseRef _instance, float value) {
+    return get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(_instance)->get()->set_skipped_in_kotlin(value);
+}
+
+
+
 class smoke_SkipProxyProxy : public ::smoke::SkipProxy, public CachedProxyBase<smoke_SkipProxyProxy> {
 public:
     smoke_SkipProxyProxy(smoke_SkipProxy_FunctionTable&& functions)
      : mFunctions(::std::move(functions))
     {
     }
+
     virtual ~smoke_SkipProxyProxy() {
         mFunctions.release(mFunctions.swift_pointer);
     }
+
     smoke_SkipProxyProxy(const smoke_SkipProxyProxy&) = delete;
     smoke_SkipProxyProxy& operator=(const smoke_SkipProxyProxy&) = delete;
+
     ::std::string not_in_java(const ::std::string& input) override {
         auto _call_result = mFunctions.smoke_SkipProxy_notInJava(mFunctions.swift_pointer, Conversion<::std::string>::toBaseRef(input));
         return Conversion<::std::string>::toCppReturn(_call_result);
@@ -85,6 +138,10 @@ public:
     }
     float not_in_dart(float input) override {
         auto _call_result = mFunctions.smoke_SkipProxy_notInDart(mFunctions.swift_pointer, input);
+        return _call_result;
+    }
+    float not_in_kotlin(float input) override {
+        auto _call_result = mFunctions.smoke_SkipProxy_notInKotlin(mFunctions.swift_pointer, input);
         return _call_result;
     }
     ::std::string get_skipped_in_java() const override {
@@ -106,6 +163,13 @@ public:
     void set_skipped_in_dart(float value) override {
         mFunctions.smoke_SkipProxy_skippedInDart_set(mFunctions.swift_pointer, value);
     }
+    float get_skipped_in_kotlin() const override {
+        auto _call_result = mFunctions.smoke_SkipProxy_skippedInKotlin_get(mFunctions.swift_pointer);
+        return _call_result;
+    }
+    void set_skipped_in_kotlin(float value) override {
+        mFunctions.smoke_SkipProxy_skippedInKotlin_set(mFunctions.swift_pointer, value);
+    }
     ::smoke::SkippedEverywhere get_skipped_everywhere() const override {
         return {};
     }
@@ -116,13 +180,21 @@ public:
     }
     void set_skipped_everywhere_too(const ::smoke::SkippedEverywhereEnum value) override {
     }
+
 private:
     smoke_SkipProxy_FunctionTable mFunctions;
 };
+
 _baseRef smoke_SkipProxy_create_proxy(smoke_SkipProxy_FunctionTable functionTable) {
     auto proxy = smoke_SkipProxyProxy::get_proxy(::std::move(functionTable));
     return proxy ? reinterpret_cast<_baseRef>(new ::std::shared_ptr< ::smoke::SkipProxy >(proxy)) : 0;
 }
+
 const void* smoke_SkipProxy_get_swift_object_from_cache(_baseRef handle) {
     return handle ? smoke_SkipProxyProxy::get_swift_object(get_pointer<::std::shared_ptr< ::smoke::SkipProxy >>(handle)->get()) : nullptr;
 }
+
+
+
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFunctions.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipFunctions.h
@@ -1,16 +1,47 @@
+
 #pragma once
+
 #include "Export.h"
 #include "OpaqueHandle.h"
 #include "dart_api_dl.h"
 #include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
+
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipFunctions_notInJava__String(int32_t _isolate_id, FfiOpaqueHandle input);
+
+
+
 _GLUECODIUM_FFI_EXPORT bool library_smoke_SkipFunctions_notInSwift__Boolean(int32_t _isolate_id, bool input);
+
+
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipFunctions_notInKotlin__String(int32_t _isolate_id, FfiOpaqueHandle input);
+
+
+
+
+
+
+
+
+
+
+
+
 _GLUECODIUM_FFI_EXPORT void library_smoke_SkipFunctions_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle);
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipFunctions_copy_handle(FfiOpaqueHandle handle);
 _GLUECODIUM_FFI_EXPORT void library_smoke_SkipFunctions_release_handle(FfiOpaqueHandle handle);
+
+
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.cpp
@@ -1,4 +1,6 @@
+
 #include "ffi_smoke_SkipProxy.h"
+
 #include "ConversionBase.h"
 #include "InstanceCache.h"
 #include "FinalizerData.h"
@@ -12,14 +14,17 @@
 #include <string>
 #include <memory>
 #include <new>
+
 class smoke_SkipProxy_Proxy : public smoke::SkipProxy {
 public:
-    smoke_SkipProxy_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s)
-        : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0), f1(f1), p0g(p0g), p0s(p0s), p1g(p1g), p1s(p1s) {
+    smoke_SkipProxy_Proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f3, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s)
+        : token(token), isolate_id(isolate_id), dart_persistent_handle(Dart_NewPersistentHandle_DL(dart_handle)), f0(f0), f1(f1), f3(f3), p0g(p0g), p0s(p0s), p1g(p1g), p1s(p1s), p3g(p3g), p3s(p3s) {
         library_cache_dart_handle_by_raw_pointer(this, isolate_id, dart_handle);
     }
+
     ~smoke_SkipProxy_Proxy() {
         gluecodium::ffi::remove_cached_proxy(token, isolate_id, "smoke_SkipProxy");
+
         auto raw_pointer_local = this;
         auto isolate_id_local = isolate_id;
         auto dart_persistent_handle_local = dart_persistent_handle;
@@ -27,18 +32,22 @@ public:
             library_uncache_dart_handle_by_raw_pointer(raw_pointer_local, isolate_id_local);
             Dart_DeletePersistentHandle_DL(dart_persistent_handle_local);
         };
+
         if (gluecodium::ffi::IsolateContext::is_current(isolate_id)) {
             deleter();
         } else {
             gluecodium::ffi::cbqm.enqueueCallback(isolate_id, deleter);
         }
     }
+
     smoke_SkipProxy_Proxy(const smoke_SkipProxy_Proxy&) = delete;
     smoke_SkipProxy_Proxy& operator=(const smoke_SkipProxy_Proxy&) = delete;
+
     std::string
     not_in_java(const std::string& input) override {
         FfiOpaqueHandle _result_handle;
-        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, FfiOpaqueHandle, FfiOpaqueHandle*)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle),
+        
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, FfiOpaqueHandle, FfiOpaqueHandle*)>(f0))(Dart_HandleFromPersistent_DL(dart_persistent_handle), 
             gluecodium::ffi::Conversion<std::string>::toFfi(input),
             &_result_handle
         ); });
@@ -46,10 +55,12 @@ public:
         delete reinterpret_cast<std::string*>(_result_handle);
         return _result;
     }
+
     bool
     not_in_swift(const bool input) override {
         bool _result_handle;
-        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, bool, bool*)>(f1))(Dart_HandleFromPersistent_DL(dart_persistent_handle),
+        
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, bool, bool*)>(f1))(Dart_HandleFromPersistent_DL(dart_persistent_handle), 
             gluecodium::ffi::Conversion<bool>::toFfi(input),
             &_result_handle
         ); });
@@ -57,10 +68,26 @@ public:
         ;
         return _result;
     }
+
     float
     not_in_dart(const float input) override {
          return {};
     }
+
+    float
+    not_in_kotlin(const float input) override {
+        float _result_handle;
+        
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, float, float*)>(f3))(Dart_HandleFromPersistent_DL(dart_persistent_handle), 
+            gluecodium::ffi::Conversion<float>::toFfi(input),
+            &_result_handle
+        ); });
+        auto _result = gluecodium::ffi::Conversion<float>::toCpp(_result_handle);
+        ;
+        return _result;
+    }
+
+
     std::string
     get_skipped_in_java() const override {
         FfiOpaqueHandle _result_handle;
@@ -69,6 +96,7 @@ public:
         delete reinterpret_cast<std::string*>(_result_handle);
         return _result;
     }
+
     void
     set_skipped_in_java(const std::string& value) override {
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, FfiOpaqueHandle)>(p0s))(
@@ -84,6 +112,7 @@ public:
         ;
         return _result;
     }
+
     void
     set_skipped_in_swift(const bool value) override {
         dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, bool)>(p1s))(
@@ -95,13 +124,31 @@ public:
     get_skipped_in_dart() const override {
         return {};
     }
+
     void
     set_skipped_in_dart(const float value) override {
+    }
+    float
+    get_skipped_in_kotlin() const override {
+        float _result_handle;
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, float*)>(p3g))(Dart_HandleFromPersistent_DL(dart_persistent_handle), &_result_handle); });
+        auto _result = gluecodium::ffi::Conversion<float>::toCpp(_result_handle);
+        ;
+        return _result;
+    }
+
+    void
+    set_skipped_in_kotlin(const float value) override {
+        dispatch([&]() { (*reinterpret_cast<bool (*)(Dart_Handle, float)>(p3s))(
+            Dart_HandleFromPersistent_DL(dart_persistent_handle),
+            gluecodium::ffi::Conversion<float>::toFfi(value)
+        ); });
     }
     smoke::SkippedEverywhere
     get_skipped_everywhere() const override {
         return {};
     }
+
     void
     set_skipped_everywhere(const smoke::SkippedEverywhere& value) override {
     }
@@ -109,19 +156,25 @@ public:
     get_skipped_everywhere_too() const override {
         return {};
     }
+
     void
     set_skipped_everywhere_too(const smoke::SkippedEverywhereEnum value) override {
     }
+
 private:
     const uint64_t token;
     const int32_t isolate_id;
     const Dart_PersistentHandle dart_persistent_handle;
     const FfiOpaqueHandle f0;
     const FfiOpaqueHandle f1;
+    const FfiOpaqueHandle f3;
     const FfiOpaqueHandle p0g;
     const FfiOpaqueHandle p0s;
     const FfiOpaqueHandle p1g;
     const FfiOpaqueHandle p1s;
+    const FfiOpaqueHandle p3g;
+    const FfiOpaqueHandle p3s;
+
     inline void dispatch(std::function<void()>&& callback) const
     {
         gluecodium::ffi::IsolateContext::is_current(isolate_id)
@@ -129,9 +182,15 @@ private:
             : gluecodium::ffi::cbqm.enqueueCallback(isolate_id, std::move(callback)).wait();
     }
 };
+
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
+
 FfiOpaqueHandle
 library_smoke_SkipProxy_notInJava__String(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle input) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -141,6 +200,9 @@ library_smoke_SkipProxy_notInJava__String(FfiOpaqueHandle _self, int32_t _isolat
         )
     );
 }
+
+
+
 bool
 library_smoke_SkipProxy_notInSwift__Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, bool input) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -150,6 +212,22 @@ library_smoke_SkipProxy_notInSwift__Boolean(FfiOpaqueHandle _self, int32_t _isol
         )
     );
 }
+
+
+
+float
+library_smoke_SkipProxy_notInKotlin__Float(FfiOpaqueHandle _self, int32_t _isolate_id, float input) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<float>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SkipProxy>>::toCpp(_self)).not_in_kotlin(
+            gluecodium::ffi::Conversion<float>::toCpp(input)
+        )
+    );
+}
+
+
+
+
 FfiOpaqueHandle
 library_smoke_SkipProxy_skippedInJava_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -157,6 +235,9 @@ library_smoke_SkipProxy_skippedInJava_get(FfiOpaqueHandle _self, int32_t _isolat
         (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SkipProxy>>::toCpp(_self)).get_skipped_in_java()
     );
 }
+
+
+
 void
 library_smoke_SkipProxy_skippedInJava_set__String(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle value) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -164,6 +245,10 @@ library_smoke_SkipProxy_skippedInJava_set__String(FfiOpaqueHandle _self, int32_t
         gluecodium::ffi::Conversion<std::string>::toCpp(value)
     );
 }
+
+
+
+
 bool
 library_smoke_SkipProxy_isSkippedInSwift_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -171,6 +256,9 @@ library_smoke_SkipProxy_isSkippedInSwift_get(FfiOpaqueHandle _self, int32_t _iso
         (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SkipProxy>>::toCpp(_self)).is_skipped_in_swift()
     );
 }
+
+
+
 void
 library_smoke_SkipProxy_isSkippedInSwift_set__Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, bool value) {
     gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
@@ -178,6 +266,42 @@ library_smoke_SkipProxy_isSkippedInSwift_set__Boolean(FfiOpaqueHandle _self, int
         gluecodium::ffi::Conversion<bool>::toCpp(value)
     );
 }
+
+
+
+
+float
+library_smoke_SkipProxy_skippedInKotlin_get(FfiOpaqueHandle _self, int32_t _isolate_id) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    return gluecodium::ffi::Conversion<float>::toFfi(
+        (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SkipProxy>>::toCpp(_self)).get_skipped_in_kotlin()
+    );
+}
+
+
+
+void
+library_smoke_SkipProxy_skippedInKotlin_set__Float(FfiOpaqueHandle _self, int32_t _isolate_id, float value) {
+    gluecodium::ffi::IsolateContext _isolate_context(_isolate_id);
+    (*gluecodium::ffi::Conversion<std::shared_ptr<smoke::SkipProxy>>::toCpp(_self)).set_skipped_in_kotlin(
+        gluecodium::ffi::Conversion<float>::toCpp(value)
+    );
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 // "Private" finalizer, not exposed to be callable from Dart.
 void
 library_smoke_SkipProxy_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
@@ -185,11 +309,13 @@ library_smoke_SkipProxy_finalizer(FfiOpaqueHandle handle, int32_t isolate_id) {
     library_uncache_dart_handle_by_raw_pointer(ptr_ptr->get(), isolate_id);
     library_smoke_SkipProxy_release_handle(handle);
 }
+
 void
 library_smoke_SkipProxy_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle) {
     FinalizerData* data = new (std::nothrow) FinalizerData{ffi_handle, isolate_id, &library_smoke_SkipProxy_finalizer};
     Dart_NewFinalizableHandle_DL(dart_handle, data, sizeof data, &library_execute_finalizer);
 }
+
 FfiOpaqueHandle
 library_smoke_SkipProxy_copy_handle(FfiOpaqueHandle handle) {
     return reinterpret_cast<FfiOpaqueHandle>(
@@ -198,29 +324,39 @@ library_smoke_SkipProxy_copy_handle(FfiOpaqueHandle handle) {
         )
     );
 }
+
 void
 library_smoke_SkipProxy_release_handle(FfiOpaqueHandle handle) {
     delete reinterpret_cast<std::shared_ptr<smoke::SkipProxy>*>(handle);
 }
+
+
 FfiOpaqueHandle
-library_smoke_SkipProxy_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s) {
+library_smoke_SkipProxy_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f3, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s) {
     auto cached_proxy = gluecodium::ffi::get_cached_proxy<smoke_SkipProxy_Proxy>(token, isolate_id, "smoke_SkipProxy");
     std::shared_ptr<smoke_SkipProxy_Proxy>* proxy_ptr;
     if (cached_proxy) {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SkipProxy_Proxy>(cached_proxy);
     } else {
         proxy_ptr = new (std::nothrow) std::shared_ptr<smoke_SkipProxy_Proxy>(
-            new (std::nothrow) smoke_SkipProxy_Proxy(token, isolate_id, dart_handle, f0, f1, p0g, p0s, p1g, p1s)
+            new (std::nothrow) smoke_SkipProxy_Proxy(token, isolate_id, dart_handle, f0, f1, f3, p0g, p0s, p1g, p1s, p3g, p3s)
         );
         gluecodium::ffi::cache_proxy(token, isolate_id, "smoke_SkipProxy", *proxy_ptr);
     }
+
     return reinterpret_cast<FfiOpaqueHandle>(proxy_ptr);
 }
+
+
+
+
+
 FfiOpaqueHandle
 library_smoke_SkipProxy_get_type_id(FfiOpaqueHandle handle) {
     const auto& type_id = ::gluecodium::get_type_repository().get_id(reinterpret_cast<std::shared_ptr<smoke::SkipProxy>*>(handle)->get());
     return reinterpret_cast<FfiOpaqueHandle>(new (std::nothrow) std::string(type_id));
 }
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.h
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/ffi/ffi_smoke_SkipProxy.h
@@ -1,22 +1,76 @@
+
 #pragma once
+
 #include "Export.h"
 #include "OpaqueHandle.h"
 #include "dart_api_dl.h"
 #include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+
+
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipProxy_notInJava__String(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle input);
+
+
+
 _GLUECODIUM_FFI_EXPORT bool library_smoke_SkipProxy_notInSwift__Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, bool input);
+
+
+
+_GLUECODIUM_FFI_EXPORT float library_smoke_SkipProxy_notInKotlin__Float(FfiOpaqueHandle _self, int32_t _isolate_id, float input);
+
+
+
+
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipProxy_skippedInJava_get(FfiOpaqueHandle _self, int32_t _isolate_id);
+
+
+
 _GLUECODIUM_FFI_EXPORT void library_smoke_SkipProxy_skippedInJava_set__String(FfiOpaqueHandle _self, int32_t _isolate_id, FfiOpaqueHandle value);
+
+
+
+
 _GLUECODIUM_FFI_EXPORT bool library_smoke_SkipProxy_isSkippedInSwift_get(FfiOpaqueHandle _self, int32_t _isolate_id);
+
+
+
 _GLUECODIUM_FFI_EXPORT void library_smoke_SkipProxy_isSkippedInSwift_set__Boolean(FfiOpaqueHandle _self, int32_t _isolate_id, bool value);
+
+
+
+
+_GLUECODIUM_FFI_EXPORT float library_smoke_SkipProxy_skippedInKotlin_get(FfiOpaqueHandle _self, int32_t _isolate_id);
+
+
+
+_GLUECODIUM_FFI_EXPORT void library_smoke_SkipProxy_skippedInKotlin_set__Float(FfiOpaqueHandle _self, int32_t _isolate_id, float value);
+
+
+
+
+
+
+
+
+
+
+
+
 _GLUECODIUM_FFI_EXPORT void library_smoke_SkipProxy_register_finalizer(FfiOpaqueHandle ffi_handle, int32_t isolate_id, Dart_Handle dart_handle);
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipProxy_copy_handle(FfiOpaqueHandle handle);
 _GLUECODIUM_FFI_EXPORT void library_smoke_SkipProxy_release_handle(FfiOpaqueHandle handle);
-_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipProxy_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s);
+
+_GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipProxy_create_proxy(uint64_t token, int32_t isolate_id, Dart_Handle dart_handle, FfiOpaqueHandle f0, FfiOpaqueHandle f1, FfiOpaqueHandle f3, FfiOpaqueHandle p0g, FfiOpaqueHandle p0s, FfiOpaqueHandle p1g, FfiOpaqueHandle p1s, FfiOpaqueHandle p3g, FfiOpaqueHandle p3s);
+
+
+
 _GLUECODIUM_FFI_EXPORT FfiOpaqueHandle library_smoke_SkipProxy_get_type_id(FfiOpaqueHandle handle);
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/inherit_from_skipped.dart
@@ -13,17 +13,23 @@ abstract class InheritFromSkipped implements SkipProxy, Finalizable {
   factory InheritFromSkipped(
     String Function(String) notInJavaLambda,
     bool Function(bool) notInSwiftLambda,
+    double Function(double) notInKotlinLambda,
     String Function() skippedInJavaGetLambda,
     void Function(String) skippedInJavaSetLambda,
     bool Function() isSkippedInSwiftGetLambda,
-    void Function(bool) isSkippedInSwiftSetLambda
+    void Function(bool) isSkippedInSwiftSetLambda,
+    double Function() skippedInKotlinGetLambda,
+    void Function(double) skippedInKotlinSetLambda
   ) => InheritFromSkipped$Lambdas(
     notInJavaLambda,
     notInSwiftLambda,
+    notInKotlinLambda,
     skippedInJavaGetLambda,
     skippedInJavaSetLambda,
     isSkippedInSwiftGetLambda,
-    isSkippedInSwiftSetLambda
+    isSkippedInSwiftSetLambda,
+    skippedInKotlinGetLambda,
+    skippedInKotlinSetLambda
   );
 
 }
@@ -44,8 +50,8 @@ final _smokeInheritfromskippedReleaseHandle = __lib.catchArgumentError(() => __l
     void Function(Pointer<Void>)
   >('library_smoke_InheritFromSkipped_release_handle'));
 final _smokeInheritfromskippedCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
-    Pointer<Void> Function(int, int, Object, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_InheritFromSkipped_create_proxy'));
 final _smokeInheritfromskippedGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
@@ -55,18 +61,24 @@ final _smokeInheritfromskippedGetTypeId = __lib.catchArgumentError(() => __lib.n
 class InheritFromSkipped$Lambdas implements InheritFromSkipped {
   String Function(String) notInJavaLambda;
   bool Function(bool) notInSwiftLambda;
+  double Function(double) notInKotlinLambda;
   String Function() skippedInJavaGetLambda;
   void Function(String) skippedInJavaSetLambda;
   bool Function() isSkippedInSwiftGetLambda;
   void Function(bool) isSkippedInSwiftSetLambda;
+  double Function() skippedInKotlinGetLambda;
+  void Function(double) skippedInKotlinSetLambda;
 
   InheritFromSkipped$Lambdas(
     this.notInJavaLambda,
     this.notInSwiftLambda,
+    this.notInKotlinLambda,
     this.skippedInJavaGetLambda,
     this.skippedInJavaSetLambda,
     this.isSkippedInSwiftGetLambda,
-    this.isSkippedInSwiftSetLambda
+    this.isSkippedInSwiftSetLambda,
+    this.skippedInKotlinGetLambda,
+    this.skippedInKotlinSetLambda
   );
 
   @override
@@ -76,6 +88,9 @@ class InheritFromSkipped$Lambdas implements InheritFromSkipped {
   bool notInSwift(bool input) =>
     notInSwiftLambda(input);
   @override
+  double notInKotlin(double input) =>
+    notInKotlinLambda(input);
+  @override
   String get skippedInJava => skippedInJavaGetLambda();
   @override
   set skippedInJava(String value) => skippedInJavaSetLambda(value);
@@ -83,6 +98,10 @@ class InheritFromSkipped$Lambdas implements InheritFromSkipped {
   bool get isSkippedInSwift => isSkippedInSwiftGetLambda();
   @override
   set isSkippedInSwift(bool value) => isSkippedInSwiftSetLambda(value);
+  @override
+  double get skippedInKotlin => skippedInKotlinGetLambda();
+  @override
+  set skippedInKotlin(double value) => skippedInKotlinSetLambda(value);
 }
 
 class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSkipped {
@@ -116,6 +135,22 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
+    }
+
+  }
+
+  @override
+  double notInKotlin(double input) {
+    final _notInKotlinFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32, Float), double Function(Pointer<Void>, int, double)>('library_smoke_SkipProxy_notInKotlin__Float'));
+    final _inputHandle = (input);
+    final _handle = this.handle;
+    final __resultHandle = _notInKotlinFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+
+    try {
+      return (__resultHandle);
+    } finally {
+
 
     }
 
@@ -169,6 +204,30 @@ class InheritFromSkipped$Impl extends __lib.NativeBase implements InheritFromSki
   }
 
 
+  double get skippedInKotlin {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInKotlin_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+
+  set skippedInKotlin(double value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Float), void Function(Pointer<Void>, int, double)>('library_smoke_SkipProxy_skippedInKotlin_set__Float'));
+    final _valueHandle = (value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+
+
+  }
+
+
 
 }
 
@@ -189,6 +248,16 @@ int _smokeInheritfromskippednotInSwiftStatic(Object _obj, int input, Pointer<Uin
     _result.value = booleanToFfi(_resultObject);
   } finally {
     booleanReleaseFfiHandle(input);
+  }
+  return 0;
+}
+int _smokeInheritfromskippednotInKotlinStatic(Object _obj, double input, Pointer<Float> _result) {
+  double? _resultObject;
+  try {
+    _resultObject = (_obj as InheritFromSkipped).notInKotlin((input));
+    _result.value = (_resultObject);
+  } finally {
+    
   }
   return 0;
 }
@@ -221,6 +290,20 @@ int _smokeInheritfromskippedisSkippedInSwiftSetStatic(Object _obj, int _value) {
   }
   return 0;
 }
+int _smokeInheritfromskippedskippedInKotlinGetStatic(Object _obj, Pointer<Float> _result) {
+  _result.value = ((_obj as InheritFromSkipped).skippedInKotlin);
+  return 0;
+}
+
+int _smokeInheritfromskippedskippedInKotlinSetStatic(Object _obj, double _value) {
+  try {
+    (_obj as InheritFromSkipped).skippedInKotlin =
+      (_value);
+  } finally {
+    
+  }
+  return 0;
+}
 
 Pointer<Void> smokeInheritfromskippedToFfi(InheritFromSkipped value) {
   if (value is __lib.NativeBase) return _smokeInheritfromskippedCopyHandle((value as __lib.NativeBase).handle);
@@ -231,10 +314,13 @@ Pointer<Void> smokeInheritfromskippedToFfi(InheritFromSkipped value) {
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeInheritfromskippednotInJavaStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Uint8, Pointer<Uint8>)>(_smokeInheritfromskippednotInSwiftStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Float, Pointer<Float>)>(_smokeInheritfromskippednotInKotlinStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeInheritfromskippedskippedInJavaGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeInheritfromskippedskippedInJavaSetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Uint8>)>(_smokeInheritfromskippedisSkippedInSwiftGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeInheritfromskippedisSkippedInSwiftSetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeInheritfromskippedisSkippedInSwiftSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Float>)>(_smokeInheritfromskippedskippedInKotlinGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Float)>(_smokeInheritfromskippedskippedInKotlinSetStatic, __lib.unknownError)
   );
 
   return result;

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_functions.dart
@@ -14,6 +14,8 @@ abstract class SkipFunctions implements Finalizable {
 
   static bool notInSwift(bool input) => $prototype.notInSwift(input);
 
+  static String notInKotlin(String input) => $prototype.notInKotlin(input);
+
   /// @nodoc
   @visibleForTesting
   static dynamic $prototype = SkipFunctions$Impl(Pointer<Void>.fromAddress(0));
@@ -38,8 +40,10 @@ final _smokeSkipfunctionsReleaseHandle = __lib.catchArgumentError(() => __lib.na
 
 
 
+
 /// @nodoc
 @visibleForTesting
+
 class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
 
   SkipFunctions$Impl(Pointer<Void> handle) : super(handle);
@@ -67,6 +71,20 @@ class SkipFunctions$Impl extends __lib.NativeBase implements SkipFunctions {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
+    }
+
+  }
+
+  String notInKotlin(String input) {
+    final _notInKotlinFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_SkipFunctions_notInKotlin__String'));
+    final _inputHandle = stringToFfi(input);
+    final __resultHandle = _notInKotlinFfi(__lib.LibraryContext.isolateId, _inputHandle);
+    stringReleaseFfiHandle(_inputHandle);
+    try {
+      return stringFromFfi(__resultHandle);
+    } finally {
+      stringReleaseFfiHandle(__resultHandle);
 
     }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_proxy.dart
@@ -13,28 +13,39 @@ abstract class SkipProxy implements Finalizable {
   factory SkipProxy(
     String Function(String) notInJavaLambda,
     bool Function(bool) notInSwiftLambda,
+    double Function(double) notInKotlinLambda,
     String Function() skippedInJavaGetLambda,
     void Function(String) skippedInJavaSetLambda,
     bool Function() isSkippedInSwiftGetLambda,
-    void Function(bool) isSkippedInSwiftSetLambda
+    void Function(bool) isSkippedInSwiftSetLambda,
+    double Function() skippedInKotlinGetLambda,
+    void Function(double) skippedInKotlinSetLambda
   ) => SkipProxy$Lambdas(
     notInJavaLambda,
     notInSwiftLambda,
+    notInKotlinLambda,
     skippedInJavaGetLambda,
     skippedInJavaSetLambda,
     isSkippedInSwiftGetLambda,
-    isSkippedInSwiftSetLambda
+    isSkippedInSwiftSetLambda,
+    skippedInKotlinGetLambda,
+    skippedInKotlinSetLambda
   );
 
 
   String notInJava(String input);
 
   bool notInSwift(bool input);
+
+  double notInKotlin(double input);
   String get skippedInJava;
   set skippedInJava(String value);
 
   bool get isSkippedInSwift;
   set isSkippedInSwift(bool value);
+
+  double get skippedInKotlin;
+  set skippedInKotlin(double value);
 
 }
 
@@ -54,8 +65,8 @@ final _smokeSkipproxyReleaseHandle = __lib.catchArgumentError(() => __lib.native
     void Function(Pointer<Void>)
   >('library_smoke_SkipProxy_release_handle'));
 final _smokeSkipproxyCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
-    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
-    Pointer<Void> Function(int, int, Object, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer, Pointer)
   >('library_smoke_SkipProxy_create_proxy'));
 final _smokeSkipproxyGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
@@ -64,21 +75,28 @@ final _smokeSkipproxyGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibr
 
 
 
+
 class SkipProxy$Lambdas implements SkipProxy {
   String Function(String) notInJavaLambda;
   bool Function(bool) notInSwiftLambda;
+  double Function(double) notInKotlinLambda;
   String Function() skippedInJavaGetLambda;
   void Function(String) skippedInJavaSetLambda;
   bool Function() isSkippedInSwiftGetLambda;
   void Function(bool) isSkippedInSwiftSetLambda;
+  double Function() skippedInKotlinGetLambda;
+  void Function(double) skippedInKotlinSetLambda;
 
   SkipProxy$Lambdas(
     this.notInJavaLambda,
     this.notInSwiftLambda,
+    this.notInKotlinLambda,
     this.skippedInJavaGetLambda,
     this.skippedInJavaSetLambda,
     this.isSkippedInSwiftGetLambda,
-    this.isSkippedInSwiftSetLambda
+    this.isSkippedInSwiftSetLambda,
+    this.skippedInKotlinGetLambda,
+    this.skippedInKotlinSetLambda
   );
 
   @override
@@ -88,6 +106,9 @@ class SkipProxy$Lambdas implements SkipProxy {
   bool notInSwift(bool input) =>
     notInSwiftLambda(input);
   @override
+  double notInKotlin(double input) =>
+    notInKotlinLambda(input);
+  @override
   String get skippedInJava => skippedInJavaGetLambda();
   @override
   set skippedInJava(String value) => skippedInJavaSetLambda(value);
@@ -95,6 +116,10 @@ class SkipProxy$Lambdas implements SkipProxy {
   bool get isSkippedInSwift => isSkippedInSwiftGetLambda();
   @override
   set isSkippedInSwift(bool value) => isSkippedInSwiftSetLambda(value);
+  @override
+  double get skippedInKotlin => skippedInKotlinGetLambda();
+  @override
+  set skippedInKotlin(double value) => skippedInKotlinSetLambda(value);
 }
 
 class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
@@ -128,6 +153,22 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
       return booleanFromFfi(__resultHandle);
     } finally {
       booleanReleaseFfiHandle(__resultHandle);
+
+    }
+
+  }
+
+  @override
+  double notInKotlin(double input) {
+    final _notInKotlinFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32, Float), double Function(Pointer<Void>, int, double)>('library_smoke_SkipProxy_notInKotlin__Float'));
+    final _inputHandle = (input);
+    final _handle = this.handle;
+    final __resultHandle = _notInKotlinFfi(_handle, __lib.LibraryContext.isolateId, _inputHandle);
+
+    try {
+      return (__resultHandle);
+    } finally {
+
 
     }
 
@@ -181,6 +222,30 @@ class SkipProxy$Impl extends __lib.NativeBase implements SkipProxy {
   }
 
 
+  double get skippedInKotlin {
+    final _getFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Float Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_SkipProxy_skippedInKotlin_get'));
+    final _handle = this.handle;
+    final __resultHandle = _getFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+
+  set skippedInKotlin(double value) {
+    final _setFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Float), void Function(Pointer<Void>, int, double)>('library_smoke_SkipProxy_skippedInKotlin_set__Float'));
+    final _valueHandle = (value);
+    final _handle = this.handle;
+    _setFfi(_handle, __lib.LibraryContext.isolateId, _valueHandle);
+
+
+  }
+
+
 
 }
 
@@ -201,6 +266,16 @@ int _smokeSkipproxynotInSwiftStatic(Object _obj, int input, Pointer<Uint8> _resu
     _result.value = booleanToFfi(_resultObject);
   } finally {
     booleanReleaseFfiHandle(input);
+  }
+  return 0;
+}
+int _smokeSkipproxynotInKotlinStatic(Object _obj, double input, Pointer<Float> _result) {
+  double? _resultObject;
+  try {
+    _resultObject = (_obj as SkipProxy).notInKotlin((input));
+    _result.value = (_resultObject);
+  } finally {
+    
   }
   return 0;
 }
@@ -233,6 +308,20 @@ int _smokeSkipproxyisSkippedInSwiftSetStatic(Object _obj, int _value) {
   }
   return 0;
 }
+int _smokeSkipproxyskippedInKotlinGetStatic(Object _obj, Pointer<Float> _result) {
+  _result.value = ((_obj as SkipProxy).skippedInKotlin);
+  return 0;
+}
+
+int _smokeSkipproxyskippedInKotlinSetStatic(Object _obj, double _value) {
+  try {
+    (_obj as SkipProxy).skippedInKotlin =
+      (_value);
+  } finally {
+    
+  }
+  return 0;
+}
 
 Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
   if (value is __lib.NativeBase) return _smokeSkipproxyCopyHandle((value as __lib.NativeBase).handle);
@@ -248,10 +337,13 @@ Pointer<Void> smokeSkipproxyToFfi(SkipProxy value) {
     value,
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>, Pointer<Pointer<Void>>)>(_smokeSkipproxynotInJavaStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Uint8, Pointer<Uint8>)>(_smokeSkipproxynotInSwiftStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Float, Pointer<Float>)>(_smokeSkipproxynotInKotlinStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Pointer<Void>>)>(_smokeSkipproxyskippedInJavaGetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeSkipproxyskippedInJavaSetStatic, __lib.unknownError),
     Pointer.fromFunction<Uint8 Function(Handle, Pointer<Uint8>)>(_smokeSkipproxyisSkippedInSwiftGetStatic, __lib.unknownError),
-    Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeSkipproxyisSkippedInSwiftSetStatic, __lib.unknownError)
+    Pointer.fromFunction<Uint8 Function(Handle, Uint8)>(_smokeSkipproxyisSkippedInSwiftSetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Float>)>(_smokeSkipproxyskippedInKotlinGetStatic, __lib.unknownError),
+    Pointer.fromFunction<Uint8 Function(Handle, Float)>(_smokeSkipproxyskippedInKotlinSetStatic, __lib.unknownError)
   );
 
   return result;

--- a/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
+++ b/gluecodium/src/test/resources/smoke/skip/output/dart/lib/src/smoke/skip_types.dart
@@ -171,6 +171,86 @@ void smokeSkiptypesNotinswiftReleaseFfiHandleNullable(Pointer<Void> handle) =>
 
 // End of SkipTypes_NotInSwift "private" section.
 
+class SkipTypes_NotInKotlin {
+  String fooField;
+
+  SkipTypes_NotInKotlin(this.fooField);
+}
+
+
+// SkipTypes_NotInKotlin "private" section, not exported.
+
+final _smokeSkiptypesNotinkotlinCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SkipTypes_NotInKotlin_create_handle'));
+final _smokeSkiptypesNotinkotlinReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SkipTypes_NotInKotlin_release_handle'));
+final _smokeSkiptypesNotinkotlinGetFieldfooField = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SkipTypes_NotInKotlin_get_field_fooField'));
+
+
+
+Pointer<Void> smokeSkiptypesNotinkotlinToFfi(SkipTypes_NotInKotlin value) {
+  final _fooFieldHandle = stringToFfi(value.fooField);
+  final _result = _smokeSkiptypesNotinkotlinCreateHandle(_fooFieldHandle);
+  stringReleaseFfiHandle(_fooFieldHandle);
+  return _result;
+}
+
+SkipTypes_NotInKotlin smokeSkiptypesNotinkotlinFromFfi(Pointer<Void> handle) {
+  final _fooFieldHandle = _smokeSkiptypesNotinkotlinGetFieldfooField(handle);
+  try {
+    return SkipTypes_NotInKotlin(
+      stringFromFfi(_fooFieldHandle)
+    );
+  } finally {
+    stringReleaseFfiHandle(_fooFieldHandle);
+  }
+}
+
+void smokeSkiptypesNotinkotlinReleaseFfiHandle(Pointer<Void> handle) => _smokeSkiptypesNotinkotlinReleaseHandle(handle);
+
+// Nullable SkipTypes_NotInKotlin
+
+final _smokeSkiptypesNotinkotlinCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SkipTypes_NotInKotlin_create_handle_nullable'));
+final _smokeSkiptypesNotinkotlinReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_SkipTypes_NotInKotlin_release_handle_nullable'));
+final _smokeSkiptypesNotinkotlinGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_SkipTypes_NotInKotlin_get_value_nullable'));
+
+Pointer<Void> smokeSkiptypesNotinkotlinToFfiNullable(SkipTypes_NotInKotlin? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeSkiptypesNotinkotlinToFfi(value);
+  final result = _smokeSkiptypesNotinkotlinCreateHandleNullable(_handle);
+  smokeSkiptypesNotinkotlinReleaseFfiHandle(_handle);
+  return result;
+}
+
+SkipTypes_NotInKotlin? smokeSkiptypesNotinkotlinFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeSkiptypesNotinkotlinGetValueNullable(handle);
+  final result = smokeSkiptypesNotinkotlinFromFfi(_handle);
+  smokeSkiptypesNotinkotlinReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeSkiptypesNotinkotlinReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeSkiptypesNotinkotlinReleaseHandleNullable(handle);
+
+// End of SkipTypes_NotInKotlin "private" section.
+
 // SkipTypes "private" section, not exported.
 
 final _smokeSkiptypesRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
@@ -185,6 +265,7 @@ final _smokeSkiptypesReleaseHandle = __lib.catchArgumentError(() => __lib.native
     Void Function(Pointer<Void>),
     void Function(Pointer<Void>)
   >('library_smoke_SkipTypes_release_handle'));
+
 
 
 class SkipTypes$Impl extends __lib.NativeBase implements SkipTypes {

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipFunctions.swift
@@ -1,18 +1,26 @@
 //
+
 //
+
 import Foundation
+
 public class SkipFunctions {
+
+
     let c_instance : _baseRef
+
     init(cSkipFunctions: _baseRef) {
         guard cSkipFunctions != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cSkipFunctions
     }
+
     deinit {
         smoke_SkipFunctions_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_SkipFunctions_release_handle(c_instance)
     }
+
     public static func notInJava(input: String) -> String {
         let c_input = moveToCType(input)
         let c_result_handle = smoke_SkipFunctions_notInJava(c_input.ref)
@@ -23,7 +31,16 @@ public class SkipFunctions {
         let c_result_handle = smoke_SkipFunctions_notInDart(c_input.ref)
         return moveFromCType(c_result_handle)
     }
+    public static func notInKotlin(input: String) -> String {
+        let c_input = moveToCType(input)
+        let c_result_handle = smoke_SkipFunctions_notInKotlin(c_input.ref)
+        return moveFromCType(c_result_handle)
+    }
+
 }
+
+
+
 internal func getRef(_ ref: SkipFunctions?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {
         return RefHolder(0)
@@ -33,6 +50,7 @@ internal func getRef(_ ref: SkipFunctions?, owning: Bool = true) -> RefHolder {
         ? RefHolder(ref: handle_copy, release: smoke_SkipFunctions_release_handle)
         : RefHolder(handle_copy)
 }
+
 extension SkipFunctions: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -42,11 +60,13 @@ extension SkipFunctions: Hashable {
     public static func == (lhs: SkipFunctions, rhs: SkipFunctions) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+
     /// :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
 }
+
 internal func SkipFunctions_copyFromCType(_ handle: _baseRef) -> SkipFunctions {
     if let swift_pointer = smoke_SkipFunctions_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipFunctions {
@@ -56,6 +76,7 @@ internal func SkipFunctions_copyFromCType(_ handle: _baseRef) -> SkipFunctions {
     smoke_SkipFunctions_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func SkipFunctions_moveFromCType(_ handle: _baseRef) -> SkipFunctions {
     if let swift_pointer = smoke_SkipFunctions_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipFunctions {
@@ -66,6 +87,7 @@ internal func SkipFunctions_moveFromCType(_ handle: _baseRef) -> SkipFunctions {
     smoke_SkipFunctions_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func SkipFunctions_copyFromCType(_ handle: _baseRef) -> SkipFunctions? {
     guard handle != 0 else {
         return nil
@@ -78,15 +100,22 @@ internal func SkipFunctions_moveFromCType(_ handle: _baseRef) -> SkipFunctions? 
     }
     return SkipFunctions_moveFromCType(handle) as SkipFunctions
 }
+
 internal func copyToCType(_ swiftClass: SkipFunctions) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: SkipFunctions) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: SkipFunctions?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: SkipFunctions?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipProxy.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipProxy.swift
@@ -1,13 +1,27 @@
 //
+
 //
+
 import Foundation
+
 public protocol SkipProxy : AnyObject {
+
     var skippedInJava: String { get set }
+
     var skippedInDart: Float { get set }
+
+    var skippedInKotlin: Float { get set }
+
     func notInJava(input: String) -> String
+
     func notInDart(input: Float) -> Float
+
+    func notInKotlin(input: Float) -> Float
 }
+
 internal class _SkipProxy: SkipProxy {
+
+
     var skippedInJava: String {
         get {
             let c_result_handle = smoke_SkipProxy_skippedInJava_get(self.c_instance)
@@ -18,6 +32,7 @@ internal class _SkipProxy: SkipProxy {
             smoke_SkipProxy_skippedInJava_set(self.c_instance, c_value.ref)
         }
     }
+
     var skippedInDart: Float {
         get {
             let c_result_handle = smoke_SkipProxy_skippedInDart_get(self.c_instance)
@@ -28,17 +43,31 @@ internal class _SkipProxy: SkipProxy {
             smoke_SkipProxy_skippedInDart_set(self.c_instance, c_value.ref)
         }
     }
+
+    var skippedInKotlin: Float {
+        get {
+            let c_result_handle = smoke_SkipProxy_skippedInKotlin_get(self.c_instance)
+            return moveFromCType(c_result_handle)
+        }
+        set {
+            let c_value = moveToCType(newValue)
+            smoke_SkipProxy_skippedInKotlin_set(self.c_instance, c_value.ref)
+        }
+    }
     let c_instance : _baseRef
+
     init(cSkipProxy: _baseRef) {
         guard cSkipProxy != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cSkipProxy
     }
+
     deinit {
         smoke_SkipProxy_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_SkipProxy_release_handle(c_instance)
     }
+
     public func notInJava(input: String) -> String {
         let c_input = moveToCType(input)
         let c_result_handle = smoke_SkipProxy_notInJava(self.c_instance, c_input.ref)
@@ -49,25 +78,42 @@ internal class _SkipProxy: SkipProxy {
         let c_result_handle = smoke_SkipProxy_notInDart(self.c_instance, c_input.ref)
         return moveFromCType(c_result_handle)
     }
+    public func notInKotlin(input: Float) -> Float {
+        let c_input = moveToCType(input)
+        let c_result_handle = smoke_SkipProxy_notInKotlin(self.c_instance, c_input.ref)
+        return moveFromCType(c_result_handle)
+    }
+
 }
+
+
+
+
+
+
 @_cdecl("_CBridgeInitsmoke_SkipProxy")
 internal func _CBridgeInitsmoke_SkipProxy(handle: _baseRef) -> UnsafeMutableRawPointer {
     let reference = _SkipProxy(cSkipProxy: handle)
     return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
 }
+
 internal func getRef(_ ref: SkipProxy?, owning: Bool = true) -> RefHolder {
+
     guard let reference = ref else {
         return RefHolder(0)
     }
+
     if let instanceReference = reference as? NativeBase {
         let handle_copy = smoke_SkipProxy_copy_handle(instanceReference.c_handle)
         return owning
             ? RefHolder(ref: handle_copy, release: smoke_SkipProxy_release_handle)
             : RefHolder(handle_copy)
     }
+
     if let descendantResult = tryDescendantGetRef(reference, owning) {
         return descendantResult
     }
+
     var functions = smoke_SkipProxy_FunctionTable()
     functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
     functions.release = {swift_class_pointer in
@@ -75,39 +121,81 @@ internal func getRef(_ ref: SkipProxy?, owning: Bool = true) -> RefHolder {
             Unmanaged<AnyObject>.fromOpaque(swift_class).release()
         }
     }
+
+
     functions.smoke_SkipProxy_notInJava = {(swift_class_pointer, input) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
         return copyToCType(swift_class.notInJava(input: moveFromCType(input))).ref
     }
+
     functions.smoke_SkipProxy_notInDart = {(swift_class_pointer, input) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
         return copyToCType(swift_class.notInDart(input: moveFromCType(input))).ref
     }
-    functions.smoke_SkipProxy_skippedInJava_get = {(swift_class_pointer) in
+
+    functions.smoke_SkipProxy_notInKotlin = {(swift_class_pointer, input) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
+        return copyToCType(swift_class.notInKotlin(input: moveFromCType(input))).ref
+    }
+
+    functions.smoke_SkipProxy_skippedInJava_get = {(swift_class_pointer) in
+
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
         return copyToCType(swift_class.skippedInJava).ref
     }
+
     functions.smoke_SkipProxy_skippedInJava_set = {(swift_class_pointer, value) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
         swift_class.skippedInJava = moveFromCType(value)
     }
+
     functions.smoke_SkipProxy_skippedInDart_get = {(swift_class_pointer) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
         return copyToCType(swift_class.skippedInDart).ref
     }
+
     functions.smoke_SkipProxy_skippedInDart_set = {(swift_class_pointer, value) in
+
         let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
         swift_class.skippedInDart = moveFromCType(value)
+    }
+
+    functions.smoke_SkipProxy_skippedInKotlin_get = {(swift_class_pointer) in
+
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
+        return copyToCType(swift_class.skippedInKotlin).ref
+    }
+
+    functions.smoke_SkipProxy_skippedInKotlin_set = {(swift_class_pointer, value) in
+
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! SkipProxy
+
+        swift_class.skippedInKotlin = moveFromCType(value)
     }
     let proxy = smoke_SkipProxy_create_proxy(functions)
     return owning ? RefHolder(ref: proxy, release: smoke_SkipProxy_release_handle) : RefHolder(proxy)
 }
+
 func tryDescendantGetRef(_ reference: SkipProxy, _ owning: Bool) -> RefHolder? {
     if reference is InheritFromSkipped {
         return getRef(reference as? InheritFromSkipped, owning: owning)
     }
     return nil
 }
+
 extension _SkipProxy: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -128,6 +216,7 @@ internal func SkipProxy_copyFromCType(_ handle: _baseRef) -> SkipProxy {
     }
     fatalError("Failed to initialize Swift object")
 }
+
 internal func SkipProxy_moveFromCType(_ handle: _baseRef) -> SkipProxy {
     if let swift_pointer = smoke_SkipProxy_get_swift_object_from_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipProxy {
@@ -146,6 +235,7 @@ internal func SkipProxy_moveFromCType(_ handle: _baseRef) -> SkipProxy {
     }
     fatalError("Failed to initialize Swift object")
 }
+
 internal func SkipProxy_copyFromCType(_ handle: _baseRef) -> SkipProxy? {
     guard handle != 0 else {
         return nil
@@ -158,15 +248,22 @@ internal func SkipProxy_moveFromCType(_ handle: _baseRef) -> SkipProxy? {
     }
     return SkipProxy_moveFromCType(handle) as SkipProxy
 }
+
 internal func copyToCType(_ swiftClass: SkipProxy) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: SkipProxy) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: SkipProxy?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: SkipProxy?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
+
+

--- a/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
+++ b/gluecodium/src/test/resources/smoke/skip/output/swift/smoke/SkipTypes.swift
@@ -1,20 +1,30 @@
 //
+
 //
+
 import Foundation
+
 public class SkipTypes {
+
+
     let c_instance : _baseRef
+
     init(cSkipTypes: _baseRef) {
         guard cSkipTypes != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cSkipTypes
     }
+
     deinit {
         smoke_SkipTypes_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_SkipTypes_release_handle(c_instance)
     }
+
     public struct NotInJava {
+
         public var fooField: String
+
         public init(fooField: String) {
             self.fooField = fooField
         }
@@ -22,8 +32,11 @@ public class SkipTypes {
             fooField = moveFromCType(smoke_SkipTypes_NotInJava_fooField_get(cHandle))
         }
     }
+
     public struct NotInDart {
+
         public var fooField: String
+
         public init(fooField: String) {
             self.fooField = fooField
         }
@@ -31,7 +44,24 @@ public class SkipTypes {
             fooField = moveFromCType(smoke_SkipTypes_NotInDart_fooField_get(cHandle))
         }
     }
+
+    public struct NotInKotlin {
+
+        public var fooField: String
+
+        public init(fooField: String) {
+            self.fooField = fooField
+        }
+        internal init(cHandle: _baseRef) {
+            fooField = moveFromCType(smoke_SkipTypes_NotInKotlin_fooField_get(cHandle))
+        }
+    }
+
+
 }
+
+
+
 internal func getRef(_ ref: SkipTypes?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {
         return RefHolder(0)
@@ -41,6 +71,7 @@ internal func getRef(_ ref: SkipTypes?, owning: Bool = true) -> RefHolder {
         ? RefHolder(ref: handle_copy, release: smoke_SkipTypes_release_handle)
         : RefHolder(handle_copy)
 }
+
 extension SkipTypes: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -50,11 +81,13 @@ extension SkipTypes: Hashable {
     public static func == (lhs: SkipTypes, rhs: SkipTypes) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+
     /// :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
 }
+
 internal func SkipTypes_copyFromCType(_ handle: _baseRef) -> SkipTypes {
     if let swift_pointer = smoke_SkipTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTypes {
@@ -64,6 +97,7 @@ internal func SkipTypes_copyFromCType(_ handle: _baseRef) -> SkipTypes {
     smoke_SkipTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func SkipTypes_moveFromCType(_ handle: _baseRef) -> SkipTypes {
     if let swift_pointer = smoke_SkipTypes_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? SkipTypes {
@@ -74,6 +108,7 @@ internal func SkipTypes_moveFromCType(_ handle: _baseRef) -> SkipTypes {
     smoke_SkipTypes_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func SkipTypes_copyFromCType(_ handle: _baseRef) -> SkipTypes? {
     guard handle != 0 else {
         return nil
@@ -86,18 +121,23 @@ internal func SkipTypes_moveFromCType(_ handle: _baseRef) -> SkipTypes? {
     }
     return SkipTypes_moveFromCType(handle) as SkipTypes
 }
+
 internal func copyToCType(_ swiftClass: SkipTypes) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: SkipTypes) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: SkipTypes?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: SkipTypes?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> SkipTypes.NotInJava {
     return SkipTypes.NotInJava(cHandle: handle)
 }
@@ -107,6 +147,7 @@ internal func moveFromCType(_ handle: _baseRef) -> SkipTypes.NotInJava {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: SkipTypes.NotInJava) -> RefHolder {
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_SkipTypes_NotInJava_create_handle(c_fooField.ref))
@@ -127,6 +168,7 @@ internal func moveFromCType(_ handle: _baseRef) -> SkipTypes.NotInJava? {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: SkipTypes.NotInJava?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -137,6 +179,7 @@ internal func copyToCType(_ swiftType: SkipTypes.NotInJava?) -> RefHolder {
 internal func moveToCType(_ swiftType: SkipTypes.NotInJava?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SkipTypes_NotInJava_release_optional_handle)
 }
+
 internal func copyFromCType(_ handle: _baseRef) -> SkipTypes.NotInDart {
     return SkipTypes.NotInDart(cHandle: handle)
 }
@@ -146,6 +189,7 @@ internal func moveFromCType(_ handle: _baseRef) -> SkipTypes.NotInDart {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: SkipTypes.NotInDart) -> RefHolder {
     let c_fooField = moveToCType(swiftType.fooField)
     return RefHolder(smoke_SkipTypes_NotInDart_create_handle(c_fooField.ref))
@@ -166,6 +210,7 @@ internal func moveFromCType(_ handle: _baseRef) -> SkipTypes.NotInDart? {
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: SkipTypes.NotInDart?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -176,3 +221,48 @@ internal func copyToCType(_ swiftType: SkipTypes.NotInDart?) -> RefHolder {
 internal func moveToCType(_ swiftType: SkipTypes.NotInDart?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SkipTypes_NotInDart_release_optional_handle)
 }
+
+internal func copyFromCType(_ handle: _baseRef) -> SkipTypes.NotInKotlin {
+    return SkipTypes.NotInKotlin(cHandle: handle)
+}
+internal func moveFromCType(_ handle: _baseRef) -> SkipTypes.NotInKotlin {
+    defer {
+        smoke_SkipTypes_NotInKotlin_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: SkipTypes.NotInKotlin) -> RefHolder {
+    let c_fooField = moveToCType(swiftType.fooField)
+    return RefHolder(smoke_SkipTypes_NotInKotlin_create_handle(c_fooField.ref))
+}
+internal func moveToCType(_ swiftType: SkipTypes.NotInKotlin) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SkipTypes_NotInKotlin_release_handle)
+}
+internal func copyFromCType(_ handle: _baseRef) -> SkipTypes.NotInKotlin? {
+    guard handle != 0 else {
+        return nil
+    }
+    let unwrappedHandle = smoke_SkipTypes_NotInKotlin_unwrap_optional_handle(handle)
+    return SkipTypes.NotInKotlin(cHandle: unwrappedHandle) as SkipTypes.NotInKotlin
+}
+internal func moveFromCType(_ handle: _baseRef) -> SkipTypes.NotInKotlin? {
+    defer {
+        smoke_SkipTypes_NotInKotlin_release_optional_handle(handle)
+    }
+    return copyFromCType(handle)
+}
+
+internal func copyToCType(_ swiftType: SkipTypes.NotInKotlin?) -> RefHolder {
+    guard let swiftType = swiftType else {
+        return RefHolder(0)
+    }
+    let c_fooField = moveToCType(swiftType.fooField)
+    return RefHolder(smoke_SkipTypes_NotInKotlin_create_optional_handle(c_fooField.ref))
+}
+internal func moveToCType(_ swiftType: SkipTypes.NotInKotlin?) -> RefHolder {
+    return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_SkipTypes_NotInKotlin_release_optional_handle)
+}
+
+
+


### PR DESCRIPTION
This series:
- implements smoke tests for 'Skip' and 'EnableIf' attributes
- fixes minor bug in generation of implementation class for interfaces