### PR TITLE
Kotlin: add smoke tests of 'nesting'

### DIFF
--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeEnum.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeEnum.kt
@@ -1,0 +1,12 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+enum class FreeEnum(private val value: Int) {
+    FOO(0),
+    BAR(1);
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeException.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeException.kt
@@ -1,0 +1,11 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class FreeException(val error: FreeEnum) : Exception(error.toString())
+
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeLambda.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeLambda.kt
@@ -1,0 +1,13 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import java.util.Date
+
+fun interface FreeLambda {
+    fun apply(p0: Date) : FreeEnum
+}
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
@@ -1,0 +1,28 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+class FreePoint {
+    var x: Double
+    var y: Double
+
+
+
+    constructor(x: Double, y: Double) {
+        this.x = x
+        this.y = y
+    }
+
+
+
+    external fun flip() : FreePoint
+
+    companion object {
+        val A_BAR: FreeEnum = FreeEnum.BAR
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
@@ -1,0 +1,97 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class LevelOne : NativeBase {
+
+    class LevelTwo : NativeBase {
+
+        class LevelThree : NativeBase {
+
+            enum class LevelFourEnum(private val value: Int) {
+                NONE(0);
+            }
+            class LevelFour {
+                var stringField: String
+
+
+
+                constructor(stringField: String) {
+                    this.stringField = stringField
+                }
+
+
+
+
+                companion object {
+                    val FOO: Boolean = false
+                    @JvmStatic external fun fooFactory() : LevelOne.LevelTwo.LevelThree.LevelFour
+                }
+            }
+
+
+
+            /*
+             * For internal use only.
+             * @hidden
+             * @param nativeHandle The handle to resources on C++ side.
+             * @param tag Tag used by callers to avoid overload resolution problems.
+             */
+            protected constructor(nativeHandle: Long, tag: Any?)
+                : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+            external fun foo(input: OuterClass.InnerInterface) : OuterInterface.InnerClass
+
+
+
+            companion object {
+                @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+            }
+        }
+
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
@@ -1,0 +1,46 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class NestedReferences : NativeBase {
+
+    class NestedReferences {
+        var stringField: String
+
+
+
+        constructor(stringField: String) {
+            this.stringField = stringField
+        }
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun insideOut(struct1: NestedReferences.NestedReferences, struct2: NestedReferences.NestedReferences) : NestedReferences
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
@@ -1,0 +1,80 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class OuterClass : NativeBase {
+
+    class InnerClass : NativeBase {
+
+
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+        external fun foo(input: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    interface InnerInterface {
+
+        fun foo(input: String) : String
+
+
+    }
+
+    class InnerInterfaceImpl : NativeBase, InnerInterface {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun foo(input: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun foo(input: String) : String
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
@@ -1,0 +1,77 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class OuterClassWithInheritance : ParentClass {
+
+    class InnerClass : NativeBase {
+
+
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+        external fun bar(input: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    interface InnerInterface {
+
+        fun baz(input: String) : String
+
+
+    }
+
+    class InnerInterfaceImpl : NativeBase, InnerInterface {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun baz(input: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, tag) {}
+
+
+
+    external fun foo(input: String) : String
+
+
+
+}

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
@@ -1,0 +1,64 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+interface OuterInterface {
+    class InnerClass : NativeBase {
+
+
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+        external fun foo(input: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    interface InnerInterface {
+
+        fun foo(input: String) : String
+
+
+    }
+
+    class InnerInterfaceImpl : NativeBase, InnerInterface {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun foo(input: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+    fun foo(input: String) : String
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -1,0 +1,147 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import java.util.Date
+import java.util.Locale
+
+class OuterStruct {
+    var field: String
+
+    enum class InnerEnum(private val value: Int) {
+        FOO(0),
+        BAR(1);
+    }
+    class InstantiationException(val error: OuterStruct.InnerEnum) : Exception(error.toString())
+
+
+    class InnerStruct {
+        var otherField: MutableList<Date>
+
+
+
+        constructor(otherField: MutableList<Date>) {
+            this.otherField = otherField
+        }
+
+
+
+        external fun doSomething() : Unit
+
+    }
+
+    class InnerClass : NativeBase {
+
+
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+        external fun fooBar() : MutableSet<Locale>
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class Builder : NativeBase {
+
+
+        constructor() : this(create(), null as Any?) {
+            cacheThisInstance();
+        }
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        private external fun cacheThisInstance()
+
+
+        external fun field(value: String) : OuterStruct.Builder
+        external fun build() : OuterStruct
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+            @JvmStatic external fun create() : Long
+        }
+    }
+    interface InnerInterface {
+
+        fun barBaz() : MutableMap<String, ByteArray>
+
+
+    }
+
+    fun interface InnerLambda {
+        fun apply() : Unit
+    }
+
+    class InnerInterfaceImpl : NativeBase, InnerInterface {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun barBaz() : MutableMap<String, ByteArray>
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class InnerLambdaImpl : NativeBase, InnerLambda {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply() : Unit
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    constructor(field: String) {
+        this.field = field
+    }
+
+
+
+    external fun doNothing() : Unit
+
+}
+

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import java.util.Date
+
+class UseFreeTypes : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun doStuff(point: FreePoint, mode: FreeEnum) : Date
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}


### PR DESCRIPTION
This change introduces smoke tests for 'nesting'
test suite. The output files were compared with
their Java counterparts to ensure the same level
of support.