### PR TITLE
Kotlin: support cached properties

### DIFF
--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesTest.kt
@@ -20,6 +20,7 @@ package com.here.android.test
 
 import com.here.android.RobolectricApplication
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -52,5 +53,45 @@ class AttributesTest {
         assertEquals(expectedStruct.intValue, result.intValue)
     }
 
+    @org.junit.Test
+    fun setGetStaticAttribute() {
+        Attributes.staticAttribute = "fooBar"
+        assertEquals("fooBar", Attributes.staticAttribute)
+    }
 
+    @org.junit.Test
+    fun getCachedProperty() {
+        val instance: CachedProperties = CachedProperties()
+        assertEquals(0, instance.callCount)
+
+        val result1: List<String> = instance.cachedProperty
+        val result2: List<String> = instance.cachedProperty
+
+        assertEquals(1, instance.callCount)
+
+        assertEquals(2, result1.size)
+        assertEquals("foo", result1[0])
+        assertEquals("bar", result1[1])
+
+        assertEquals(result1, result2)
+        assertTrue(result1 === result2)
+    }
+
+    @org.junit.Test
+    fun getStaticCachedProperty() {
+        assertEquals(0, CachedProperties.staticCallCount)
+
+        val result1: ByteArray = CachedProperties.staticCachedProperty
+        val result2: ByteArray = CachedProperties.staticCachedProperty
+
+        assertEquals(1, CachedProperties.staticCallCount)
+
+        assertEquals(3, result1.size)
+        assertEquals(0, result1[0].toInt())
+        assertEquals(1, result1[1].toInt())
+        assertEquals(2, result1[2].toInt())
+
+        assertEquals(result1, result2)
+        assertTrue(result1 === result2)
+    }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
@@ -43,6 +43,7 @@ import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeType
 import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
+import com.here.gluecodium.model.lime.LimeTypedElement
 import com.here.gluecodium.model.lime.LimeValue
 
 internal class KotlinNameResolver(
@@ -86,6 +87,8 @@ internal class KotlinNameResolver(
 
         return "$prefix.$elementName"
     }
+
+    override fun resolveGetterName(element: Any) = (element as? LimeTypedElement)?.let { kotlinNameRules.getGetterName(it) }
 
     private fun resolveComment(limeComment: LimeComment): String {
         // TODO: implement me!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -68,7 +68,9 @@
 
 {{#properties}}
 {{#unless isStatic}}
+{{#set property=this isCached=attributes.cached}}{{#property}}
 {{prefixPartial "kotlin/KotlinProperty" "    "}}
+{{/property}}{{/set}}
 {{/unless}}
 {{/properties}}
 
@@ -80,7 +82,9 @@
 {{/classElement.interfaceInheritedFunctions}}
 {{#classElement.interfaceInheritedProperties}}
 {{#unless isStatic}}
+{{#set property=this isCached=attributes.cached}}{{#property}}
 {{prefixPartial "kotlin/KotlinProperty" "    "}}
+{{/property}}{{/set}}
 {{/unless}}
 {{/classElement.interfaceInheritedProperties}}
 {{/set}}{{/if}}
@@ -102,7 +106,9 @@
 {{#ifPredicate "hasStaticProperties"}}
 {{#properties}}
 {{#if isStatic}}
+{{#set property=this isCached=attributes.cached}}{{#property}}
 {{prefixPartial "kotlin/KotlinProperty" "        "}}
+{{/property}}{{/set}}
 {{/if}}
 {{/properties}}
 {{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -68,11 +68,7 @@
 
 {{#properties}}
 {{#unless isStatic}}
-{{#if setter}}    var{{/if}}{{!!
-}}{{#unless setter}}    val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-        external get{{#setter}}
-        external set{{/setter}}
+{{prefixPartial "kotlin/KotlinProperty" "    "}}
 {{/unless}}
 {{/properties}}
 
@@ -84,11 +80,7 @@
 {{/classElement.interfaceInheritedFunctions}}
 {{#classElement.interfaceInheritedProperties}}
 {{#unless isStatic}}
-{{#if setter}}    override var{{/if}}{{!!
-}}{{#unless setter}}    override val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-        external get{{#setter}}
-        external set{{/setter}}
+{{prefixPartial "kotlin/KotlinProperty" "    "}}
 {{/unless}}
 {{/classElement.interfaceInheritedProperties}}
 {{/set}}{{/if}}
@@ -110,11 +102,7 @@
 {{#ifPredicate "hasStaticProperties"}}
 {{#properties}}
 {{#if isStatic}}
-{{#if setter}}        @JvmStatic var{{/if}}{{!!
-}}{{#unless setter}}        @JvmStatic val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-            external get{{#setter}}
-            external set{{/setter}}
+{{prefixPartial "kotlin/KotlinProperty" "        "}}
 {{/if}}
 {{/properties}}
 {{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -39,7 +39,9 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{#set override=true}}
 {{#properties}}
 {{#unless isStatic}}
+{{#set property=this isCached=attributes.cached}}{{#property}}
 {{prefixPartial "kotlin/KotlinProperty" "    "}}
+{{/property}}{{/set}}
 {{/unless}}
 {{/properties}}
 {{/set}}
@@ -52,7 +54,9 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{/classElement.inheritedFunctions}}
 {{#classElement.inheritedProperties}}
 {{#unless isStatic}}
+{{#set property=this isCached=attributes.cached}}{{#property}}
 {{prefixPartial "kotlin/KotlinProperty" "    "}}
+{{/property}}{{/set}}
 {{/unless}}
 {{/classElement.inheritedProperties}}
 {{/set}}{{/if}}
@@ -74,7 +78,9 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{#ifPredicate "hasStaticProperties"}}
 {{#properties}}
 {{#if isStatic}}
+{{#set property=this isCached=attributes.cached}}{{#property}}
 {{prefixPartial "kotlin/KotlinProperty" "        "}}
+{{/property}}{{/set}}
 {{/if}}
 {{/properties}}
 {{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -36,15 +36,13 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{/functions}}
 {{/set}}
 
+{{#set override=true}}
 {{#properties}}
 {{#unless isStatic}}
-{{#if setter}}    override var{{/if}}{{!!
-}}{{#unless setter}}    override val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-        external get{{#setter}}
-        external set{{/setter}}
+{{prefixPartial "kotlin/KotlinProperty" "    "}}
 {{/unless}}
 {{/properties}}
+{{/set}}
 
 {{#if this.parentInterfaces}}{{#set override=true classElement=this}}
 {{#classElement.inheritedFunctions}}
@@ -54,11 +52,7 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{/classElement.inheritedFunctions}}
 {{#classElement.inheritedProperties}}
 {{#unless isStatic}}
-{{#if setter}}    override var{{/if}}{{!!
-}}{{#unless setter}}    override val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-        external get{{#setter}}
-        external set{{/setter}}
+{{prefixPartial "kotlin/KotlinProperty" "    "}}
 {{/unless}}
 {{/classElement.inheritedProperties}}
 {{/set}}{{/if}}
@@ -80,11 +74,7 @@ class {{resolveName}}Impl : NativeBase, {{resolveName}} {
 {{#ifPredicate "hasStaticProperties"}}
 {{#properties}}
 {{#if isStatic}}
-{{#if setter}}        @JvmStatic var{{/if}}{{!!
-}}{{#unless setter}}        @JvmStatic val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-            external get{{#setter}}
-            external set{{/setter}}
+{{prefixPartial "kotlin/KotlinProperty" "        "}}
 {{/if}}
 {{/properties}}
 {{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -30,15 +30,13 @@ interface {{resolveName}} {{!!
 {{/functions}}
 {{/set}}
 
+{{#set isInterface=true}}
 {{#properties}}
 {{#unless isStatic}}
-{{#if setter}}    var{{/if}}{{!!
-}}{{#unless setter}}    val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-        get{{#setter}}
-        set{{/setter}}
+{{prefixPartial "kotlin/KotlinProperty" "    "}}
 {{/unless}}
 {{/properties}}
+{{/set}}
 
 {{#ifPredicate "needsCompanionObject"}}
     companion object {

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
@@ -23,5 +23,23 @@
 }}{{#if setter}}var{{/if}}{{!!
 }}{{#unless setter}}val{{/unless}}{{!!
 }} {{resolveName}}: {{resolveName typeRef}}
+{{#unless isCached}}
     {{#unless isInterface}}external {{/unless}}get{{#setter}}
     {{#unless isInterface}}external {{/unless}}set{{/setter}}
+{{/unless}}
+{{#if isCached}}
+    get() {
+        if (!is_cached_{{resolveName}}) {
+            cache_{{resolveName}} = {{resolveName this "" "getter"}}_private()
+            is_cached_{{resolveName}} = true
+        }
+
+        return cache_{{resolveName}}{{#unless typeRef.isNullable}}!!{{/unless}}
+    }
+
+{{#if isStatic}}@JvmStatic {{/if}}private var is_cached_{{resolveName}} = false
+{{#if isStatic}}@JvmStatic {{/if}}private var cache_{{resolveName}}: {{resolveName typeRef}}{{!!
+}}{{#unless typeRef.isNullable}}?{{/unless}} = null
+{{#if isStatic}}@JvmStatic {{/if}}external private fun {{resolveName this "" "getter"}}_private() : {{resolveName typeRef}}
+
+{{/if}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
@@ -1,0 +1,27 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#if isStatic}}@JvmStatic {{/if}}{{!!
+}}{{#if override}}override {{/if}}{{!!
+}}{{#if setter}}var{{/if}}{{!!
+}}{{#unless setter}}val{{/unless}}{{!!
+}} {{resolveName}}: {{resolveName typeRef}}
+    {{#unless isInterface}}external {{/unless}}get{{#setter}}
+    {{#unless isInterface}}external {{/unless}}set{{/setter}}

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
@@ -1,0 +1,61 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CachedProperties : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+    val cachedProperty: MutableList<String>
+        get() {
+            if (!is_cached_cachedProperty) {
+                cache_cachedProperty = getCachedProperty_private()
+                is_cached_cachedProperty = true
+            }
+
+            return cache_cachedProperty!!
+        }
+
+    private var is_cached_cachedProperty = false
+    private var cache_cachedProperty: MutableList<String>? = null
+    external private fun getCachedProperty_private() : MutableList<String>
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic val staticCachedProperty: ByteArray
+            get() {
+                if (!is_cached_staticCachedProperty) {
+                    cache_staticCachedProperty = getStaticCachedProperty_private()
+                    is_cached_staticCachedProperty = true
+                }
+
+                return cache_staticCachedProperty!!
+            }
+
+        @JvmStatic private var is_cached_staticCachedProperty = false
+        @JvmStatic private var cache_staticCachedProperty: ByteArray? = null
+        @JvmStatic external private fun getStaticCachedProperty_private() : ByteArray
+
+
+    }
+}

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterface.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface PropertiesInterface {
+    class ExampleStruct {
+        var value: Double
+
+
+
+        constructor(value: Double) {
+            this.value = value
+        }
+
+
+
+
+    }
+
+
+
+    var structProperty: PropertiesInterface.ExampleStruct
+        get
+        set
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
@@ -1,0 +1,30 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class PropertiesInterfaceImpl : NativeBase, PropertiesInterface {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+    override var structProperty: PropertiesInterface.ExampleStruct
+        external get
+        external set
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}


### PR DESCRIPTION
This change implements handling of 'Cached' attribute
for properties. When a property in LIME file is annotated
as cached, then it will be queried just once from C++.

Appropriate functional and smoke tests are also provided.