### PR TITLE
smoke tests: add 'namerules' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/name_rules/input/commandlineoptions.txt
+++ b/gluecodium/src/test/resources/smoke/name_rules/input/commandlineoptions.txt
@@ -2,3 +2,4 @@
 -cppnamerules $INPUT_FOLDER/namerules/cpp.properties
 -javanamerules $INPUT_FOLDER/namerules/java.properties
 -swiftnamerules $INPUT_FOLDER/namerules/swift.properties
+-kotlinnamerules $INPUT_FOLDER/namerules/kotlin.properties

--- a/gluecodium/src/test/resources/smoke/name_rules/input/namerules/kotlin.properties
+++ b/gluecodium/src/test/resources/smoke/name_rules/input/namerules/kotlin.properties
@@ -1,0 +1,16 @@
+field=lower_snake_case
+parameter=lowerCamelCase
+constant=UPPER_SNAKE_CASE
+enumerator=UPPER_SNAKE_CASE
+method=lower_snake_case
+setter=lower_snake_case
+setter.prefix=set
+getter=lower_snake_case
+getter.prefix=get
+getter.prefix.boolean=is
+property.prefix.boolean=is
+property=lowerCamelCase
+type=UPPER_SNAKE_CASE
+error=UpperCamelCase
+error.suffix=Exception
+type.suffix=KT

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -1,0 +1,72 @@
+/*
+
+ *
+ */
+
+package com.example.namerules
+
+import com.example.NativeBase
+
+class NAME_RULES_KT : NativeBase {
+
+    enum class EXAMPLE_ERROR_CODE_KT(private val value: Int) {
+        NONE(0),
+        FATAL(1);
+    }
+    class ExampleException(val error: NAME_RULES_KT.EXAMPLE_ERROR_CODE_KT) : Exception(error.toString())
+
+
+    class EXAMPLE_STRUCT_KT {
+        var value: Double
+        var int_value: MutableList<Long>
+
+
+
+        constructor(value: Double, int_value: MutableList<Long>) {
+            this.value = value
+            this.int_value = int_value
+        }
+
+
+
+
+    }
+
+
+    constructor() : this(create(), null as Any?) {
+        cacheThisInstance();
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    private external fun cacheThisInstance()
+
+
+    external fun some_method(someArgument: NAME_RULES_KT.EXAMPLE_STRUCT_KT) : Double
+
+    var intProperty: Long
+        external get
+        external set
+
+    var isBooleanProperty: Boolean
+        external get
+        external set
+
+    var structProperty: NAME_RULES_KT.EXAMPLE_STRUCT_KT
+        external get
+        external set
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun create() : Long
+    }
+}

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT.cpp
@@ -1,0 +1,240 @@
+/*
+
+ *
+ */
+
+#include "com_example_namerules_NAME_RULES_KT.h"
+#include "com_example_namerules_NAME_RULES_KT_EXAMPLE_ERROR_CODE_KT__Conversion.h"
+#include "com_example_namerules_NAME_RULES_KT_EXAMPLE_STRUCT_KT__Conversion.h"
+#include "com_example_namerules_NAME_RULES_KT__Conversion.h"
+#include "JniExceptionThrower.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jlong
+Java_com_example_namerules_NAME_1RULES_1KT_create(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+
+
+    auto _result = ::namerules::NameRules::create();
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::namerules::NameRules >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+jdouble
+Java_com_example_namerules_NAME_1RULES_1KT_some_1method(JNIEnv* _jenv, jobject _jinstance, jobject jsomeArgument)
+
+{
+
+    ::jni::JniExceptionThrower _throw_exception(_jenv);
+
+
+
+    ::namerules::NameRules::ExampleStruct someArgument = ::jni::convert_from_jni(_jenv,
+            ::jni::make_non_releasing_ref(jsomeArgument),
+            ::jni::TypeId<::namerules::NameRules::ExampleStruct>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (
+
+        ::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto nativeCallResult = (*pInstanceSharedPointer)->someMethod(someArgument);
+
+
+    auto errorCode = nativeCallResult.error();
+    if (!nativeCallResult.has_value())
+    {
+        auto nErrorValue = static_cast<::namerules::NameRules::ExampleErrorCode>(errorCode.value());
+        auto jErrorValue = ::jni::convert_to_jni(_jenv, nErrorValue);
+
+        auto exceptionClass = ::jni::find_class(_jenv, "com/example/namerules/NAME_RULES_KT$ExampleException");
+        auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/namerules/NAME_RULES_KT$EXAMPLE_ERROR_CODE_KT;)V");
+        auto exception = ::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
+        _throw_exception.register_exception(std::move(exception));
+        return nativeCallResult.unsafe_value();
+    }
+    auto _result = nativeCallResult.unsafe_value();
+
+
+    return _result;
+}
+
+
+jlong
+Java_com_example_namerules_NAME_1RULES_1KT_get_1int_1property(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (
+
+        ::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->retrieve_int_property();
+
+    return _result;
+}
+
+
+
+void
+Java_com_example_namerules_NAME_1RULES_1KT_set_1int_1property(JNIEnv* _jenv, jobject _jinstance, jlong jvalue)
+
+{
+
+
+
+    uint32_t value = jvalue;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (
+
+        ::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->STORE_INT_PROPERTY_NOW(value);
+
+}
+
+
+
+jboolean
+Java_com_example_namerules_NAME_1RULES_1KT_is_1boolean_1property(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (
+
+        ::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->really_boolean_property();
+
+    return _result;
+}
+
+
+
+void
+Java_com_example_namerules_NAME_1RULES_1KT_set_1boolean_1property(JNIEnv* _jenv, jobject _jinstance, jboolean jvalue)
+
+{
+
+
+
+    bool value = jvalue;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (
+
+        ::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->STORE_BOOLEAN_PROPERTY_NOW(value);
+
+}
+
+
+
+jobject
+Java_com_example_namerules_NAME_1RULES_1KT_get_1struct_1property(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (
+
+        ::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->retrieve_struct_property();
+
+    return ::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+void
+Java_com_example_namerules_NAME_1RULES_1KT_set_1struct_1property(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+
+{
+
+
+
+    ::namerules::NameRules::ExampleStruct value = ::jni::convert_from_jni(_jenv,
+            ::jni::make_non_releasing_ref(jvalue),
+            ::jni::TypeId<::namerules::NameRules::ExampleStruct>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*> (
+
+        ::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->STORE_STRUCT_PROPERTY_NOW(value);
+
+}
+
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::namerules::NameRules>*>(_jpointerRef);
+    ::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+JNIEXPORT void JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = ::jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = ::jni::get_class_native_handle(_jenv, jobj);
+    auto nobj = *reinterpret_cast<std::shared_ptr<::namerules::NameRules>*>(long_ptr);
+
+    ::jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT.h
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT.h
@@ -1,0 +1,44 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jlong JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_create(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jdouble JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_some_1method(JNIEnv* _jenv, jobject _jinstance, jobject jsomeArgument);
+
+JNIEXPORT jlong JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_get_1int_1property(JNIEnv* _jenv, jobject _jinstance);
+
+JNIEXPORT void JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_set_1int_1property(JNIEnv* _jenv, jobject _jinstance, jlong jvalue);
+
+
+JNIEXPORT jboolean JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_is_1boolean_1property(JNIEnv* _jenv, jobject _jinstance);
+
+JNIEXPORT void JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_set_1boolean_1property(JNIEnv* _jenv, jobject _jinstance, jboolean jvalue);
+
+
+JNIEXPORT jobject JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_get_1struct_1property(JNIEnv* _jenv, jobject _jinstance);
+
+JNIEXPORT void JNICALL
+Java_com_example_namerules_NAME_1RULES_1KT_set_1struct_1property(JNIEnv* _jenv, jobject _jinstance, jobject jvalue);
+
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_ERROR_CODE_KT__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_ERROR_CODE_KT__Conversion.cpp
@@ -1,0 +1,54 @@
+/*
+
+ *
+ */
+
+#include "com_example_namerules_NAME_RULES_KT_EXAMPLE_ERROR_CODE_KT__Conversion.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+
+namespace jni
+{
+
+::namerules::NameRules::ExampleErrorCode
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::namerules::NameRules::ExampleErrorCode>)
+{
+    return ::namerules::NameRules::ExampleErrorCode(
+        ::jni::get_field_value(_jenv, _jinput, "value", TypeId<int32_t>{}));
+}
+
+std::optional<::namerules::NameRules::ExampleErrorCode>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::namerules::NameRules::ExampleErrorCode>>)
+{
+    return _jinput
+        ? std::optional<::namerules::NameRules::ExampleErrorCode>(convert_from_jni(_jenv, _jinput, TypeId<::namerules::NameRules::ExampleErrorCode>{}))
+        : std::optional<::namerules::NameRules::ExampleErrorCode>{};
+}
+
+REGISTER_JNI_CLASS_CACHE("com/example/namerules/NAME_RULES_KT$EXAMPLE_ERROR_CODE_KT", com_example_namerules_NAME_1RULES_1KT_00024EXAMPLE_1ERROR_1CODE_1KT, ::namerules::NameRules::ExampleErrorCode)
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::namerules::NameRules::ExampleErrorCode _ninput)
+{
+    auto& javaClass = CachedJavaClass<::namerules::NameRules::ExampleErrorCode>::java_class;
+    const char* enumeratorName = nullptr;
+    switch(_ninput) {
+        case(::namerules::NameRules::ExampleErrorCode::NONE):
+            enumeratorName = "NONE";
+            break;
+        case(::namerules::NameRules::ExampleErrorCode::FATAL):
+            enumeratorName = "FATAL";
+            break;
+    }
+    jfieldID fieldID = _jenv->GetStaticFieldID(javaClass.get(), enumeratorName, "Lcom/example/namerules/NAME_RULES_KT$EXAMPLE_ERROR_CODE_KT;");
+    return make_local_ref(_jenv, _jenv->GetStaticObjectField(javaClass.get(), fieldID));
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::optional<::namerules::NameRules::ExampleErrorCode> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_ERROR_CODE_KT__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_ERROR_CODE_KT__Conversion.h
@@ -1,0 +1,19 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "namerules/NameRules.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace jni
+{
+JNIEXPORT ::namerules::NameRules::ExampleErrorCode convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::namerules::NameRules::ExampleErrorCode>);
+JNIEXPORT std::optional<::namerules::NameRules::ExampleErrorCode> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::namerules::NameRules::ExampleErrorCode>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::namerules::NameRules::ExampleErrorCode _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::namerules::NameRules::ExampleErrorCode> _ninput);
+}

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_STRUCT_KT__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_STRUCT_KT__Conversion.cpp
@@ -1,0 +1,62 @@
+/*
+
+ *
+ */
+
+#include "com_example_namerules_NAME_RULES_KT_EXAMPLE_STRUCT_KT__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+
+namespace jni
+{
+
+::namerules::NameRules::ExampleStruct
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::namerules::NameRules::ExampleStruct>)
+{
+    ::namerules::NameRules::ExampleStruct _nout{};
+    double n_m_value = ::jni::get_field_value(
+        _jenv,
+        _jinput,
+        "value",
+        TypeId<double>{} );
+    _nout.m_value = n_m_value;
+    ::std::vector< int64_t > n_m_int_value = convert_from_jni(
+        _jenv,
+        ::jni::get_object_field_value(_jenv, _jinput, "int_value", "Ljava/util/List;"),
+        TypeId<::std::vector< int64_t >>{} );
+    _nout.m_int_value = n_m_int_value;
+    return _nout;
+}
+
+std::optional<::namerules::NameRules::ExampleStruct>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::namerules::NameRules::ExampleStruct>>)
+{
+    return _jinput
+        ? std::optional<::namerules::NameRules::ExampleStruct>(convert_from_jni(_jenv, _jinput, TypeId<::namerules::NameRules::ExampleStruct>{}))
+        : std::optional<::namerules::NameRules::ExampleStruct>{};
+}
+
+REGISTER_JNI_CLASS_CACHE("com/example/namerules/NAME_RULES_KT$EXAMPLE_STRUCT_KT", com_example_namerules_NAME_1RULES_1KT_00024EXAMPLE_1STRUCT_1KT, ::namerules::NameRules::ExampleStruct)
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::namerules::NameRules::ExampleStruct& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::namerules::NameRules::ExampleStruct>::java_class;
+    auto _jresult = ::jni::alloc_object(_jenv, javaClass);
+
+    ::jni::set_field_value(_jenv, _jresult, "value", _ninput.m_value);
+
+    auto jm_int_value = convert_to_jni(_jenv, _ninput.m_int_value);
+    ::jni::set_object_field_value(_jenv, _jresult, "int_value", "Ljava/util/List;", jm_int_value);
+    return _jresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::optional<::namerules::NameRules::ExampleStruct> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_STRUCT_KT__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/jni/com_example_namerules_NAME_RULES_KT_EXAMPLE_STRUCT_KT__Conversion.h
@@ -1,0 +1,19 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "namerules/NameRules.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace jni
+{
+JNIEXPORT ::namerules::NameRules::ExampleStruct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::namerules::NameRules::ExampleStruct>);
+JNIEXPORT std::optional<::namerules::NameRules::ExampleStruct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::namerules::NameRules::ExampleStruct>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::namerules::NameRules::ExampleStruct& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::namerules::NameRules::ExampleStruct> _ninput);
+}


### PR DESCRIPTION
This change introduces the expected output for
smoke tests, which is aligned with the same test
suite for Java generator to ensure that the level
of support in Kotlin is the same.