### PR TITLE
Kotlin: support usage of external types

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -303,7 +303,7 @@ feature(CircularDependencies cpp android swift dart SOURCES
     input/lime/Circular.lime
 )
 
-feature(ExternalTypes cpp android swift dart SOURCES
+feature(ExternalTypes cpp android android-kotlin swift dart SOURCES
     input/src/cpp/include/ExternalTypes.h
     input/src/cpp/include/MyClass.h
     input/src/cpp/src/ExternalTypes.cpp
@@ -320,6 +320,12 @@ feature(JavaExternalTypes android SOURCES
     input/src/cpp/JavaExternalTypes.cpp
 
     input/lime/JavaExternalTypes.lime
+)
+
+feature(KotlinExternalTypes android-kotlin SOURCES
+    input/src/cpp/KotlinExternalTypes.cpp
+
+    input/lime/KotlinExternalTypes.lime
 )
 
 if(NOT APPLE)

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ExternalTypesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ExternalTypesTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+import com.here.android.external.AnotherExternalStruct
+import com.here.android.external.ExternalEnum
+import com.here.android.external.ExternalStruct
+import java.time.Month
+
+import android.os.Parcel
+import android.os.Parcelable
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class ExternalTypesTest {
+
+    class MyKotlinClass : MyClass {
+        override fun foo() = 77
+    }
+
+    @org.junit.Test
+    fun useExternalTypes() {
+        val externalStruct = ExternalStruct("foo", "bar", mutableListOf(7, 11), AnotherExternalStruct(42))
+        val inputStruct = UseExternalTypes.StructWithExternalTypes(externalStruct, ExternalEnum.BAR)
+        val resultStruct = UseExternalTypes.extractExternalStruct(inputStruct)
+
+        assertEquals("foo", resultStruct.stringField)
+        assertEquals("bar", resultStruct.externalStringField)
+        assertEquals(2, resultStruct.externalArrayField.size)
+        assertEquals(7, resultStruct.externalArrayField[0])
+        assertEquals(11, resultStruct.externalArrayField[1])
+        assertEquals(42, resultStruct.externalStructField.intField)
+    }
+
+    @org.junit.Test
+    fun useExternalTypesExternalEnum() {
+        val externalStruct = ExternalStruct("foo", "bar", mutableListOf(7, 11), AnotherExternalStruct(42))
+        val inputStruct = UseExternalTypes.StructWithExternalTypes(externalStruct, ExternalEnum.BAR)
+        val resultEnum = UseExternalTypes.extractExternalEnum(inputStruct)
+
+        assertEquals(ExternalEnum.BAR, resultEnum)
+    }
+
+    @org.junit.Test
+    fun useKotlinExternalStructCurrency() {
+        val currency = java.util.Currency.getInstance("EUR")
+        val result = UseKotlinExternalTypes.currencyRoundTrip(currency)
+
+        assertEquals(currency.getCurrencyCode(), result.getCurrencyCode())
+        assertEquals(currency.getNumericCode(), result.getNumericCode())
+    }
+
+    @org.junit.Test
+    fun useKotlinExternalStructTimeZone() {
+        val timeZone = java.util.SimpleTimeZone(2, "foobar")
+        timeZone.rawOffset = 42
+
+        val result = UseKotlinExternalTypes.timeZoneRoundTrip(timeZone)
+        assertEquals(timeZone.rawOffset, result.rawOffset)
+    }
+
+    @org.junit.Test
+    fun useKotlinExternalEnum() {
+        val month = Month.of(2)
+        val result = UseKotlinExternalTypes.monthRoundTrip(month)
+
+        assertEquals(month, result)
+    }
+
+    @org.junit.Test
+    fun useKotlinExternalColor() {
+        val color = android.graphics.Color.argb(0, 0, 127, 255)
+        val result = UseKotlinExternalTypes.colorRoundTrip(color)
+
+        assertEquals(color, result)
+    }
+
+    @org.junit.Test
+    fun useKotlinExternalSeason() {
+        val season = "SPRING"
+        val result = UseKotlinExternalTypes.seasonRoundTrip(season)
+
+        assertEquals(season, result)
+    }
+
+
+    @org.junit.Test
+    fun useKotlinExternalTypesInStruct() {
+        val timeZone = java.util.SimpleTimeZone(2, "foobar")
+        timeZone.setRawOffset(42)
+
+        val struct = KotlinExternalTypesStruct(
+            java.util.Currency.getInstance("EUR"),
+            timeZone,
+            Month.of(2),
+            android.graphics.Color.argb(0, 0, 127, 255),
+            "SPRING"
+        )
+
+        val result = UseKotlinExternalTypes.structRoundTrip(struct)
+
+        assertEquals(struct.currency.getCurrencyCode(), result.currency.getCurrencyCode())
+        assertEquals(struct.timeZone.getRawOffset(), result.timeZone.getRawOffset())
+        assertEquals(struct.month, result.month)
+        assertEquals(struct.color, result.color)
+        assertEquals(struct.season, result.season)
+    }
+
+    @org.junit.Test
+    fun useMyClass() {
+        val result: Int = UseMyClass().callBar(MyKotlinClass())
+        assertEquals(77, result)
+    }
+
+    @org.junit.Test
+    fun createSomeSerializableExternalStruct() {
+        val struct = ExternalMarkedAsSerializable(42)
+        assertFalse(Parcelable::class.java.isInstance(struct))
+    }
+
+    @org.junit.Test
+    fun createSomeSerializableExternalStructWithExternalSerializableField() {
+        val externalStruct = AnExternalStruct(42)
+        val mainStruct = SerializableStructWithExternalField(externalStruct)
+
+        val parcel = Parcel.obtain()
+        parcel.writeParcelable(mainStruct, 0)
+        parcel.setDataPosition(0)
+
+        val resultStruct: SerializableStructWithExternalField? = parcel.readParcelable(java.lang.Thread.currentThread().getContextClassLoader())
+
+        assertNotNull(resultStruct)
+        assertTrue(Parcelable::class.java.isInstance(mainStruct))
+        assertEquals(42, resultStruct!!.someStruct.data)
+    }
+
+    @org.junit.Test
+    fun unboxVeryBoolean() {
+        val veryBoolean = true
+        val result = UseKotlinExternalTypes.veryBooleanUnbox(veryBoolean)
+
+        assertEquals(true, result)
+    }
+
+    @org.junit.Test
+    fun checkExternalConst() {
+        val result = UseKotlinExternalConst.DEFAULT_TRUTH
+        assertEquals(true, result)
+    }
+}

--- a/functional-tests/functional/input/lime/KotlinExternalTypes.lime
+++ b/functional-tests/functional/input/lime/KotlinExternalTypes.lime
@@ -1,0 +1,123 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+@Immutable
+struct Currency {
+    external {
+        kotlin name "java.util.Currency"
+    }
+
+    currencyCode: String external { kotlin getterName "getCurrencyCode" }
+    numericCode: Int external { kotlin getterName "getNumericCode" }
+}
+
+struct TimeZone {
+    external {
+        kotlin name "java.util.SimpleTimeZone"
+    }
+
+    rawOffset: Int external {
+        kotlin getterName "getRawOffset"
+        kotlin setterName "setRawOffset"
+    }
+}
+
+struct SystemColor {
+    external {
+        kotlin name "kotlin.Int?"
+        kotlin converter "com.here.android.test.ColorConverter"
+    }
+
+    red: Float
+    green: Float
+    blue: Float
+    alpha: Float
+}
+
+enum Month {
+    external {
+        kotlin name "java.time.Month"
+    }
+
+    JANUARY = 1,
+    FEBRUARY,
+    MARCH
+}
+
+enum Season {
+    external {
+        kotlin name "kotlin.String"
+        kotlin converter "com.here.android.test.SeasonConverter"
+    }
+
+    WINTER,
+    SPRING,
+    SUMMER,
+    AUTUMN
+}
+
+class UseKotlinExternalTypes {
+    static fun currencyRoundTrip(input: Currency): Currency
+    static fun timeZoneRoundTrip(input: TimeZone): TimeZone
+    static fun monthRoundTrip(input: Month): Month
+    static fun colorRoundTrip(input: SystemColor): SystemColor
+    static fun seasonRoundTrip(input: Season): Season
+
+    static fun structRoundTrip(input: KotlinExternalTypesStruct): KotlinExternalTypesStruct
+    static fun veryBooleanUnbox(input: VeryBoolean): Boolean
+}
+
+struct KotlinExternalTypesStruct {
+    currency: Currency
+    timeZone: TimeZone
+    month: Month
+    color: SystemColor
+    season: Season
+}
+
+@Serializable
+struct ExternalMarkedAsSerializable {
+    external {
+        kotlin name "com.here.android.test.AnExternalStruct"
+        kotlin converter "com.here.android.test.ExternalStructMarkedAsSerializableConverter"
+    }
+
+    `field`: Int
+}
+
+@Serializable
+struct SerializableStructWithExternalField {
+    someStruct: ExternalMarkedAsSerializable
+}
+
+struct VeryBoolean {
+    external {
+        kotlin name "kotlin.Boolean?"
+        kotlin converter "com.here.android.test.BooleanConverter"
+    }
+
+    value: Boolean
+    constructor make(value: Boolean)
+}
+
+struct UseKotlinExternalConst {
+    stringField: String
+    @Internal
+    const defaultTruth: VeryBoolean = {true}
+}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/AnExternalStruct.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/AnExternalStruct.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import android.os.Parcel
+import android.os.Parcelable
+
+class AnExternalStruct : Parcelable {
+    var data: Int
+
+    private constructor(parcel: Parcel) {
+        this.data = parcel.readInt()
+    }
+
+    constructor(data: Int) {
+        this.data = data
+    }
+
+    override fun describeContents() = 0
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        parcel.writeInt(data)
+    }
+
+    companion object CREATOR : Parcelable.Creator<AnExternalStruct> {
+        override fun createFromParcel(parcel: Parcel) = AnExternalStruct(parcel)
+        override fun newArray(size: Int) = arrayOfNulls<AnExternalStruct?>(size)
+    }
+}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/BooleanConverter.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/BooleanConverter.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+object BooleanConverter {
+    @JvmStatic
+    fun convertFromInternal(internalBoolean: VeryBoolean) : Boolean? {
+        return internalBoolean.value
+    }
+
+    @JvmStatic
+    fun convertToInternal(systemBoolean: Boolean?) : VeryBoolean {
+        return VeryBoolean(systemBoolean!!)
+    }
+}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ColorConverter.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ColorConverter.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import kotlin.math.round
+
+object ColorConverter {
+    @JvmStatic
+    fun convertFromInternal(internalColor: SystemColor): Int? {
+        return android.graphics.Color.argb(
+            round(internalColor.alpha * 255).toInt(),
+            round(internalColor.red * 255).toInt(),
+            round(internalColor.green * 255).toInt(),
+            round(internalColor.blue * 255).toInt()
+        )
+    }
+
+    @JvmStatic
+    fun convertToInternal(systemColor: Int?): SystemColor {
+        return SystemColor(
+            android.graphics.Color.red(systemColor!!) / 255.0f,
+            android.graphics.Color.green(systemColor!!) / 255.0f,
+            android.graphics.Color.blue(systemColor!!) / 255.0f,
+            android.graphics.Color.alpha(systemColor!!) / 255.0f
+        )
+    }
+}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ExternalStructMarkedAsSerializableConverter.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ExternalStructMarkedAsSerializableConverter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+object ExternalStructMarkedAsSerializableConverter {
+    @JvmStatic
+    fun convertFromInternal(struct: ExternalMarkedAsSerializable) = AnExternalStruct(struct.field)
+
+    @JvmStatic
+    fun convertToInternal(s: com.here.android.test.AnExternalStruct) = ExternalMarkedAsSerializable(s.data)
+}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SeasonConverter.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SeasonConverter.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+object SeasonConverter {
+    @JvmStatic
+    fun convertFromInternal(season: Season) = season.name
+
+    @JvmStatic
+    fun convertToInternal(seasonString: String) = Season.valueOf(seasonString)
+}

--- a/functional-tests/functional/input/src/cpp/KotlinExternalTypes.cpp
+++ b/functional-tests/functional/input/src/cpp/KotlinExternalTypes.cpp
@@ -1,0 +1,62 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/KotlinExternalTypesStruct.h"
+#include "test/UseKotlinExternalTypes.h"
+#include "test/VeryBoolean.h"
+
+namespace test
+{
+Currency
+UseKotlinExternalTypes::currency_round_trip(const Currency& input) {
+    return input;
+}
+
+TimeZone
+UseKotlinExternalTypes::time_zone_round_trip(const TimeZone& input) {
+    return input;
+}
+
+Month
+UseKotlinExternalTypes::month_round_trip(const Month input) {
+    return input;
+}
+
+SystemColor
+UseKotlinExternalTypes::color_round_trip(const SystemColor& input) {
+    return input;
+}
+
+Season
+UseKotlinExternalTypes::season_round_trip(const Season input) {
+    return input;
+}
+
+KotlinExternalTypesStruct
+UseKotlinExternalTypes::struct_round_trip(const KotlinExternalTypesStruct& input) {
+    return input;
+}
+
+bool
+UseKotlinExternalTypes::very_boolean_unbox(const VeryBoolean& input) { return input.value; }
+
+VeryBoolean
+VeryBoolean::make(const bool value) { return VeryBoolean{value}; }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTemplates.kt
@@ -68,7 +68,7 @@ internal class JniTemplates(
     private val nameResolvers =
         mapOf(
             "" to jniNameResolver,
-            "signature" to JniTypeSignatureNameResolver(jniNameResolver, fullInternalPackages),
+            "signature" to JniTypeSignatureNameResolver(jniNameResolver, fullInternalPackages, platformAttribute),
             "mangled" to JniMangledNameResolver(jniNameResolver),
             "C++" to cppNameResolver,
             "C++ FQN" to CppFullNameResolver(nameCache),

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTypeSignatureNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/jni/JniTypeSignatureNameResolver.kt
@@ -21,8 +21,10 @@ package com.here.gluecodium.generator.jni
 
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.generator.common.NameResolver
+import com.here.gluecodium.model.lime.LimeAttributeType
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+import com.here.gluecodium.model.lime.LimeExternalDescriptor
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeRef
@@ -30,9 +32,13 @@ import com.here.gluecodium.model.lime.LimeTypeRef
 internal class JniTypeSignatureNameResolver(
     private val baseNameResolver: JniNameResolver,
     private val internalPackages: List<String>,
+    private val platformAttribute: LimeAttributeType,
 ) : NameResolver {
+    private val kotlinSpecificResolver = JniKotlinSpecificSignatureResolver()
+
     override fun resolveName(element: Any) =
         when (element) {
+            is String -> resolveExternalStringName(element)
             is LimeType -> resolveTypeSignature(element)
             is LimeTypeRef -> resolveTypeRefSignature(element)
             is LimeReturnType -> resolveTypeRefSignature(element.typeRef)
@@ -47,11 +53,25 @@ internal class JniTypeSignatureNameResolver(
         }
     }
 
-    private fun resolveTypeSignature(limeType: LimeType) =
-        when (limeType) {
+    private fun resolveExternalStringName(typeName: String): String {
+        return if (kotlinSpecificResolver.isBasicKotlinType(typeName)) {
+            kotlinSpecificResolver.resolveExternalKotlinName(typeName)
+        } else {
+            "L" + baseNameResolver.resolveName(typeName) + ";"
+        }
+    }
+
+    private fun resolveTypeSignature(limeType: LimeType): String {
+        val externalName = limeType.external?.getFor(platformAttribute)?.get(LimeExternalDescriptor.NAME_NAME)
+        if (externalName != null) {
+            return resolveExternalStringName(externalName)
+        }
+
+        return when (limeType) {
             is LimeBasicType -> resolveBasicTypeSignature(limeType.typeId)
             else -> "L" + baseNameResolver.resolveName(limeType) + ";"
         }
+    }
 
     private fun resolveBasicTypeSignature(typeId: TypeId) =
         when (typeId) {
@@ -82,4 +102,68 @@ internal class JniTypeSignatureNameResolver(
             TypeId.DOUBLE -> "Ljava/lang/Double;"
             else -> resolveBasicTypeSignature(typeId)
         }
+
+    inner class JniKotlinSpecificSignatureResolver {
+        fun isBasicKotlinType(typeName: String): Boolean {
+            val rawTypeName = if (isNullable(typeName)) typeName.dropLast(1) else typeName
+            return KOTLIN_FUNDAMENTALS.contains(rawTypeName)
+        }
+
+        private fun isNullable(typeName: String) = typeName.endsWith("?")
+
+        fun resolveExternalKotlinName(typeName: String): String {
+            val isTypeNullable = isNullable(typeName)
+            val rawTypeName = if (isTypeNullable) typeName.dropLast(1) else typeName
+            val typeId = KOTLIN_FUNDAMENTALS_TYPE_ID[rawTypeName]
+
+            if (typeId != null) {
+                return if (isTypeNullable) {
+                    resolveNullableBasicTypeSignature(typeId)
+                } else {
+                    resolveBasicTypeSignature(typeId)
+                }
+            }
+
+            // Certain basic types are not represented as Gluecodium types e.g. Char.
+            return if (isTypeNullable) {
+                resolveNullableExternalKotlinNameWithoutTypeId(typeName)
+            } else {
+                resolveExternalKotlinNameWithoutTypeId(typeName)
+            }
+        }
+
+        private fun resolveExternalKotlinNameWithoutTypeId(typeName: String): String {
+            return when (typeName) {
+                "kotlin.Char" -> "C"
+                else -> throw GluecodiumExecutionException("Unsupported basic Kotlin type: $typeName")
+            }
+        }
+
+        private fun resolveNullableExternalKotlinNameWithoutTypeId(typeName: String): String {
+            return when (typeName) {
+                "kotlin.Char" -> "Ljava/lang/Char;"
+                else -> throw GluecodiumExecutionException("Unsupported basic Kotlin type: $typeName")
+            }
+        }
+    }
+
+    companion object {
+        val KOTLIN_FUNDAMENTALS =
+            setOf(
+                "kotlin.Boolean", "kotlin.Byte", "kotlin.Short", "kotlin.Int",
+                "kotlin.Long", "kotlin.Float", "kotlin.Double", "kotlin.String", "kotlin.Char",
+            )
+
+        val KOTLIN_FUNDAMENTALS_TYPE_ID =
+            mapOf(
+                "kotlin.Boolean" to TypeId.BOOLEAN,
+                "kotlin.Byte" to TypeId.INT8,
+                "kotlin.Short" to TypeId.INT16,
+                "kotlin.Int" to TypeId.INT32,
+                "kotlin.Long" to TypeId.INT64,
+                "kotlin.Float" to TypeId.FLOAT,
+                "kotlin.Double" to TypeId.DOUBLE,
+                "kotlin.String" to TypeId.STRING,
+            )
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinValueResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinValueResolver.kt
@@ -23,6 +23,7 @@ import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
 import com.here.gluecodium.model.lime.LimeEnumerator
+import com.here.gluecodium.model.lime.LimeExternalDescriptor.Companion.NAME_NAME
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeSet
@@ -107,7 +108,26 @@ internal class KotlinValueResolver(private val nameResolver: KotlinNameResolver)
             throw GluecodiumExecutionException("Unsupported type ${actualType.javaClass.name} for struct initializer")
         }
         val values = limeValue.values.joinToString(", ") { resolveValue(it) }
+
+        if (limeValue.values.size == 1) {
+            val externalName = actualType.external?.kotlin?.get(NAME_NAME) ?: ""
+            if (isFundamentalKotlinType(externalName)) {
+                return values
+            }
+        }
+
         return "${nameResolver.resolveReferenceName(actualType)}($values)"
+    }
+
+    private fun isFundamentalKotlinType(type: String): Boolean {
+        val rawType = if (type.endsWith("?")) type.dropLast(1) else type
+        val fundamentals =
+            setOf(
+                "kotlin.Boolean", "kotlin.Byte", "kotlin.Short",
+                "kotlin.Int", "kotlin.Long", "kotlin.Float",
+                "kotlin.Double", "kotlin.String", "kotlin.Char",
+            )
+        return fundamentals.contains(rawType)
     }
 
     private fun mapSpecialValue(limeValue: LimeValue.Special): String {


### PR DESCRIPTION
This commit introduces a set of test cases for
usage of external types for Kotlin generated code.
It also fills the gaps in the existing implementation
to make the tests pass.
    
Two important notes:
 - fundamental numeric types of Kotlin are deliberately
 used with '?' suffix when defining the external types,
 because currently JNI templates assume that the used type
 is an object
 - for fundamental types this assumption is true only if
  the nullable version is used; for instance 'Kotlin.Int'
  is mapped to trivial 'int' whether 'Kotlin.Int?' is mapped
  to 'java.lang.Integer'
    
The support for usage of non-nullable optional types as the
external types will be added in a follow-up PR, because it
requires changes in JNI mustache files