### PR TITLE
smoke tests: add 'locale' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/LocaleDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/LocaleDefaults.kt
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import java.util.Locale
+
+class LocaleDefaults {
+    var english: Locale
+    var latAmSpanish: Locale
+    var romanshSursilvan: Locale
+    var serbianCyrillic: Locale
+    var traditionalChineseTaiwan: Locale
+    var zuerichGerman: Locale
+
+
+
+    constructor() {
+        this.english = Locale.forLanguageTag("en")
+        this.latAmSpanish = Locale.forLanguageTag("es-419")
+        this.romanshSursilvan = Locale.forLanguageTag("rm-sursilv")
+        this.serbianCyrillic = Locale.forLanguageTag("sr-Cyrl")
+        this.traditionalChineseTaiwan = Locale.forLanguageTag("nan-Hant-TW")
+        this.zuerichGerman = Locale.forLanguageTag("gsw-u-sd-chzh")
+    }
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
@@ -1,0 +1,51 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import java.util.Locale
+
+class Locales : NativeBase {
+
+    class LocaleStruct {
+        var localeField: Locale
+
+
+
+        constructor(localeField: Locale) {
+            this.localeField = localeField
+        }
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun localeMethod(input: Locale) : Locale
+
+    var localeProperty: Locale
+        external get
+        external set
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.
