### PR TITLE
smoke tests: add 'packages' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
@@ -1,0 +1,46 @@
+/*
+
+ *
+ */
+
+package com.example.smoke.off
+
+import com.example.NativeBase
+
+class NestedPackages : NativeBase {
+
+    class SomeStruct {
+        var someField: String
+
+
+
+        constructor(someField: String) {
+            this.someField = someField
+        }
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun basicMethod(input: NestedPackages.SomeStruct) : NestedPackages.SomeStruct
+    }
+}

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+package com.example.smokeoff
+
+import com.example.NativeBase
+
+class UnderscorePackage : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun basicMethod(inputString: String) : String
+    }
+}


### PR DESCRIPTION
This change introduces the expected output for
smoke tests, which is aligned with the same test
suite for Java generator to ensure that the level
of support in Kotlin is the same.