### PR TITLE
Kotlin: test usage of collection fields

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -233,7 +233,7 @@ feature(WeakListeners swift SOURCES
     input/lime/WeakListeners.lime
 )
 
-feature(GenericTypes cpp android swift dart SOURCES
+feature(GenericTypes cpp android android-kotlin swift dart SOURCES
     input/src/cpp/Arrays.cpp
     input/src/cpp/SetType.cpp
     input/src/cpp/Maps.cpp

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ArraysTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ArraysTest.kt
@@ -1,0 +1,399 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class ArraysTest {
+    val floatDelta = 0.000000000001f
+    val doubleDelta = 0.000000000001
+
+    @org.junit.Test
+    fun reverseStringArray() {
+        val first = "abc"
+        val second = "def"
+
+        val stringList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseStringArray(stringList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals("def", resultsList[0])
+        assertEquals("abc", resultsList[1])
+    }
+
+    @org.junit.Test
+    fun methodWithInlineArray() {
+        val first: Short = 77
+        val second: Short = 21
+
+        val shortList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseArrayInline(shortList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseInt8Array() {
+        val first: Byte = 55
+        val second: Byte = 33
+
+        val byteList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseInt8Array(byteList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseInt16Array() {
+        val first: Short = 77
+        val second: Short = 21
+
+        val shortList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseInt16Array(shortList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseInt32Array() {
+        val first: Int = 57
+        val second: Int = 23
+
+        val intList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseInt32Array(intList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseInt64Array() {
+        val first: Long = 17L
+        val second: Long = 23L
+
+        val longList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseInt64Array(longList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseUint8Array() {
+        val first: Short = 77
+        val second: Short = 21
+
+        val shortList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseUint8Array(shortList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseUint16Array() {
+        val first: Int = 57
+        val second: Int = 23
+
+        val intList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseUint16Array(intList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseUint32Array() {
+        val first: Long = 17L
+        val second: Long = 23L
+
+        val longList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseUint32Array(longList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseUint64Array() {
+        val first: Long = 17L
+        val second: Long = 23L
+
+        val longList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseUint64Array(longList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0])
+        assertEquals(first, resultsList[1])
+    }
+
+    @org.junit.Test
+    fun reverseFloatArray() {
+        val first: Float = 77.77f
+        val second: Float = 23.23f
+
+        val floatList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseFloatArray(floatList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0], floatDelta)
+        assertEquals(first, resultsList[1], floatDelta)
+    }
+
+    @org.junit.Test
+    fun reverseDoubleArray() {
+        val first: Double = 22.22
+        val second: Double = 66.66
+
+        val doubleList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseDoubleArray(doubleList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second, resultsList[0], doubleDelta)
+        assertEquals(first, resultsList[1], doubleDelta)
+    }
+
+    @org.junit.Test
+    fun methodWithBooleanArray() {
+        val booleanList = mutableListOf<Boolean>(true, true, false)
+        val resultsList = Arrays.reverseBoolArray(booleanList)
+
+        assertEquals(3, resultsList.size)
+        assertFalse(resultsList[0])
+        assertTrue(resultsList[1])
+        assertTrue(resultsList[2])
+    }
+
+    @org.junit.Test
+    fun reverseStructArray() {
+        val first = Arrays.BasicStruct(22.22)
+        val second = Arrays.BasicStruct(33.33)
+
+        val structList = mutableListOf(first, second)
+        val resultsList = Arrays.reverseStructArray(structList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second.value, resultsList[0].value, doubleDelta)
+        assertEquals(first.value, resultsList[1].value, doubleDelta)
+    }
+
+    @org.junit.Test
+    fun reverseMapsArray() {
+        val first = mutableMapOf(32.toShort() to "abc")
+        val second = mutableMapOf<Short, String>()
+
+        val input = mutableListOf(first, second)
+        val result = Arrays.reverseMapsArray(input)
+
+        assertEquals(2, result.size)
+        assertEquals(second, result[0])
+        assertEquals(first, result[1])
+    }
+
+    @org.junit.Test
+    fun reverseArrayMapsArray() {
+        val first = mutableMapOf(42.toShort() to mutableListOf("john", "doe"))
+        val second = mutableMapOf(44.toShort() to mutableListOf("example", "dot", "com"))
+
+        val input = mutableListOf(first, second)
+        val result = Arrays.reverseArrayMapsArray(input)
+
+        assertEquals(2, result.size)
+        assertEquals(second, result[0])
+        assertEquals(first, result[1])
+    }
+
+    @org.junit.Test
+    fun methodWithExplicitInstanceArray() {
+        val first = InstancesFactory.createSimpleInstantiableOne()
+        first.setStringValue("FIRST STRING")
+
+        val second = InstancesFactory.createSimpleInstantiableOne()
+        second.setStringValue("SECOND STRING")
+
+        val instancesArray = mutableListOf(first, second)
+        val resultsList = Arrays.reverseExplicitInstancesArray(instancesArray)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second.getStringValue(), resultsList[0].getStringValue())
+        assertEquals(first.getStringValue(), resultsList[1].getStringValue())
+    }
+
+    @org.junit.Test
+    fun methodWithImplicitInstanceArray() {
+        val first = InstancesFactory.createSimpleInstantiableOne()
+        first.setStringValue("FIRST STRING")
+
+        val second = InstancesFactory.createSimpleInstantiableOne()
+        second.setStringValue("SECOND STRING")
+
+        val instancesArray = mutableListOf(first, second)
+        val resultsList: List<SimpleInstantiableOne> = Arrays.reverseImplicitInstancesArray(instancesArray)
+
+        assertEquals(2, resultsList.size)
+        assertEquals(second.getStringValue(), resultsList[0].getStringValue())
+        assertEquals(first.getStringValue(), resultsList[1].getStringValue())
+    }
+
+    @org.junit.Test
+    fun reverseNestedPrimitiveArray() {
+        val nestedDoubleList = mutableListOf(mutableListOf(11.11, 22.22), mutableListOf(33.33, 44.44))
+        val resultsList = Arrays.reverseNestedPrimitiveArray(nestedDoubleList)
+
+        assertEquals(2, resultsList.size)
+
+        val firstResult = resultsList[0]
+        assertEquals(2, firstResult.size)
+        assertEquals(nestedDoubleList[1][1], firstResult[0], doubleDelta)
+        assertEquals(nestedDoubleList[1][0], firstResult[1], doubleDelta)
+
+        val secondResult = resultsList[1]
+        assertEquals(2, secondResult.size)
+        assertEquals(nestedDoubleList[0][1], secondResult[0], doubleDelta)
+        assertEquals(nestedDoubleList[0][0], secondResult[1], doubleDelta)
+    }
+
+    @org.junit.Test
+    fun reverseNestedStructArray() {
+        val nestedStructList = mutableListOf(
+            mutableListOf(Arrays.BasicStruct(11.11), Arrays.BasicStruct(22.22)),
+            mutableListOf(Arrays.BasicStruct(33.33), Arrays.BasicStruct(44.44))
+        )
+
+        val resultsList = Arrays.reverseNestedStructArray(nestedStructList)
+
+        val firstResult = resultsList[0]
+        assertEquals(2, firstResult.size)
+        assertEquals(nestedStructList[1][1].value, firstResult[0].value, doubleDelta)
+        assertEquals(nestedStructList[1][0].value, firstResult[1].value, doubleDelta)
+
+        val secondResult = resultsList[1]
+        assertEquals(2, secondResult.size)
+        assertEquals(nestedStructList[0][1].value, secondResult[0].value, doubleDelta)
+        assertEquals(nestedStructList[0][0].value, secondResult[1].value, doubleDelta)
+    }
+
+    @org.junit.Test
+    fun reverseNestedArraysInline() {
+        val nestedLongList = mutableListOf(mutableListOf(21L, 31L), mutableListOf(45L, 75L))
+        val resultsList = Arrays.reverseNestedArraysInline(nestedLongList)
+
+        assertEquals(2, resultsList.size)
+
+        val firstResult = resultsList[0]
+        assertEquals(2, firstResult.size)
+        assertEquals(nestedLongList[1][1], firstResult[0])
+        assertEquals(nestedLongList[1][0], firstResult[1])
+
+        val secondResult = resultsList[1]
+        assertEquals(2, secondResult.size)
+        assertEquals(nestedLongList[0][1], secondResult[0])
+        assertEquals(nestedLongList[0][0], secondResult[1])
+    }
+
+    @org.junit.Test
+    fun mergeArraysOfStructsWithArrays() {
+        val instance1 = InstancesFactory.createSimpleInstantiableOne()
+        instance1.setStringValue("Instance 1: STRING")
+
+        val instance2 = InstancesFactory.createSimpleInstantiableOne()
+        instance2.setStringValue("Instance 2: STRING")
+
+        val instance3 = InstancesFactory.createSimpleInstantiableOne()
+        instance3.setStringValue("Instance 3: STRING")
+
+        val instancesArray1 = mutableListOf(instance1, instance2)
+        val instancesArray2 = mutableListOf(instance3)
+        val instancesArray3 = mutableListOf<SimpleInstantiableOne>()
+
+        val struct1 = Arrays.FancyStruct(
+            mutableListOf("struct", "1"),
+            mutableListOf(1.toShort(), 2.toShort()),
+            instancesArray1
+        )
+
+        val struct2 = Arrays.FancyStruct(
+            mutableListOf("struct", "2"),
+            mutableListOf(3.toShort(), 4.toShort()),
+            instancesArray2
+        )
+
+        val struct3 =  Arrays.FancyStruct(
+            mutableListOf("struct", "3"),
+            mutableListOf(5.toShort(), 6.toShort()),
+            instancesArray3
+        )
+
+        val fancyStructList1 = mutableListOf(struct1, struct2)
+        val fancyStructList2 = mutableListOf(struct3)
+        val resultsList = Arrays.mergeArraysOfStructsWithArrays(fancyStructList1, fancyStructList2)
+
+        assertEquals(3, resultsList.size)
+
+        assertEquals("struct", resultsList[0].messages[0])
+        assertEquals("3", resultsList[0].messages[1])
+        assertTrue(resultsList[0].instances.isEmpty())
+
+        assertEquals("2", resultsList[1].messages[1])
+        assertEquals(1, resultsList[1].instances.size)
+        assertEquals("Instance 3: STRING", resultsList[1].instances[0].getStringValue())
+
+        assertEquals("1", resultsList[2].messages[1])
+        assertEquals(2, resultsList[2].instances.size)
+        assertEquals("Instance 1: STRING", resultsList[2].instances[0].getStringValue())
+        assertEquals("Instance 2: STRING", resultsList[2].instances[1].getStringValue())
+    }
+
+    @org.junit.Test
+    fun reverseArrayOfAliases_emptyList() {
+        val stringList = mutableListOf<String>()
+        val resultsList = Arrays.reverseArrayOfAliases(stringList)
+
+        assertEquals(0, resultsList.size)
+    }
+
+    @org.junit.Test
+    fun reverseArrayOfAliases_reversesArray() {
+        val stringList = mutableListOf("abc", "def")
+        val resultsList = Arrays.reverseArrayOfAliases(stringList)
+
+        assertEquals(2, resultsList.size)
+        assertEquals("def", resultsList[0])
+        assertEquals("abc", resultsList[1])
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/MapsTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/MapsTest.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class MapsTest {
+    @org.junit.Test
+    fun methodWithMaps_emptyMap() {
+        val intStringMap= mutableMapOf<Int, String>()
+        val resultsMap = Maps.methodWithMap(intStringMap)
+
+        assertEquals(0, resultsMap.size)
+    }
+
+    @org.junit.Test
+    fun methodWithMaps_multipleItems() {
+        val intStringMap = mutableMapOf(11 to "abc", 22 to "def", 33 to "ghi")
+        val resultsMap = Maps.methodWithMap(intStringMap)
+
+        assertEquals(3, resultsMap.size)
+
+        // The method returns string values in uppercase
+        assertEquals("ABC", resultsMap[11])
+        assertEquals("DEF", resultsMap[22])
+        assertEquals("GHI", resultsMap[33])
+    }
+
+    @org.junit.Test
+    fun methodWithMapToArray_emptyMap() {
+        val arrayMap = mutableMapOf<Short, MutableList<String>>()
+        val resultsMap = Maps.methodWithMapOfArrays(arrayMap)
+
+        assertEquals(0, resultsMap.size)
+    }
+
+    @org.junit.Test
+    fun methodWithMapToArray_multipleItems() {
+        val arrayMap = mutableMapOf(
+            11.toShort() to mutableListOf("abc"),
+            22.toShort() to mutableListOf("def", "ghi"),
+            33.toShort() to mutableListOf(),
+        )
+
+        val resultsMap = Maps.methodWithMapOfArrays(arrayMap)
+        assertEquals(3, resultsMap.size)
+
+        // The method returns string values in uppercase
+        assertEquals(mutableListOf("ABC"), resultsMap[11.toShort()])
+        assertEquals(mutableListOf("DEF", "GHI"), resultsMap[22.toShort()])
+        assertEquals(emptyList<String>(), resultsMap[33.toShort()])
+    }
+
+    @org.junit.Test
+    fun methodWithMapToStruct_emptyMap() {
+        val byteStructMap = mutableMapOf<Short, Maps.SomeStruct>()
+        val resultsMap = Maps.methodWithMapToStruct(byteStructMap)
+
+        assertEquals(0, resultsMap.size)
+    }
+
+    @org.junit.Test
+    fun methodWithMapToStruct_multipleItems() {
+        val byteStructMap = mutableMapOf(
+            11.toShort() to Maps.SomeStruct("abc"),
+            22.toShort() to Maps.SomeStruct("def"),
+            33.toShort() to Maps.SomeStruct("ghi"),
+        )
+
+        val resultsMap = Maps.methodWithMapToStruct(byteStructMap)
+        assertEquals(3, resultsMap.size)
+
+        // The method returns string values in uppercase
+        assertEquals("ABC", resultsMap[11.toShort()]!!.value)
+        assertEquals("DEF", resultsMap[22.toShort()]!!.value)
+        assertEquals("GHI", resultsMap[33.toShort()]!!.value)
+    }
+
+    @org.junit.Test
+    fun methodWithNestedMap_emptyMap() {
+        val byteMapMap = mutableMapOf<Short, MutableMap<Short, Maps.SomeStruct>>()
+        val resultsMap = Maps.methodWithNestedMap(byteMapMap)
+
+        assertEquals(0, resultsMap.size)
+    }
+
+    @org.junit.Test
+    fun methodWithNestedMap_multipleItems() {
+        val inputMap = mutableMapOf(
+            55.toShort() to mutableMapOf(
+                11.toShort() to Maps.SomeStruct("abc"),
+                22.toShort() to Maps.SomeStruct("def"),
+                33.toShort() to Maps.SomeStruct("ghi"),
+            ),
+            77.toShort() to mutableMapOf<Short, Maps.SomeStruct>()
+        )
+
+        val resultsMap = Maps.methodWithNestedMap(inputMap)
+        assertEquals(2, resultsMap.size)
+
+        // First map should have 3 elements converted to uppercase inside structs.
+        val resultSubMap: Map<Short, Maps.SomeStruct> = resultsMap[55.toShort()]!!
+        assertEquals(3, resultSubMap.size)
+
+        // The method returns string values in uppercase
+        assertEquals("ABC", resultSubMap[11.toShort()]!!.value)
+        assertEquals("DEF", resultSubMap[22.toShort()]!!.value)
+        assertEquals("GHI", resultSubMap[33.toShort()]!!.value)
+
+        // The second map should remain empty.
+        assertEquals(0, resultsMap[77.toShort()]!!.size)
+    }
+
+    @org.junit.Test
+    fun methodWithStructWithMap_emptyMap() {
+        val structWithMap = Maps.StructWithMap(mutableMapOf())
+        val result = Maps.methodWithStructWithMap(structWithMap)
+
+        assertEquals(0, result.errorMapping.size)
+    }
+
+    @org.junit.Test
+    fun methodWithStructWithMap_multipleItems() {
+        val structWithMap = Maps.StructWithMap(mutableMapOf(11 to "abc", 22 to "def", 33 to "ghi"))
+
+        val result = Maps.methodWithStructWithMap(structWithMap)
+        assertEquals(3, result.errorMapping.size)
+
+        // The method returns string values in uppercase
+        assertEquals("ABC", result.errorMapping[11])
+        assertEquals("DEF", result.errorMapping[22])
+        assertEquals("GHI", result.errorMapping[33])
+    }
+
+    @org.junit.Test
+    fun methodWithEnumToStringMap_emptyMap() {
+        val enumStringMap = mutableMapOf<Maps.SomeEnum, String>()
+        val resultsMap = Maps.methodWithEnumToStringMap(enumStringMap)
+
+        assertEquals(0, resultsMap.size)
+    }
+
+    @org.junit.Test
+    fun methodWithEnumToStringMap_multipleItems() {
+        val enumStringMap = mutableMapOf<Maps.SomeEnum, String>(
+            Maps.SomeEnum.FOO_VALUE to "this is foo",
+            Maps.SomeEnum.BAR_VALUE to "this is bar",
+        )
+
+        val resultsMap = Maps.methodWithEnumToStringMap(enumStringMap)
+        assertEquals(2, resultsMap.size)
+
+        // The method returns string values in uppercase
+        assertEquals("THIS IS FOO", resultsMap[Maps.SomeEnum.FOO_VALUE])
+        assertEquals("THIS IS BAR", resultsMap[Maps.SomeEnum.BAR_VALUE])
+    }
+
+    @org.junit.Test
+    fun methodWithMapOfInstances() {
+        val first = InterfacesFactory.createSimpleInterfaceOne()
+        first.setStringValue("first =")
+
+        val second = InterfacesFactory.createSimpleInterfaceOne()
+        second.setStringValue("second =")
+
+        val inputMap = mutableMapOf("primo" to first, "secundo" to second)
+        val resultsMap = Maps.methodWithMapOfInstances(inputMap)
+        assertEquals(2, resultsMap.size)
+
+        assertNotNull(resultsMap["primo"])
+        assertEquals("first = primo", resultsMap["primo"]!!.getStringValue())
+
+        assertNotNull(resultsMap["secundo"])
+        assertEquals("second = secundo", resultsMap["secundo"]!!.getStringValue())
+    }
+
+    @org.junit.Test
+    fun structToStringMapRoundTrip() {
+        val input = mutableMapOf(
+            Maps.EquatableStruct("foo") to "foo",
+            Maps.EquatableStruct("bar") to "bar",
+        )
+
+        val result = Maps.structToStringRoundTrip(input)
+        assertEquals(input, result)
+    }
+
+    @org.junit.Test
+    fun classToStringMapRoundTrip() {
+        val input = mutableMapOf(
+            SomeEquatableClass("foo") to "foo",
+            SomeEquatableClass("bar") to "bar",
+        )
+
+        val result = Maps.classToStringRoundTrip(input)
+        assertEquals(input, result)
+    }
+
+    @org.junit.Test
+    fun SomePointerEquatableClassToStringMapRoundTrip() {
+        val input = mutableMapOf(
+            SomePointerEquatableClass("foo") to "foo",
+            SomePointerEquatableClass("bar") to "bar",
+        )
+
+        val result = Maps.somePointerEquatableClassToStringRoundTrip(input)
+        assertEquals(input, result)
+    }
+}

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/SerializationTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/SerializationTest.kt
@@ -24,6 +24,7 @@ import org.junit.Assert.assertTrue
 
 import android.os.Parcel
 import com.here.android.RobolectricApplication
+import java.util.EnumSet
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -44,7 +45,7 @@ class SerializationTest {
 
         val serializableStruct = SerializableStruct(
             true, 42.toByte(), 542.toShort(), 65542, 2147484000L, 1.0f, 2.0, "nonsense", nestedStruct,
-            byteBuffer, stringList, structList, errorMap, hashSet, mutableSetOf(FooEnum.BAR),
+            byteBuffer, stringList, structList, errorMap, hashSet, EnumSet.of(FooEnum.BAR),
             FooEnum.BAR
         )
 
@@ -91,6 +92,7 @@ class SerializationTest {
         assertTrue(resultStruct.setField.contains("bar"))
         assertEquals(serializableStruct.enumSetField.size, resultStruct.enumSetField.size)
         assertTrue(resultStruct.enumSetField.contains(FooEnum.BAR))
+        assertTrue(resultStruct.enumSetField is EnumSet<*>)
         assertEquals(serializableStruct.enumField, resultStruct.enumField)
     }
 }

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/SetTypeTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/SetTypeTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+import java.util.Collections
+import java.util.EnumSet
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class SetTypeTest {
+    @org.junit.Test
+    fun emptyStringSetRoundTrip() {
+        val stringSet = mutableSetOf<String>()
+        val result = SetType.stringSetRoundTrip(stringSet)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @org.junit.Test
+    fun stringSetRoundTrip() {
+        val stringSet = Collections.singleton("foo")
+        val result = SetType.stringSetRoundTrip(stringSet)
+
+        assertEquals(stringSet, result)
+    }
+
+    @org.junit.Test
+    fun emptyEnumSetRoundTrip() {
+        val enumSet = mutableSetOf<SetType.SomeEnum>()
+        val result = SetType.enumSetRoundTrip(enumSet)
+
+        assertTrue(result.isEmpty())
+    }
+
+    @org.junit.Test
+    fun enumSetRoundTrip() {
+        val enumSet = Collections.singleton(SetType.SomeEnum.ON)
+        val result = SetType.enumSetRoundTrip(enumSet)
+
+        assertTrue(result is EnumSet<*>)
+        assertEquals(enumSet, result)
+    }
+
+    @org.junit.Test
+    fun nullNullableSetRoundTrip() {
+        val result = SetType.nullableIntSetRoundTrip(null)
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun emptyNullableSetRoundTrip() {
+        val intSet = mutableSetOf<Int>()
+        val result = SetType.nullableIntSetRoundTrip(intSet)
+
+        assertTrue(result!!.isEmpty())
+    }
+
+    @org.junit.Test
+    fun nullableSetRoundTrip() {
+        val intSet = Collections.singleton(42)
+        val result = SetType.nullableIntSetRoundTrip(intSet)
+
+        assertEquals(intSet, result)
+    }
+
+    @org.junit.Test
+    fun structSetRoundTrip() {
+        val input = Collections.singleton(SetType.EquatableStruct("foo"))
+        val result = SetType.structSetRoundTrip(input)
+
+        assertEquals(input, result)
+    }
+
+    @org.junit.Test
+    fun classSetRoundTrip() {
+        val input = Collections.singleton(SomeEquatableClass("foo"))
+        val result = SetType.classSetRoundTrip(input)
+
+        assertEquals(input, result)
+    }
+
+    @org.junit.Test
+    fun somePointerEquatableClassSetRoundTrip() {
+        val input = Collections.singleton(SomePointerEquatableClass("foo"))
+        val result = SetType.pointerEquatableSetRoundTrip(input)
+
+        assertEquals(input, result)
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
@@ -119,7 +119,7 @@ internal class KotlinNameResolver(
             TypeId.LOCALE -> "Locale"
         }
 
-    private fun resolveTypeRef(limeTypeRef: LimeTypeRef): String {
+    fun resolveTypeRef(limeTypeRef: LimeTypeRef): String {
         val limeType = limeTypeRef.type.actualType
         val externalName = limeType.external?.kotlin?.get(NAME_NAME)
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinValueResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinValueResolver.kt
@@ -22,6 +22,7 @@ package com.here.gluecodium.generator.kotlin
 import com.here.gluecodium.cli.GluecodiumExecutionException
 import com.here.gluecodium.model.lime.LimeBasicType
 import com.here.gluecodium.model.lime.LimeBasicType.TypeId
+import com.here.gluecodium.model.lime.LimeEnumeration
 import com.here.gluecodium.model.lime.LimeEnumerator
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
@@ -89,7 +90,17 @@ internal class KotlinValueResolver(private val nameResolver: KotlinNameResolver)
 
             is LimeSet -> {
                 val values = limeValue.values.joinToString(", ") { resolveValue(it) }
-                "mutableSetOf($values)"
+                if (limeType.elementType.type.actualType is LimeEnumeration) {
+                    when {
+                        values.isEmpty() -> {
+                            val typeName = nameResolver.resolveTypeRef(limeType.elementType)
+                            "EnumSet.noneOf($typeName::class.java)"
+                        }
+                        else -> "EnumSet.of($values)"
+                    }
+                } else {
+                    "mutableSetOf($values)"
+                }
             }
 
             is LimeMap -> {

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinParcelableImpl.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinParcelableImpl.mustache
@@ -54,7 +54,8 @@ parcel.readList(this.{{resolveName field}}, Thread.currentThread().getContextCla
 parcel.readMap(this.{{resolveName field}}, Thread.currentThread().getContextClassLoader()){{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeSet"}}var __{{resolveName field}} = arrayListOf<{{resolveName type.elementType}}>()
 parcel.readList(__{{resolveName field}}, Thread.currentThread().getContextClassLoader())
-this.{{resolveName field}} = __{{resolveName field}}.toMutableSet(){{/instanceOf}}{{!!
+{{#instanceOf type.elementType.type.actualType "LimeEnumeration"}}this.{{resolveName field}} = EnumSet.copyOf(__{{resolveName field}}){{/instanceOf}}{{!!
+}}{{#notInstanceOf type.elementType.type.actualType "LimeEnumeration"}}this.{{resolveName field}} = __{{resolveName field}}.toMutableSet(){{/notInstanceOf}}{{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeStruct"}}this.{{resolveName field}} = parcel.readParcelable(Thread.currentThread().getContextClassLoader()){{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeEnumeration"}}this.{{resolveName field}} = {{resolveName typeRef}}.values()[parcel.readInt()]{{/instanceOf}}{{!!
 }}{{#instanceOf type "LimeBasicType"}}{{#switch type.typeId.toString}}{{!!

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
@@ -1,0 +1,59 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class Enums : NativeBase {
+
+    enum class SimpleEnum(private val value: Int) {
+        FIRST(0),
+        SECOND(1);
+    }
+    enum class InternalErrorCode(private val value: Int) {
+        ERROR_NONE(0),
+        ERROR_FATAL(999);
+    }
+    class ErrorStruct {
+        var type: Enums.InternalErrorCode
+        var message: String
+
+
+
+        constructor(type: Enums.InternalErrorCode, message: String) {
+            this.type = type
+            this.message = message
+        }
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun methodWithEnumeration(input: Enums.SimpleEnum) : Enums.SimpleEnum
+        @JvmStatic external fun flipEnumValue(input: Enums.InternalErrorCode) : Enums.InternalErrorCode
+        @JvmStatic external fun extractEnumFromStruct(input: Enums.ErrorStruct) : Enums.InternalErrorCode
+        @JvmStatic external fun createStructWithEnumInside(type: Enums.InternalErrorCode, message: String) : Enums.ErrorStruct
+    }
+}

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollection.kt
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class EnumsInTypeCollection {
+
+    enum class TCEnum(private val value: Int) {
+        FIRST(0),
+        SECOND(1);
+    }
+
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class EnumsInTypeCollectionInterface : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun flipEnumValue(input: EnumsInTypeCollection.TCEnum) : EnumsInTypeCollection.TCEnum
+    }
+}

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class EnumSets {
+    var enumSetField: MutableSet<GenericTypesWithCompoundTypes.SomeEnum>
+
+
+
+    constructor() {
+        this.enumSetField = mutableSetOf()
+    }
+
+
+
+
+    companion object {
+        val ENUM_SET_CONST: MutableSet<GenericTypesWithCompoundTypes.SomeEnum> = mutableSetOf(GenericTypesWithCompoundTypes.SomeEnum.FOO, GenericTypesWithCompoundTypes.SomeEnum.BAR)
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
@@ -5,6 +5,7 @@
 
 package com.example.smoke
 
+import java.util.EnumSet
 
 class EnumSets {
     var enumSetField: MutableSet<GenericTypesWithCompoundTypes.SomeEnum>
@@ -12,14 +13,14 @@ class EnumSets {
 
 
     constructor() {
-        this.enumSetField = mutableSetOf()
+        this.enumSetField = EnumSet.noneOf(GenericTypesWithCompoundTypes.SomeEnum::class.java)
     }
 
 
 
 
     companion object {
-        val ENUM_SET_CONST: MutableSet<GenericTypesWithCompoundTypes.SomeEnum> = mutableSetOf(GenericTypesWithCompoundTypes.SomeEnum.FOO, GenericTypesWithCompoundTypes.SomeEnum.BAR)
+        val ENUM_SET_CONST: MutableSet<GenericTypesWithCompoundTypes.SomeEnum> = EnumSet.of(GenericTypesWithCompoundTypes.SomeEnum.FOO, GenericTypesWithCompoundTypes.SomeEnum.BAR)
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
@@ -1,0 +1,64 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class GenericTypesWithBasicTypes : NativeBase {
+
+    class StructWithGenerics {
+        var numbersList: MutableList<Short>
+        var numbersMap: MutableMap<Short, String>
+        var numbersSet: MutableSet<Short>
+
+
+
+        constructor(numbersList: MutableList<Short>, numbersMap: MutableMap<Short, String>, numbersSet: MutableSet<Short>) {
+            this.numbersList = numbersList
+            this.numbersMap = numbersMap
+            this.numbersSet = numbersSet
+        }
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun methodWithList(input: MutableList<Int>) : MutableList<Int>
+    external fun methodWithMap(input: MutableMap<Int, Boolean>) : MutableMap<Int, Boolean>
+    external fun methodWithSet(input: MutableSet<Int>) : MutableSet<Int>
+    external fun methodWithListTypeAlias(input: MutableList<String>) : MutableList<String>
+    external fun methodWithMapTypeAlias(input: MutableMap<String, String>) : MutableMap<String, String>
+    external fun methodWithSetTypeAlias(input: MutableSet<String>) : MutableSet<String>
+
+    var listProperty: MutableList<Float>
+        external get
+        external set
+    var mapProperty: MutableMap<Float, Double>
+        external get
+        external set
+    var setProperty: MutableSet<Float>
+        external get
+        external set
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
@@ -1,0 +1,75 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class GenericTypesWithCompoundTypes : NativeBase {
+
+    enum class SomeEnum(private val value: Int) {
+        FOO(0),
+        BAR(1);
+    }
+    enum class ExternalEnum(private val value: Int) {
+        ON(0),
+        OFF(1);
+    }
+    class BasicStruct {
+        var value: Double
+
+
+
+        constructor(value: Double) {
+            this.value = value
+        }
+
+
+
+
+    }
+
+    class ExternalStruct {
+        var string: String
+
+
+
+        constructor(string: String) {
+            this.string = string
+        }
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun methodWithStructList(input: MutableList<GenericTypesWithCompoundTypes.BasicStruct>) : MutableList<GenericTypesWithCompoundTypes.ExternalStruct>
+    external fun methodWithStructMap(input: MutableMap<String, GenericTypesWithCompoundTypes.BasicStruct>) : MutableMap<String, GenericTypesWithCompoundTypes.ExternalStruct>
+    external fun methodWithEnumList(input: MutableList<GenericTypesWithCompoundTypes.SomeEnum>) : MutableList<GenericTypesWithCompoundTypes.ExternalEnum>
+    external fun methodWithEnumMapKey(input: MutableMap<GenericTypesWithCompoundTypes.SomeEnum, Boolean>) : MutableMap<GenericTypesWithCompoundTypes.ExternalEnum, Boolean>
+    external fun methodWithEnumMapValue(input: MutableMap<Int, GenericTypesWithCompoundTypes.SomeEnum>) : MutableMap<Int, GenericTypesWithCompoundTypes.ExternalEnum>
+    external fun methodWithEnumSet(input: MutableSet<GenericTypesWithCompoundTypes.SomeEnum>) : MutableSet<GenericTypesWithCompoundTypes.ExternalEnum>
+    external fun methodWithInstancesList(input: MutableList<DummyClass>) : MutableList<DummyInterface>
+    external fun methodWithInstancesMap(input: MutableMap<Int, DummyClass>) : MutableMap<Int, DummyInterface>
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
@@ -1,0 +1,38 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class GenericTypesWithGenericTypes : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun methodWithListOfLists(input: MutableList<MutableList<Int>>) : MutableList<MutableList<Int>>
+    external fun methodWithMapOfMaps(input: MutableMap<Int, MutableMap<Int, Boolean>>) : MutableMap<MutableMap<Int, Boolean>, Boolean>
+    external fun methodWithSetOfSets(input: MutableSet<MutableSet<Int>>) : MutableSet<MutableSet<Int>>
+    external fun methodWithListAndMap(input: MutableList<MutableMap<Int, Boolean>>) : MutableMap<Int, MutableList<Int>>
+    external fun methodWithListAndSet(input: MutableList<MutableSet<Int>>) : MutableSet<MutableList<Int>>
+    external fun methodWithMapAndSet(input: MutableMap<Int, MutableSet<Int>>) : MutableSet<MutableMap<Int, Boolean>>
+    external fun methodWithMapGenericKeys(input: MutableMap<MutableSet<Int>, Boolean>) : MutableMap<MutableList<Int>, Boolean>
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
+++ b/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
@@ -7,6 +7,7 @@ package com.example.smoke
 
 import android.os.Parcel
 import android.os.Parcelable
+import java.util.EnumSet
 
 class Serialization {
 
@@ -76,7 +77,7 @@ class Serialization {
             this.setField = __setField.toMutableSet()
             var __enumSetField = arrayListOf<Serialization.SomeEnum>()
             parcel.readList(__enumSetField, Thread.currentThread().getContextClassLoader())
-            this.enumSetField = __enumSetField.toMutableSet()
+            this.enumSetField = EnumSet.copyOf(__enumSetField)
             this.enumField = Serialization.SomeEnum.values()[parcel.readInt()]!!
         }
 


### PR DESCRIPTION
This series brings new functional tests related to usage of collection fields for Kotlin generator:
- ArraysTest.kt
- MapsTest.kt
- SetTypeTest.kt

Moreover it adds smoke tests for collections and enumerations. It also fixes the gap related to
lack of usage of EnumSet by Kotlin generator. The usage of the mentioned class is introduced
to ensure that the behavior is identical to Java generator.