### PR TITLE
Ensure that platform code called from constructor receives valid object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features
  * Several placeholder files can be specified with CMake property `GLUECODIUM_DOCS_PLACEHOLDERS_LIST` or placeholders can be directly specified in CMake property `GLUECODIUM_DOCS_PLACEHOLDERS`.
+ * The new annotation called `@AfterConstruction()` is available and can be used to specify function called after the construction of an object finishes. It should be used for calling platform code from the constructor. More information can be found in `docs/lime_attributes.md`.
 
 ## 13.11.0
 Release date 2025-03-03

--- a/docs/lime_attributes.md
+++ b/docs/lime_attributes.md
@@ -55,6 +55,20 @@ only `const` and `field constructor` can be skipped in C++.
 * **@EnableIf(**\[**Tag** **=**\] **"**_CustomTag_**"**__)__ or **@EnableIf(**__CustomTag__**)**: marks an element to be
 enabled only if a custom tag with that name was defined through command-line parameters. If the tag is not present, the
 element is skipped (not generated). Custom tags are case-insensitive.
+* **@AfterConstruction(**_"someFunction(this, someConstructorArg)"_**)** - can be used only with constructors of classes.
+It specifies a function that should be called after the constructor call finishes and the object is properly created and cached.
+It is required when `this` object needs to be passed to some platform method during construction. The function call inside
+`@AfterConstructed()` annotation can use any of parameters of the constructor in any order. In order to refer to this/self
+object `this` keyword should be used in LIME file. Note: the parameter of static function in Swift needs to be named `self`
+in order to ensure that the code compiles.
+To understand the purpose of the usage let's consider the following situation:
+  * we have a constructor, which takes an interface: `constructor(someInterface: SomeInterface)`
+  * we want to call a method of the interface from the constructor with the newly created object: `someInterface.doSomething(this)`
+  * if the call is performed from C++ factory function implemented by the user of the generated code, then at the moment
+of call the platform object (Java, Swift, Dart) is not properly constructed and cached
+  * to avoid such problematic situations and breaking the cache/leaking objects `@AfterConstruction()` should be used --
+all the work related to using interfaces or derived classes that may require passing the object back to the platform code from constructor should be done inside
+the function specified via `@AfterConstruction()`
 
 Java-specific attributes
 ------------------------

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -197,6 +197,7 @@ feature(Listeners cpp android android-kotlin swift dart SOURCES
     input/src/cpp/MultiListener.cpp
     input/src/cpp/InterfaceWithStatic.cpp
     input/src/cpp/ConvolutedRoundTrip.cpp
+    input/src/cpp/ListenerAsConstructorParam.cpp
 
     input/lime/StringListeners.lime
     input/lime/ListenerRoundtrip.lime
@@ -206,6 +207,7 @@ feature(Listeners cpp android android-kotlin swift dart SOURCES
     input/lime/MultiListener.lime
     input/lime/InterfaceWithStatic.lime
     input/lime/ConvolutedRoundTrip.lime
+    input/lime/ListenerAsConstructorParam.lime
 )
 
 feature(ComplexListeners cpp android swift dart SOURCES

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test
+
+import com.here.android.RobolectricApplication
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+import com.here.android.lorem.ipsum.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+@Config(application = RobolectricApplication::class)
+class ListenerAsConstructorParamTest {
+
+    class CelsiusObserver : TemperatureObserver {
+        private var updatesCounter: Int = 0
+        private var lastCelsiusTemperature: Double = 0.0
+
+        fun getUpdatesCount(): Int = updatesCounter
+        fun getLastCelsiusTemperature(): Double = lastCelsiusTemperature
+
+        override fun onTemperatureUpdate(thermometer: Thermometer) {
+            lastCelsiusTemperature = thermometer.getCelsius()
+            ++updatesCounter
+        }
+    }
+
+    @org.junit.Test
+    fun celsiusObserverIsUpdatedFromConstructorWhenAfterConstructedAttributeUsed() {
+        // Given temperature observer, which receives updates about temperature.
+        val observer: CelsiusObserver = CelsiusObserver()
+        val observers: MutableList<TemperatureObserver> = mutableListOf(observer)
+
+        // When creating observed subject.
+        val thermometer: Thermometer = Thermometer(Duration.ofSeconds(1), observers)
+
+        // Then subject informed about its state during creation.
+        val delta: Double = 0.00000001
+        assertEquals(observer.getUpdatesCount(), 1)
+        assertEquals(observer.getLastCelsiusTemperature(), thermometer.getCelsius(), delta)
+
+        // When creating another observed subject.
+        val anotherThermometer: Thermometer = Thermometer(observers)
+
+        // Then subject informed about its state during creation.
+        assertEquals(observer.getUpdatesCount(), 2)
+        assertEquals(observer.getLastCelsiusTemperature(), anotherThermometer.getCelsius(), delta)
+    }
+}

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
@@ -53,7 +53,7 @@ public class ListenerAsConstructorParamTest {
   }
 
   @Test
-  public void celsiusObserverIsUpdatedFromConstructor() {
+  public void celsiusObserverIsUpdatedFromConstructorWhenAfterConstructedAttributeUsed() {
     // Given temperature observer, which receives updates about temperature.
     CelsiusObserver observer = new CelsiusObserver();
 
@@ -67,5 +67,12 @@ public class ListenerAsConstructorParamTest {
     double delta = 0.00000001;
     assertEquals(observer.getUpdatesCount(), 1);
     assertEquals(observer.getLastCelsius(), thermometer.getCelsius(), delta);
+
+    // When creating another observed subject.
+    Thermometer anotherThermometer = new Thermometer(observers);
+
+    // Then subject informed about its state during creation.
+    assertEquals(observer.getUpdatesCount(), 2);
+    assertEquals(observer.getLastCelsius(), anotherThermometer.getCelsius(), delta);
   }
 }

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+package com.here.android.test;
+
+import static junit.framework.Assert.assertEquals;
+
+import android.os.Build;
+import com.here.android.lorem.ipsum.time.Duration;
+import com.here.android.RobolectricApplication;
+import java.util.ArrayList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = Build.VERSION_CODES.M, application = RobolectricApplication.class)
+public class ListenerAsConstructorParamTest {
+
+  static class CelsiusObserver implements TemperatureObserver {
+    private int updatesCount = 0;
+    private double lastReadTemperature = 0.0;
+
+    public int getUpdatesCount() {
+      return updatesCount;
+    }
+
+    public double getLastCelsius() {
+      return lastReadTemperature;
+    }
+
+    @Override
+    public void onTemperatureUpdate(Thermometer thermometer) {
+      lastReadTemperature = thermometer.getCelsius();
+      ++updatesCount;
+    }
+  }
+
+  @Test
+  public void celsiusObserverIsUpdatedFromConstructor() {
+    // Given temperature observer, which receives updates about temperature.
+    CelsiusObserver observer = new CelsiusObserver();
+
+    ArrayList<TemperatureObserver> observers = new ArrayList();
+    observers.add(observer);
+
+    // When creating observed subject.
+    Thermometer thermometer = new Thermometer(Duration.ofSeconds(1), observers);
+
+    // Then subject informed about its state during creation.
+    double delta = 0.00000001;
+    assertEquals(observer.getUpdatesCount(), 1);
+    assertEquals(observer.getLastCelsius(), thermometer.getCelsius(), delta);
+  }
+}

--- a/functional-tests/functional/dart/main.dart
+++ b/functional-tests/functional/dart/main.dart
@@ -40,6 +40,7 @@ import "test/Inheritance_test.dart" as InheritanceTests;
 import "test/Interfaces_test.dart" as InterfacesTests;
 import "test/InterfaceWithStatic_test.dart" as InterfaceWithStaticTests;
 import "test/Lambdas_test.dart" as LambdasTests;
+import "test/ListenerAsConstructorParam_test.dart" as ListenerAsConstructorParamTests;
 import "test/Lists_test.dart" as ListsTests;
 import "test/Listeners_test.dart" as ListenersTests;
 import "test/ListenerInheritance_test.dart" as ListenerInheritanceTests;
@@ -89,6 +90,7 @@ final _allTests = [
   InterfacesTests.main,
   InterfaceWithStaticTests.main,
   LambdasTests.main,
+  ListenerAsConstructorParamTests.main,
   ListsTests.main,
   ListenersTests.main,
   ListenerInheritanceTests.main,

--- a/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
+++ b/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
@@ -1,0 +1,58 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import "package:test/test.dart";
+import "package:functional/test.dart";
+import "../test_suite.dart";
+
+final _testSuite = TestSuite("ListenerAsConstructorParam");
+
+class CelsiusObserver implements TemperatureObserver {
+     int updatesCount = 0;
+     double lastReadTemperature = 0.0;
+
+     @override
+     void onTemperatureUpdate(Thermometer thermometer) {
+         lastReadTemperature = thermometer.getCelsius();
+         ++updatesCount;
+     }
+}
+
+void main() {
+  _testSuite.test("CelsiusObserver is updated from constructor when 'AfterConstructed' attribute used", () {
+      // Given temperature observer, which receives updates about temperature.
+      var observer = CelsiusObserver();
+      var observers = [observer];
+
+      // When creating observed subject.
+      var thermometer = Thermometer.makeWithDuration(Duration(seconds: 1), observers);
+
+      // Then subject informed about its state during creation.
+      expect(observer.updatesCount, equals(1));
+      expect(observer.lastReadTemperature, equals(thermometer.getCelsius()));
+
+      // When creating another observed subject.
+      var anotherThermometer = Thermometer.makeWithoutDuration(observers);
+
+      // Then subject informed about its state during creation.
+      expect(observer.updatesCount, equals(2));
+      expect(observer.lastReadTemperature, equals(anotherThermometer.getCelsius()));
+  });
+}

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -20,7 +20,14 @@ package test
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
-    constructor make(interval: Duration, observers: List<TemperatureObserver>)
+    @AfterConstruction("notifyObservers(this, observers)")
+    constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
+
+    @AfterConstruction("notifyObservers(this, observers)")
+    constructor makeWithoutDuration(observers: List<TemperatureObserver>)
+
+    @Internal
+    static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
 
     fun forceUpdate()
 

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -1,0 +1,35 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package test
+
+// A class, which reads temperature and updates observers according to the given interval.
+// "Subject" in observer design pattern.
+class Thermometer {
+    constructor make(interval: Duration, observers: List<TemperatureObserver>)
+
+    fun forceUpdate()
+
+    fun getCelsius(): Double
+    fun getKelvin(): Double
+    fun getFahrenheit(): Double
+}
+
+// Observer interface for monitoring changes in thermometer ("Observer of subject").
+interface TemperatureObserver {
+    fun onTemperatureUpdate(thermometer: Thermometer)
+}

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -26,7 +26,6 @@ class Thermometer {
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithoutDuration(observers: List<TemperatureObserver>)
 
-    @Internal
     static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
 
     fun forceUpdate()

--- a/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
+++ b/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
@@ -1,0 +1,83 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+#include "test/Thermometer.h"
+#include "test/TemperatureObserver.h"
+
+#include <chrono>
+#include <memory>
+#include <random>
+#include <vector>
+
+namespace test {
+
+class ThermometerImpl : public ::test::Thermometer, public std::enable_shared_from_this<ThermometerImpl> {
+public:
+    explicit ThermometerImpl(const ::std::chrono::seconds interval, const ::std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers)
+        : m_interval{interval}, m_observers{observers}, m_temperatureInCelsius{0.0}
+    {}
+
+    ~ThermometerImpl() override = default;
+
+    void force_update() override {
+        m_temperatureInCelsius = m_temperatureDistribution(m_mersenne_twister);
+    }
+
+    double get_celsius() override {
+        return m_temperatureInCelsius;
+    }
+
+    double get_kelvin() override {
+        return m_temperatureInCelsius + 273.15;
+    }
+
+    double get_fahrenheit() override {
+        return (m_temperatureInCelsius * 9 / 5) + 32;
+    }
+
+    void notify_observers() {
+        for (auto& observer: m_observers) {
+            observer->on_temperature_update(shared_from_this());
+        }
+    }
+
+private:
+    ::std::chrono::seconds m_interval;
+    ::std::vector<::std::shared_ptr<::test::TemperatureObserver>> m_observers;
+    double m_temperatureInCelsius;
+
+    // Temperature readout is random from range [-15, 30].
+    std::random_device m_random_device;
+    std::mt19937 m_mersenne_twister{m_random_device()};
+    std::uniform_real_distribution<double> m_temperatureDistribution{-15.0, 30.0};
+};
+
+::std::shared_ptr<::test::Thermometer> Thermometer::make(
+    const ::std::chrono::seconds interval,
+    const ::std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers
+) {
+    auto thermometer = std::make_shared<ThermometerImpl>(interval, observers);
+    thermometer->force_update();
+    thermometer->notify_observers();
+
+    return thermometer;
+}
+
+} // namespace test

--- a/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
+++ b/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
@@ -1,0 +1,66 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------
+
+import XCTest
+import functional
+
+class ListenerAsConstructorParamTest: XCTestCase {
+    class CelsiusObserver : TemperatureObserver {
+        private var updatesCount: Int = 0
+        private var lastReadTemperature: Double = 0.0
+
+        func getUpdatesCount() -> Int {
+          return updatesCount
+        }
+
+        func getLastCelsius() -> Double {
+          return lastReadTemperature
+        }
+
+        func onTemperatureUpdate(thermometer: Thermometer) -> Void {
+          lastReadTemperature = thermometer.getCelsius()
+          updatesCount += 1
+        }
+      }
+
+    func testObserverUpdateWhenAfterConstructedUsed() {
+      // Given temperature observer, which receives updates about temperature.
+      let observer = CelsiusObserver()
+      let observers = [observer]
+
+      // When creating observed subject.
+      let thermometer = Thermometer(interval: 1, observers: observers)
+
+      // Then subject informed about its state during creation.
+      XCTAssertEqual(1, observer.getUpdatesCount())
+      XCTAssertEqual(thermometer.getCelsius(), observer.getLastCelsius(), accuracy: 0.000001)
+
+      // When creating another observed subject.
+      let anotherThermometer = Thermometer(observers: observers)
+
+      // Then subject informed about its state during creation.
+      XCTAssertEqual(2, observer.getUpdatesCount())
+      XCTAssertEqual(anotherThermometer.getCelsius(), observer.getLastCelsius(), accuracy: 0.000001)
+    }
+
+    static var allTests = [
+      ("testObserverUpdateWhenAfterConstructedUsed", testObserverUpdateWhenAfterConstructedUsed)
+    ]
+}

--- a/functional-tests/functional/swift/main.swift
+++ b/functional-tests/functional/swift/main.swift
@@ -50,6 +50,7 @@ func getAllTests() -> [XCTestCaseEntry] {
         testCase(InterfacesTests.allTests),
         testCase(InterfaceWithStaticTests.allTests),
         testCase(LambdasTests.allTests),
+        testCase(ListenerAsConstructorParamTest.allTests),
         testCase(ListenerInheritanceTests.allTests),
         testCase(ListenerRoundtripTests.allTests),
         testCase(ListenerWithAttributesTests.allTests),

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -183,6 +183,13 @@ void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
 {{#unless parent.attributes.nocache}}
   __lib.cacheInstance(_result_handle, _result);
 {{/unless}}
+{{#this.attributes.afterconstruction}}
+  {{resolveName function}}({{!!
+}}{{#function.parameters}}{{!!
+}}{{#isEq this.name "this"}}_result{{/isEq}}{{!!
+}}{{#isNotEq this.name "this"}}{{resolveName}}{{/isNotEq}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/function.parameters}});
+{{/this.attributes.afterconstruction}}
   _{{resolveName parent "Ffi"}}RegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
   return _result;
 }

--- a/gluecodium/src/main/resources/templates/java/JavaClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaClass.mustache
@@ -35,6 +35,12 @@
 {{#unless classElement.attributes.nocache}}
         cacheThisInstance();
 {{/unless}}
+{{#this.attributes.afterconstruction}}
+        {{resolveName function}}({{!!
+}}{{#function.parameters}}{{!!
+}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/function.parameters}});
+{{/this.attributes.afterconstruction}}
     }
 {{/constructors}}{{/set}}
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -36,6 +36,12 @@
 {{#unless classElement.attributes.nocache}}
         cacheThisInstance();
 {{/unless}}
+{{#this.attributes.afterconstruction}}
+        {{resolveName function}}({{!!
+}}{{#function.parameters}}{{!!
+}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/function.parameters}})
+{{/this.attributes.afterconstruction}}
     }
 {{/constructors}}{{/set}}
 

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -47,6 +47,13 @@
 {{#unless class.attributes.nocache}}
         {{resolveName class "CBridge"}}_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
 {{/unless}}
+{{#this.attributes.afterconstruction}}
+        {{resolveName class }}.{{resolveName function}}({{!!
+}}{{#function.parameters}}{{!!
+}}{{#isEq this.name "this"}}self: self{{/isEq}}{{!!
+}}{{#isNotEq this.name "this"}}{{resolveName}}: {{resolveName}}{{/isNotEq}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/function.parameters}});
+{{/this.attributes.afterconstruction}}
     }
 
 {{/constructors}}{{/set}}

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -20,8 +20,14 @@ package smoke
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
-    @AfterConstruction("someMethod(observers, this)")
-    constructor make(interval: Duration, observers: List<TemperatureObserver>)
+    @AfterConstruction("notifyObservers(this, observers)")
+    constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
+
+    @AfterConstruction("notifyObservers(this, observers)")
+    constructor makeWithoutDuration(observers: List<TemperatureObserver>)
+
+    @Internal
+    static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
 
     fun forceUpdate()
 

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -1,0 +1,35 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package smoke
+
+// A class, which reads temperature and updates observers according to the given interval.
+// "Subject" in observer design pattern.
+class Thermometer {
+    constructor make(interval: Duration, observers: List<TemperatureObserver>)
+
+    fun forceUpdate()
+
+    fun getCelsius(): Double
+    fun getKelvin(): Double
+    fun getFahrenheit(): Double
+}
+
+// Observer interface for monitoring changes in thermometer ("Observer of subject").
+interface TemperatureObserver {
+    fun onTemperatureUpdate(thermometer: Thermometer)
+}

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -20,6 +20,7 @@ package smoke
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
+    @AfterConstruction("someMethod(observers, this)")
     constructor make(interval: Duration, observers: List<TemperatureObserver>)
 
     fun forceUpdate()

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -26,7 +26,6 @@ class Thermometer {
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithoutDuration(observers: List<TemperatureObserver>)
 
-    @Internal
     static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
 
     fun forceUpdate()

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
@@ -1,0 +1,15 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+
+interface TemperatureObserver {
+
+    fun onTemperatureUpdate(thermometer: Thermometer) : Unit
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -1,0 +1,47 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+import com.example.time.Duration
+
+class Thermometer : NativeBase {
+
+
+    constructor(interval: Duration, observers: MutableList<TemperatureObserver>) : this(makeWithDuration(interval, observers), null as Any?) {
+        cacheThisInstance();
+    }
+    constructor(observers: MutableList<TemperatureObserver>) : this(makeWithoutDuration(observers), null as Any?) {
+        cacheThisInstance();
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    private external fun cacheThisInstance()
+
+
+    external fun forceUpdate() : Unit
+    external fun getCelsius() : Double
+    external fun getKelvin() : Double
+    external fun getFahrenheit() : Double
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun makeWithDuration(interval: Duration, observers: MutableList<TemperatureObserver>) : Long
+        @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
+        @JvmStatic internal external fun notifyObservers(self: Thermometer, observers: MutableList<TemperatureObserver>) : Unit
+    }
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -13,9 +13,11 @@ class Thermometer : NativeBase {
 
     constructor(interval: Duration, observers: MutableList<TemperatureObserver>) : this(makeWithDuration(interval, observers), null as Any?) {
         cacheThisInstance();
+        notifyObservers(this, observers)
     }
     constructor(observers: MutableList<TemperatureObserver>) : this(makeWithoutDuration(observers), null as Any?) {
         cacheThisInstance();
+        notifyObservers(this, observers)
     }
 
     /*

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -44,6 +44,6 @@ class Thermometer : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         @JvmStatic external fun makeWithDuration(interval: Duration, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
-        @JvmStatic internal external fun notifyObservers(self: Thermometer, observers: MutableList<TemperatureObserver>) : Unit
+        @JvmStatic external fun notifyObservers(self: Thermometer, observers: MutableList<TemperatureObserver>) : Unit
     }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImpl.cpp
@@ -1,0 +1,52 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserverImpl.h"
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+void
+Java_com_example_smoke_TemperatureObserverImpl_onTemperatureUpdate(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer)
+
+{
+
+
+
+    ::std::shared_ptr< ::smoke::Thermometer > thermometer = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jthermometer),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::TemperatureObserver>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_temperature_update(thermometer);
+
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_TemperatureObserverImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::TemperatureObserver>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImpl.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImpl.h
@@ -1,0 +1,21 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_TemperatureObserverImpl_onTemperatureUpdate(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImplCppProxy.cpp
@@ -1,0 +1,35 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserverImplCppProxy.h"
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_TemperatureObserver_CppProxy::com_example_smoke_TemperatureObserver_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_TemperatureObserver") {
+}
+
+void
+com_example_smoke_TemperatureObserver_CppProxy::on_temperature_update( const ::std::shared_ptr< ::smoke::Thermometer >& nthermometer ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jthermometer = convert_to_jni( jniEnv, nthermometer );
+    callJavaMethod<void>( "onTemperatureUpdate", "(Lcom/example/smoke/Thermometer;)V", jniEnv , jthermometer);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserverImplCppProxy.h
@@ -1,0 +1,28 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/TemperatureObserver.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_TemperatureObserver_CppProxy final : public CppProxyBase, public ::smoke::TemperatureObserver {
+public:
+    com_example_smoke_TemperatureObserver_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_TemperatureObserver_CppProxy( const com_example_smoke_TemperatureObserver_CppProxy& ) = delete;
+    com_example_smoke_TemperatureObserver_CppProxy& operator=( const com_example_smoke_TemperatureObserver_CppProxy& ) = delete;
+
+
+    void on_temperature_update( const ::std::shared_ptr< ::smoke::Thermometer >& nthermometer ) override;
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserver__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserver__Conversion.cpp
@@ -1,0 +1,78 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_TemperatureObserverImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/TemperatureObserverImpl", com_example_smoke_TemperatureObserver, "smoke_TemperatureObserver", ::smoke::TemperatureObserver)
+
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::TemperatureObserver>& result)
+{
+    CppProxyBase::createProxy<::smoke::TemperatureObserver, com_example_smoke_TemperatureObserver_CppProxy>(env, obj, "com_example_smoke_TemperatureObserver", result);
+}
+
+
+std::shared_ptr<::smoke::TemperatureObserver> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::TemperatureObserver>>)
+{
+    std::shared_ptr<::smoke::TemperatureObserver> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::TemperatureObserver>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::TemperatureObserver>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::TemperatureObserver>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::TemperatureObserver>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserver__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_TemperatureObserver__Conversion.h
@@ -1,0 +1,24 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/TemperatureObserver.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::TemperatureObserver> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::TemperatureObserver>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::TemperatureObserver>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
@@ -1,0 +1,196 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jlong
+Java_com_example_smoke_Thermometer_makeWithDuration(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers)
+
+{
+
+
+
+    ::std::chrono::seconds interval = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinterval),
+            ::gluecodium::jni::TypeId<::std::chrono::seconds>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto _result = ::smoke::Thermometer::make_with_duration(interval,observers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+jlong
+Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers)
+
+{
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto _result = ::smoke::Thermometer::make_without_duration(observers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+void
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+
+{
+
+
+
+    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jself),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    ::smoke::Thermometer::notify_observers(self,observers);
+
+}
+
+void
+Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->force_update();
+
+}
+
+jdouble
+Java_com_example_smoke_Thermometer_getCelsius(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_celsius();
+
+    return _result;
+}
+
+jdouble
+Java_com_example_smoke_Thermometer_getKelvin(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_kelvin();
+
+    return _result;
+}
+
+jdouble
+Java_com_example_smoke_Thermometer_getFahrenheit(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_fahrenheit();
+
+    return _result;
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = ::gluecodium::jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = ::gluecodium::jni::get_class_native_handle(_jenv, jobj);
+    auto nobj = *reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*>(long_ptr);
+
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
@@ -1,0 +1,33 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_makeWithDuration(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jdouble JNICALL
+Java_com_example_smoke_Thermometer_getCelsius(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jdouble JNICALL
+Java_com_example_smoke_Thermometer_getKelvin(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jdouble JNICALL
+Java_com_example_smoke_Thermometer_getFahrenheit(JNIEnv* _jenv, jobject _jinstance);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer__Conversion.cpp
@@ -1,0 +1,71 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/Thermometer", com_example_smoke_Thermometer, ::smoke::Thermometer)
+
+
+
+std::shared_ptr<::smoke::Thermometer> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::Thermometer>>)
+{
+    std::shared_ptr<::smoke::Thermometer> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::Thermometer>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    auto &javaClass = CachedJavaClass<::smoke::Thermometer>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::Thermometer>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer__Conversion.h
@@ -1,0 +1,24 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/Thermometer.h"
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::Thermometer> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::Thermometer>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::Thermometer>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/TemperatureObserver.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/TemperatureObserver.java
@@ -1,0 +1,17 @@
+/*
+
+ *
+ */
+
+package com.example.smoke;
+
+import android.support.annotation.NonNull;
+
+/**
+ * <p>Observer interface for monitoring changes in thermometer (&quot;Observer of subject&quot;).
+ */
+public interface TemperatureObserver {
+
+    void onTemperatureUpdate(@NonNull final Thermometer thermometer);
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -54,7 +54,7 @@ public final class Thermometer extends NativeBase {
     private static native long makeWithoutDuration(@NonNull final List<TemperatureObserver> observers);
 
 
-    static native void notifyObservers(@NonNull final Thermometer self, @NonNull final List<TemperatureObserver> observers);
+    public static native void notifyObservers(@NonNull final Thermometer self, @NonNull final List<TemperatureObserver> observers);
 
 
     public native void forceUpdate();

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -18,8 +18,16 @@ public final class Thermometer extends NativeBase {
 
 
     public Thermometer(@NonNull final Duration interval, @NonNull final List<TemperatureObserver> observers) {
-        this(make(interval, observers), (Object)null);
+        this(makeWithDuration(interval, observers), (Object)null);
         cacheThisInstance();
+        notifyObservers(this, observers);
+    }
+
+
+    public Thermometer(@NonNull final List<TemperatureObserver> observers) {
+        this(makeWithoutDuration(observers), (Object)null);
+        cacheThisInstance();
+        notifyObservers(this, observers);
     }
 
     /**
@@ -41,7 +49,12 @@ public final class Thermometer extends NativeBase {
     private native void cacheThisInstance();
 
 
-    private static native long make(@NonNull final Duration interval, @NonNull final List<TemperatureObserver> observers);
+    private static native long makeWithDuration(@NonNull final Duration interval, @NonNull final List<TemperatureObserver> observers);
+
+    private static native long makeWithoutDuration(@NonNull final List<TemperatureObserver> observers);
+
+
+    static native void notifyObservers(@NonNull final Thermometer self, @NonNull final List<TemperatureObserver> observers);
 
 
     public native void forceUpdate();

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -1,0 +1,61 @@
+/*
+
+ *
+ */
+
+package com.example.smoke;
+
+import android.support.annotation.NonNull;
+import com.example.NativeBase;
+import com.example.time.Duration;
+import java.util.List;
+
+/**
+ * <p>A class, which reads temperature and updates observers according to the given interval.
+ * &quot;Subject&quot; in observer design pattern.
+ */
+public final class Thermometer extends NativeBase {
+
+
+    public Thermometer(@NonNull final Duration interval, @NonNull final List<TemperatureObserver> observers) {
+        this(make(interval, observers), (Object)null);
+        cacheThisInstance();
+    }
+
+    /**
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The SDK nativeHandle instance.
+     * @param dummy The SDK dummy instance.
+     */
+    protected Thermometer(final long nativeHandle, final Object dummy) {
+        super(nativeHandle, new Disposer() {
+            @Override
+            public void disposeNative(long handle) {
+                disposeNativeHandle(handle);
+            }
+        });
+    }
+
+    private static native void disposeNativeHandle(long nativeHandle);
+    private native void cacheThisInstance();
+
+
+    private static native long make(@NonNull final Duration interval, @NonNull final List<TemperatureObserver> observers);
+
+
+    public native void forceUpdate();
+
+
+    public native double getCelsius();
+
+
+    public native double getKelvin();
+
+
+    public native double getFahrenheit();
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImpl.cpp
@@ -1,0 +1,52 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserverImpl.h"
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+void
+Java_com_example_smoke_TemperatureObserverImpl_onTemperatureUpdate(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer)
+
+{
+
+
+
+    ::std::shared_ptr< ::smoke::Thermometer > thermometer = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jthermometer),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::TemperatureObserver>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->on_temperature_update(thermometer);
+
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_TemperatureObserverImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::TemperatureObserver>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImpl.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImpl.h
@@ -1,0 +1,21 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_TemperatureObserverImpl_onTemperatureUpdate(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImplCppProxy.cpp
@@ -1,0 +1,35 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserverImplCppProxy.h"
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_TemperatureObserver_CppProxy::com_example_smoke_TemperatureObserver_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_TemperatureObserver") {
+}
+
+void
+com_example_smoke_TemperatureObserver_CppProxy::on_temperature_update( const ::std::shared_ptr< ::smoke::Thermometer >& nthermometer ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jthermometer = convert_to_jni( jniEnv, nthermometer );
+    callJavaMethod<void>( "onTemperatureUpdate", "(Lcom/example/smoke/Thermometer;)V", jniEnv , jthermometer);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserverImplCppProxy.h
@@ -1,0 +1,28 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/TemperatureObserver.h"
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_TemperatureObserver_CppProxy final : public CppProxyBase, public ::smoke::TemperatureObserver {
+public:
+    com_example_smoke_TemperatureObserver_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_TemperatureObserver_CppProxy( const com_example_smoke_TemperatureObserver_CppProxy& ) = delete;
+    com_example_smoke_TemperatureObserver_CppProxy& operator=( const com_example_smoke_TemperatureObserver_CppProxy& ) = delete;
+
+
+    void on_temperature_update( const ::std::shared_ptr< ::smoke::Thermometer >& nthermometer ) override;
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserver__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserver__Conversion.cpp
@@ -1,0 +1,78 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_TemperatureObserverImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/TemperatureObserverImpl", com_example_smoke_TemperatureObserver, "smoke_TemperatureObserver", ::smoke::TemperatureObserver)
+
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::TemperatureObserver>& result)
+{
+    CppProxyBase::createProxy<::smoke::TemperatureObserver, com_example_smoke_TemperatureObserver_CppProxy>(env, obj, "com_example_smoke_TemperatureObserver", result);
+}
+
+
+std::shared_ptr<::smoke::TemperatureObserver> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::TemperatureObserver>>)
+{
+    std::shared_ptr<::smoke::TemperatureObserver> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::TemperatureObserver>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::TemperatureObserver>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::TemperatureObserver>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::TemperatureObserver>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserver__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_TemperatureObserver__Conversion.h
@@ -1,0 +1,24 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/TemperatureObserver.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::TemperatureObserver> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::TemperatureObserver>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::TemperatureObserver>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
@@ -1,0 +1,145 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer.h"
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jlong
+Java_com_example_smoke_Thermometer_make(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers)
+
+{
+
+
+
+    ::std::chrono::seconds interval = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinterval),
+            ::gluecodium::jni::TypeId<::std::chrono::seconds>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto _result = ::smoke::Thermometer::make(interval,observers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+void
+Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->force_update();
+
+}
+
+jdouble
+Java_com_example_smoke_Thermometer_getCelsius(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_celsius();
+
+    return _result;
+}
+
+jdouble
+Java_com_example_smoke_Thermometer_getKelvin(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_kelvin();
+
+    return _result;
+}
+
+jdouble
+Java_com_example_smoke_Thermometer_getFahrenheit(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_fahrenheit();
+
+    return _result;
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = ::gluecodium::jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = ::gluecodium::jni::get_class_native_handle(_jenv, jobj);
+    auto nobj = *reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*>(long_ptr);
+
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
@@ -16,7 +16,7 @@
 extern "C" {
 
 jlong
-Java_com_example_smoke_Thermometer_make(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers)
+Java_com_example_smoke_Thermometer_makeWithDuration(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers)
 
 {
 
@@ -36,7 +36,7 @@ Java_com_example_smoke_Thermometer_make(JNIEnv* _jenv, jobject _jinstance, jobje
 
 
 
-    auto _result = ::smoke::Thermometer::make(interval,observers);
+    auto _result = ::smoke::Thermometer::make_with_duration(interval,observers);
 
     auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
     if (nSharedPtr == nullptr)
@@ -45,6 +45,57 @@ Java_com_example_smoke_Thermometer_make(JNIEnv* _jenv, jobject _jinstance, jobje
         return 0;
     }
     return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+jlong
+Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers)
+
+{
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto _result = ::smoke::Thermometer::make_without_duration(observers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+void
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+
+{
+
+
+
+    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jself),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    ::smoke::Thermometer::notify_observers(self,observers);
+
 }
 
 void

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
@@ -12,7 +12,11 @@ extern "C" {
 #endif
 
 JNIEXPORT jlong JNICALL
-Java_com_example_smoke_Thermometer_make(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers);
+Java_com_example_smoke_Thermometer_makeWithDuration(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance);
 JNIEXPORT jdouble JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
@@ -1,0 +1,29 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_make(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jdouble JNICALL
+Java_com_example_smoke_Thermometer_getCelsius(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jdouble JNICALL
+Java_com_example_smoke_Thermometer_getKelvin(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jdouble JNICALL
+Java_com_example_smoke_Thermometer_getFahrenheit(JNIEnv* _jenv, jobject _jinstance);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer__Conversion.cpp
@@ -1,0 +1,71 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Thermometer__Conversion.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/Thermometer", com_example_smoke_Thermometer, ::smoke::Thermometer)
+
+
+
+std::shared_ptr<::smoke::Thermometer> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::Thermometer>>)
+{
+    std::shared_ptr<::smoke::Thermometer> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::Thermometer>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::Thermometer>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    auto &javaClass = CachedJavaClass<::smoke::Thermometer>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::Thermometer>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer__Conversion.h
@@ -1,0 +1,24 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/Thermometer.h"
+#include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::Thermometer> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::Thermometer>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::Thermometer>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/TemperatureObserver.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/TemperatureObserver.h
@@ -1,0 +1,41 @@
+// -------------------------------------------------------------------------------------------------
+//
+
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/TypeRepository.h"
+#include <memory>
+
+
+namespace smoke {
+
+    class Thermometer;
+
+
+}
+
+namespace smoke {
+/**
+ * Observer interface for monitoring changes in thermometer ("Observer of subject").
+
+ */
+class _GLUECODIUM_CPP_EXPORT TemperatureObserver {
+public:
+    TemperatureObserver();
+    virtual ~TemperatureObserver();
+
+
+public:
+    /**
+     *
+     * \param[in] thermometer @NotNull
+     */
+    virtual void on_temperature_update( const ::std::shared_ptr< ::smoke::Thermometer >& thermometer ) = 0;
+};
+
+
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -1,0 +1,51 @@
+// -------------------------------------------------------------------------------------------------
+//
+
+//
+// -------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include "gluecodium/DurationHash.h"
+#include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/VectorHash.h"
+#include <chrono>
+#include <memory>
+#include <vector>
+
+
+namespace smoke {
+
+    class TemperatureObserver;
+
+
+}
+
+namespace smoke {
+/**
+ * A class, which reads temperature and updates observers according to the given interval.
+ * "Subject" in observer design pattern.
+
+ */
+class _GLUECODIUM_CPP_EXPORT Thermometer {
+public:
+    Thermometer();
+    virtual ~Thermometer();
+
+
+public:
+    /**
+     *
+     * \param[in] interval
+     * \param[in] observers
+     * \return @NotNull
+     */
+    static ::std::shared_ptr< ::smoke::Thermometer > make( const ::std::chrono::seconds interval, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    virtual void force_update(  ) = 0;
+    virtual double get_celsius(  ) = 0;
+    virtual double get_kelvin(  ) = 0;
+    virtual double get_fahrenheit(  ) = 0;
+};
+
+
+}

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -40,7 +40,19 @@ public:
      * \param[in] observers
      * \return @NotNull
      */
-    static ::std::shared_ptr< ::smoke::Thermometer > make( const ::std::chrono::seconds interval, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    static ::std::shared_ptr< ::smoke::Thermometer > make_with_duration( const ::std::chrono::seconds interval, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    /**
+     *
+     * \param[in] observers
+     * \return @NotNull
+     */
+    static ::std::shared_ptr< ::smoke::Thermometer > make_without_duration( const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    /**
+     *
+     * \param[in] self @NotNull
+     * \param[in] observers
+     */
+    static void notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& self, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     virtual void force_update(  ) = 0;
     virtual double get_celsius(  ) = 0;
     virtual double get_kelvin(  ) = 0;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/temperature_observer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/temperature_observer.dart
@@ -1,0 +1,138 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/_type_repository.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/smoke/thermometer.dart';
+
+/// Observer interface for monitoring changes in thermometer ("Observer of subject").
+abstract class TemperatureObserver implements Finalizable {
+  /// Observer interface for monitoring changes in thermometer ("Observer of subject").
+
+  factory TemperatureObserver(
+    void Function(Thermometer) onTemperatureUpdateLambda,
+
+  ) => TemperatureObserver$Lambdas(
+    onTemperatureUpdateLambda,
+
+  );
+
+
+  void onTemperatureUpdate(Thermometer thermometer);
+}
+
+
+// TemperatureObserver "private" section, not exported.
+
+final _smokeTemperatureobserverRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_TemperatureObserver_register_finalizer'));
+final _smokeTemperatureobserverCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TemperatureObserver_copy_handle'));
+final _smokeTemperatureobserverReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_TemperatureObserver_release_handle'));
+final _smokeTemperatureobserverCreateProxy = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint64, Int32, Handle, Pointer),
+    Pointer<Void> Function(int, int, Object, Pointer)
+  >('library_smoke_TemperatureObserver_create_proxy'));
+final _smokeTemperatureobserverGetTypeId = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_TemperatureObserver_get_type_id'));
+
+
+class TemperatureObserver$Lambdas implements TemperatureObserver {
+  void Function(Thermometer) onTemperatureUpdateLambda;
+
+  TemperatureObserver$Lambdas(
+    this.onTemperatureUpdateLambda,
+
+  );
+
+  @override
+  void onTemperatureUpdate(Thermometer thermometer) =>
+    onTemperatureUpdateLambda(thermometer);
+}
+
+class TemperatureObserver$Impl extends __lib.NativeBase implements TemperatureObserver {
+
+  TemperatureObserver$Impl(Pointer<Void> handle) : super(handle);
+
+  @override
+  void onTemperatureUpdate(Thermometer thermometer) {
+    final _onTemperatureUpdateFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32, Pointer<Void>), void Function(Pointer<Void>, int, Pointer<Void>)>('library_smoke_TemperatureObserver_onTemperatureUpdate__Thermometer'));
+    final _thermometerHandle = smokeThermometerToFfi(thermometer);
+    final _handle = this.handle;
+    _onTemperatureUpdateFfi(_handle, __lib.LibraryContext.isolateId, _thermometerHandle);
+    smokeThermometerReleaseFfiHandle(_thermometerHandle);
+
+  }
+
+
+}
+
+int _smokeTemperatureobserveronTemperatureUpdateStatic(Object _obj, Pointer<Void> thermometer) {
+
+  try {
+    (_obj as TemperatureObserver).onTemperatureUpdate(smokeThermometerFromFfi(thermometer));
+  } finally {
+    smokeThermometerReleaseFfiHandle(thermometer);
+  }
+  return 0;
+}
+
+
+Pointer<Void> smokeTemperatureobserverToFfi(TemperatureObserver value) {
+  if (value is __lib.NativeBase) return _smokeTemperatureobserverCopyHandle((value as __lib.NativeBase).handle);
+
+  final result = _smokeTemperatureobserverCreateProxy(
+    __lib.getObjectToken(value),
+    __lib.LibraryContext.isolateId,
+    value,
+    Pointer.fromFunction<Uint8 Function(Handle, Pointer<Void>)>(_smokeTemperatureobserveronTemperatureUpdateStatic, __lib.unknownError)
+  );
+
+  return result;
+}
+
+TemperatureObserver smokeTemperatureobserverFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is TemperatureObserver) return instance;
+
+  final _typeIdHandle = _smokeTemperatureobserverGetTypeId(handle);
+  final factoryConstructor = __lib.typeRepository[stringFromFfi(_typeIdHandle)];
+  stringReleaseFfiHandle(_typeIdHandle);
+
+  final _copiedHandle = _smokeTemperatureobserverCopyHandle(handle);
+  final result = factoryConstructor != null
+    ? factoryConstructor(_copiedHandle)
+    : TemperatureObserver$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeTemperatureobserverRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeTemperatureobserverReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeTemperatureobserverReleaseHandle(handle);
+
+Pointer<Void> smokeTemperatureobserverToFfiNullable(TemperatureObserver? value) =>
+  value != null ? smokeTemperatureobserverToFfi(value) : Pointer<Void>.fromAddress(0);
+
+TemperatureObserver? smokeTemperatureobserverFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeTemperatureobserverFromFfi(handle) : null;
+
+void smokeTemperatureobserverReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeTemperatureobserverReleaseHandle(handle);
+
+// End of TemperatureObserver "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -72,6 +72,9 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
 
     __lib.cacheInstance(_result_handle, _result);
 
+
+    notifyObservers(_result, observers);
+
     _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
@@ -82,6 +85,9 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     final _result = Thermometer$Impl(_result_handle);
 
     __lib.cacheInstance(_result_handle, _result);
+
+
+    notifyObservers(_result, observers);
 
     _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -1,0 +1,200 @@
+
+
+import 'dart:ffi';
+import 'package:library/src/_library_context.dart' as __lib;
+import 'package:library/src/_native_base.dart' as __lib;
+import 'package:library/src/_token_cache.dart' as __lib;
+import 'package:library/src/builtin_types__conversion.dart';
+import 'package:library/src/generic_types__conversion.dart';
+import 'package:library/src/smoke/temperature_observer.dart';
+import 'package:meta/meta.dart';
+
+/// A class, which reads temperature and updates observers according to the given interval.
+///
+/// "Subject" in observer design pattern.
+abstract class Thermometer implements Finalizable {
+
+  factory Thermometer.makeWithDuration(Duration interval, List<TemperatureObserver> observers) => $prototype.makeWithDuration(interval, observers);
+
+  factory Thermometer.makeWithoutDuration(List<TemperatureObserver> observers) => $prototype.makeWithoutDuration(observers);
+
+
+  static void notifyObservers(Thermometer self, List<TemperatureObserver> observers) => $prototype.notifyObservers(self, observers);
+
+  void forceUpdate();
+
+  double getCelsius();
+
+  double getKelvin();
+
+  double getFahrenheit();
+
+  /// @nodoc
+  @visibleForTesting
+  static dynamic $prototype = Thermometer$Impl(Pointer<Void>.fromAddress(0));
+}
+
+
+// Thermometer "private" section, not exported.
+
+final _smokeThermometerRegisterFinalizer = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>, Int32, Handle),
+    void Function(Pointer<Void>, int, Object)
+  >('library_smoke_Thermometer_register_finalizer'));
+final _smokeThermometerCopyHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Thermometer_copy_handle'));
+final _smokeThermometerReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Thermometer_release_handle'));
+
+
+
+
+
+
+
+
+
+/// @nodoc
+@visibleForTesting
+
+class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
+
+  Thermometer$Impl(Pointer<Void> handle) : super(handle);
+
+
+  Thermometer makeWithDuration(Duration interval, List<TemperatureObserver> observers) {
+    final _result_handle = _makeWithDuration(interval, observers);
+    final _result = Thermometer$Impl(_result_handle);
+
+    __lib.cacheInstance(_result_handle, _result);
+
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+
+
+  Thermometer makeWithoutDuration(List<TemperatureObserver> observers) {
+    final _result_handle = _makeWithoutDuration(observers);
+    final _result = Thermometer$Impl(_result_handle);
+
+    __lib.cacheInstance(_result_handle, _result);
+
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+
+  static Pointer<Void> _makeWithDuration(Duration interval, List<TemperatureObserver> observers) {
+    final _makeWithDurationFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Thermometer_makeWithDuration__Duration_ListOf_smoke_TemperatureObserver'));
+    final _intervalHandle = durationToFfi(interval);
+    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
+    final __resultHandle = _makeWithDurationFfi(__lib.LibraryContext.isolateId, _intervalHandle, _observersHandle);
+    durationReleaseFfiHandle(_intervalHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+    return __resultHandle;
+  }
+
+  static Pointer<Void> _makeWithoutDuration(List<TemperatureObserver> observers) {
+    final _makeWithoutDurationFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>)>('library_smoke_Thermometer_makeWithoutDuration__ListOf_smoke_TemperatureObserver'));
+    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
+    final __resultHandle = _makeWithoutDurationFfi(__lib.LibraryContext.isolateId, _observersHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+    return __resultHandle;
+  }
+
+  void notifyObservers(Thermometer self, List<TemperatureObserver> observers) {
+    final _notifyObserversFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>, Pointer<Void>), void Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Thermometer_notifyObservers__Thermometer_ListOf_smoke_TemperatureObserver'));
+    final _selfHandle = smokeThermometerToFfi(self);
+    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
+    _notifyObserversFfi(__lib.LibraryContext.isolateId, _selfHandle, _observersHandle);
+    smokeThermometerReleaseFfiHandle(_selfHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+
+  }
+
+  @override
+  void forceUpdate() {
+    final _forceUpdateFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Pointer<Void>, Int32), void Function(Pointer<Void>, int)>('library_smoke_Thermometer_forceUpdate'));
+    final _handle = this.handle;
+    _forceUpdateFfi(_handle, __lib.LibraryContext.isolateId);
+
+  }
+
+  @override
+  double getCelsius() {
+    final _getCelsiusFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Thermometer_getCelsius'));
+    final _handle = this.handle;
+    final __resultHandle = _getCelsiusFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+  @override
+  double getKelvin() {
+    final _getKelvinFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Thermometer_getKelvin'));
+    final _handle = this.handle;
+    final __resultHandle = _getKelvinFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+  @override
+  double getFahrenheit() {
+    final _getFahrenheitFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Double Function(Pointer<Void>, Int32), double Function(Pointer<Void>, int)>('library_smoke_Thermometer_getFahrenheit'));
+    final _handle = this.handle;
+    final __resultHandle = _getFahrenheitFfi(_handle, __lib.LibraryContext.isolateId);
+    try {
+      return (__resultHandle);
+    } finally {
+
+
+    }
+
+  }
+
+
+}
+
+Pointer<Void> smokeThermometerToFfi(Thermometer value) =>
+  _smokeThermometerCopyHandle((value as __lib.NativeBase).handle);
+
+Thermometer smokeThermometerFromFfi(Pointer<Void> handle) {
+  if (handle.address == 0) throw StateError("Expected non-null value.");
+  final instance = __lib.getCachedInstance(handle);
+  if (instance != null && instance is Thermometer) return instance;
+
+  final _copiedHandle = _smokeThermometerCopyHandle(handle);
+  final result = Thermometer$Impl(_copiedHandle);
+  __lib.cacheInstance(_copiedHandle, result);
+  _smokeThermometerRegisterFinalizer(_copiedHandle, __lib.LibraryContext.isolateId, result);
+  return result;
+}
+
+void smokeThermometerReleaseFfiHandle(Pointer<Void> handle) =>
+  _smokeThermometerReleaseHandle(handle);
+
+Pointer<Void> smokeThermometerToFfiNullable(Thermometer? value) =>
+  value != null ? smokeThermometerToFfi(value) : Pointer<Void>.fromAddress(0);
+
+Thermometer? smokeThermometerFromFfiNullable(Pointer<Void> handle) =>
+  handle.address != 0 ? smokeThermometerFromFfi(handle) : null;
+
+void smokeThermometerReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeThermometerReleaseHandle(handle);
+
+// End of Thermometer "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/TemperatureObserver.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/TemperatureObserver.swift
@@ -1,0 +1,149 @@
+//
+
+//
+
+import Foundation
+
+/// Observer interface for monitoring changes in thermometer ("Observer of subject").
+public protocol TemperatureObserver : AnyObject {
+
+    func onTemperatureUpdate(thermometer: Thermometer) -> Void
+}
+
+internal class _TemperatureObserver: TemperatureObserver {
+
+    let c_instance : _baseRef
+
+    init(cTemperatureObserver: _baseRef) {
+        guard cTemperatureObserver != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cTemperatureObserver
+    }
+
+    deinit {
+        smoke_TemperatureObserver_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_TemperatureObserver_release_handle(c_instance)
+    }
+
+    public func onTemperatureUpdate(thermometer: Thermometer) -> Void {
+        let c_thermometer = moveToCType(thermometer)
+        smoke_TemperatureObserver_onTemperatureUpdate(self.c_instance, c_thermometer.ref)
+    }
+
+}
+
+
+
+
+
+
+@_cdecl("_CBridgeInitsmoke_TemperatureObserver")
+internal func _CBridgeInitsmoke_TemperatureObserver(handle: _baseRef) -> UnsafeMutableRawPointer {
+    let reference = _TemperatureObserver(cTemperatureObserver: handle)
+    return Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+}
+
+internal func getRef(_ ref: TemperatureObserver?, owning: Bool = true) -> RefHolder {
+
+    guard let reference = ref else {
+        return RefHolder(0)
+    }
+
+    if let instanceReference = reference as? NativeBase {
+        let handle_copy = smoke_TemperatureObserver_copy_handle(instanceReference.c_handle)
+        return owning
+            ? RefHolder(ref: handle_copy, release: smoke_TemperatureObserver_release_handle)
+            : RefHolder(handle_copy)
+    }
+
+    var functions = smoke_TemperatureObserver_FunctionTable()
+    functions.swift_pointer = Unmanaged<AnyObject>.passRetained(reference).toOpaque()
+    functions.release = {swift_class_pointer in
+        if let swift_class = swift_class_pointer {
+            Unmanaged<AnyObject>.fromOpaque(swift_class).release()
+        }
+    }
+
+
+    functions.smoke_TemperatureObserver_onTemperatureUpdate = {(swift_class_pointer, thermometer) in
+
+        let swift_class = Unmanaged<AnyObject>.fromOpaque(swift_class_pointer!).takeUnretainedValue() as! TemperatureObserver
+
+        swift_class.onTemperatureUpdate(thermometer: Thermometer_moveFromCType(thermometer))
+    }
+    let proxy = smoke_TemperatureObserver_create_proxy(functions)
+    return owning ? RefHolder(ref: proxy, release: smoke_TemperatureObserver_release_handle) : RefHolder(proxy)
+}
+
+extension _TemperatureObserver: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+internal func TemperatureObserver_copyFromCType(_ handle: _baseRef) -> TemperatureObserver {
+    if let swift_pointer = smoke_TemperatureObserver_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TemperatureObserver {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_TemperatureObserver_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TemperatureObserver {
+        return re_constructed
+    }
+    if let swift_pointer = smoke_TemperatureObserver_get_typed(smoke_TemperatureObserver_copy_handle(handle)),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? TemperatureObserver {
+        smoke_TemperatureObserver_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+
+internal func TemperatureObserver_moveFromCType(_ handle: _baseRef) -> TemperatureObserver {
+    if let swift_pointer = smoke_TemperatureObserver_get_swift_object_from_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TemperatureObserver {
+        smoke_TemperatureObserver_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_TemperatureObserver_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? TemperatureObserver {
+        smoke_TemperatureObserver_release_handle(handle)
+        return re_constructed
+    }
+    if let swift_pointer = smoke_TemperatureObserver_get_typed(handle),
+        let typed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeRetainedValue() as? TemperatureObserver {
+        smoke_TemperatureObserver_cache_swift_object_wrapper(handle, swift_pointer)
+        return typed
+    }
+    fatalError("Failed to initialize Swift object")
+}
+
+internal func TemperatureObserver_copyFromCType(_ handle: _baseRef) -> TemperatureObserver? {
+    guard handle != 0 else {
+        return nil
+    }
+    return TemperatureObserver_moveFromCType(handle) as TemperatureObserver
+}
+internal func TemperatureObserver_moveFromCType(_ handle: _baseRef) -> TemperatureObserver? {
+    guard handle != 0 else {
+        return nil
+    }
+    return TemperatureObserver_moveFromCType(handle) as TemperatureObserver
+}
+
+internal func copyToCType(_ swiftClass: TemperatureObserver) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: TemperatureObserver) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+internal func copyToCType(_ swiftClass: TemperatureObserver?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: TemperatureObserver?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -16,6 +16,7 @@ public class Thermometer {
         }
         c_instance = _result
         smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+        Thermometer.notifyObservers(self: self, observers: observers);
     }
 
 
@@ -26,6 +27,7 @@ public class Thermometer {
         }
         c_instance = _result
         smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+        Thermometer.notifyObservers(self: self, observers: observers);
     }
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -1,0 +1,159 @@
+//
+
+//
+
+import Foundation
+
+/// A class, which reads temperature and updates observers according to the given interval.
+/// "Subject" in observer design pattern.
+public class Thermometer {
+
+
+    public init(interval: TimeInterval, observers: [TemperatureObserver]) {
+        let _result = Thermometer.makeWithDuration(interval: interval, observers: observers)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+    }
+
+
+    public init(observers: [TemperatureObserver]) {
+        let _result = Thermometer.makeWithoutDuration(observers: observers)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+    }
+
+
+    let c_instance : _baseRef
+
+    init(cThermometer: _baseRef) {
+        guard cThermometer != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = cThermometer
+    }
+
+    deinit {
+        smoke_Thermometer_remove_swift_object_from_wrapper_cache(c_instance)
+        smoke_Thermometer_release_handle(c_instance)
+    }
+
+    private static func makeWithDuration(interval: TimeInterval, observers: [TemperatureObserver]) -> _baseRef {
+        let c_interval = moveToCType(interval)
+        let c_observers = foobar_moveToCType(observers)
+        let c_result_handle = smoke_Thermometer_makeWithDuration(c_interval.ref, c_observers.ref)
+        return moveFromCType(c_result_handle)
+    }
+    private static func makeWithoutDuration(observers: [TemperatureObserver]) -> _baseRef {
+        let c_observers = foobar_moveToCType(observers)
+        let c_result_handle = smoke_Thermometer_makeWithoutDuration(c_observers.ref)
+        return moveFromCType(c_result_handle)
+    }
+    public static func notifyObservers(self: Thermometer, observers: [TemperatureObserver]) -> Void {
+        let c_self = moveToCType(self)
+        let c_observers = foobar_moveToCType(observers)
+        smoke_Thermometer_notifyObservers(c_self.ref, c_observers.ref)
+    }
+    public func forceUpdate() -> Void {
+        smoke_Thermometer_forceUpdate(self.c_instance)
+    }
+    public func getCelsius() -> Double {
+        let c_result_handle = smoke_Thermometer_getCelsius(self.c_instance)
+        return moveFromCType(c_result_handle)
+    }
+    public func getKelvin() -> Double {
+        let c_result_handle = smoke_Thermometer_getKelvin(self.c_instance)
+        return moveFromCType(c_result_handle)
+    }
+    public func getFahrenheit() -> Double {
+        let c_result_handle = smoke_Thermometer_getFahrenheit(self.c_instance)
+        return moveFromCType(c_result_handle)
+    }
+
+}
+
+
+
+internal func getRef(_ ref: Thermometer?, owning: Bool = true) -> RefHolder {
+    guard let c_handle = ref?.c_instance else {
+        return RefHolder(0)
+    }
+    let handle_copy = smoke_Thermometer_copy_handle(c_handle)
+    return owning
+        ? RefHolder(ref: handle_copy, release: smoke_Thermometer_release_handle)
+        : RefHolder(handle_copy)
+}
+
+extension Thermometer: NativeBase {
+    /// :nodoc:
+    var c_handle: _baseRef { return c_instance }
+}
+extension Thermometer: Hashable {
+    /// :nodoc:
+    public static func == (lhs: Thermometer, rhs: Thermometer) -> Bool {
+        return lhs.c_handle == rhs.c_handle
+    }
+
+    /// :nodoc:
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(c_handle)
+    }
+}
+
+internal func Thermometer_copyFromCType(_ handle: _baseRef) -> Thermometer {
+    if let swift_pointer = smoke_Thermometer_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Thermometer {
+        return re_constructed
+    }
+    let result = Thermometer(cThermometer: smoke_Thermometer_copy_handle(handle))
+    smoke_Thermometer_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+
+internal func Thermometer_moveFromCType(_ handle: _baseRef) -> Thermometer {
+    if let swift_pointer = smoke_Thermometer_get_swift_object_from_wrapper_cache(handle),
+        let re_constructed = Unmanaged<AnyObject>.fromOpaque(swift_pointer).takeUnretainedValue() as? Thermometer {
+        smoke_Thermometer_release_handle(handle)
+        return re_constructed
+    }
+    let result = Thermometer(cThermometer: handle)
+    smoke_Thermometer_cache_swift_object_wrapper(handle, Unmanaged<AnyObject>.passUnretained(result).toOpaque())
+    return result
+}
+
+internal func Thermometer_copyFromCType(_ handle: _baseRef) -> Thermometer? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Thermometer_moveFromCType(handle) as Thermometer
+}
+internal func Thermometer_moveFromCType(_ handle: _baseRef) -> Thermometer? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Thermometer_moveFromCType(handle) as Thermometer
+}
+
+internal func copyToCType(_ swiftClass: Thermometer) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: Thermometer) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+internal func copyToCType(_ swiftClass: Thermometer?) -> RefHolder {
+    return getRef(swiftClass, owning: false)
+}
+
+internal func moveToCType(_ swiftClass: Thermometer?) -> RefHolder {
+    return getRef(swiftClass, owning: true)
+}
+
+
+

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -214,13 +214,14 @@ internal class AntlrLimeModelBuilder(
                     getComment("throws", it.docComment(), it),
                 )
             }
+        val parameters = getPreviousResults(LimeParameter::class.java)
         val limeElement =
             LimeFunction(
                 path = currentPath,
                 comment = structuredCommentsStack.peek().description,
-                attributes = AntlrLimeConverter.convertAnnotations(currentPath, ctx.annotation()),
+                attributes = AntlrLimeConverter.convertAnnotationsForConstructor(currentPath, ctx.annotation(), classTypeRef, parameters),
                 returnType = LimeReturnType(classTypeRef),
-                parameters = getPreviousResults(LimeParameter::class.java),
+                parameters = parameters,
                 thrownType = exceptionType,
                 isStatic = true,
                 isConstructor = true,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeType.kt
@@ -25,6 +25,7 @@ enum class LimeAttributeType(
     private val tag: String,
     val defaultValueType: LimeAttributeValueType? = null,
 ) {
+    AFTER_CONSTRUCTION("AfterConstruction", LimeAttributeValueType.FUNCTION),
     CPP("Cpp", LimeAttributeValueType.NAME),
     JAVA("Java", LimeAttributeValueType.NAME),
     KOTLIN("Kotlin", LimeAttributeValueType.NAME),

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributeValueType.kt
@@ -28,6 +28,7 @@ enum class LimeAttributeValueType(private val tag: String) {
     ENABLE_IF("EnableIf"),
     FULL_NAME("FullName"),
     FUNCTION_NAME("FunctionName"),
+    FUNCTION("Function"),
     INTERNAL("Internal"),
     LABEL("Label"),
     MESSAGE("Message"),

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributes.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributes.kt
@@ -142,6 +142,24 @@ class LimeAttributes private constructor(
             return this
         }
 
+        fun have(type: LimeAttributeType) = attributes[type] != null
+
+        fun get(
+            attributeType: LimeAttributeType,
+            valueType: LimeAttributeValueType,
+        ): Any? {
+            return attributes[attributeType]?.get(valueType)
+        }
+
+        fun overwriteAttribute(
+            attributeType: LimeAttributeType,
+            valueType: LimeAttributeValueType,
+            newValue: Any?,
+        ): Builder {
+            attributes.getOrPut(attributeType) { mutableMapOf() }.compute(valueType) { _, _ -> newValue }
+            return this
+        }
+
         fun addAttributeIfAbsent(
             attributeType: LimeAttributeType,
             valueType: LimeAttributeValueType,


### PR DESCRIPTION
----------------- Description of problem -----------------

Let's consider the following situation:
- we have a constructor, which takes an interface: `constructor(someInterface: SomeInterface)`
- we want to call a method of the interface from the constructor with the newly created object: `someInterface.doSomething(this)`
- if the call is performed from C++ factory function implemented by the user of the generated code, then at the moment of call the platform object (Java, Swift, Dart) is not properly constructed and cached
- to avoid such problematic situations and breaking the cache/leaking objects the newly implemented `@AfterConstruction()` attribute should be used

It was confirmed that in the case of Java weak reference leak happened in the described scenario.

----------------- Designed solution -----------------
In order to be able to use listeners in constructor the new attribute called `AfterConstruction`
has been implemented. It allows users to specify a 'hook' function that will be called for the
given object after it is properly created and cached. The user must implement the mentioned hook.

For more information please check `docs/lime_attributes.md`.