### PR TITLE
Validate comment's placeholders during initialization

### DIFF
--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -738,7 +738,14 @@ internal class AntlrLimeModelBuilder(
                 }
             }.trimIndent().split('\n').joinToString("\n") { line -> line.trimEnd() }
 
-        return AntlrLimeConverter.parseStructuredComment(commentString, ctx.getStart().line, currentPath, commentPlaceholders)
+        return try {
+            AntlrLimeConverter.parseStructuredComment(commentString, ctx.getStart().line, currentPath, commentPlaceholders)
+        } catch (e: IllegalArgumentException) {
+            val position = ctx.getStart()
+            throw ParseCancellationException(
+                "line ${position.line}:${position.charPositionInLine}, ${e.message}",
+            )
+        }
     }
 
     private fun parseExternalDescriptor(ctx: LimeParser.ExternalDescriptorContext?): LimeExternalDescriptor? {

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimedocBuilder.kt
@@ -35,13 +35,13 @@ internal class AntlrLimedocBuilder(
         get() {
             val description = commentsCollector[Pair("", "")] ?: LimeComment(currentPath)
             val isExcluded = commentsCollector.containsKey(excludeKey)
-            return LimeStructuredComment(description.withExcluded(isExcluded).withPlaceholders(commentPlaceholders), commentsCollector)
+            return LimeStructuredComment(description.withExcluded(isExcluded), commentsCollector)
         }
 
     // Overrides
 
     override fun exitDescription(ctx: LimedocParser.DescriptionContext) {
-        commentsCollector[Pair("", "")] = LimeComment(currentPath, contentCollector.toList())
+        commentsCollector[Pair("", "")] = LimeComment(currentPath, contentCollector.toList(), placeholders = commentPlaceholders)
         contentCollector.clear()
     }
 
@@ -73,7 +73,7 @@ internal class AntlrLimedocBuilder(
         val tagName = ctx.tagName().text
         val tagParameter = ctx.blockTagParameter()?.text ?: ""
         commentsCollector[Pair(tagName, tagParameter)] =
-            LimeComment(currentPath, contentCollector.toList())
+            LimeComment(currentPath, contentCollector.toList(), placeholders = commentPlaceholders)
         contentCollector.clear()
     }
 

--- a/lime-loader/src/test/java/com/here/gluecodium/loader/AntlrLimeModelBuilderTest.kt
+++ b/lime-loader/src/test/java/com/here/gluecodium/loader/AntlrLimeModelBuilderTest.kt
@@ -32,7 +32,9 @@ import org.antlr.v4.runtime.misc.ParseCancellationException
 import org.antlr.v4.runtime.tree.TerminalNode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -158,5 +160,20 @@ class AntlrLimeModelBuilderTest {
         assertEquals(result.comment.toString(), "Some property\nThis is old way of documenting properties")
         assertTrue(result.valueComment.isEmpty())
         assertTrue(result.additionalDescriptionComment.isEmpty())
+    }
+
+    @Test
+    fun exactFileLocationIsThrownWhenUnknownPlaceholderCommentIsPresent() {
+        pushDocComment("@value Some property belonging to {@Placeholder special_component}")
+        pushDocComment("@description Some description of property that says about {@Placeholder another_component}")
+
+        val exception =
+            assertThrows(ParseCancellationException::class.java) {
+                modelBuilder.enterProperty(propertyContext)
+            }
+
+        assertNotNull(exception.message)
+        assertTrue(exception.message!!.contains("Invalid comment placeholder requested"))
+        assertTrue(exception.message!!.startsWith("line "))
     }
 }

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
@@ -31,6 +31,16 @@ class LimeComment(
     val isExcluded: Boolean = false,
     val placeholders: Map<String, LimeComment> = emptyMap(),
 ) {
+    init {
+        taggedSections.forEach {
+            if (isPlaceholder(it.first)) {
+                if (!placeholders.contains(it.second)) {
+                    throw IllegalArgumentException("Invalid comment placeholder requested: ${it.second}.")
+                }
+            }
+        }
+    }
+
     constructor(comment: String, path: LimePath = LimePath.EMPTY_PATH) : this(path, listOf("" to comment))
 
     fun isEmpty() = taggedSections.all { it.second.isEmpty() }
@@ -51,8 +61,6 @@ class LimeComment(
         }
     }
 
-    fun withPlaceholders(newPlaceholders: Map<String, LimeComment>) = LimeComment(path, taggedSections, isExcluded, newPlaceholders)
-
     override fun toString() =
         taggedSections.joinToString("") {
             when (it.first) {
@@ -68,10 +76,5 @@ class LimeComment(
     private fun resolvePlaceholder(
         name: String,
         platform: String,
-    ): String {
-        val placeholderComment =
-            placeholders[name]
-                ?: throw IllegalArgumentException("Invalid comment placeholder requested: $name.")
-        return placeholderComment.getFor(platform)
-    }
+    ): String = placeholders[name]!!.getFor(platform)
 }


### PR DESCRIPTION
The initial commit, which introduced usage of
placeholders checked if a placeholder exists
when getting the conent of comment. It was
problematic because the exact location of
a file, which contains invalid placeholder
was not known.

This commit adjusts that by moving the validation
to init block of LimeComment. This way LIME model
builder may throw ParseCancellationExcetion.

Before this change the error looked as follows when invalid placeholder was used:

```
java.lang.IllegalArgumentException Invalid comment placeholder requested: Interface.
```

Now the stack contains the following information:
```
com.here.gluecodium.loader.LimeLoadingException: Syntax errors found, see log for details.
```

And the standard error contains the full path:
```
SEVERE: com.here.gluecodium.loader.LimeBasedLimeModelLoader loadFile:
    File /some/path/Comments.lime, line 20:0, Invalid comment placeholder requested: Interface.
```
