### PR TITLE
functional tests: implement 'Dates' tests for Kotlin

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -375,7 +375,7 @@ feature(CallbacksWithThreads cpp android dart SOURCES
     input/lime/ListenersThreads.lime
 )
 
-feature(Dates cpp android swift dart SOURCES
+feature(Dates cpp android android-kotlin swift dart SOURCES
     input/src/cpp/Dates.cpp
 
     input/lime/Dates.lime

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/DatesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/DatesTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.Calendar
+import java.util.Date
+import java.util.GregorianCalendar
+import java.util.TimeZone
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class DatesTest {
+
+    @org.junit.Test
+    fun dateAttributeRoundTrip() {
+        val date = Date()
+        Dates.dateAttribute = date
+
+        assertEquals(date, Dates.dateAttribute)
+    }
+
+    @org.junit.Test
+    fun dateMethodRoundTrip() {
+        val date = Date(1, 3, 5, 7, 9, 11)
+        val dateCalendar: Calendar = GregorianCalendar()
+        dateCalendar.setTime(date)
+
+        val result = Dates.increaseDate(date)
+        val resultCalendar = GregorianCalendar()
+        resultCalendar.setTime(result)
+
+        assertEquals(dateCalendar.get(Calendar.YEAR), resultCalendar.get(Calendar.YEAR))
+        assertEquals(dateCalendar.get(Calendar.MONTH), resultCalendar.get(Calendar.MONTH))
+        assertEquals(dateCalendar.get(Calendar.DATE) + 1, resultCalendar.get(Calendar.DATE))
+        assertEquals(dateCalendar.get(Calendar.HOUR) + 1, resultCalendar.get(Calendar.HOUR))
+        assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND))
+    }
+
+    @org.junit.Test
+    fun dateMethodNullableNullRoundTrip() {
+        val result = Dates.increaseDateMaybe(null)
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun dateMethodNullableRoundTrip() {
+        val date = Date(1, 3, 5, 7, 9, 11)
+        val dateCalendar: Calendar = GregorianCalendar()
+        dateCalendar.setTime(date)
+
+        val result: Date? = Dates.increaseDateMaybe(date)
+        assertNotNull(result)
+
+        val resultCalendar: Calendar = GregorianCalendar()
+        resultCalendar.setTime(result!!)
+
+        assertEquals(dateCalendar.get(Calendar.YEAR), resultCalendar.get(Calendar.YEAR))
+        assertEquals(dateCalendar.get(Calendar.MONTH), resultCalendar.get(Calendar.MONTH))
+        assertEquals(dateCalendar.get(Calendar.DATE) + 1, resultCalendar.get(Calendar.DATE))
+        assertEquals(dateCalendar.get(Calendar.HOUR) + 1, resultCalendar.get(Calendar.HOUR))
+        assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND))
+    }
+
+    @org.junit.Test
+    fun steadyDateMethodRoundTrip() {
+        val date: Date = Date(1, 3, 5, 7, 9, 11)
+        val dateCalendar: Calendar = GregorianCalendar()
+        dateCalendar.setTime(date)
+
+        val result: Date = DatesSteady.increaseDate(date)
+        val resultCalendar: Calendar = GregorianCalendar()
+        resultCalendar.setTime(result)
+
+        assertEquals(dateCalendar.get(Calendar.YEAR), resultCalendar.get(Calendar.YEAR))
+        assertEquals(dateCalendar.get(Calendar.MONTH), resultCalendar.get(Calendar.MONTH))
+        assertEquals(dateCalendar.get(Calendar.DATE) + 1, resultCalendar.get(Calendar.DATE))
+        assertEquals(dateCalendar.get(Calendar.HOUR) + 1, resultCalendar.get(Calendar.HOUR))
+        assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND))
+    }
+
+    @org.junit.Test
+    fun steadyDateMethodNullableNullRoundTrip() {
+        val result = DatesSteady.increaseDateMaybe(null)
+        assertNull(result)
+    }
+
+    @org.junit.Test
+    fun steadyDateMethodNullableRoundTrip() {
+        val date: Date = Date(1, 3, 5, 7, 9, 11)
+        val dateCalendar: Calendar = GregorianCalendar()
+        dateCalendar.setTime(date)
+
+        val result: Date? = DatesSteady.increaseDateMaybe(date)
+        assertNotNull(result)
+
+        val resultCalendar: Calendar = GregorianCalendar()
+        resultCalendar.setTime(result!!)
+
+        assertEquals(dateCalendar.get(Calendar.YEAR), resultCalendar.get(Calendar.YEAR))
+        assertEquals(dateCalendar.get(Calendar.MONTH), resultCalendar.get(Calendar.MONTH))
+        assertEquals(dateCalendar.get(Calendar.DATE) + 1, resultCalendar.get(Calendar.DATE))
+        assertEquals(dateCalendar.get(Calendar.HOUR) + 1, resultCalendar.get(Calendar.HOUR))
+        assertEquals(dateCalendar.get(Calendar.MINUTE) + 1, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(dateCalendar.get(Calendar.SECOND) + 1, resultCalendar.get(Calendar.SECOND))
+    }
+
+    @org.junit.Test
+    fun dateDefaultsCet() {
+        val defaults: DateDefaults = DateDefaults()
+        val date: Date = defaults.dateTime
+
+        val resultCalendar: Calendar = GregorianCalendar(TimeZone.getTimeZone("UTC"))
+        resultCalendar.setTime(date)
+
+        assertEquals(2022, resultCalendar.get(Calendar.YEAR))
+        assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH))
+        assertEquals(4, resultCalendar.get(Calendar.DATE))
+        assertEquals(9, resultCalendar.get(Calendar.HOUR))
+        assertEquals(15, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(17, resultCalendar.get(Calendar.SECOND))
+    }
+
+    @org.junit.Test
+    fun dateDefaultsUtc() {
+        val defaults: DateDefaults = DateDefaults()
+        val date: Date = defaults.dateTimeUtc
+
+        val resultCalendar: Calendar = GregorianCalendar(TimeZone.getTimeZone("UTC"))
+        resultCalendar.setTime(date)
+
+        assertEquals(2022, resultCalendar.get(Calendar.YEAR))
+        assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH))
+        assertEquals(4, resultCalendar.get(Calendar.DATE))
+        assertEquals(9, resultCalendar.get(Calendar.HOUR))
+        assertEquals(15, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(17, resultCalendar.get(Calendar.SECOND))
+    }
+
+    @org.junit.Test
+    fun dateDefaultsBefore() {
+        val defaults: DateDefaults = DateDefaults()
+        val date: Date = defaults.beforeEpoch
+
+        val resultCalendar: Calendar = GregorianCalendar(TimeZone.getTimeZone("UTC"))
+        resultCalendar.setTime(date)
+
+        assertEquals(1922, resultCalendar.get(Calendar.YEAR))
+        assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH))
+        assertEquals(4, resultCalendar.get(Calendar.DATE))
+        assertEquals(9, resultCalendar.get(Calendar.HOUR))
+        assertEquals(15, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(17, resultCalendar.get(Calendar.SECOND))
+    }
+
+    @org.junit.Test
+    fun dateDefaultsCpp() {
+        val defaults: DateDefaults = DateDefaults.getCppDefaults()
+        val date: Date = defaults.dateTimeUtc
+
+        val resultCalendar: Calendar = GregorianCalendar(TimeZone.getTimeZone("UTC"))
+        resultCalendar.setTime(date)
+
+        assertEquals(2022, resultCalendar.get(Calendar.YEAR))
+        assertEquals(GregorianCalendar.FEBRUARY, resultCalendar.get(Calendar.MONTH))
+        assertEquals(4, resultCalendar.get(Calendar.DATE))
+        assertEquals(9, resultCalendar.get(Calendar.HOUR))
+        assertEquals(15, resultCalendar.get(Calendar.MINUTE))
+        assertEquals(17, resultCalendar.get(Calendar.SECOND))
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportCollector.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportCollector.kt
@@ -30,6 +30,7 @@ import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeStruct
+import com.here.gluecodium.model.lime.LimeTypeAlias
 
 internal class KotlinImportCollector(
     private val importsResolver: KotlinImportResolver,
@@ -46,6 +47,7 @@ internal class KotlinImportCollector(
                 is LimeFunction -> collectFunctionImports(limeElement)
                 is LimeLambda -> collectFunctionImports(limeElement.asFunction())
                 is LimeConstant -> importsResolver.resolveElementImports(limeElement.value)
+                is LimeTypeAlias -> importsResolver.resolveElementImports(limeElement)
                 is LimeField ->
                     limeElement.defaultValue?.let { importsResolver.resolveElementImports(it) } ?: emptyList()
                 else -> emptyList()

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportResolver.kt
@@ -40,6 +40,7 @@ import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
+import com.here.gluecodium.model.lime.LimeTypeAlias
 import com.here.gluecodium.model.lime.LimeTypeRef
 import com.here.gluecodium.model.lime.LimeValue
 
@@ -53,6 +54,7 @@ internal class KotlinImportResolver(
 
     override fun resolveElementImports(limeElement: LimeElement): List<String> =
         when (limeElement) {
+            is LimeTypeAlias -> resolveTypeRefImports(limeElement.typeRef)
             is LimeContainerWithInheritance -> resolveClassInterfaceImports(limeElement)
             is LimeStruct -> resolveStructImports(limeElement)
             is LimeFunction -> resolveFunctionImports(limeElement)


### PR DESCRIPTION
This change introduces functional tests for 'Dates'
test suite for Kotlin. The logic was inspired by the
functional tests suite for Java to ensure the same
level of support in Kotlin.

Moreover, handling of imports for type aliases was adjusted.
The usage of 'LimeTypeAlias' was not present in imports
resolver and imports collector. This change updates the code
to avoid problems with missing imports.