### PR TITLE
Kotlin: functional tests for 'Skip' and 'EnableIf'

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -460,7 +460,7 @@ feature(Visibility android swift dart SOURCES
     input/src/cpp/VisibilityInternal.cpp
 )
 
-feature(SkipAttribute cpp android swift dart SOURCES
+feature(SkipAttribute cpp android android-kotlin swift dart SOURCES
     input/lime/Skip.lime
     input/lime/SkipTags.lime
     input/lime/SkipTagsInPlatform.lime

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/SkipElementTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/SkipElementTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class SkipElementTest {
+    // Compile-time check that SkipTagsInKotlin contains exactly one method.
+    class SkipTagsInKotlinImpl : SkipTagsInKotlin {
+        override fun dontSkipTagged() {}
+    }
+
+    @org.junit.Test
+    fun autoTagRoundTrip() {
+        val value: SkipEnumeratorAutoTag = SkipEnumeratorAutoTag.THREE
+        val result: SkipEnumeratorAutoTag = UseSkipEnumerator.autoTagRoundTrip(value)
+
+        assertEquals(value, result)
+    }
+
+    @org.junit.Test
+    fun explicitTagRoundTrip() {
+        val value: SkipEnumeratorExplicitTag = SkipEnumeratorExplicitTag.THREE
+        val result: SkipEnumeratorExplicitTag = UseSkipEnumerator.explicitTagRoundTrip(value)
+
+        assertEquals(value, result)
+    }
+
+}

--- a/functional-tests/functional/input/lime/EnableIfInPlatform.lime
+++ b/functional-tests/functional/input/lime/EnableIfInPlatform.lime
@@ -17,7 +17,7 @@
 
 package test
 
-@Skip(Swift, Dart)
+@Skip(Swift, Dart, Kotlin)
 interface EnableTagsInJava {
     @Java(EnableIf = "Lite")
     fun enableTagged()
@@ -27,7 +27,7 @@ interface EnableTagsInJava {
     fun enableTaggedList()
 }
 
-@Skip(Java, Dart)
+@Skip(Java, Dart, Kotlin)
 interface EnableTagsInSwift {
     @Swift(EnableIf = "Lite")
     fun enableTagged()
@@ -37,7 +37,7 @@ interface EnableTagsInSwift {
     fun enableTaggedList()
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Swift, Kotlin)
 interface EnableTagsInDart {
     @Dart(EnableIf = "Lite")
     fun enableTagged()
@@ -47,11 +47,22 @@ interface EnableTagsInDart {
     fun enableTaggedList()
 }
 
+@Skip(Java, Swift, Dart)
+interface EnableTagsInKotlin {
+    @Kotlin(EnableIf = "Lite")
+    fun enableTagged()
+    @Kotlin(EnableIf = "Pro")
+    fun dontEnableTagged()
+    @Kotlin(EnableIf = ["Lite", "Pro"])
+    fun enableTaggedList()
+}
+
 struct EnableIfField {
     intField: Int
     @Java(EnableIf = "Pro")
     @Swift(EnableIf = "Pro")
     @Dart(EnableIf = "Pro")
+    @Kotlin(EnableIf = "Pro")
     stringField: String
     boolField: Boolean
 }

--- a/functional-tests/functional/input/lime/Skip.lime
+++ b/functional-tests/functional/input/lime/Skip.lime
@@ -24,6 +24,8 @@ class SkipFunctions {
     static fun notInSwift(input: Boolean): Boolean
     @Dart(Skip)
     static fun notInDart(input: Float): Float
+    @Kotlin(Skip)
+    static fun notInKotlin(input: Float): Float
 }
 
 class SkipTypes {
@@ -39,8 +41,12 @@ class SkipTypes {
     struct NotInDart {
         fooField: String
     }
+    @Kotlin(Skip)
+    struct NotInKotlin {
+        fooField: String
+    }
 
-    @Dart(Skip) @Java(Skip) @Swift(Skip)
+    @Dart(Skip) @Java(Skip) @Swift(Skip) @Kotlin(Skip)
     fun useListInDart(): List<NotInDart>
 }
 
@@ -51,6 +57,8 @@ interface SkipProxy {
     fun notInSwift(input: Boolean): Boolean
     @Dart(Skip)
     fun notInDart(input: Float): Float
+    @Kotlin(Skip)
+    fun notInKotlin(input: Int): Int
 
     @Java(Skip)
     property skippedInJava: String
@@ -58,21 +66,23 @@ interface SkipProxy {
     property skippedInSwift: Boolean
     @Dart(Skip)
     property skippedInDart: Float
+    @Kotlin(Skip)
+    property skippedInKotlin: Int
 
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     property skippedEverywhere: SkippedEverywhere
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     property skippedEverywhereToo: SkippedEverywhereEnum
 }
 
-@Java(Skip) @Swift(Skip) @Dart(Skip)
+@Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
 struct SkippedEverywhere {
     nothingToSeeHere: String
 
     fun useMapInDart(foo: Map<Int, SkipTypes.NotInDart>)
 }
 
-@Java(Skip) @Swift(Skip) @Dart(Skip)
+@Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
 enum SkippedEverywhereEnum {
     nothingToSeeHere
 }
@@ -81,7 +91,7 @@ interface InheritFromSkipped: SkipProxy { }
 
 struct SkipFieldInPlatform {
     intField: Int
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     stringField: String
     boolField: Boolean
 }
@@ -90,13 +100,13 @@ class ClassWithStructWithSkipLambdaInPlatform {
     struct SkipLambdaInPlatform {
         intField: Int
 
-        @Skip(Java, Dart, Swift)
+        @Skip(Java, Dart, Swift, Kotlin)
         lambda SomeLambda = () -> Int
 
-        @Skip(Java, Dart, Swift)
+        @Skip(Java, Dart, Swift, Kotlin)
         someLambda: SomeLambda
 
-        @Skip(Java, Dart, Swift)
+        @Skip(Java, Dart, Swift, Kotlin)
         fun useLambda(someLambda: SomeLambda): SomeLambda
     }
 }
@@ -104,7 +114,7 @@ class ClassWithStructWithSkipLambdaInPlatform {
 @Immutable
 struct SkipFieldInPlatformImmutable {
     intField: Int
-    @Java(Skip) @Swift(Skip) @Dart(Skip)
+    @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
     stringField: DummyStruct = {}
     boolField: Boolean
 }
@@ -116,7 +126,7 @@ struct DummyStruct {
 interface SkipSetter {
     property foo: String {
         get
-        @Java(Skip) @Swift(Skip) @Dart(Skip)
+        @Java(Skip) @Swift(Skip) @Dart(Skip) @Kotlin(Skip)
         set
     }
 }

--- a/functional-tests/functional/input/lime/SkipTags.lime
+++ b/functional-tests/functional/input/lime/SkipTags.lime
@@ -40,6 +40,7 @@ struct SkipTypesTags {
   @Java(Skip = "Lite")
   @Swift(Skip = "Lite")
   @Dart(Skip = "Lite")
+  @Kotlin(Skip = "Lite")
   enum SkipPlatform { N0 }
 }
 
@@ -53,5 +54,6 @@ class SkippedFunctionClass {
     @Java(Skip = "Lite")
     @Swift(Skip = "Lite")
     @Dart(Skip = "Lite")
+    @Kotlin(Skip = "Lite")
     fun doFoo(input: SkipTypesTags.SkipPlatform)
 }

--- a/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
+++ b/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
@@ -17,7 +17,7 @@
 
 package test
 
-@Skip(Swift, Dart)
+@Skip(Swift, Dart, Kotlin)
 interface SkipTagsInJava {
     @Java(Skip = "Lite")
     fun skipTagged()
@@ -27,7 +27,7 @@ interface SkipTagsInJava {
     fun skipTaggedList()
 }
 
-@Skip(Java, Dart)
+@Skip(Java, Dart, Kotlin)
 interface SkipTagsInSwift {
     @Swift(Skip = "Lite")
     fun skipTagged()
@@ -37,12 +37,22 @@ interface SkipTagsInSwift {
     fun skipTaggedList()
 }
 
-@Skip(Java, Swift)
+@Skip(Java, Swift, Kotlin)
 interface SkipTagsInDart {
     @Dart(Skip = "Lite")
     fun skipTagged()
     @Dart(Skip = "Pro")
     fun dontSkipTagged()
     @Dart(Skip = ["Lite", "Pro"])
+    fun skipTaggedList()
+}
+
+@Skip(Swift, Dart, Java)
+interface SkipTagsInKotlin {
+    @Kotlin(Skip = "Lite")
+    fun skipTagged()
+    @Kotlin(Skip = "Pro")
+    fun dontSkipTagged()
+    @Kotlin(Skip = ["Lite", "Pro"])
     fun skipTaggedList()
 }

--- a/functional-tests/functional/input/src/cpp/Skip.cpp
+++ b/functional-tests/functional/input/src/cpp/Skip.cpp
@@ -36,4 +36,9 @@ float
 SkipFunctions::not_in_dart(const float input) {
     return input;
 }
+
+float
+SkipFunctions::not_in_kotlin(const float input) {
+    return input;
+}
 }

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 interface {{resolveName}} {{!!
-}}{{#if this.parents}}extends {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
+}}{{#if this.parents}}: {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
 {{>kotlin/KotlinContainerContents}}
 
 {{#set isInterface=true classElement=this}}


### PR DESCRIPTION
This change:
- adjusts the input LIME files of functional tests for 'Skip' and 'EnableIf' attributes
- adds a new functional test called 'SkipElementTest.kt'
- fixes a minor bug related to inheritance of interfaces