### PR TITLE
Kotlin: add smoke tests for platform names

### DIFF
--- a/gluecodium/src/test/resources/smoke/platform_names/input/PlatformNames.lime
+++ b/gluecodium/src/test/resources/smoke/platform_names/input/PlatformNames.lime
@@ -21,30 +21,35 @@ package smoke
 @Java("barTypes")
 @Swift("bazTypes")
 @Dart("weeTypes")
+@Kotlin("dodoTypes")
 struct PlatformNames {
 
     @Cpp("fooStruct")
     @Java("barStruct")
     @Swift("bazStruct")
     @Dart("weeStruct")
+    @Kotlin("dodoStruct")
     struct BasicStruct {
 
         @Cpp("FOO_FIELD")
         @Java("BAR_FIELD")
         @Swift("BAZ_FIELD")
         @Dart("WEE_FIELD")
+        @Kotlin("DODO_FIELD")
         stringField: String
 
         @Cpp("FooCreate")
         @Java("BarCreate")
         @Swift("BazCreate")
         @Dart("WeeCreate")
+        @Kotlin("DodoCreate")
         constructor make(
 
             @Cpp("FooParameter")
             @Java("BarParameter")
             @Swift(Name = "BazParameter", Label = "_")
             @Dart("WeeParameter")
+            @Kotlin("DodoParameter")
             basicParameter: String
         )
     }
@@ -53,17 +58,20 @@ struct PlatformNames {
     @Java("barEnum")
     @Swift("bazEnum")
     @Dart("werrEnum")
+    @Kotlin("dodoEnum")
     enum BasicEnum {
 
         @Cpp("foo_item")
         @Java("bar_item")
         @Swift("BAZ_ITEM")
         @Dart("WEE_ITEM")
+        @Kotlin("DODO_ITEM")
         BASIC_ITEM
     }
 
     @Cpp("fooTypedef")
     @Swift("bazTypedef")
+    @Kotlin("dodoTypedef")
     typealias BasicTypedef = Double
 }
 
@@ -71,18 +79,21 @@ struct PlatformNames {
 @Java("barInterface")
 @Swift("bazInterface")
 @Dart("weeInterface")
+@Kotlin("dodoInterface")
 class PlatformNamesInterface {
 
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
     @Dart("WeeMethod")
+    @Kotlin("DodoMethod")
     fun basicMethod(
 
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift(Name = "BazParameter", Label = "_")
         @Dart("WeeParameter")
+        @Kotlin("DodoParameter")
         basicParameter: String
     ): PlatformNames.BasicStruct
 
@@ -90,17 +101,20 @@ class PlatformNamesInterface {
     @Java("make")
     @Swift("make")
     @Dart("make")
+    @Kotlin("make")
     constructor create(
 
         @Cpp("makeParameter")
         @Java("makeParameter")
         @Swift(Name = "makeParameter", Label = "_")
         @Dart("makeParameter")
+        @Kotlin("makeParameter")
         basicParameter: String
     )
 
     @Swift("BAZ_PROPERTY")
     @Dart("WEE_PROPERTY")
+    @Kotlin("DODO_PROPERTY")
     property basicProperty: UInt {
         @Cpp("GET_FOO_PROPERTY")
         @Java("GET_BAR_PROPERTY")
@@ -115,18 +129,21 @@ class PlatformNamesInterface {
 @Java("barListener")
 @Swift("bazListener")
 @Dart("weeListener")
+@Kotlin("dodoListener")
 interface PlatformNamesListener {
 
     @Cpp("FooMethod")
     @Java("BarMethod")
     @Swift("BazMethod")
     @Dart("WeeMethod")
+    @Kotlin("DodoMethod")
     fun basicMethod(
 
         @Cpp("FooParameter")
         @Java("BarParameter")
         @Swift(Name = "BazParameter", Label = "_")
         @Dart("WeeParameter")
+        @Kotlin("DodoParameter")
         basicParameter: String
     )
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
@@ -1,0 +1,41 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import com.example.smoke.dodoInterface
+import com.example.smoke.dodoTypes
+
+class dodoInterface : NativeBase {
+
+
+    constructor(makeParameter: String) : this(make(makeParameter), null as Any?) {
+        cacheThisInstance();
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    private external fun cacheThisInstance()
+
+    external fun DodoMethod(DodoParameter: String) : dodoTypes.dodoStruct
+
+    var DODO_PROPERTY: Long
+        external get
+        external set
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun make(makeParameter: String) : Long
+    }
+}

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
@@ -1,0 +1,27 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class dodoListenerImpl : NativeBase, dodoListener {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun DodoMethod(DodoParameter: String) : Unit
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
@@ -1,0 +1,31 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.smoke.dodoTypes
+
+class dodoTypes() {
+
+    enum class dodoEnum(private val value: Int) {
+        DODO_ITEM(0);
+    }
+    class dodoStruct(var DODO_FIELD: String) {
+
+
+
+        companion object {
+            @JvmStatic external fun DodoCreate(DodoParameter: String) : Long
+        }
+
+    }
+
+
+
+
+
+}
+
+


### PR DESCRIPTION
This commit brings a new smoke test related to
platform names. The existing 'PlatformNames.lime'
file is extended for Kotlin.