### PR TITLE
JNI: use external field for the given platform

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniGeneratorPredicates.kt
@@ -110,6 +110,15 @@ internal class JniGeneratorPredicates(
             "shouldRetain" to { limeElement: Any ->
                 limeElement is LimeNamedElement && shouldRetain(limeElement)
             },
+            "hasExternalConverter" to { limeElement: Any ->
+                limeElement is LimeNamedElement && limeElement.external?.getFor(platformAttribute)?.get("converter") != null
+            },
+            "hasExternalGetterName" to { limeElement: Any ->
+                limeElement is LimeNamedElement && limeElement.external?.getFor(platformAttribute)?.get("getterName") != null
+            },
+            "hasExternalSetterName" to { limeElement: Any ->
+                limeElement is LimeNamedElement && limeElement.external?.getFor(platformAttribute)?.get("setterName") != null
+            },
         )
 
     fun shouldRetain(limeElement: LimeNamedElement) =

--- a/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/EnumConversionImplementation.mustache
@@ -34,16 +34,16 @@ namespace {{.}}
 namespace jni
 {
 {{#enum}}
-{{#if external.java.converter}}
+{{#set ConvertedType=this}}{{#eval "external" platformName}}{{#if this.converter}}
 {{>jni/ExternalConversionClassCache}}
-{{/if}}
+{{/if}}{{/eval}}{{/set}}
 
 {{resolveName "C++ FQN"}}
-convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{#if external.java.converter}}_ext{{/if}}, TypeId<{{resolveName "C++ FQN"}}>)
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{#ifPredicate "hasExternalConverter"}}_ext{{/ifPredicate}}, TypeId<{{resolveName "C++ FQN"}}>)
 {
-{{#if external.java.converter}}
+{{#set ConvertedType=this}}{{#eval "external" platformName}}{{#if this.converter}}
 {{prefixPartial "jni/ExternalConversionFromJni" "    "}}
-{{/if}}
+{{/if}}{{/eval}}{{/set}}
 {{#ifPredicate "needsOrdinalConversion"}}
     auto ordinal = call_java_method<jint>(_jenv, _jinput, "ordinal", "()I");
     switch(ordinal) {
@@ -84,13 +84,14 @@ convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}} _ninput)
 {{/unless}}{{/enumerators}}
     }
     jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "L{{resolveName this "" "ref"}};");
-{{#unless external.java.converter}}
+{{#unlessPredicate "hasExternalConverter"}}
     return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
-{{/unless}}{{#if external.java.converter}}
+{{/unlessPredicate}}{{!!
+}}{{#set ConvertedType=this}}{{#eval "external" platformName}}{{#if this.converter}}
     auto _jresult = make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
 {{prefixPartial "jni/ExternalConversionToJni" "    "}}
     return _jresult;
-{{/if}}
+{{/if}}{{/eval}}{{/set}}
 }
 
 JniReference<jobject>

--- a/gluecodium/src/main/resources/templates/jni/ExternalConversionClassCache.mustache
+++ b/gluecodium/src/main/resources/templates/jni/ExternalConversionClassCache.mustache
@@ -20,9 +20,9 @@
   !}}
 namespace
 {
-struct Dummy{{resolveName external.java.converter "mangled"}}Type final {};
+struct Dummy{{resolveName this.converter "mangled"}}Type final {};
 }
 
-REGISTER_JNI_CLASS_CACHE("{{resolveName external.java.converter ""}}", {{!!
-}}{{resolveName external.java.converter "mangled"}}, {{!!
-}}Dummy{{resolveName external.java.converter "mangled"}}Type)
+REGISTER_JNI_CLASS_CACHE("{{resolveName this.converter ""}}", {{!!
+}}{{resolveName this.converter "mangled"}}, {{!!
+}}Dummy{{resolveName this.converter "mangled"}}Type)

--- a/gluecodium/src/main/resources/templates/jni/ExternalConversionFromJni.mustache
+++ b/gluecodium/src/main/resources/templates/jni/ExternalConversionFromJni.mustache
@@ -19,13 +19,13 @@
   !
   !}}
 auto& converterClass = CachedJavaClass<Dummy{{!!
-}}{{resolveName external.java.converter "mangled"}}Type>::java_class;
+}}{{resolveName this.converter "mangled"}}Type>::java_class;
 
 auto convertMethodId = _jenv->GetStaticMethodID(
-    converterClass.get(), "convertToInternal", "(L{{resolveName external.java.name ""}};)L{{resolveName this "" "ref"}};");
+    converterClass.get(), "convertToInternal", "(L{{resolveName this.name ""}};)L{{resolveName ConvertedType "" "ref"}};");
 if (convertMethodId == NULL) {
     throw_new_runtime_exception(_jenv, "Static method 'convertToInternal({{!!
-    }}L{{resolveName external.java.name ""}};)L{{resolveName this "" "ref"}};' not found.");
+    }}L{{resolveName this.name ""}};)L{{resolveName ConvertedType "" "ref"}};' not found.");
     return {};
 }
 

--- a/gluecodium/src/main/resources/templates/jni/ExternalConversionToJni.mustache
+++ b/gluecodium/src/main/resources/templates/jni/ExternalConversionToJni.mustache
@@ -18,13 +18,13 @@
   ! License-Filename: LICENSE
   !
   !}}
-auto& converterClass = CachedJavaClass<Dummy{{resolveName external.java.converter "mangled"}}Type>::java_class;
+auto& converterClass = CachedJavaClass<Dummy{{resolveName this.converter "mangled"}}Type>::java_class;
 
 auto convertMethodId = _jenv->GetStaticMethodID(
-    converterClass.get(), "convertFromInternal", "(L{{resolveName this "" "ref"}};)L{{resolveName external.java.name ""}};");
+    converterClass.get(), "convertFromInternal", "(L{{resolveName ConvertedType "" "ref"}};)L{{resolveName this.name ""}};");
 if (convertMethodId == NULL) {
     throw_new_runtime_exception(_jenv, "Static method 'convertFromInternal({{!!
-    }}L{{resolveName this "" "ref"}};)L{{resolveName external.java.name ""}};' not found.");
+    }}L{{resolveName ConvertedType "" "ref"}};)L{{resolveName this.name ""}};' not found.");
     return {};
 }{{!!
     }}

--- a/gluecodium/src/main/resources/templates/jni/FunctionSignaturePrefix.mustache
+++ b/gluecodium/src/main/resources/templates/jni/FunctionSignaturePrefix.mustache
@@ -18,7 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
-Java_{{#if container.external.java.converter}}{{#resolveName container "" "ref"}}{{resolveName "mangled"}}{{/resolveName}}{{/if}}{{!!
-}}{{#unless container.external.java.converter}}{{resolveName container "mangled"}}{{/unless}}{{!!
+Java_{{#ifPredicate container "hasExternalConverter"}}{{#resolveName container "" "ref"}}{{resolveName "mangled"}}{{/resolveName}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate container "hasExternalConverter"}}{{resolveName container "mangled"}}{{/unlessPredicate}}{{!!
 }}{{#instanceOf container "LimeInterface"}}Impl{{/instanceOf}}{{!!
 }}{{#instanceOf container "LimeLambda"}}Impl{{/instanceOf}}

--- a/gluecodium/src/main/resources/templates/jni/Implementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/Implementation.mustache
@@ -194,7 +194,7 @@ jint
 }}).release(){{/if}}{{!!
 }}{{#unless returnType.typeRef.attributes.optimized}}{{!!
 }}{{>common/InternalNamespace}}jni::{{#returnType}}{{>jni/JniConversionPrefix}}{{/returnType}}{{!!
-}}convert_to_jni{{#if isConstructor container.external.java.converter}}_internal{{/if}}{{!!
+}}convert_to_jni{{#if isConstructor}}{{#ifPredicate container "hasExternalConverter"}}_internal{{/ifPredicate}}{{/if}}{{!!
 }}(_jenv, _result).release(){{/unless}}{{/unlessPredicate}}{{!!
 }}{{#ifPredicate returnType.typeRef "isJniPrimitive"}}_result{{/ifPredicate}};{{/unlessPredicate}}{{/unless}}
 }

--- a/gluecodium/src/main/resources/templates/jni/StructConversionHeader.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionHeader.mustache
@@ -40,9 +40,9 @@ JNIEXPORT {{resolveName "C++ FQN"}} convert_from_jni(JNIEnv* _jenv, const JniRef
 JNIEXPORT std::optional<{{resolveName "C++ FQN"}}> convert_from_jni({{!!
 }}JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<{{resolveName "C++ FQN"}}>>);
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput);
-{{#if external.java.converter constructors}}
+{{#if constructors}}{{#ifPredicate "hasExternalConverter"}}
 JNIEXPORT JniReference<jobject> convert_to_jni_internal(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput);
-{{/if}}
+{{/ifPredicate}}{{/if}}
 JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<{{resolveName "C++ FQN"}}> _ninput);
 {{/struct}}
 }

--- a/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
+++ b/gluecodium/src/main/resources/templates/jni/StructConversionImplementation.mustache
@@ -35,27 +35,27 @@ namespace {{.}}
 namespace jni
 {
 {{#struct}}
-{{#if external.java.converter}}
+{{#set ConvertedType=this}}{{#eval "external" platformName}}{{#if this.converter}}
 {{>jni/ExternalConversionClassCache}}
-{{/if}}
+{{/if}}{{/eval}}{{/set}}
 
 {{resolveName "C++ FQN"}}
 convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
-}}{{#if external.java.converter}}_ext{{/if}}, TypeId<{{resolveName "C++ FQN"}}>)
+}}{{#ifPredicate "hasExternalConverter"}}_ext{{/ifPredicate}}, TypeId<{{resolveName "C++ FQN"}}>)
 {
-{{#if external.java.converter}}
+{{#set ConvertedType=this}}{{#eval "external" platformName}}{{#if this.converter}}
 {{prefixPartial "jni/ExternalConversionFromJni" "    "}}
-{{/if}}
+{{/if}}{{/eval}}{{/set}}
     {{#unlessPredicate "hasImmutableFields"}}{{resolveName "C++ FQN"}} _nout{};{{/unlessPredicate}}
-{{#fields}}{{#ifPredicate "shouldRetain"}}{{#if external.java.getterName}}{{#unlessPredicate typeRef "isJniPrimitive"}}
+{{#fields}}{{#ifPredicate "shouldRetain"}}{{#ifPredicate "hasExternalGetterName"}}{{#unlessPredicate typeRef "isJniPrimitive"}}
     auto j_{{resolveName "C++"}} = call_java_method<{{resolveName typeRef}}>(_jenv, _jinput, {{!!
-    }}"{{external.java.getterName}}", "(){{resolveName typeRef "signature"}}");
+    }}"{{eval "external" platformName "getterName"}}", "(){{resolveName typeRef "signature"}}");
     auto n_{{resolveName "C++"}} = {{>jni/JniConversionPrefix}}convert_from_jni(_jenv, j_{{resolveName "C++"}}, TypeId<{{resolveName typeRef "C++"}}>{});
 {{/unlessPredicate}}{{#ifPredicate typeRef "isJniPrimitive"}}
     auto n_{{resolveName "C++"}} = call_java_method<{{resolveName typeRef}}>(_jenv, _jinput, {{!!
-    }}"{{external.java.getterName}}", "(){{resolveName typeRef "signature"}}");
-{{/ifPredicate}}{{/if}}{{!!
-}}{{#unless external.java.getterName}}{{#notInstanceOf typeRef.type.actualType "LimeBasicType"}}
+    }}"{{eval "external" platformName "getterName"}}", "(){{resolveName typeRef "signature"}}");
+{{/ifPredicate}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "hasExternalGetterName"}}{{#notInstanceOf typeRef.type.actualType "LimeBasicType"}}
 {{#if typeRef.attributes.optimized}}
     auto j_{{resolveName "C++"}} = get_object_field_value(_jenv, _jinput, "{{resolveName}}", "L{{resolveName typeRef.type.actualType}};");
     auto {{resolveName "C++"}}_handle = get_class_native_handle(_jenv, j_{{resolveName "C++"}});
@@ -73,7 +73,7 @@ convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput{{!!
         _jinput,
         "{{resolveName}}",
         TypeId<{{resolveName typeRef "C++"}}>{} );
-{{/instanceOf}}{{/unless}}
+{{/instanceOf}}{{/unlessPredicate}}
     {{#unlessPredicate struct "hasImmutableFields"}}_nout.{{!!
     }}{{#ifPredicate "hasCppSetter"}}{{resolveName this "C++" "setter"}}(n_{{resolveName this "C++"}}){{/ifPredicate}}{{!!
     }}{{#unlessPredicate "hasCppSetter"}}{{resolveName this "C++"}} = n_{{resolveName this "C++"}}{{/unlessPredicate}}{{!!
@@ -100,12 +100,12 @@ JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput)
 {
 {{>convertToJniBody}}
-{{#if external.java.converter}}
+{{#set ConvertedType=this}}{{#eval "external" platformName}}{{#if this.converter}}
 {{prefixPartial "jni/ExternalConversionToJni" "    "}}
-{{/if}}
+{{/if}}{{/eval}}{{/set}}
     return _jresult;
 }
-{{#if external.java.converter constructors}}
+{{#if constructors}}{{#ifPredicate "hasExternalConverter"}}
 
 JniReference<jobject>
 convert_to_jni_internal(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput)
@@ -113,7 +113,7 @@ convert_to_jni_internal(JNIEnv* _jenv, const {{resolveName "C++ FQN"}}& _ninput)
 {{>convertToJniBody}}
     return _jresult;
 }
-{{/if}}
+{{/ifPredicate}}{{/if}}
 
 JniReference<jobject>
 convert_to_jni(JNIEnv* _jenv, const std::optional<{{resolveName "C++ FQN"}}> _ninput)
@@ -141,15 +141,15 @@ convert_to_jni(JNIEnv* _jenv, const std::optional<{{resolveName "C++ FQN"}}> _ni
 }}{{+convertToJniBody}}{{!!
 }}    auto& javaClass = CachedJavaClass<{{resolveName "C++ FQN"}}>::java_class;
     auto _jresult = {{>common/InternalNamespace}}jni::alloc_object(_jenv, javaClass);
-{{#set struct=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}{{#if external.java.setterName}}{{#unlessPredicate typeRef "isJniPrimitive"}}
+{{#set struct=this}}{{#fields}}{{#ifPredicate "shouldRetain"}}{{#ifPredicate "hasExternalSetterName"}}{{#unlessPredicate typeRef "isJniPrimitive"}}
     auto j{{resolveName "C++"}} = {{>jni/JniConversionPrefix}}convert_to_jni(_jenv, {{>getCppFieldValue}});
-    call_java_method<void>(_jenv, _jresult, "{{external.java.setterName}}", {{!!
+    call_java_method<void>(_jenv, _jresult, "{{eval "external" platformName "setterName"}}", {{!!
     }}"({{resolveName typeRef "signature"}})V", j{{cppField.name}});
 {{/unlessPredicate}}{{#ifPredicate typeRef "isJniPrimitive"}}
-    call_java_method<void>(_jenv, _jresult, "{{external.java.setterName}}", {{!!
+    call_java_method<void>(_jenv, _jresult, "{{eval "external" platformName "setterName"}}", {{!!
     }}"({{resolveName typeRef "signature"}})V", {{>getCppFieldValue}});
-{{/ifPredicate}}{{/if}}{{!!
-}}{{#unless external.java.setterName}}{{#notInstanceOf typeRef.type.actualType "LimeBasicType"}}
+{{/ifPredicate}}{{/ifPredicate}}{{!!
+}}{{#unlessPredicate "hasExternalSetterName"}}{{#notInstanceOf typeRef.type.actualType "LimeBasicType"}}
     auto j{{resolveName "C++"}} = {{#if typeRef.attributes.optimized}}{{!!
 }}convert_to_jni_optimized(_jenv, {{>getCppFieldValue}}, "{{resolveName struct "" "ref"}}${{resolveName typeRef "" "ref"}}"){{/if}}{{!!
 }}{{#unless typeRef.attributes.optimized}}{{>jni/JniConversionPrefix}}convert_to_jni(_jenv, {{>getCppFieldValue}}){{/unless}};
@@ -157,5 +157,5 @@ convert_to_jni(JNIEnv* _jenv, const std::optional<{{resolveName "C++ FQN"}}> _ni
     }}_jenv, _jresult, "{{resolveName}}", "L{{resolveName typeRef.type.actualType}};", j{{resolveName "C++"}});
 {{/notInstanceOf}}{{#instanceOf typeRef.type.actualType "LimeBasicType"}}
     {{>common/InternalNamespace}}jni::set_field_value(_jenv, _jresult, "{{resolveName}}", {{>getCppFieldValue}});
-{{/instanceOf}}{{/unless}}{{/ifPredicate}}{{/fields}}{{/set}}{{!!
+{{/instanceOf}}{{/unlessPredicate}}{{/ifPredicate}}{{/fields}}{{/set}}{{!!
 }}{{/convertToJniBody}}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo.h
@@ -1,0 +1,21 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jobject JNICALL
+Java_com_example_smoke_JavaExternalCtor_make(JNIEnv* _jenv, jobject _jinstance, jstring jfield);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_Foo__Conversion.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/JavaExternalCtor.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::JavaExternalCtor convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::JavaExternalCtor>);
+JNIEXPORT std::optional<::smoke::JavaExternalCtor> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::JavaExternalCtor>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::JavaExternalCtor& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni_internal(JNIEnv* _jenv, const ::smoke::JavaExternalCtor& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::JavaExternalCtor> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_DurationExternal__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_DurationExternal__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "core/duration.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT std::chrono::duration<uint64_t, std::ratio<1,1000>> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::chrono::duration<uint64_t, std::ratio<1,1000>>>);
+JNIEXPORT std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::chrono::duration<uint64_t, std::ratio<1,1000>>& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<std::chrono::duration<uint64_t, std::ratio<1,1000>>> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums.h
@@ -1,0 +1,21 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Enums_methodWithExternalEnum(JNIEnv* _jenv, jobject _jinstance, jobject jinput);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_ExternalEnum__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_ExternalEnum__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "foo/Bar.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::Enums::External_Enum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Enums::External_Enum>);
+JNIEXPORT std::optional<::smoke::Enums::External_Enum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Enums::External_Enum>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Enums::External_Enum _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Enums::External_Enum> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_VeryExternalEnum__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Enums_VeryExternalEnum__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "foo/Bar.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::fire::SomeVeryExternalEnum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::fire::SomeVeryExternalEnum>);
+JNIEXPORT std::optional<::fire::SomeVeryExternalEnum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::fire::SomeVeryExternalEnum>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::fire::SomeVeryExternalEnum _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::fire::SomeVeryExternalEnum> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalClass.h
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ExternalClass_someMethod(JNIEnv* _jenv, jobject _jinstance, jbyte jsomeParameter);
+
+JNIEXPORT jstring JNICALL
+Java_com_example_smoke_ExternalClass_getSomeProperty(JNIEnv* _jenv, jobject _jinstance);
+
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterfaceImpl.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_ExternalInterfaceImpl.h
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_ExternalInterfaceImpl_someMethod(JNIEnv* _jenv, jobject _jinstance, jbyte jsomeParameter);
+
+JNIEXPORT jstring JNICALL
+Java_com_example_smoke_ExternalInterfaceImpl_getSomeProperty(JNIEnv* _jenv, jobject _jinstance);
+
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_JavaExternalTypesStruct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_JavaExternalTypesStruct__Conversion.h
@@ -1,0 +1,27 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/JavaExternalTypesStruct.h"
+#include "java_lang_Integer__Conversion.h"
+#include "java_lang_String__Conversion.h"
+#include "java_time_Month__Conversion.h"
+#include "java_util_Currency__Conversion.h"
+#include "java_util_SimpleTimeZone__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::JavaExternalTypesStruct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::JavaExternalTypesStruct>);
+JNIEXPORT std::optional<::smoke::JavaExternalTypesStruct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::JavaExternalTypesStruct>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::JavaExternalTypesStruct& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::JavaExternalTypesStruct> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jobject JNICALL
+Java_com_example_smoke_Structs_getExternalStruct(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jobject JNICALL
+Java_com_example_smoke_Structs_getAnotherExternalStruct(JNIEnv* _jenv, jobject _jinstance);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/com_example_smoke_Structs_ExternalStruct__Conversion.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "foo/Bar.h"
+#include "com_example_smoke_Structs_AnotherExternalStruct__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::Structs::ExternalStruct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Structs::ExternalStruct>);
+JNIEXPORT std::optional<::smoke::Structs::ExternalStruct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Structs::ExternalStruct>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Structs::ExternalStruct& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Structs::ExternalStruct> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_Integer__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_Integer__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/SystemColor.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::SystemColor convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::SystemColor>);
+JNIEXPORT std::optional<::smoke::SystemColor> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::SystemColor>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::SystemColor& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::SystemColor> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_String__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_lang_String__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/Season.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::Season convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Season>);
+JNIEXPORT std::optional<::smoke::Season> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Season>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Season _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Season> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_time_Month__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_time_Month__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/Month.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::Month convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Month>);
+JNIEXPORT std::optional<::smoke::Month> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Month>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Month _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Month> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_Currency__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_Currency__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/Currency.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::Currency convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::Currency>);
+JNIEXPORT std::optional<::smoke::Currency> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::Currency>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Currency& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::Currency> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_SimpleTimeZone__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android/jni/java_util_SimpleTimeZone__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/TimeZone.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::smoke::TimeZone convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::TimeZone>);
+JNIEXPORT std::optional<::smoke::TimeZone> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::TimeZone>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::TimeZone& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::TimeZone> _ninput);
+}
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeType.kt
@@ -27,7 +27,7 @@ enum class LimeAttributeType(
 ) {
     CPP("Cpp", LimeAttributeValueType.NAME),
     JAVA("Java", LimeAttributeValueType.NAME),
-    KOTLIN("KOTLIN", LimeAttributeValueType.NAME),
+    KOTLIN("Kotlin", LimeAttributeValueType.NAME),
     SWIFT("Swift", LimeAttributeValueType.NAME),
     DART("Dart", LimeAttributeValueType.NAME),
     ASYNC("Async"),


### PR DESCRIPTION
JniTemplates class is used for two platforms: Java and Kotlin.
In the past it was used only for Java. Therefore, its mustache
files used 'external.java' explicitly.
    
This was the root cause of problems with generation of JNI layer
for Kotlin when external types with converters were used.
    
This commit adjusts mustache templates to use 'external' field
for the selected platform. This is achieved via new predicates
as well as usage of 'EvalHelper'.

This change brings also more smoke tests of JNI layer for external
types.