### PR TITLE
Kotlin: validate and fix usage of 'typealias'

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
@@ -41,6 +41,7 @@ import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeValue
 
@@ -58,6 +59,7 @@ internal class KotlinNameResolver(
         when (element) {
             is LimeComment -> resolveComment(element)
             is LimeValue -> resolveValue(element)
+            is LimeTypeAlias -> kotlinNameRules.getName(element)
             is LimeType -> resolveTypeName(element)
             is LimeTypeRef -> resolveTypeRef(element)
             is LimeReturnType -> resolveTypeRef(element.typeRef)

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
@@ -23,7 +23,10 @@
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}) : {{!!
-}}{{#if isStructure}}{{resolveName returnType}}{{/if}}{{!!
+}}{{#if isStructure}}{{!!
+}}{{#unless this.isConstructor}}{{resolveName returnType}}{{/unless}}{{!!
+}}{{#if this.isConstructor}}{{resolveName returnType.typeRef.type}}{{/if}}{{!!
+}}{{/if}}{{!!
 }}{{#unless isStructure}}{{!!
 }}{{#unless this.isConstructor}}{{resolveName returnType}}{{/unless}}{{!!
 }}{{#if this.isConstructor}}Long{{/if}}{{!!

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
@@ -26,7 +26,7 @@ class dodoTypes {
 
 
         companion object {
-            @JvmStatic external fun DodoCreate(DodoParameter: String) : dodoTypes.dodoStruct
+            @JvmStatic external fun DodoCreate(DodoParameter: String) : dodoStruct
         }
     }
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
@@ -27,8 +27,9 @@ class Structs : NativeBase {
 
 
 
+
         companion object {
-            @JvmStatic external fun fromPolar(phi: Double, r: Double) : Structs.Point
+            @JvmStatic external fun fromPolar(phi: Double, r: Double) : Point
         }
     }
 
@@ -42,6 +43,7 @@ class Structs : NativeBase {
             this.a = a
             this.b = b
         }
+
 
 
 
@@ -84,6 +86,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
     class NestingImmutableStruct {
@@ -94,6 +97,7 @@ class Structs : NativeBase {
         constructor(structField: Structs.AllTypesStruct) {
             this.structField = structField
         }
+
 
 
 
@@ -110,6 +114,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
     class StructWithArrayOfImmutable {
@@ -120,6 +125,7 @@ class Structs : NativeBase {
         constructor(arrayField: MutableList<Structs.AllTypesStruct>) {
             this.arrayField = arrayField
         }
+
 
 
 
@@ -151,6 +157,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
     class MutableStructWithCppAccessors {
@@ -169,6 +176,7 @@ class Structs : NativeBase {
             this.nontrivialPointField = nontrivialPointField
             this.nontrivialOptionalPoint = null
         }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
@@ -25,15 +25,19 @@ class StructsWithMethods {
         }
 
 
+
+
         external fun distanceTo(other: StructsWithMethods.Vector) : Double
         external fun add(other: StructsWithMethods.Vector) : StructsWithMethods.Vector
 
         companion object {
             @JvmStatic external fun validate(x: Double, y: Double) : Boolean
-            @JvmStatic external fun create(x: Double, y: Double) : StructsWithMethods.Vector
-            @JvmStatic external fun create(other: StructsWithMethods.Vector) : StructsWithMethods.Vector
+            @JvmStatic external fun create(x: Double, y: Double) : Vector
+            @JvmStatic external fun create(other: StructsWithMethods.Vector) : Vector
         }
     }
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -29,17 +29,21 @@ class StructsWithMethodsInterface : NativeBase {
         }
 
 
+
+
         external fun distanceTo(other: StructsWithMethodsInterface.Vector3) : Double
         external fun add(other: StructsWithMethodsInterface.Vector3) : StructsWithMethodsInterface.Vector3
 
         companion object {
             @JvmStatic external fun validate(x: Double, y: Double, z: Double) : Boolean
-            @JvmStatic external fun create(input: String) : StructsWithMethodsInterface.Vector3
-            @JvmStatic external fun create(other: StructsWithMethodsInterface.Vector3) : StructsWithMethodsInterface.Vector3
+            @JvmStatic external fun create(input: String) : Vector3
+            @JvmStatic external fun create(other: StructsWithMethodsInterface.Vector3) : Vector3
         }
     }
 
     class StructWithStaticMethodsOnly {
+
+
 
 
 
@@ -60,6 +64,7 @@ class StructsWithMethodsInterface : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/input/TypeDefs.lime
+++ b/gluecodium/src/test/resources/smoke/typedefs/input/TypeDefs.lime
@@ -54,6 +54,9 @@ class TypeDefs {
     property primitiveTypeProperty: List<PrimitiveTypeDef>
 }
 
+typealias GlobalListTypeDef = List<Float>
+typealias GlobalMapTypeDef = Map<Int, String>
+
 struct TypeCollection {
     struct Point {
         x: Double

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalListTypeDef.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalListTypeDef.kt
@@ -1,0 +1,9 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+typealias GlobalListTypeDef = MutableList<Float>

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalMapTypeDef.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalMapTypeDef.kt
@@ -1,0 +1,9 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+typealias GlobalMapTypeDef = MutableMap<Int, String>

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
@@ -1,0 +1,51 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class TypeCollection {
+
+    class Point {
+        var x: Double
+        var y: Double
+
+
+
+        constructor(x: Double, y: Double) {
+            this.x = x
+            this.y = y
+        }
+
+
+
+
+    }
+
+    class StructHavingAliasFieldDefinedBelow {
+        var field: Long
+
+
+
+        constructor(field: Long) {
+            this.field = field
+        }
+
+
+
+
+    }
+
+
+
+
+
+
+
+    companion object {
+        val INVALID_STORAGE_ID: Long = 0L
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
@@ -1,0 +1,68 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class TypeDefs : NativeBase {
+
+    class StructHavingAliasFieldDefinedBelow {
+        var field: Double
+
+
+
+        constructor(field: Double) {
+            this.field = field
+        }
+
+
+
+
+    }
+
+    class TestStruct {
+        var something: String
+
+
+
+        constructor(something: String) {
+            this.something = something
+        }
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+    var primitiveTypeProperty: MutableList<Double>
+        external get
+        external set
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun methodWithPrimitiveTypeDef(input: Double) : Double
+        @JvmStatic external fun methodWithComplexTypeDef(input: MutableList<TypeDefs.TestStruct>) : MutableList<TypeDefs.TestStruct>
+        @JvmStatic external fun returnNestedIntTypeDef(input: Double) : Double
+        @JvmStatic external fun returnTestStructTypeDef(input: TypeDefs.TestStruct) : TypeDefs.TestStruct
+        @JvmStatic external fun returnNestedStructTypeDef(input: TypeDefs.TestStruct) : TypeDefs.TestStruct
+        @JvmStatic external fun returnTypeDefPointFromTypeCollection(input: TypeCollection.Point) : TypeCollection.Point
+    }
+}

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cbridge/include/GenericCollections.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cbridge/include/GenericCollections.h
@@ -1,30 +1,66 @@
 //
+
 //
+
 #pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 #include "cbridge/include/BaseHandle.h"
 #include "cbridge/include/Export.h"
+#include <stdbool.h>
 #include <stdint.h>
+
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Double_create_handle();
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Double_copy_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT void foobar_ArrayOf__Double_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT uint64_t foobar_ArrayOf__Double_count(_baseRef handle);
 _GLUECODIUM_C_EXPORT double foobar_ArrayOf__Double_get(_baseRef handle, uint64_t index);
 _GLUECODIUM_C_EXPORT void foobar_ArrayOf__Double_append(_baseRef handle, double item);
+
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Double_create_optional_handle();
 _GLUECODIUM_C_EXPORT void foobar_ArrayOf__Double_release_optional_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Double_unwrap_optional_handle(_baseRef handle);
+
+_GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Float_create_handle();
+_GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Float_copy_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT void foobar_ArrayOf__Float_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT uint64_t foobar_ArrayOf__Float_count(_baseRef handle);
+_GLUECODIUM_C_EXPORT float foobar_ArrayOf__Float_get(_baseRef handle, uint64_t index);
+_GLUECODIUM_C_EXPORT void foobar_ArrayOf__Float_append(_baseRef handle, float item);
+
+_GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Float_create_optional_handle();
+_GLUECODIUM_C_EXPORT void foobar_ArrayOf__Float_release_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf__Float_unwrap_optional_handle(_baseRef handle);
+
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf_smoke_TypeDefs_TestStruct_create_handle();
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf_smoke_TypeDefs_TestStruct_copy_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT void foobar_ArrayOf_smoke_TypeDefs_TestStruct_release_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT uint64_t foobar_ArrayOf_smoke_TypeDefs_TestStruct_count(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf_smoke_TypeDefs_TestStruct_get(_baseRef handle, uint64_t index);
 _GLUECODIUM_C_EXPORT void foobar_ArrayOf_smoke_TypeDefs_TestStruct_append(_baseRef handle, _baseRef item);
+
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf_smoke_TypeDefs_TestStruct_create_optional_handle();
 _GLUECODIUM_C_EXPORT void foobar_ArrayOf_smoke_TypeDefs_TestStruct_release_optional_handle(_baseRef handle);
 _GLUECODIUM_C_EXPORT _baseRef foobar_ArrayOf_smoke_TypeDefs_TestStruct_unwrap_optional_handle(_baseRef handle);
+
+_GLUECODIUM_C_EXPORT _baseRef foobar_MapOf__Int_To__String_create_handle();
+_GLUECODIUM_C_EXPORT void foobar_MapOf__Int_To__String_release_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef foobar_MapOf__Int_To__String_iterator(_baseRef handle);
+_GLUECODIUM_C_EXPORT void foobar_MapOf__Int_To__String_iterator_release_handle(_baseRef iterator_handle);
+_GLUECODIUM_C_EXPORT void foobar_MapOf__Int_To__String_put(_baseRef handle, int32_t key, _baseRef value);
+_GLUECODIUM_C_EXPORT bool foobar_MapOf__Int_To__String_iterator_is_valid(_baseRef handle, _baseRef iterator_handle);
+_GLUECODIUM_C_EXPORT void foobar_MapOf__Int_To__String_iterator_increment(_baseRef iterator_handle);
+_GLUECODIUM_C_EXPORT int32_t foobar_MapOf__Int_To__String_iterator_key(_baseRef iterator_handle);
+_GLUECODIUM_C_EXPORT _baseRef foobar_MapOf__Int_To__String_iterator_value(_baseRef iterator_handle);
+
+_GLUECODIUM_C_EXPORT _baseRef foobar_MapOf__Int_To__String_create_optional_handle();
+_GLUECODIUM_C_EXPORT void foobar_MapOf__Int_To__String_release_optional_handle(_baseRef handle);
+_GLUECODIUM_C_EXPORT _baseRef foobar_MapOf__Int_To__String_unwrap_optional_handle(_baseRef handle);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalListTypeDef.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalListTypeDef.h
@@ -1,0 +1,17 @@
+// -------------------------------------------------------------------------------------------------
+//
+
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/VectorHash.h"
+#include <vector>
+
+namespace smoke {
+using GlobalListTypeDef = ::std::vector< float >;
+
+
+}

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalMapTypeDef.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalMapTypeDef.h
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+//
+
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/UnorderedMapHash.h"
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace smoke {
+using GlobalMapTypeDef = ::std::unordered_map< int32_t, ::std::string >;
+
+
+}

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalListTypeDef.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalListTypeDef.swift
@@ -1,0 +1,10 @@
+//
+
+//
+
+import Foundation
+
+public typealias GlobalListTypeDef = [Float]
+
+
+

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalMapTypeDef.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalMapTypeDef.swift
@@ -1,0 +1,10 @@
+//
+
+//
+
+import Foundation
+
+public typealias GlobalMapTypeDef = [Int32: String]
+
+
+


### PR DESCRIPTION
The way how names were resolved for standalone global type alias
usage in the case of Kotlin generator was invalid. It also caused problems
when building the LIME input of functional tests for external types.

This series introduces smoke tests and fixes the problem in name resolver.