### PR TITLE
functional tests: fix broken tests of 'Skip/EnableIf'

### DIFF
--- a/functional-tests/functional/input/lime/EnableIfSkipped.lime
+++ b/functional-tests/functional/input/lime/EnableIfSkipped.lime
@@ -24,16 +24,12 @@ class EnableIfSkipped {
     static property skipQuoted: String
 }
 
-struct EnableIfTypesSkipped {
-  @EnableIf(ExperimentalBar)
-  enum SkippedMe {
-      NOPE
-  }
+@EnableIf(ExperimentalBar)
+enum SkippedMe {
+    NOPE
+}
 
-  @EnableIf(ExperimentalBar)
-  struct SkippedMeToo {
-      `field`: SkippedMe
-  }
-
-  const PlaceHolderSkipped: Boolean = true
+@EnableIf(ExperimentalBar)
+struct SkippedMeToo {
+    `field`: SkippedMe
 }

--- a/functional-tests/functional/input/lime/SkipTags.lime
+++ b/functional-tests/functional/input/lime/SkipTags.lime
@@ -25,16 +25,6 @@ class SkipTagsOnly {
 }
 
 struct SkipTypesTags {
-  @Skip(Lite)
-  enum SkipMe {
-      NOPE
-  }
-
-  @Skip(Lite)
-  struct SkipMeToo {
-      `field`: SkipMe
-  }
-
   const PlaceHolder: Boolean = true
 
   @Java(Skip = "Lite")
@@ -42,6 +32,16 @@ struct SkipTypesTags {
   @Dart(Skip = "Lite")
   @Kotlin(Skip = "Lite")
   enum SkipPlatform { N0 }
+}
+
+@Skip(Lite)
+enum SkipMe {
+  NOPE
+}
+
+@Skip(Lite)
+struct SkipMeToo {
+  `field`: SkipMe
 }
 
 struct SkipField {

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkipMe.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkipMe.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+// Should fail if such type is already defined.
+class SkipMe {}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkipMeToo.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkipMeToo.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+// Should fail if such type is already defined.
+enum class SkipMeToo {}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkippedMe.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkippedMe.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+// Should fail if such type is already defined.
+class SkippedMe {}

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkippedMeToo.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/SkippedMeToo.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+// Should fail if such type is already defined.
+enum class SkippedMeToo {}


### PR DESCRIPTION
The functional tests define types that should be skipped
in 'functional/input/src' to trigger redefinition error
when 'Skip/EnableIf' works incorrectly.
    
Sadly, the input LIME files are incorrectly defined.
Even when 'Skip/EnableIf' is removed from the types,
which shall trigger compilation error they do not do
it.
    
The root cause of the problem is definition of the types
which should be skipped as nested types. The types defined
in 'functional/input/src' are not defined as nested types.
    
When the types in LIME files are defined as standalone types
and 'Skip/EnableIf' is removed, then compilation error is
correctly triggered.
    
Thus, this commit changes input LIME files to define the
interesting types as standalone ones.

Moreover, this change adds missing files that should trigger compilation
error when 'Skip/EnableIf' works incorrectly in the generator for Kotlin.