### PR TITLE
smoke tests: add 'listeners' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class Calculator : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun registerListener(listener: CalculatorListener) : Unit
+        @JvmStatic external fun unregisterListener(listener: CalculatorListener) : Unit
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListener.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListener.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface CalculatorListener {
+    class ResultStruct {
+        var result: Double
+
+
+
+        constructor(result: Double) {
+            this.result = result
+        }
+
+
+
+
+    }
+
+
+    fun onCalculationResult(calculationResult: Double) : Unit
+    fun onCalculationResultConst(calculationResult: Double) : Unit
+    fun onCalculationResultStruct(calculationResult: CalculatorListener.ResultStruct) : Unit
+    fun onCalculationResultArray(calculationResult: MutableList<Double>) : Unit
+    fun onCalculationResultMap(calculationResults: MutableMap<String, Double>) : Unit
+    fun onCalculationResultInstance(calculationResult: CalculationResult) : Unit
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CalculatorListenerImpl : NativeBase, CalculatorListener {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun onCalculationResult(calculationResult: Double) : Unit
+    override external fun onCalculationResultConst(calculationResult: Double) : Unit
+    override external fun onCalculationResultStruct(calculationResult: CalculatorListener.ResultStruct) : Unit
+    override external fun onCalculationResultArray(calculationResult: MutableList<Double>) : Unit
+    override external fun onCalculationResultMap(calculationResults: MutableMap<String, Double>) : Unit
+    override external fun onCalculationResultInstance(calculationResult: CalculationResult) : Unit
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
@@ -1,0 +1,15 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface InternalListener {
+
+    fun onEvent() : Unit
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
@@ -1,0 +1,27 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class InternalListenerImpl : NativeBase, InternalListener {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun onEvent() : Unit
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullable.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullable.kt
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface ListenerWithNullable {
+
+    fun methodWithByte(input: Byte?) : Byte?
+    fun methodWithUByte(input: Short?) : Short?
+    fun methodWithShort(input: Short?) : Short?
+    fun methodWithUShort(input: Int?) : Int?
+    fun methodWithInt(input: Int?) : Int?
+    fun methodWithUInt(input: Long?) : Long?
+    fun methodWithLong(input: Long?) : Long?
+    fun methodWithULong(input: Long?) : Long?
+    fun methodWithDouble(input: Boolean?) : Boolean?
+    fun methodWithFloat(input: Float?) : Float?
+    fun methodWithDouble(input: Double?) : Double?
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
@@ -1,0 +1,37 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ListenerWithNullableImpl : NativeBase, ListenerWithNullable {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun methodWithByte(input: Byte?) : Byte?
+    override external fun methodWithUByte(input: Short?) : Short?
+    override external fun methodWithShort(input: Short?) : Short?
+    override external fun methodWithUShort(input: Int?) : Int?
+    override external fun methodWithInt(input: Int?) : Int?
+    override external fun methodWithUInt(input: Long?) : Long?
+    override external fun methodWithLong(input: Long?) : Long?
+    override external fun methodWithULong(input: Long?) : Long?
+    override external fun methodWithDouble(input: Boolean?) : Boolean?
+    override external fun methodWithFloat(input: Float?) : Float?
+    override external fun methodWithDouble(input: Double?) : Double?
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
@@ -1,0 +1,60 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface ListenerWithProperties {
+    enum class ResultEnum(private val value: Int) {
+        NONE(0),
+        RESULT(1);
+    }
+    class ResultStruct {
+        var result: Double
+
+
+
+        constructor(result: Double) {
+            this.result = result
+        }
+
+
+
+
+    }
+
+
+
+    var message: String
+        get
+        set
+
+    var packedMessage: CalculationResult
+        get
+        set
+
+    var structuredMessage: ListenerWithProperties.ResultStruct
+        get
+        set
+
+    var enumeratedMessage: ListenerWithProperties.ResultEnum
+        get
+        set
+
+    var arrayedMessage: MutableList<String>
+        get
+        set
+
+    var mappedMessage: MutableMap<String, Double>
+        get
+        set
+
+    var bufferedMessage: ByteArray
+        get
+        set
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
@@ -1,0 +1,54 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ListenerWithPropertiesImpl : NativeBase, ListenerWithProperties {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+    override var message: String
+        external get
+        external set
+
+    override var packedMessage: CalculationResult
+        external get
+        external set
+
+    override var structuredMessage: ListenerWithProperties.ResultStruct
+        external get
+        external set
+
+    override var enumeratedMessage: ListenerWithProperties.ResultEnum
+        external get
+        external set
+
+    override var arrayedMessage: MutableList<String>
+        external get
+        external set
+
+    override var mappedMessage: MutableMap<String, Double>
+        external get
+        external set
+
+    override var bufferedMessage: ByteArray
+        external get
+        external set
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
@@ -1,0 +1,39 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface ListenersWithReturnValues {
+    enum class ResultEnum(private val value: Int) {
+        NONE(0),
+        RESULT(1);
+    }
+    class ResultStruct {
+        var result: Double
+
+
+
+        constructor(result: Double) {
+            this.result = result
+        }
+
+
+
+
+    }
+
+
+    fun fetchDataDouble() : Double
+    fun fetchDataString() : String
+    fun fetchDataStruct() : ListenersWithReturnValues.ResultStruct
+    fun fetchDataEnum() : ListenersWithReturnValues.ResultEnum
+    fun fetchDataArray() : MutableList<Double>
+    fun fetchDataMap() : MutableMap<String, Double>
+    fun fetchDataInstance() : CalculationResult
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ListenersWithReturnValuesImpl : NativeBase, ListenersWithReturnValues {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun fetchDataDouble() : Double
+    override external fun fetchDataString() : String
+    override external fun fetchDataStruct() : ListenersWithReturnValues.ResultStruct
+    override external fun fetchDataEnum() : ListenersWithReturnValues.ResultEnum
+    override external fun fetchDataArray() : MutableList<Double>
+    override external fun fetchDataMap() : MutableMap<String, Double>
+    override external fun fetchDataInstance() : CalculationResult
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/CppProxyBase.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/CppProxyBase.cpp
@@ -1,0 +1,188 @@
+/*
+
+ *
+ */
+
+#include "CppProxyBase.h"
+#include "JniBase.h"
+#include "JniThrowNewException.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+namespace
+{
+class GlobalJniLock final {
+public:
+    void
+    lock( )
+    {
+        cacheMutex.lock( );
+    }
+
+    void
+    unlock( )
+    {
+        jniEnvForCurrentThread = nullptr;
+        cacheMutex.unlock( );
+    }
+
+    void
+    setJniEnvForCurrentThread( JNIEnv* env ) noexcept
+    {
+        jniEnvForCurrentThread = env;
+    }
+
+    JNIEnv*
+    getJniEnvForCurrentThread( ) noexcept
+    {
+        if ( jniEnvForCurrentThread == nullptr )
+        {
+            jniEnvForCurrentThread = ::gluecodium::jni::getJniEnvironmentForCurrentThread( );
+        }
+        return jniEnvForCurrentThread;
+    }
+
+private:
+    ::std::mutex cacheMutex;
+    JNIEnv* jniEnvForCurrentThread = nullptr;
+};
+
+static GlobalJniLock sGlobalJniLock;
+
+struct ProxyCacheKey final
+{
+    jobject jObject;
+    jint jHashCode;
+    ::std::string type_key;
+
+    bool operator==( const ProxyCacheKey& other ) const noexcept
+    {
+        return jHashCode == other.jHashCode &&
+            sGlobalJniLock.getJniEnvForCurrentThread( )->IsSameObject( jObject, other.jObject );
+    }
+};
+
+struct ProxyCacheKeyHash final
+{
+    inline size_t
+    operator( )( const ProxyCacheKey& key ) const noexcept
+    {
+        size_t result = 7;
+        result = 31 * result + key.jHashCode;
+        result = 31 * result + ::std::hash<::std::string>{}(key.type_key);
+        return result;
+    }
+};
+
+using ReverseCacheKey = const void*;
+using ProxyCache = ::std::unordered_map< ProxyCacheKey, ::std::weak_ptr< CppProxyBase >, ProxyCacheKeyHash >;
+using ReverseProxyCache = ::std::unordered_map<ReverseCacheKey, jobject>;
+
+static ProxyCache sProxyCache;
+static ReverseProxyCache sReverseProxyCache;
+} // namespace
+
+JNIEnv*
+CppProxyBase::getJniEnvironment( ) noexcept
+{
+    return ::gluecodium::jni::getJniEnvironmentForCurrentThread( );
+}
+
+CppProxyBase::CppProxyBase( ::gluecodium::jni::JniReference<jobject> globalRef,
+                            jint jHashCode,
+                            ::std::string type_key ) noexcept
+    : mGlobalRef( std::move( globalRef ) ), jHashCode( jHashCode ), type_key( std::move( type_key ) )
+{
+}
+
+CppProxyBase::~CppProxyBase( )
+{
+    JNIEnv* jniEnv = getJniEnvironment( );
+
+    const ::std::lock_guard< GlobalJniLock > lock( sGlobalJniLock );
+    sGlobalJniLock.setJniEnvForCurrentThread( jniEnv );
+    sProxyCache.erase( ProxyCacheKey{mGlobalRef.get(), jHashCode, type_key} );
+    removeSelfFromReverseCache( );
+}
+
+std::shared_ptr<CppProxyBase>
+CppProxyBase::createProxyImpl( JNIEnv* const jenv,
+                               const JniReference<jobject>& jobj,
+                               const ::std::string& type_key,
+                               const bool do_cache,
+                               const ProxyFactoryFun factory)
+{
+    JniReference<jobject> globalRef = new_global_ref(jenv, jobj.get());
+    const jint jHashCode = getHashCode(jenv, jobj.get());
+    const ProxyCacheKey key{globalRef.get(), jHashCode, type_key};
+
+    const ::std::lock_guard< GlobalJniLock > lock( sGlobalJniLock );
+    sGlobalJniLock.setJniEnvForCurrentThread( jenv );
+
+    if (do_cache) {
+        if (const auto it = sProxyCache.find(key); it != sProxyCache.end())
+        {
+            if (auto cachedProxy = it->second.lock())
+            {
+                return cachedProxy;
+            }
+        }
+    }
+
+    auto [newProxy, reverseCacheKey] = factory(std::move(globalRef), jHashCode);
+
+    if (newProxy == nullptr) {
+        throw_new_runtime_exception(jenv, "Cannot allocate native memory.");
+    } else if (do_cache) {
+        sProxyCache[key] = ::std::weak_ptr<CppProxyBase>(newProxy);
+        registerInReverseCache(newProxy.get(), reverseCacheKey, key.jObject);
+    }
+    return newProxy;
+}
+
+jint
+CppProxyBase::getHashCode(JNIEnv* const jniEnv, const jobject jObj)
+{
+    const auto systemClass = find_class(jniEnv, "java/lang/System");
+    const jmethodID jMethodId
+        = jniEnv->GetStaticMethodID(systemClass.get(), "identityHashCode", "(Ljava/lang/Object;)I");
+
+    return jniEnv->CallStaticIntMethod(systemClass.get(), jMethodId, jObj);
+}
+
+void CppProxyBase::registerInReverseCache( CppProxyBase* const proxyBase,
+                                           ReverseCacheKey reverseCacheKey,
+                                           const jobject jObj )
+{
+    proxyBase->mReverseCacheKey = reverseCacheKey;
+    sReverseProxyCache[reverseCacheKey] = jObj;
+}
+
+void CppProxyBase::removeSelfFromReverseCache( )
+{
+    if ( mReverseCacheKey != nullptr )
+    {
+        sReverseProxyCache.erase( mReverseCacheKey );
+        mReverseCacheKey = nullptr;
+    }
+}
+
+JniReference<jobject>
+CppProxyBase::getJavaObjectFromReverseCache(JNIEnv* jniEnv, ReverseCacheKey reverseCacheKey) {
+    const ::std::lock_guard< GlobalJniLock > lock( sGlobalJniLock );
+    if (const auto it = sReverseProxyCache.find(reverseCacheKey); it != sReverseProxyCache.end())
+    {
+        return make_local_ref(jniEnv, jniEnv->NewLocalRef(it->second));
+    }
+    return nullptr;
+}
+
+} // namespace jni
+} // namespace gluecodium

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/CppProxyBase.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/CppProxyBase.h
@@ -1,0 +1,123 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#include "JniTemplateMetainfo.h"
+#include "JniReference.h"
+#include "JniCallJavaMethod.h"
+#include "JniCallbackErrorChecking.h"
+
+#include <memory>
+#include <new>
+#include <string>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class JNIEXPORT CppProxyBase
+{
+private:
+    using ReverseCacheKey = const void*;
+    using ProxyFactoryResult = std::pair<std::shared_ptr<CppProxyBase>, ReverseCacheKey>;
+    using ProxyFactoryFun = ProxyFactoryResult(*)(JniReference<jobject>, jint);
+
+    template<typename ResultType, typename ImplType>
+    struct ProxyFactory {
+        static ProxyFactoryResult
+        create(JniReference<jobject> globalRef, jint jHashCode)
+        {
+            ImplType* const newProxyInstance = new (::std::nothrow ) ImplType{std::move(globalRef), jHashCode};
+            const ResultType* const castedToResult = newProxyInstance;
+            return std::make_pair(std::shared_ptr<ImplType>{newProxyInstance}, castedToResult);
+        }
+    };
+
+    static std::shared_ptr<CppProxyBase>
+    createProxyImpl( JNIEnv* jenv,
+                     const JniReference<jobject>& jobj,
+                     const ::std::string& type_key,
+                     bool do_cache,
+                     ProxyFactoryFun factory);
+
+    template < typename ResultType, typename ImplType >
+    static void
+    createProxy( JNIEnv* jenv,
+                 const JniReference<jobject>& jobj,
+                 const ::std::string& type_key,
+                 bool do_cache,
+                 ::std::shared_ptr< ResultType >& result )
+    {
+        if (auto proxy = createProxyImpl( jenv, jobj, type_key, do_cache, &ProxyFactory<ResultType, ImplType>::create ))
+        {
+            result = ::std::static_pointer_cast< ImplType >( proxy );;
+        }
+    }
+
+public:
+    template < typename ResultType, typename ImplType >
+    static void
+    createProxy( JNIEnv* jenv,
+                 const JniReference<jobject>& jobj,
+                 const ::std::string& type_key,
+                 ::std::shared_ptr< ResultType >& result )
+    {
+        createProxy<ResultType, ImplType>(jenv, jobj, type_key, true, result);
+    }
+
+    template < typename ResultType, typename ImplType >
+    static void
+    createProxyNoCache( JNIEnv* jenv,
+                 const JniReference<jobject>& jobj,
+                 const ::std::string& type_key,
+                 ::std::shared_ptr< ResultType >& result )
+    {
+        createProxy<ResultType, ImplType>(jenv, jobj, type_key, false, result);
+    }
+
+    template <class T>
+    static JniReference<jobject> getJavaObject(JNIEnv* jenv, T* interfacePtr) {
+        return getJavaObjectFromReverseCache(jenv, interfacePtr);
+    }
+
+protected:
+    CppProxyBase(JniReference<jobject> globalRef, jint jHashCode, ::std::string type_key) noexcept;
+
+    virtual ~CppProxyBase( );
+
+    template< typename ResultType, class ... Args >
+    typename std::conditional<IsDerivedFromJObject<ResultType>::value, JniReference<ResultType>, ResultType>::type
+    callJavaMethod( const char* methodName,
+                    const char* jniSignature,
+                    JNIEnv* jniEnv,
+                    const Args& ... args ) const
+    {
+        return call_java_method<ResultType>(jniEnv, mGlobalRef, methodName, jniSignature, args...);
+    }
+
+    static JNIEnv* getJniEnvironment( ) noexcept;
+
+private:
+    static jint getHashCode( JNIEnv* jniEnv, jobject jObj );
+
+    static void registerInReverseCache( CppProxyBase* proxyBase,
+                                        ReverseCacheKey reverseCacheKey,
+                                        jobject jObj );
+    void removeSelfFromReverseCache( );
+    static JniReference<jobject> getJavaObjectFromReverseCache(JNIEnv* jniEnv, ReverseCacheKey reverseCacheKey);
+
+private:
+    const JniReference<jobject> mGlobalRef;
+    const jint jHashCode;
+    ReverseCacheKey mReverseCacheKey = nullptr;
+    const ::std::string type_key;
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImpl.cpp
@@ -1,0 +1,169 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_CalculatorListenerImpl.h"
+#include "com_example_smoke_CalculatorListener_ResultStruct__Conversion.h"
+#include "com_example_smoke_CalculatorListener__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+void
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResult(JNIEnv* _jenv, jobject _jinstance, jdouble jcalculationResult)
+
+{
+
+
+
+    double calculationResult = jcalculationResult;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_calculation_result(calculationResult);
+
+}
+
+void
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultConst(JNIEnv* _jenv, jobject _jinstance, jdouble jcalculationResult)
+
+{
+
+
+
+    double calculationResult = jcalculationResult;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_calculation_result_const(calculationResult);
+
+}
+
+void
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultStruct(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResult)
+
+{
+
+
+
+    ::smoke::CalculatorListener::ResultStruct calculationResult = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jcalculationResult),
+            ::gluecodium::jni::TypeId<::smoke::CalculatorListener::ResultStruct>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_calculation_result_struct(calculationResult);
+
+}
+
+void
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultArray(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResult)
+
+{
+
+
+
+    ::std::vector< double > calculationResult = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jcalculationResult),
+            ::gluecodium::jni::TypeId<::std::vector< double >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_calculation_result_array(calculationResult);
+
+}
+
+void
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultMap(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResults)
+
+{
+
+
+
+    ::smoke::CalculatorListener::NamedCalculationResults calculationResults = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jcalculationResults),
+            ::gluecodium::jni::TypeId<::smoke::CalculatorListener::NamedCalculationResults>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_calculation_result_map(calculationResults);
+
+}
+
+void
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultInstance(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResult)
+
+{
+
+
+
+    ::std::shared_ptr< ::smoke::CalculationResult > calculationResult = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jcalculationResult),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::CalculationResult >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_calculation_result_instance(calculationResult);
+
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_CalculatorListenerImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImpl.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImpl.h
@@ -1,0 +1,31 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResult(JNIEnv* _jenv, jobject _jinstance, jdouble jcalculationResult);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultConst(JNIEnv* _jenv, jobject _jinstance, jdouble jcalculationResult);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultStruct(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResult);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultArray(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResult);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultMap(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResults);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_CalculatorListenerImpl_onCalculationResultInstance(JNIEnv* _jenv, jobject _jinstance, jobject jcalculationResult);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImplCppProxy.cpp
@@ -1,0 +1,101 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_CalculatorListenerImplCppProxy.h"
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_CalculatorListener_ResultStruct__Conversion.h"
+#include "com_example_smoke_CalculatorListener__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_CalculatorListener_CppProxy::com_example_smoke_CalculatorListener_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_CalculatorListener") {
+}
+
+void
+com_example_smoke_CalculatorListener_CppProxy::on_calculation_result( const double ncalculationResult ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jdouble jcalculationResult = ncalculationResult;
+    callJavaMethod<void>( "onCalculationResult", "(D)V", jniEnv , jcalculationResult);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+void
+com_example_smoke_CalculatorListener_CppProxy::on_calculation_result_const( const double ncalculationResult ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    jdouble jcalculationResult = ncalculationResult;
+    callJavaMethod<void>( "onCalculationResultConst", "(D)V", jniEnv , jcalculationResult);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+void
+com_example_smoke_CalculatorListener_CppProxy::on_calculation_result_struct( const ::smoke::CalculatorListener::ResultStruct& ncalculationResult ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jcalculationResult = convert_to_jni( jniEnv, ncalculationResult );
+    callJavaMethod<void>( "onCalculationResultStruct", "(Lcom/example/smoke/CalculatorListener$ResultStruct;)V", jniEnv , jcalculationResult);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+void
+com_example_smoke_CalculatorListener_CppProxy::on_calculation_result_array( const ::std::vector< double >& ncalculationResult ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jcalculationResult = convert_to_jni( jniEnv, ncalculationResult );
+    callJavaMethod<void>( "onCalculationResultArray", "(Ljava/util/List;)V", jniEnv , jcalculationResult);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+void
+com_example_smoke_CalculatorListener_CppProxy::on_calculation_result_map( const ::smoke::CalculatorListener::NamedCalculationResults& ncalculationResults ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jcalculationResults = convert_to_jni( jniEnv, ncalculationResults );
+    callJavaMethod<void>( "onCalculationResultMap", "(Ljava/util/Map;)V", jniEnv , jcalculationResults);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+void
+com_example_smoke_CalculatorListener_CppProxy::on_calculation_result_instance( const ::std::shared_ptr< ::smoke::CalculationResult >& ncalculationResult ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jcalculationResult = convert_to_jni( jniEnv, ncalculationResult );
+    callJavaMethod<void>( "onCalculationResultInstance", "(Lcom/example/smoke/CalculationResult;)V", jniEnv , jcalculationResult);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListenerImplCppProxy.h
@@ -1,0 +1,38 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/CalculatorListener.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_CalculatorListener_CppProxy final : public CppProxyBase, public ::smoke::CalculatorListener {
+public:
+    com_example_smoke_CalculatorListener_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_CalculatorListener_CppProxy( const com_example_smoke_CalculatorListener_CppProxy& ) = delete;
+    com_example_smoke_CalculatorListener_CppProxy& operator=( const com_example_smoke_CalculatorListener_CppProxy& ) = delete;
+
+
+    void on_calculation_result( const double ncalculationResult ) override;
+
+    void on_calculation_result_const( const double ncalculationResult ) const override;
+
+    void on_calculation_result_struct( const ::smoke::CalculatorListener::ResultStruct& ncalculationResult ) override;
+
+    void on_calculation_result_array( const ::std::vector< double >& ncalculationResult ) override;
+
+    void on_calculation_result_map( const ::smoke::CalculatorListener::NamedCalculationResults& ncalculationResults ) override;
+
+    void on_calculation_result_instance( const ::std::shared_ptr< ::smoke::CalculationResult >& ncalculationResult ) override;
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListener__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListener__Conversion.cpp
@@ -1,0 +1,78 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_CalculatorListener__Conversion.h"
+#include "com_example_smoke_CalculatorListenerImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/CalculatorListenerImpl", com_example_smoke_CalculatorListener, "smoke_CalculatorListener", ::smoke::CalculatorListener)
+
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::CalculatorListener>& result)
+{
+    CppProxyBase::createProxy<::smoke::CalculatorListener, com_example_smoke_CalculatorListener_CppProxy>(env, obj, "com_example_smoke_CalculatorListener", result);
+}
+
+
+std::shared_ptr<::smoke::CalculatorListener> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::CalculatorListener>>)
+{
+    std::shared_ptr<::smoke::CalculatorListener> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::CalculatorListener>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::CalculatorListener>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::CalculatorListener>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::CalculatorListener>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListener__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_CalculatorListener__Conversion.h
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/CalculatorListener.h"
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_CalculatorListener_ResultStruct__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::CalculatorListener> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::CalculatorListener>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::CalculatorListener>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImpl.cpp
@@ -1,0 +1,144 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_InterfaceWithStaticImpl.h"
+#include "com_example_smoke_InterfaceWithStatic__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jstring
+Java_com_example_smoke_InterfaceWithStaticImpl_regularFunction(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::InterfaceWithStatic>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->regular_function();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+jstring
+Java_com_example_smoke_InterfaceWithStaticImpl_staticFunction(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+
+
+    auto _result = ::smoke::InterfaceWithStatic::static_function();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+jstring
+Java_com_example_smoke_InterfaceWithStaticImpl_getRegularProperty(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::InterfaceWithStatic>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_regular_property();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+void
+Java_com_example_smoke_InterfaceWithStaticImpl_setRegularProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)
+
+{
+
+
+
+    ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::InterfaceWithStatic>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->set_regular_property(value);
+
+}
+
+
+
+jstring
+Java_com_example_smoke_InterfaceWithStaticImpl_getStaticProperty(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+
+
+    auto _result = ::smoke::InterfaceWithStatic::get_static_property();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+void
+Java_com_example_smoke_InterfaceWithStaticImpl_setStaticProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue)
+
+{
+
+
+
+    ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+
+
+    ::smoke::InterfaceWithStatic::set_static_property(value);
+
+}
+
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_InterfaceWithStaticImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::InterfaceWithStatic>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImpl.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImpl.h
@@ -1,0 +1,23 @@
+/*
+ *
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+JNIEXPORT jstring JNICALL
+Java_com_example_smoke_InterfaceWithStaticImpl_regularFunction(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jstring JNICALL
+Java_com_example_smoke_InterfaceWithStaticImpl_staticFunction(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jstring JNICALL
+Java_com_example_smoke_InterfaceWithStaticImpl_getRegularProperty(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_InterfaceWithStaticImpl_setRegularProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue);
+JNIEXPORT jstring JNICALL
+Java_com_example_smoke_InterfaceWithStaticImpl_getStaticProperty(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_InterfaceWithStaticImpl_setStaticProperty(JNIEnv* _jenv, jobject _jinstance, jstring jvalue);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.cpp
@@ -1,0 +1,66 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_InterfaceWithStaticImplCppProxy.h"
+#include "com_example_smoke_InterfaceWithStatic__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_InterfaceWithStatic_CppProxy::com_example_smoke_InterfaceWithStatic_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_InterfaceWithStatic") {
+}
+
+::std::string
+com_example_smoke_InterfaceWithStatic_CppProxy::regular_function(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jstring>( "regularFunction", "()Ljava/lang/String;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
+
+
+
+}
+
+
+::std::string
+com_example_smoke_InterfaceWithStatic_CppProxy::get_regular_property(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jstring>( "getRegularProperty", "()Ljava/lang/String;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_InterfaceWithStatic_CppProxy::set_regular_property( const ::std::string& nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setRegularProperty", "(Ljava/lang/String;)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_InterfaceWithStaticImplCppProxy.h
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/InterfaceWithStatic.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_InterfaceWithStatic_CppProxy final : public CppProxyBase, public ::smoke::InterfaceWithStatic {
+public:
+    com_example_smoke_InterfaceWithStatic_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_InterfaceWithStatic_CppProxy( const com_example_smoke_InterfaceWithStatic_CppProxy& ) = delete;
+    com_example_smoke_InterfaceWithStatic_CppProxy& operator=( const com_example_smoke_InterfaceWithStatic_CppProxy& ) = delete;
+
+
+    ::std::string regular_function(  ) override;
+
+
+    ::std::string get_regular_property(  ) const override;
+
+    void set_regular_property( const ::std::string& nvalue ) override;
+
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullableImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullableImplCppProxy.cpp
@@ -1,0 +1,186 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_ListenerWithNullableImplCppProxy.h"
+#include "com_example_smoke_ListenerWithNullable__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_ListenerWithNullable_CppProxy::com_example_smoke_ListenerWithNullable_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_ListenerWithNullable") {
+}
+
+std::optional< int8_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_byte( const std::optional< int8_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithByte", "(Ljava/lang/Byte;)Ljava/lang/Byte;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int8_t >>{});
+
+
+
+}
+
+std::optional< uint8_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_byte( const std::optional< uint8_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithUByte", "(Ljava/lang/Short;)Ljava/lang/Short;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint8_t >>{});
+
+
+
+}
+
+std::optional< int16_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_short( const std::optional< int16_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithShort", "(Ljava/lang/Short;)Ljava/lang/Short;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int16_t >>{});
+
+
+
+}
+
+std::optional< uint16_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_short( const std::optional< uint16_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithUShort", "(Ljava/lang/Integer;)Ljava/lang/Integer;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint16_t >>{});
+
+
+
+}
+
+std::optional< int32_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_int( const std::optional< int32_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithInt", "(Ljava/lang/Integer;)Ljava/lang/Integer;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int32_t >>{});
+
+
+
+}
+
+std::optional< uint32_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_int( const std::optional< uint32_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithUInt", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint32_t >>{});
+
+
+
+}
+
+std::optional< int64_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_long( const std::optional< int64_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithLong", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< int64_t >>{});
+
+
+
+}
+
+std::optional< uint64_t >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_u_long( const std::optional< uint64_t >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithULong", "(Ljava/lang/Long;)Ljava/lang/Long;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< uint64_t >>{});
+
+
+
+}
+
+std::optional< bool >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const std::optional< bool >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithDouble", "(Ljava/lang/Boolean;)Ljava/lang/Boolean;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< bool >>{});
+
+
+
+}
+
+std::optional< float >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_float( const std::optional< float >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithFloat", "(Ljava/lang/Float;)Ljava/lang/Float;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< float >>{});
+
+
+
+}
+
+std::optional< double >
+com_example_smoke_ListenerWithNullable_CppProxy::method_with_double( const std::optional< double >& ninput ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jinput = convert_to_jni( jniEnv, ninput );
+    auto _result = callJavaMethod<jobject>( "methodWithDouble", "(Ljava/lang/Double;)Ljava/lang/Double;", jniEnv , jinput);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<std::optional< double >>{});
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullableImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullableImplCppProxy.h
@@ -1,0 +1,48 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/ListenerWithNullable.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_ListenerWithNullable_CppProxy final : public CppProxyBase, public ::smoke::ListenerWithNullable {
+public:
+    com_example_smoke_ListenerWithNullable_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_ListenerWithNullable_CppProxy( const com_example_smoke_ListenerWithNullable_CppProxy& ) = delete;
+    com_example_smoke_ListenerWithNullable_CppProxy& operator=( const com_example_smoke_ListenerWithNullable_CppProxy& ) = delete;
+
+
+    std::optional< int8_t > method_with_byte( const std::optional< int8_t >& ninput ) override;
+
+    std::optional< uint8_t > method_with_u_byte( const std::optional< uint8_t >& ninput ) override;
+
+    std::optional< int16_t > method_with_short( const std::optional< int16_t >& ninput ) override;
+
+    std::optional< uint16_t > method_with_u_short( const std::optional< uint16_t >& ninput ) override;
+
+    std::optional< int32_t > method_with_int( const std::optional< int32_t >& ninput ) override;
+
+    std::optional< uint32_t > method_with_u_int( const std::optional< uint32_t >& ninput ) override;
+
+    std::optional< int64_t > method_with_long( const std::optional< int64_t >& ninput ) override;
+
+    std::optional< uint64_t > method_with_u_long( const std::optional< uint64_t >& ninput ) override;
+
+    std::optional< bool > method_with_double( const std::optional< bool >& ninput ) override;
+
+    std::optional< float > method_with_float( const std::optional< float >& ninput ) override;
+
+    std::optional< double > method_with_double( const std::optional< double >& ninput ) override;
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullable__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullable__Conversion.cpp
@@ -1,0 +1,78 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_ListenerWithNullable__Conversion.h"
+#include "com_example_smoke_ListenerWithNullableImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ListenerWithNullableImpl", com_example_smoke_ListenerWithNullable, "smoke_ListenerWithNullable", ::smoke::ListenerWithNullable)
+
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ListenerWithNullable>& result)
+{
+    CppProxyBase::createProxy<::smoke::ListenerWithNullable, com_example_smoke_ListenerWithNullable_CppProxy>(env, obj, "com_example_smoke_ListenerWithNullable", result);
+}
+
+
+std::shared_ptr<::smoke::ListenerWithNullable> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenerWithNullable>>)
+{
+    std::shared_ptr<::smoke::ListenerWithNullable> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::ListenerWithNullable>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenerWithNullable>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::ListenerWithNullable>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ListenerWithNullable>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullable__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithNullable__Conversion.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/ListenerWithNullable.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::ListenerWithNullable> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenerWithNullable>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenerWithNullable>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.cpp
@@ -1,0 +1,241 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_ListenerWithPropertiesImplCppProxy.h"
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_ListenerWithProperties_ResultEnum__Conversion.h"
+#include "com_example_smoke_ListenerWithProperties_ResultStruct__Conversion.h"
+#include "com_example_smoke_ListenerWithProperties__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_ListenerWithProperties_CppProxy::com_example_smoke_ListenerWithProperties_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_ListenerWithProperties") {
+}
+
+
+::std::string
+com_example_smoke_ListenerWithProperties_CppProxy::get_message(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jstring>( "getMessage", "()Ljava/lang/String;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_ListenerWithProperties_CppProxy::set_message( const ::std::string& nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setMessage", "(Ljava/lang/String;)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+
+::std::shared_ptr< ::smoke::CalculationResult >
+com_example_smoke_ListenerWithProperties_CppProxy::get_packed_message(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "getPackedMessage", "()Lcom/example/smoke/CalculationResult;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::shared_ptr< ::smoke::CalculationResult >>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_ListenerWithProperties_CppProxy::set_packed_message( const ::std::shared_ptr< ::smoke::CalculationResult >& nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setPackedMessage", "(Lcom/example/smoke/CalculationResult;)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+
+::smoke::ListenerWithProperties::ResultStruct
+com_example_smoke_ListenerWithProperties_CppProxy::get_structured_message(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "getStructuredMessage", "()Lcom/example/smoke/ListenerWithProperties$ResultStruct;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenerWithProperties::ResultStruct>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_ListenerWithProperties_CppProxy::set_structured_message( const ::smoke::ListenerWithProperties::ResultStruct& nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setStructuredMessage", "(Lcom/example/smoke/ListenerWithProperties$ResultStruct;)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+
+::smoke::ListenerWithProperties::ResultEnum
+com_example_smoke_ListenerWithProperties_CppProxy::get_enumerated_message(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "getEnumeratedMessage", "()Lcom/example/smoke/ListenerWithProperties$ResultEnum;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenerWithProperties::ResultEnum>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_ListenerWithProperties_CppProxy::set_enumerated_message( const ::smoke::ListenerWithProperties::ResultEnum nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setEnumeratedMessage", "(Lcom/example/smoke/ListenerWithProperties$ResultEnum;)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+
+::std::vector< ::std::string >
+com_example_smoke_ListenerWithProperties_CppProxy::get_arrayed_message(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "getArrayedMessage", "()Ljava/util/List;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::vector< ::std::string >>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_ListenerWithProperties_CppProxy::set_arrayed_message( const ::std::vector< ::std::string >& nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setArrayedMessage", "(Ljava/util/List;)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+
+::smoke::ListenerWithProperties::StringToDouble
+com_example_smoke_ListenerWithProperties_CppProxy::get_mapped_message(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "getMappedMessage", "()Ljava/util/Map;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenerWithProperties::StringToDouble>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_ListenerWithProperties_CppProxy::set_mapped_message( const ::smoke::ListenerWithProperties::StringToDouble& nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setMappedMessage", "(Ljava/util/Map;)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+
+::std::shared_ptr< ::std::vector< uint8_t > >
+com_example_smoke_ListenerWithProperties_CppProxy::get_buffered_message(  ) const {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jbyteArray>( "getBufferedMessage", "()[B", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::shared_ptr< ::std::vector< uint8_t > >>{});
+
+
+
+}
+
+
+
+void
+com_example_smoke_ListenerWithProperties_CppProxy::set_buffered_message( const ::std::shared_ptr< ::std::vector< uint8_t > >& nvalue ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jvalue = convert_to_jni( jniEnv, nvalue );
+    callJavaMethod<void>( "setBufferedMessage", "([B)V", jniEnv , jvalue);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithPropertiesImplCppProxy.h
@@ -1,0 +1,68 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/ListenerWithProperties.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_ListenerWithProperties_CppProxy final : public CppProxyBase, public ::smoke::ListenerWithProperties {
+public:
+    com_example_smoke_ListenerWithProperties_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_ListenerWithProperties_CppProxy( const com_example_smoke_ListenerWithProperties_CppProxy& ) = delete;
+    com_example_smoke_ListenerWithProperties_CppProxy& operator=( const com_example_smoke_ListenerWithProperties_CppProxy& ) = delete;
+
+
+
+    ::std::string get_message(  ) const override;
+
+    void set_message( const ::std::string& nvalue ) override;
+
+
+
+    ::std::shared_ptr< ::smoke::CalculationResult > get_packed_message(  ) const override;
+
+    void set_packed_message( const ::std::shared_ptr< ::smoke::CalculationResult >& nvalue ) override;
+
+
+
+    ::smoke::ListenerWithProperties::ResultStruct get_structured_message(  ) const override;
+
+    void set_structured_message( const ::smoke::ListenerWithProperties::ResultStruct& nvalue ) override;
+
+
+
+    ::smoke::ListenerWithProperties::ResultEnum get_enumerated_message(  ) const override;
+
+    void set_enumerated_message( const ::smoke::ListenerWithProperties::ResultEnum nvalue ) override;
+
+
+
+    ::std::vector< ::std::string > get_arrayed_message(  ) const override;
+
+    void set_arrayed_message( const ::std::vector< ::std::string >& nvalue ) override;
+
+
+
+    ::smoke::ListenerWithProperties::StringToDouble get_mapped_message(  ) const override;
+
+    void set_mapped_message( const ::smoke::ListenerWithProperties::StringToDouble& nvalue ) override;
+
+
+
+    ::std::shared_ptr< ::std::vector< uint8_t > > get_buffered_message(  ) const override;
+
+    void set_buffered_message( const ::std::shared_ptr< ::std::vector< uint8_t > >& nvalue ) override;
+
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithProperties__Conversion.cpp
@@ -1,0 +1,78 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_ListenerWithProperties__Conversion.h"
+#include "com_example_smoke_ListenerWithPropertiesImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ListenerWithPropertiesImpl", com_example_smoke_ListenerWithProperties, "smoke_ListenerWithProperties", ::smoke::ListenerWithProperties)
+
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ListenerWithProperties>& result)
+{
+    CppProxyBase::createProxy<::smoke::ListenerWithProperties, com_example_smoke_ListenerWithProperties_CppProxy>(env, obj, "com_example_smoke_ListenerWithProperties", result);
+}
+
+
+std::shared_ptr<::smoke::ListenerWithProperties> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenerWithProperties>>)
+{
+    std::shared_ptr<::smoke::ListenerWithProperties> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::ListenerWithProperties>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenerWithProperties>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::ListenerWithProperties>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ListenerWithProperties>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithProperties__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenerWithProperties__Conversion.h
@@ -1,0 +1,26 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/ListenerWithProperties.h"
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_ListenerWithProperties_ResultEnum__Conversion.h"
+#include "com_example_smoke_ListenerWithProperties_ResultStruct__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::ListenerWithProperties> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenerWithProperties>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenerWithProperties>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.cpp
@@ -1,0 +1,122 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_ListenersWithReturnValuesImplCppProxy.h"
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_ListenersWithReturnValues_ResultEnum__Conversion.h"
+#include "com_example_smoke_ListenersWithReturnValues_ResultStruct__Conversion.h"
+#include "com_example_smoke_ListenersWithReturnValues__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_ListenersWithReturnValues_CppProxy::com_example_smoke_ListenersWithReturnValues_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_ListenersWithReturnValues") {
+}
+
+double
+com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_double(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jdouble>( "fetchDataDouble", "()D", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return _result;
+
+
+
+}
+
+::std::string
+com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_string(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jstring>( "fetchDataString", "()Ljava/lang/String;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
+
+
+
+}
+
+::smoke::ListenersWithReturnValues::ResultStruct
+com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_struct(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "fetchDataStruct", "()Lcom/example/smoke/ListenersWithReturnValues$ResultStruct;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenersWithReturnValues::ResultStruct>{});
+
+
+
+}
+
+::smoke::ListenersWithReturnValues::ResultEnum
+com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_enum(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "fetchDataEnum", "()Lcom/example/smoke/ListenersWithReturnValues$ResultEnum;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenersWithReturnValues::ResultEnum>{});
+
+
+
+}
+
+::std::vector< double >
+com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_array(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "fetchDataArray", "()Ljava/util/List;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::vector< double >>{});
+
+
+
+}
+
+::smoke::ListenersWithReturnValues::StringToDouble
+com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_map(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "fetchDataMap", "()Ljava/util/Map;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::smoke::ListenersWithReturnValues::StringToDouble>{});
+
+
+
+}
+
+::std::shared_ptr< ::smoke::CalculationResult >
+com_example_smoke_ListenersWithReturnValues_CppProxy::fetch_data_instance(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jobject>( "fetchDataInstance", "()Lcom/example/smoke/CalculationResult;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::shared_ptr< ::smoke::CalculationResult >>{});
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValuesImplCppProxy.h
@@ -1,0 +1,40 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/ListenersWithReturnValues.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_ListenersWithReturnValues_CppProxy final : public CppProxyBase, public ::smoke::ListenersWithReturnValues {
+public:
+    com_example_smoke_ListenersWithReturnValues_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_ListenersWithReturnValues_CppProxy( const com_example_smoke_ListenersWithReturnValues_CppProxy& ) = delete;
+    com_example_smoke_ListenersWithReturnValues_CppProxy& operator=( const com_example_smoke_ListenersWithReturnValues_CppProxy& ) = delete;
+
+
+    double fetch_data_double(  ) override;
+
+    ::std::string fetch_data_string(  ) override;
+
+    ::smoke::ListenersWithReturnValues::ResultStruct fetch_data_struct(  ) override;
+
+    ::smoke::ListenersWithReturnValues::ResultEnum fetch_data_enum(  ) override;
+
+    ::std::vector< double > fetch_data_array(  ) override;
+
+    ::smoke::ListenersWithReturnValues::StringToDouble fetch_data_map(  ) override;
+
+    ::std::shared_ptr< ::smoke::CalculationResult > fetch_data_instance(  ) override;
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValues__Conversion.cpp
@@ -1,0 +1,78 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_ListenersWithReturnValues__Conversion.h"
+#include "com_example_smoke_ListenersWithReturnValuesImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/ListenersWithReturnValuesImpl", com_example_smoke_ListenersWithReturnValues, "smoke_ListenersWithReturnValues", ::smoke::ListenersWithReturnValues)
+
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::ListenersWithReturnValues>& result)
+{
+    CppProxyBase::createProxy<::smoke::ListenersWithReturnValues, com_example_smoke_ListenersWithReturnValues_CppProxy>(env, obj, "com_example_smoke_ListenersWithReturnValues", result);
+}
+
+
+std::shared_ptr<::smoke::ListenersWithReturnValues> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenersWithReturnValues>>)
+{
+    std::shared_ptr<::smoke::ListenersWithReturnValues> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::ListenersWithReturnValues>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenersWithReturnValues>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::ListenersWithReturnValues>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::ListenersWithReturnValues>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValues__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_ListenersWithReturnValues__Conversion.h
@@ -1,0 +1,26 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/ListenersWithReturnValues.h"
+#include "com_example_smoke_CalculationResult__Conversion.h"
+#include "com_example_smoke_ListenersWithReturnValues_ResultEnum__Conversion.h"
+#include "com_example_smoke_ListenersWithReturnValues_ResultStruct__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::ListenersWithReturnValues> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::ListenersWithReturnValues>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::ListenersWithReturnValues>& _ninput);
+
+}
+}


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.
