### PR TITLE
Implement placeholders for comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gluecodium project Release Notes
 
+## Unreleased
+### Features:
+ * Implemented placeholders for comments. Gluecodium supports a new `-docsplaceholderslist` CLI parameter and `GLUECODIUM_DOCS_PLACEHOLDERS_LIST` CMake flag, which allow specifying the file with definition of placeholders. More information about possible usage can be found in `lime_markup.md`.
+
 ## 13.10.4
 Release date 2025-02-13
 ### Bug fixes:

--- a/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
@@ -304,6 +304,14 @@ _gluecodium_define_target_property(
     "This property is initialized by the value of the GLUECODIUM_ENABLE_INTERNAL_DEBUG_CHECKS_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
 )
 
+_gluecodium_define_target_property(
+  GLUECODIUM_DOCS_PLACEHOLDERS_LIST
+  BRIEF_DOCS "The path to a file with placeholders list for documentation."
+  FULL_DOCS
+    "The path to a file with placeholders list for documentation."
+    "This property is initialized by the value of the GLUECODIUM_DOCS_PLACEHOLDERS_LIST_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
 # TODO: Add read-only properties
 
 function(_gluecodium_get_default_value_for_variable result _property)

--- a/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
@@ -158,6 +158,7 @@ function(_prepare_gluecodium_config_file file_path)
   _append_path_option(kotlinnamerules GLUECODIUM_KOTLIN_NAMERULES)
   _append_path_option(swiftnamerules GLUECODIUM_SWIFT_NAMERULES)
   _append_path_option(dartnamerules GLUECODIUM_DART_NAMERULES)
+  _append_path_option(docsplaceholderslist GLUECODIUM_DOCS_PLACEHOLDERS_LIST)
 
   _append_option(output GLUECODIUM_OUTPUT_MAIN)
   _append_option(commonoutput GLUECODIUM_OUTPUT_COMMON)

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_PLACEHOLDERS_LIST "${CMAKE_CURRENT_LIST_DIR}/someNonexistentPlaceholders.properties")

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/lime/foo.lime
@@ -1,0 +1,28 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+class Foo {
+
+}
+
+interface Bar {
+    fun bar()
+}
+
+lambda Baz = (Int) -> Void

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/successful.regex
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-nonexistent-file-XFAIL/successful.regex
@@ -1,0 +1,1 @@
+Failed reading options: File .*/someNonexistentPlaceholders.properties does not exist

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/CMakeLists.txt
@@ -1,0 +1,69 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/check_file_contains_string_after_build.cmake)
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generators)
+list(SORT _gluecodium_generators)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generators})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_PLACEHOLDERS_LIST "${CMAKE_CURRENT_LIST_DIR}/placeholders.properties")
+
+string(REPLACE ";" "-" GENERATORS_DIR_NAME "${_gluecodium_generators}")
+
+set(GENERATED_MAIN_DIR_PATH "${CMAKE_CURRENT_BINARY_DIR}/gluecodium/dummySharedLibrary/${GENERATORS_DIR_NAME}/main")
+set(GENERATED_MAIN_DART_FILES_PATH "${GENERATED_MAIN_DIR_PATH}/dart/lib/src/unit/test")
+set(GENERATED_MAIN_JAVA_FILES_PATH "${GENERATED_MAIN_DIR_PATH}/android/com/example/unit/test")
+set(GENERATED_MAIN_CPP_FILES_PATH "${GENERATED_MAIN_DIR_PATH}/cpp/include/unit/test")
+set(GENERATED_MAIN_SWIFT_FILES_PATH "${GENERATED_MAIN_DIR_PATH}/swift/unit/test")
+
+if(dart IN_LIST _gluecodium_generators)
+    check_file_contains_string_after_build(
+        dummySharedLibrary "${GENERATED_MAIN_DART_FILES_PATH}/foo.dart" "'A sentence for Dart is nice.'")
+endif()
+
+if(android IN_LIST _gluecodium_generators)
+    check_file_contains_string_after_build(
+        dummySharedLibrary "${GENERATED_MAIN_JAVA_FILES_PATH}/Foo.java" "'A sentence for Java is funny.'")
+endif()
+
+if(swift IN_LIST _gluecodium_generators)
+    check_file_contains_string_after_build(
+            dummySharedLibrary "${GENERATED_MAIN_SWIFT_FILES_PATH}/Foo.swift" "'A sentence for Swift is good.'")
+endif()
+
+check_file_contains_string_after_build(
+    dummySharedLibrary "${GENERATED_MAIN_CPP_FILES_PATH}/Foo.h" "'A sentence for Cpp is the best.'")

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/lime/foo.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+// This special sentence: '{@Placeholder special_sentence}'
+class Foo {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/placeholders.properties
+++ b/cmake/tests/unit/gluecodium_generate/docsplaceholderslist-works-for-platform-tags/placeholders.properties
@@ -1,0 +1,5 @@
+special_sentence="A sentence for \
+  {@Java Java is funny.}\
+  {@Swift Swift is good.}\
+  {@Dart Dart is nice.}\
+  {@Cpp Cpp is the best.}"

--- a/cmake/tests/utils/check_file_contains_string_after_build.cmake
+++ b/cmake/tests/utils/check_file_contains_string_after_build.cmake
@@ -1,0 +1,41 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+#[=======================================================================[.rst:
+
+.. command:check_file_contains_string_after_build
+
+Checks that provided file contains a given string after given target is built.
+Adds post build command which tries to grep for a given string.
+
+  check_file_contains_string_after_build(
+     <target>       # Target to add post build command
+     <file_path>    # File or directory path to check
+     <needle>       # String to look for in the file.
+   )
+#]=======================================================================]
+
+function(check_file_contains_string_after_build _target file_path needle)
+  add_custom_command(
+    TARGET ${_target}
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E echo
+            "Loads a file '${file_path}' and looks for '${needle}'. The file does not contain it if command fails."
+    COMMAND ${CMAKE_COMMAND} -DCHECK_FILE_CONTAINS_FILE_PATH="${file_path}"
+                             -DCHECK_FILE_CONTAINS_NEEDLE="${needle}"
+                             -P "${GLUECODIUM_CMAKE_TESTS_DIR}/utils/run_check_file_contains_string.cmake")
+endfunction()

--- a/cmake/tests/utils/run_check_file_contains_string.cmake
+++ b/cmake/tests/utils/run_check_file_contains_string.cmake
@@ -19,7 +19,7 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 include("${CMAKE_CURRENT_LIST_DIR}/message_colored.cmake")
 
-set(_required_vars CHECK_FILE_DOES_NOT_CONTAIN_FILE_PATH CHECK_FILE_DOES_NOT_CONTAIN_NEEDLE)
+set(_required_vars CHECK_FILE_CONTAINS_FILE_PATH CHECK_FILE_CONTAINS_NEEDLE)
 
 foreach(_required_variable ${_required_vars})
   if(NOT DEFINED ${_required_variable})
@@ -27,16 +27,21 @@ foreach(_required_variable ${_required_vars})
   endif()
 endforeach()
 
-if(NOT EXISTS ${CHECK_FILE_DOES_NOT_CONTAIN_FILE_PATH})
-    message_colored(RED FATAL_ERROR "${CHECK_FILE_DOES_NOT_CONTAIN_FILE_PATH} does not exist!")
+if(NOT EXISTS ${CHECK_FILE_CONTAINS_FILE_PATH})
+    message_colored(RED FATAL_ERROR "${CHECK_FILE_CONTAINS_FILE_PATH} does not exist!")
 endif()
 
-file(STRINGS ${CHECK_FILE_DOES_NOT_CONTAIN_FILE_PATH} _lines)
+file(STRINGS ${CHECK_FILE_CONTAINS_FILE_PATH} _lines)
+
+set(FOUND_NEEDLE FALSE)
 
 foreach(_line IN LISTS _lines)
-    if("${_line}" MATCHES "${CHECK_FILE_DOES_NOT_CONTAIN_NEEDLE}")
-        message_colored(
-            RED FATAL_ERROR
-            "The file ${CHECK_FILE_DOES_NOT_CONTAIN_FILE_PATH} contains: ${CHECK_FILE_DOES_NOT_CONTAIN_NEEDLE}")
+    if("${_line}" MATCHES "${CHECK_FILE_CONTAINS_NEEDLE}")
+        set(FOUND_NEEDLE TRUE)
+        break()
     endif()
 endforeach()
+
+if(NOT ${FOUND_NEEDLE})
+    message_colored(RED FATAL_ERROR "The file ${CHECK_FILE_CONTAINS_FILE_PATH} does not contain: ${CHECK_FILE_CONTAINS_NEEDLE}")
+endif()

--- a/docs/lime_markdown.md
+++ b/docs/lime_markdown.md
@@ -194,6 +194,39 @@ Multiple platform tags can be combined in a single `{@ }` section, if necessary:
 // Process something{@Cpp @Java  the right way}.
 ```
 
+Placeholder comments
+--------------------------
+Certain syntax may be used very often when documenting code. Let's look at the following example:
+```
+// This is {@Java interface}{@Swift protocol}{@Dart abstract class}{@Cpp abstract class}.
+```
+
+The type used to represent an interface can have different names depending on the output language.
+To avoid repeating such complicated syntax the placeholders can be specified and used e.g.:
+```
+// This is {@Placeholder interfaceString}.
+```
+
+The syntax above instructs Gluecodium to insert the content of placeholder with name `interfaceString`
+into the selected place.
+
+The content of placeholders is specified via properties file, which is then supplied when invoking
+generator via `-docsplaceholderslist` CLI parameter or `GLUECODIUM_DOCS_PLACEHOLDERS_LIST` CMake parameter.
+
+Each placeholder needs to be defined as `<PLACEHOLDER_NAME>="<PLACEHOLDER_VALUE>"`.
+Please notice the usage of quotation - it is required. Moreover, if multiline string needs to be defined then
+appropriate line end must be defined according to '.properties' format and newline must be escaped via `\n`:
+```
+some_multiline="This \
+  is the first line!\n \
+  This is the second line."
+```
+
+In the case of `interfaceString` placeholder the file content may look like this:
+```
+interfaceString="{@Java interface}{@Swift protocol}{@Dart abstract class}{@Cpp abstract class}"
+```
+
 Character escaping in documentation comments
 --------------------------------------------
 

--- a/functional-tests/config/placeholders.properties
+++ b/functional-tests/config/placeholders.properties
@@ -1,0 +1,5 @@
+interface="{@Java interface}{@Swift protocol}{@Dart abstract class}{@Cpp abstract class}"
+longMultilinePlaceholder="This is a placeholder, which has multiple lines. \
+  Here we have continuation of the first line.\n \
+  But this should be rendered in line below.\n \
+  This too!"

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -544,6 +544,7 @@ set_target_properties(functional_bindings PROPERTIES
     GLUECODIUM_DART_LIBRARY_NAME "functional"
     GLUECODIUM_DART_NAMERULES "${CMAKE_CURRENT_SOURCE_DIR}/../config/dart.properties"
     GLUECODIUM_COPYRIGHT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/../config/COPYRIGHT"
+    GLUECODIUM_DOCS_PLACEHOLDERS_LIST "${CMAKE_CURRENT_SOURCE_DIR}/../config/placeholders.properties"
     GLUECODIUM_TAGS "Lite,ExperimentalFoo"
     GLUECODIUM_VERBOSE ON)
 

--- a/functional-tests/functional/input/lime/Comments.lime
+++ b/functional-tests/functional/input/lime/Comments.lime
@@ -17,7 +17,7 @@
 
 package test
 
-// This is some very useful interface.
+// This is some very useful {@Placeholder interface}.
 class comments {
     // This is some very useful struct.
     struct SomeStruct {
@@ -130,6 +130,7 @@ class MultiLineComments {
 }
 
 // This is some very useful interface. There is a lot to say about this interface. at least it has a long comment.
+// {@Placeholder longMultilinePlaceholder}
 class LongComments {
     // This is very important method. It has very important parameters. It has side effects.
     fun someMethodWithLongComment(

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -87,7 +87,12 @@ class Gluecodium(
 
         val limeModel: LimeModel
         try {
-            limeModel = modelLoader.loadModel(gluecodiumOptions.idlSources, gluecodiumOptions.auxiliaryIdlSources)
+            limeModel =
+                modelLoader.loadModel(
+                    gluecodiumOptions.idlSources,
+                    gluecodiumOptions.auxiliaryIdlSources,
+                    gluecodiumOptions.docsPlaceholders,
+                )
         } catch (e: LimeModelLoaderException) {
             LOGGER.severe(e.message)
             return false

--- a/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/GluecodiumOptions.kt
@@ -28,4 +28,5 @@ data class GluecodiumOptions(
     var isValidatingOnly: Boolean = false,
     var isEnableCaching: Boolean = false,
     var isStrictMode: Boolean = false,
+    var docsPlaceholders: Map<String, String> = emptyMap(),
 )

--- a/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/SmokeTest.kt
@@ -54,6 +54,7 @@ class SmokeTest(
     val errorCollector = NiceErrorCollector()
 
     private lateinit var gluecodium: Gluecodium
+    private lateinit var docsPlaceholders: Map<String, String>
 
     private val results = mutableListOf<GeneratedFile>()
 
@@ -79,6 +80,7 @@ class SmokeTest(
     @Before
     fun setUp() {
         val options = getOptions()
+        docsPlaceholders = options.first.docsPlaceholders
         gluecodium = spyk(Gluecodium(options.first, options.second))
         every { gluecodium.output(any(), any()) }.answers {
             @Suppress("UNCHECKED_CAST")
@@ -104,7 +106,8 @@ class SmokeTest(
 
         assumeFalse("No reference files were found", referenceFiles.isEmpty())
 
-        val limeModel = LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()))
+        val limeModel =
+            LOADER.loadModel(listOf(inputDirectory.toString()), listOf(auxDirectory.toString()), docsPlaceholders)
         val validationResult = gluecodium.validateModel(limeModel)
         if (validationShouldFail) {
             assertFalse(validationResult)

--- a/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
@@ -196,6 +196,19 @@ class OptionReaderTest {
         assertEquals(listOf(TEST_KOTLIN_PACKAGE_LIST), options!!.second.kotlinInternalPackages)
     }
 
+    @Test
+    fun docsplaceholderslistMissingFile() {
+        // Arrange, Act
+        val path = "someFileThatDoesNotExists.properties"
+        val exception =
+            assertThrows(OptionReaderException::class.java, {
+                OptionReader.read(arrayOf("-docsplaceholderslist", path))
+            })
+
+        // Assert
+        assertTrue(exception.message!!.startsWith("File $path does not exist"))
+    }
+
     private fun prepareToRead(
         optionName: String,
         optionValue: String,

--- a/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/Comments.lime
@@ -17,7 +17,7 @@
 
 package smoke
 
-// This is some very useful interface.
+// This is some very useful {@Placeholder interface}.
 class comments {
     // This is some very useful struct.
     // @constructor This is how easy it is to construct.
@@ -150,6 +150,7 @@ class MultiLineComments {
 }
 
 // This is some very useful interface. There is a lot to say about this interface. at least it has a long comment.
+// {@Placeholder longMultilinePlaceholder}
 class LongComments {
     // This is very important method. It has very important parameters. It has side effects.
     // @param[input] Very useful input parameter. You must not confuse it with the second parameter. But they are similar.

--- a/gluecodium/src/test/resources/smoke/comments/input/commandlineoptions.txt
+++ b/gluecodium/src/test/resources/smoke/comments/input/commandlineoptions.txt
@@ -1,0 +1,7 @@
+-input $INPUT_FOLDER
+-docsplaceholderslist $INPUT_FOLDER/placeholders.properties
+-auxinput $AUX_FOLDER
+-intnamespace gluecodium
+-javanonnullannotation android.support.annotation.NonNull
+-javanullableannotation android.support.annotation.Nullable
+-internalprefix foobar_

--- a/gluecodium/src/test/resources/smoke/comments/input/placeholders.properties
+++ b/gluecodium/src/test/resources/smoke/comments/input/placeholders.properties
@@ -1,0 +1,5 @@
+interface="{@Java interface}{@Swift protocol}{@Dart abstract class}{@Cpp abstract class}"
+longMultilinePlaceholder="This is a placeholder, which has multiple lines. \
+  Here we have continuation of the first line.\n \
+  But this should be rendered in line below.\n \
+  This too!"

--- a/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/LongComments.java
+++ b/gluecodium/src/test/resources/smoke/comments/output/android/com/example/smoke/LongComments.java
@@ -1,14 +1,21 @@
 /*
- *
 
+ *
  */
+
 package com.example.smoke;
+
 import android.support.annotation.NonNull;
 import com.example.NativeBase;
+
 /**
  * <p>This is some very useful interface. There is a lot to say about this interface. at least it has a long comment.
+ * This is a placeholder, which has multiple lines. Here we have continuation of the first line.
+ * But this should be rendered in line below.
+ * This too!
  */
 public final class LongComments extends NativeBase {
+
     /**
      * For internal use only.
      * @hidden
@@ -23,7 +30,10 @@ public final class LongComments extends NativeBase {
             }
         });
     }
+
     private static native void disposeNativeHandle(long nativeHandle);
+
+
     /**
      * <p>This is very important method. It has very important parameters. It has side effects.
      * @param input <p>Very useful input parameter. You must not confuse it with the second parameter. But they are similar.
@@ -31,4 +41,8 @@ public final class LongComments extends NativeBase {
      * @return <p>If you provide a useful input and a useful ratio you can expect a useful output. Just kidding do not expect anything from a method until you see its body.
      */
     public native float someMethodWithLongComment(@NonNull final String input, final double ratio);
+
+
+
 }
+

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/Comments.h
@@ -16,7 +16,7 @@
 
 namespace smoke {
 /**
- * This is some very useful interface.
+ * This is some very useful abstract class.
 
  */
 class _GLUECODIUM_CPP_EXPORT Comments {

--- a/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/LongComments.h
+++ b/gluecodium/src/test/resources/smoke/comments/output/cpp/include/smoke/LongComments.h
@@ -12,6 +12,9 @@
 namespace smoke {
 /**
  * This is some very useful interface. There is a lot to say about this interface. at least it has a long comment.
+ * This is a placeholder, which has multiple lines. Here we have continuation of the first line.
+ * But this should be rendered in line below.
+ * This too!
 
  */
 class _GLUECODIUM_CPP_EXPORT LongComments {

--- a/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
+++ b/gluecodium/src/test/resources/smoke/comments/output/dart/lib/src/smoke/comments.dart
@@ -7,7 +7,7 @@ import 'package:library/src/_token_cache.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
 import 'package:meta/meta.dart';
 
-/// This is some very useful interface.
+/// This is some very useful abstract class.
 abstract class Comments implements Finalizable {
 
   /// This is some very useful constant.
@@ -461,6 +461,7 @@ final _someMethodWithAllCommentssmokeCommentsSomemethodwithallcommentsStringRetu
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Comments_someMethodWithAllComments__String_return_has_error'));
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/Comments.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-/// This is some very useful interface.
+/// This is some very useful protocol.
 public class Comments {
 
     /// This is some very useful typedef.

--- a/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
+++ b/gluecodium/src/test/resources/smoke/comments/output/swift/smoke/LongComments.swift
@@ -1,19 +1,30 @@
 //
+
 //
+
 import Foundation
+
 /// This is some very useful interface. There is a lot to say about this interface. at least it has a long comment.
+/// This is a placeholder, which has multiple lines. Here we have continuation of the first line.
+/// But this should be rendered in line below.
+/// This too!
 public class LongComments {
+
+
     let c_instance : _baseRef
+
     init(cLongComments: _baseRef) {
         guard cLongComments != 0 else {
             fatalError("Nullptr value is not supported for initializers")
         }
         c_instance = cLongComments
     }
+
     deinit {
         smoke_LongComments_remove_swift_object_from_wrapper_cache(c_instance)
         smoke_LongComments_release_handle(c_instance)
     }
+
     /// This is very important method. It has very important parameters. It has side effects.
     /// - Parameters:
     ///   - input: Very useful input parameter. You must not confuse it with the second parameter. But they are similar.
@@ -25,7 +36,11 @@ public class LongComments {
         let c_result_handle = smoke_LongComments_someMethodWithLongComment(self.c_instance, c_input.ref, c_ratio.ref)
         return moveFromCType(c_result_handle)
     }
+
 }
+
+
+
 internal func getRef(_ ref: LongComments?, owning: Bool = true) -> RefHolder {
     guard let c_handle = ref?.c_instance else {
         return RefHolder(0)
@@ -35,6 +50,7 @@ internal func getRef(_ ref: LongComments?, owning: Bool = true) -> RefHolder {
         ? RefHolder(ref: handle_copy, release: smoke_LongComments_release_handle)
         : RefHolder(handle_copy)
 }
+
 extension LongComments: NativeBase {
     /// :nodoc:
     var c_handle: _baseRef { return c_instance }
@@ -44,11 +60,13 @@ extension LongComments: Hashable {
     public static func == (lhs: LongComments, rhs: LongComments) -> Bool {
         return lhs.c_handle == rhs.c_handle
     }
+
     /// :nodoc:
     public func hash(into hasher: inout Hasher) {
         hasher.combine(c_handle)
     }
 }
+
 internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
     if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {
@@ -58,6 +76,7 @@ internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments {
     smoke_LongComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments {
     if let swift_pointer = smoke_LongComments_get_swift_object_from_wrapper_cache(handle),
         let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? LongComments {
@@ -68,6 +87,7 @@ internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments {
     smoke_LongComments_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
     return result
 }
+
 internal func LongComments_copyFromCType(_ handle: _baseRef) -> LongComments? {
     guard handle != 0 else {
         return nil
@@ -80,15 +100,22 @@ internal func LongComments_moveFromCType(_ handle: _baseRef) -> LongComments? {
     }
     return LongComments_moveFromCType(handle) as LongComments
 }
+
 internal func copyToCType(_ swiftClass: LongComments) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: LongComments) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
 internal func copyToCType(_ swiftClass: LongComments?) -> RefHolder {
     return getRef(swiftClass, owning: false)
 }
+
 internal func moveToCType(_ swiftClass: LongComments?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
+
+
+

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -78,15 +78,17 @@ internal object AntlrLimeConverter {
 
     fun parseStructuredComment(
         commentString: String,
-        lineNumber: Int,
-        limePath: LimePath,
+        lineNumber: Int = 1,
+        limePath: LimePath = LimePath.EMPTY_PATH,
+        commentPlaceholders: Map<String, LimeComment> = emptyMap(),
     ): LimeStructuredComment {
         val lexer = LimedocLexer(CharStreams.fromString(commentString))
         val parser = LimedocParser(CommonTokenStream(lexer))
         parser.removeErrorListeners()
+
         parser.addErrorListener(ThrowingErrorListener(lineNumber - 1))
 
-        val builder = AntlrLimedocBuilder(limePath)
+        val builder = AntlrLimedocBuilder(limePath, commentPlaceholders)
         ParseTreeWalker.DEFAULT.walk(builder, parser.documentation())
 
         return builder.result

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -59,6 +59,7 @@ import java.util.LinkedList
 
 internal class AntlrLimeModelBuilder(
     private val referenceResolver: LimeReferenceResolver,
+    private val commentPlaceholders: Map<String, LimeComment>,
     contextStack: ModelBuilderContextStack<LimeNamedElement> = ModelBuilderContextStack(),
 ) : AntlrLimeModelBuilderBase(contextStack) {
     private val pathStack = LinkedList<LimePath>()
@@ -737,7 +738,7 @@ internal class AntlrLimeModelBuilder(
                 }
             }.trimIndent().split('\n').joinToString("\n") { line -> line.trimEnd() }
 
-        return AntlrLimeConverter.parseStructuredComment(commentString, ctx.getStart().line, currentPath)
+        return AntlrLimeConverter.parseStructuredComment(commentString, ctx.getStart().line, currentPath, commentPlaceholders)
     }
 
     private fun parseExternalDescriptor(ctx: LimeParser.ExternalDescriptorContext?): LimeExternalDescriptor? {

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
@@ -24,7 +24,10 @@ import com.here.gluecodium.antlr.LimedocParserBaseListener
 import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimePath
 
-internal class AntlrLimedocBuilder(private val currentPath: LimePath) : LimedocParserBaseListener() {
+internal class AntlrLimedocBuilder(
+    private val currentPath: LimePath,
+    private val commentPlaceholders: Map<String, LimeComment>,
+) : LimedocParserBaseListener() {
     private val commentsCollector = mutableMapOf<Pair<String, String>, LimeComment>()
     private val contentCollector = mutableListOf<Pair<String, String>>()
 
@@ -32,7 +35,7 @@ internal class AntlrLimedocBuilder(private val currentPath: LimePath) : LimedocP
         get() {
             val description = commentsCollector[Pair("", "")] ?: LimeComment(currentPath)
             val isExcluded = commentsCollector.containsKey(excludeKey)
-            return LimeStructuredComment(description.withExcluded(isExcluded), commentsCollector)
+            return LimeStructuredComment(description.withExcluded(isExcluded).withPlaceholders(commentPlaceholders), commentsCollector)
         }
 
     // Overrides

--- a/lime-loader/src/test/java/com/here/gluecodium/loader/AntlrLimeModelBuilderTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/loader/AntlrLimeModelBuilderTest.kt
@@ -71,7 +71,7 @@ class AntlrLimeModelBuilderTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxed = true)
-        modelBuilder = AntlrLimeModelBuilder(referenceResolver, contextStack)
+        modelBuilder = AntlrLimeModelBuilder(referenceResolver, emptyMap(), contextStack)
 
         val simpleIdContext = mockk<LimeParser.SimpleIdContext>()
         every { simpleIdContext.text } returns "foo"

--- a/lime-loader/src/test/java/com/here/gluecodium/loader/LimeBasedLimeModelLoaderTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/loader/LimeBasedLimeModelLoaderTest.kt
@@ -19,6 +19,7 @@
 
 package com.here.gluecodium.loader
 
+import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimePath
 import com.here.gluecodium.model.lime.LimeReferenceResolver
@@ -46,6 +47,7 @@ class LimeBasedLimeModelLoaderTest {
                 any<String>(),
                 any<LimeReferenceResolver>(),
                 any<MutableMap<String, List<LimePath>>>(),
+                any<Map<String, LimeComment>>(),
             )
         } answers {
             listOf(object : LimeNamedElement(LimePath(listOf(firstArg()), emptyList())) {})
@@ -72,6 +74,7 @@ class LimeBasedLimeModelLoaderTest {
                 match<String> { it.endsWith("bar.lime") },
                 any<LimeReferenceResolver>(),
                 any<MutableMap<String, List<LimePath>>>(),
+                any<Map<String, LimeComment>>(),
             )
         }
     }
@@ -87,6 +90,7 @@ class LimeBasedLimeModelLoaderTest {
                 match<String> { it.endsWith("bar.lime") },
                 any<LimeReferenceResolver>(),
                 any<MutableMap<String, List<LimePath>>>(),
+                any<Map<String, LimeComment>>(),
             )
         }
     }
@@ -105,6 +109,7 @@ class LimeBasedLimeModelLoaderTest {
                 match<String> { it.endsWith("bar.lime") },
                 any<LimeReferenceResolver>(),
                 any<MutableMap<String, List<LimePath>>>(),
+                any<Map<String, LimeComment>>(),
             )
         }
     }

--- a/lime-loader/src/test/java/com/here/gluecodium/loader/LimeBasedLimeModelLoaderTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/loader/LimeBasedLimeModelLoaderTest.kt
@@ -28,6 +28,7 @@ import io.mockk.every
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -112,5 +113,25 @@ class LimeBasedLimeModelLoaderTest {
                 any<Map<String, LimeComment>>(),
             )
         }
+    }
+
+    @Test
+    fun loadModelWithInvalidPlaceholdersRaisesError() {
+        val docsPlaceholders = mapOf("invalidPlaceholder" to "@{Parsing this will fail.}")
+
+        val exception = assertThrows( LimeLoadingException::class.java) {
+            modelLoader.loadModel(listOf("foo.lime"), emptyList(), docsPlaceholders)
+        }
+
+        assertTrue(exception.message!!.startsWith("Could not parse placeholder:"))
+    }
+
+    @Test
+    fun loadModelWithValidPlaceholders() {
+        val docsPlaceholders = mapOf("validPlaceholder" to "{@Java Java specific text} and other text.")
+
+        val result = modelLoader.loadModel(listOf("foo.lime"), emptyList(), docsPlaceholders)
+        assertEquals(1, result.topElements.size)
+        assertTrue(result.topElements.first().fullName.endsWith("foo.lime"))
     }
 }

--- a/lime-loader/src/test/java/com/here/gluecodium/loader/LimeBasedLimeModelLoaderTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/loader/LimeBasedLimeModelLoaderTest.kt
@@ -119,9 +119,10 @@ class LimeBasedLimeModelLoaderTest {
     fun loadModelWithInvalidPlaceholdersRaisesError() {
         val docsPlaceholders = mapOf("invalidPlaceholder" to "@{Parsing this will fail.}")
 
-        val exception = assertThrows( LimeLoadingException::class.java) {
-            modelLoader.loadModel(listOf("foo.lime"), emptyList(), docsPlaceholders)
-        }
+        val exception =
+            assertThrows(LimeLoadingException::class.java) {
+                modelLoader.loadModel(listOf("foo.lime"), emptyList(), docsPlaceholders)
+            }
 
         assertTrue(exception.message!!.startsWith("Could not parse placeholder:"))
     }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeModelLoader.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeModelLoader.kt
@@ -30,6 +30,7 @@ interface LimeModelLoader {
     fun loadModel(
         idlSources: List<String>,
         auxiliaryIdlSources: List<String>,
+        docsPlaceholders: Map<String, String> = emptyMap(),
     ): LimeModel
 
     companion object {


### PR DESCRIPTION
----- Motivation -----
When creating documentation comments there are elements, which may be
used often. Sometimes the repetition leads to problems. Let's look at the following
example showing the code needed to properly word the `interface` for different outputs:

```
{@Java interface}{@Swift protocol}{@Dart abstract class}{@Cpp abstract class}
```

It is easy to forget adding wording for one of output platforms. Moreover, the mistake
may be repeated if this long syntax is copied to other places in the code.

----- Solution -----
The placeholders for comments are introduced to solve the described problem.
Instead of using the long syntax the new `{@Placeholder <PLACEHOLDER_NAME>}`
can be used.

The new configuration parameters, which allow setting placeholders file are available:
 - CLI: `-docsplaceholderslist`
 - CMake: `GLUECODIUM_DOCS_PLACEHOLDERS_LIST`

The file must follow `.properties` file format and must contain the known comment placeholders
as `placeholder_name="placeholder_value"`.

Note: the placeholders respect the usual LIME markup -- it means that nested platforms tag can
be used, but they are not required.