### PR TITLE
functional tests: implement 'nesting' tests for Kotlin

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -425,7 +425,7 @@ feature(FullName dart SOURCES
     input/lime/FullName.lime
 )
 
-feature(Nesting cpp android swift dart SOURCES
+feature(Nesting cpp android android-kotlin swift dart SOURCES
     input/src/cpp/TopLevelTypes.cpp
     input/src/cpp/NestedContainers.cpp
     input/src/cpp/NestedClassWithProperty.cpp

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/NestingTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/NestingTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class NestingTest {
+    @org.junit.Test
+    fun nestedClassMethod() {
+        val result = OuterStruct.InnerClass.fooBar()
+        assertEquals(42, result.toList().first())
+    }
+
+    @org.junit.Test
+    fun nestedException() {
+        assertThrows(OuterStruct.InstantiationException::class.java) {
+            OuterStruct.doNothing()
+        }
+    }
+}


### PR DESCRIPTION
This change introduces functional tests for 'nesting' test suite for Kotlin.
The logic was inspired by the functional test suite for Java to ensure the
same level of support in Kotlin.