### PR TITLE
Release version 13.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Gluecodium project Release Notes
 
-## Unreleased
+## 13.11.0
+Release date 2025-03-03
 ### Features:
  * Implemented placeholders for comments. Gluecodium supports a new `-docsplaceholderslist` CLI parameter and `GLUECODIUM_DOCS_PLACEHOLDERS_LIST` CMake flag, which allow specifying the file with definition of placeholders. More information about possible usage can be found in `lime_markup.md`.
 

--- a/gluecodium/src/main/resources/version.properties
+++ b/gluecodium/src/main/resources/version.properties
@@ -1,1 +1,1 @@
-version = 13.10.4
+version = 13.11.0


### PR DESCRIPTION
Features:
 * Implemented placeholders for comments. Gluecodium supports a new `-docsplaceholderslist` CLI parameter and `GLUECODIUM_DOCS_PLACEHOLDERS_LIST` CMake flag, which allow specifying the file with definition of placeholders. More information about possible usage can be found in `lime_markup.md`
