### PR TITLE
smoke tests: add 'lambdas' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/lambdas/input/Lambdas.lime
+++ b/gluecodium/src/test/resources/smoke/lambdas/input/Lambdas.lime
@@ -21,10 +21,11 @@ class Lambdas {
     lambda Producer = () -> String
     // Should confuse everyone thoroughly
     @Java(Name = "Confounder", FunctionName = "confuse")
+    @Kotlin(Name = "Confounder", FunctionName = "confuse")
     @Swift("Convoluter")
     lambda Confuser = (String) -> Producer
     lambda Consumer = (String) -> Void
-    lambda Indexer = (String, @Java("index") Float) -> Int
+    lambda Indexer = (String, @Kotlin("idx") @Java("index") Float) -> Int
     lambda NullableConfuser = (String?) -> Producer?
 
     fun deconfuse(value: String, confuser: Confuser): Producer

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
@@ -1,0 +1,146 @@
+/*
+
+ *
+ */
+
+@file:JvmName("Lambdas")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class Lambdas : NativeBase {
+
+    fun interface Producer {
+        fun apply() : String
+    }
+
+    fun interface Confounder {
+        fun confuse(p0: String) : Lambdas.Producer
+    }
+
+    fun interface Consumer {
+        fun apply(p0: String) : Unit
+    }
+
+    fun interface Indexer {
+        fun apply(p0: String, idx: Float) : Int
+    }
+
+    fun interface NullableConfuser {
+        fun apply(p0: String?) : Lambdas.Producer?
+    }
+
+    class ProducerImpl : NativeBase, Producer {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply() : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class ConfounderImpl : NativeBase, Confounder {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun confuse(p0: String) : Lambdas.Producer
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class ConsumerImpl : NativeBase, Consumer {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String) : Unit
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class IndexerImpl : NativeBase, Indexer {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String, idx: Float) : Int
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class NullableConfuserImpl : NativeBase, NullableConfuser {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String?) : Lambdas.Producer?
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun deconfuse(value: String, confuser: Lambdas.Confounder) : Lambdas.Producer
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun fuse(items: MutableList<String>, callback: Lambdas.Indexer) : MutableMap<Int, String>
+    }
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
@@ -1,0 +1,40 @@
+/*
+
+ *
+ */
+
+@file:JvmName("LambdasInterface")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+interface LambdasInterface {
+    fun interface TakeScreenshotCallback {
+        fun apply(p0: ByteArray?) : Unit
+    }
+
+    class TakeScreenshotCallbackImpl : NativeBase, TakeScreenshotCallback {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: ByteArray?) : Unit
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+    fun takeScreenshot(callback: LambdasInterface.TakeScreenshotCallback) : Unit
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducer.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducer.kt
@@ -1,0 +1,14 @@
+/*
+
+ *
+ */
+
+@file:JvmName("StandaloneProducer")
+
+package com.example.smoke
+
+
+fun interface StandaloneProducer {
+    fun apply() : String
+}
+

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducerImpl.kt
@@ -1,0 +1,29 @@
+/*
+
+ *
+ */
+
+@file:JvmName("StandaloneProducerImpl")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class StandaloneProducerImpl : NativeBase, StandaloneProducer {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun apply() : String
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas.cpp
@@ -1,0 +1,87 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Lambdas.h"
+#include "com_example_smoke_Lambdas_Confounder__Conversion.h"
+#include "com_example_smoke_Lambdas_Indexer__Conversion.h"
+#include "com_example_smoke_Lambdas_Producer__Conversion.h"
+#include "com_example_smoke_Lambdas__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jobject
+Java_com_example_smoke_Lambdas_deconfuse(JNIEnv* _jenv, jobject _jinstance, jstring jvalue, jobject jconfuser)
+
+{
+
+
+
+    ::std::string value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    ::smoke::Lambdas::Confuser confuser = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jconfuser),
+            ::gluecodium::jni::TypeId<::smoke::Lambdas::Confuser>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Lambdas>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->deconfuse(value,confuser);
+
+    return ::gluecodium::jni::com_example_smoke_Lambdas_00024Producer_convert_to_jni(_jenv, _result).release();
+}
+
+jobject
+Java_com_example_smoke_Lambdas_fuse(JNIEnv* _jenv, jobject _jinstance, jobject jitems, jobject jcallback)
+
+{
+
+
+
+    ::std::vector< ::std::string > items = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jitems),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::string >>{});
+
+
+
+    ::smoke::Lambdas::Indexer callback = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jcallback),
+            ::gluecodium::jni::TypeId<::smoke::Lambdas::Indexer>{});
+
+
+
+
+
+    auto _result = ::smoke::Lambdas::fuse(items,callback);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Lambdas_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Lambdas>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ConfounderImpl.cpp
@@ -1,0 +1,50 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Lambdas_ConfounderImpl.h"
+#include "com_example_smoke_Lambdas_Confounder__Conversion.h"
+#include "com_example_smoke_Lambdas_Producer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jobject
+Java_com_example_smoke_Lambdas_00024ConfounderImpl_confuse(JNIEnv* _jenv, jobject _jinstance, jstring jp0)
+
+{
+
+
+
+    ::std::string p0 = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jp0),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<::smoke::Lambdas::Confuser*>(
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+    auto _result = (*pInstanceSharedPointer)(p0);
+
+    return ::gluecodium::jni::com_example_smoke_Lambdas_00024Producer_convert_to_jni(_jenv, _result).release();
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Lambdas_00024ConfounderImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    delete reinterpret_cast<::smoke::Lambdas::Confuser*>(_jpointerRef);
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ConfounderImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ConfounderImplCppProxy.cpp
@@ -1,0 +1,37 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Lambdas_ConfounderImplCppProxy.h"
+#include "com_example_smoke_Lambdas_Confounder__Conversion.h"
+#include "com_example_smoke_Lambdas_Producer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_Lambdas_00024Confounder_CppProxy::com_example_smoke_Lambdas_00024Confounder_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_Lambdas_00024Confounder") {
+}
+
+::smoke::Lambdas::Producer
+com_example_smoke_Lambdas_00024Confounder_CppProxy::operator()( const ::std::string& np0 ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jp0 = convert_to_jni( jniEnv, np0 );
+    auto _result = callJavaMethod<jobject>( "confuse", "(Ljava/lang/String;)Lcom/example/smoke/Lambdas$Producer;", jniEnv , jp0);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return com_example_smoke_Lambdas_00024Producer_convert_from_jni( jniEnv, _result, TypeId<::smoke::Lambdas::Producer>{});
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_Confounder__Conversion.cpp
@@ -1,0 +1,73 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Lambdas_Confounder__Conversion.h"
+#include "com_example_smoke_Lambdas_ConfounderImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/Lambdas$ConfounderImpl", com_example_smoke_Lambdas_00024Confounder, ::smoke::Lambdas::Confuser)
+
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::Lambdas::Confuser& result)
+{
+    std::shared_ptr<com_example_smoke_Lambdas_00024Confounder_CppProxy> _nproxy{};
+    CppProxyBase::createProxy<com_example_smoke_Lambdas_00024Confounder_CppProxy, com_example_smoke_Lambdas_00024Confounder_CppProxy>(env, obj, "com_example_smoke_Lambdas_00024Confounder", _nproxy);
+    result = std::bind(&com_example_smoke_Lambdas_00024Confounder_CppProxy::operator(), _nproxy, std::placeholders::_1);
+}
+
+
+::smoke::Lambdas::Confuser convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::Lambdas::Confuser>)
+{
+    ::smoke::Lambdas::Confuser _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<::smoke::Lambdas::Confuser*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::Lambdas::Confuser& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    JniReference<jobject> jResult;
+
+    auto &javaClass = CachedJavaClass<::smoke::Lambdas::Confuser>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) ::smoke::Lambdas::Confuser(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_Confounder__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_Confounder__Conversion.h
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/Lambdas.h"
+#include <functional>
+#include "com_example_smoke_Lambdas_Producer__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT ::smoke::Lambdas::Confuser convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::Lambdas::Confuser>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::smoke::Lambdas::Confuser& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_IndexerImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_IndexerImplCppProxy.cpp
@@ -1,0 +1,37 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Lambdas_IndexerImplCppProxy.h"
+#include "com_example_smoke_Lambdas_Indexer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_Lambdas_00024Indexer_CppProxy::com_example_smoke_Lambdas_00024Indexer_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_Lambdas_00024Indexer") {
+}
+
+int32_t
+com_example_smoke_Lambdas_00024Indexer_CppProxy::operator()( const ::std::string& np0, const float nidx ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto jp0 = convert_to_jni( jniEnv, np0 );
+    jfloat jidx = nidx;
+    auto _result = callJavaMethod<jint>( "apply", "(Ljava/lang/String;F)I", jniEnv , jp0, jidx);
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return _result;
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_Indexer__Conversion.cpp
@@ -1,0 +1,73 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Lambdas_Indexer__Conversion.h"
+#include "com_example_smoke_Lambdas_IndexerImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/Lambdas$IndexerImpl", com_example_smoke_Lambdas_00024Indexer, ::smoke::Lambdas::Indexer)
+
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::Lambdas::Indexer& result)
+{
+    std::shared_ptr<com_example_smoke_Lambdas_00024Indexer_CppProxy> _nproxy{};
+    CppProxyBase::createProxy<com_example_smoke_Lambdas_00024Indexer_CppProxy, com_example_smoke_Lambdas_00024Indexer_CppProxy>(env, obj, "com_example_smoke_Lambdas_00024Indexer", _nproxy);
+    result = std::bind(&com_example_smoke_Lambdas_00024Indexer_CppProxy::operator(), _nproxy, std::placeholders::_1, std::placeholders::_2);
+}
+
+
+::smoke::Lambdas::Indexer convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::Lambdas::Indexer>)
+{
+    ::smoke::Lambdas::Indexer _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<::smoke::Lambdas::Indexer*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::Lambdas::Indexer& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    JniReference<jobject> jResult;
+
+    auto &javaClass = CachedJavaClass<::smoke::Lambdas::Indexer>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) ::smoke::Lambdas::Indexer(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.cpp
@@ -1,0 +1,35 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Lambdas_ProducerImplCppProxy.h"
+#include "com_example_smoke_Lambdas_Producer__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_smoke_Lambdas_00024Producer_CppProxy::com_example_smoke_Lambdas_00024Producer_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_smoke_Lambdas_00024Producer") {
+}
+
+::std::string
+com_example_smoke_Lambdas_00024Producer_CppProxy::operator()(  ) {
+
+    JNIEnv* jniEnv = getJniEnvironment( );
+    auto _result = callJavaMethod<jstring>( "apply", "()Ljava/lang/String;", jniEnv  );
+
+    checkExceptionAndReportIfAny(jniEnv);
+
+    return convert_from_jni( jniEnv, _result, TypeId<::std::string>{});
+
+
+
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_Lambdas_ProducerImplCppProxy.h
@@ -1,0 +1,29 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/Lambdas.h"
+#include <functional>
+#include "CppProxyBase.h"
+#include "JniReference.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+class com_example_smoke_Lambdas_00024Producer_CppProxy final : public CppProxyBase {
+public:
+    com_example_smoke_Lambdas_00024Producer_CppProxy( JniReference<jobject> globalRef, jint _jHashCode ) noexcept;
+    com_example_smoke_Lambdas_00024Producer_CppProxy( const com_example_smoke_Lambdas_00024Producer_CppProxy& ) = delete;
+    com_example_smoke_Lambdas_00024Producer_CppProxy& operator=( const com_example_smoke_Lambdas_00024Producer_CppProxy& ) = delete;
+
+
+    ::std::string operator()(  );
+};
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_OverloadedLambda__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_OverloadedLambda__Conversion.cpp
@@ -1,0 +1,132 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_OverloadedLambda__Conversion.h"
+#include "com_example_smoke_OverloadedLambdaImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/OverloadedLambdaImpl", com_example_smoke_OverloadedLambda, ::smoke::OverloadedLambda)
+
+void com_example_smoke_OverloadedLambda_createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::OverloadedLambda& result)
+{
+    std::shared_ptr<com_example_smoke_OverloadedLambda_CppProxy> _nproxy{};
+    CppProxyBase::createProxy<com_example_smoke_OverloadedLambda_CppProxy, com_example_smoke_OverloadedLambda_CppProxy>(env, obj, "com_example_smoke_OverloadedLambda", _nproxy);
+    result = std::bind(&com_example_smoke_OverloadedLambda_CppProxy::operator(), _nproxy, std::placeholders::_1);
+}
+
+
+::smoke::OverloadedLambda com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::OverloadedLambda>)
+{
+    ::smoke::OverloadedLambda _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<::smoke::OverloadedLambda*>(long_ptr);
+        }
+    }
+    else
+    {
+        com_example_smoke_OverloadedLambda_createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _jenv, const ::smoke::OverloadedLambda& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    JniReference<jobject> jResult;
+
+    auto &javaClass = CachedJavaClass<::smoke::OverloadedLambda>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) ::smoke::OverloadedLambda(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+
+    return jResult;
+}
+
+std::optional<::smoke::OverloadedLambda>
+com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::OverloadedLambda>>) {
+    return _jobj
+        ? std::optional<::smoke::OverloadedLambda>(com_example_smoke_OverloadedLambda_convert_from_jni(_env, _jobj, TypeId<::smoke::OverloadedLambda>{}))
+        : std::optional<::smoke::OverloadedLambda>{};
+}
+
+JniReference<jobject>
+com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<::smoke::OverloadedLambda>& _ninput) {
+    return _ninput ? com_example_smoke_OverloadedLambda_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
+}
+
+JniReference<jobject>
+com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* const env, const std::vector<::smoke::OverloadedLambda>& input)
+{
+    JavaArrayListAdder list_appender{env};
+
+    for (const auto& element : input)
+    {
+        list_appender.add(com_example_smoke_OverloadedLambda_convert_to_jni(env, element));
+    }
+
+    return list_appender.fetch_container();
+}
+
+JniReference<jobject>
+com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<std::vector<::smoke::OverloadedLambda>>& _ninput) {
+    return _ninput ? com_example_smoke_OverloadedLambda_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
+}
+
+std::vector<::smoke::OverloadedLambda>
+com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* const env, const JniReference<jobject>& array_list, TypeId<std::vector<::smoke::OverloadedLambda>>) {
+    std::vector<::smoke::OverloadedLambda> result{};
+    if (env->IsSameObject(array_list.get(), nullptr))
+    {
+        return result;
+    }
+
+    const JavaListIterator list_iterator(env, array_list);
+
+    const jint length = list_iterator.length();
+
+    result.reserve(length);
+
+    for (jint i = 0; i < length; i++)
+    {
+        result.emplace_back(com_example_smoke_OverloadedLambda_convert_from_jni(
+            env, list_iterator.get(array_list, i), TypeId<::smoke::OverloadedLambda>{}));
+    }
+
+    return result;
+}
+
+std::optional<std::vector<::smoke::OverloadedLambda>>
+com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::OverloadedLambda>>>) {
+    return _arrayList
+        ? std::optional<std::vector<::smoke::OverloadedLambda>>(com_example_smoke_OverloadedLambda_convert_from_jni(_env, _arrayList, TypeId<std::vector<::smoke::OverloadedLambda>>{}))
+        : std::optional<std::vector<::smoke::OverloadedLambda>>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_OverloadedLambda__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_OverloadedLambda__Conversion.h
@@ -1,0 +1,97 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/OverloadedLambda.h"
+#include <functional>
+#include "JniCallJavaMethod.h"
+#include "JniJavaContainers.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT ::smoke::OverloadedLambda com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::OverloadedLambda>);
+JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _jenv, const ::smoke::OverloadedLambda& _ninput);
+JNIEXPORT std::optional<::smoke::OverloadedLambda> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::OverloadedLambda>>);
+JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<::smoke::OverloadedLambda>& _ninput);
+
+// Functions to create ArrayLists from C++ vectors and vice versa, for overloaded lambdas.
+
+JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::vector<::smoke::OverloadedLambda>& _ninput);
+JNIEXPORT JniReference<jobject> com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<std::vector<::smoke::OverloadedLambda>>& _ninput);
+JNIEXPORT std::vector<::smoke::OverloadedLambda> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<::smoke::OverloadedLambda>>);
+JNIEXPORT std::optional<std::vector<::smoke::OverloadedLambda>> com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::OverloadedLambda>>>);
+
+// Templated functions to create HashMaps from C++ unordered_maps and vice versa, for overloaded lambdas as values.
+
+template <typename K, typename Hash>
+JniReference<jobject>
+com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* const env, const std::unordered_map<K, ::smoke::OverloadedLambda, Hash>& input)
+{
+    JavaHashMapAdder map_adder{env};
+
+    for (const auto& pair : input)
+    {
+        map_adder.add(convert_to_jni(env, pair.first),
+                      com_example_smoke_OverloadedLambda_convert_to_jni(env, pair.second));
+    }
+
+    return map_adder.fetch_hash_map();
+}
+
+template <typename K, typename Hash>
+JniReference<jobject>
+com_example_smoke_OverloadedLambda_convert_to_jni(JNIEnv* _env, const std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>& _ninput)
+{
+    return _ninput ? com_example_smoke_OverloadedLambda_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
+}
+
+template <typename K, typename Hash>
+std::unordered_map<K, ::smoke::OverloadedLambda, Hash>
+com_example_smoke_OverloadedLambda_convert_from_jni(
+    JNIEnv* const env, const JniReference<jobject>& java_map, TypeId<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>)
+{
+    std::unordered_map<K, ::smoke::OverloadedLambda, Hash> result{};
+
+    if (env->IsSameObject(java_map.get(), nullptr))
+    {
+        return result;
+    }
+
+    const JavaMapIterator map_iterator(env, java_map);
+
+    while(map_iterator.has_next())
+    {
+        const auto& key_value = map_iterator.next();
+        result.emplace(convert_from_jni(env, key_value.first, TypeId<K>{}),
+                       com_example_smoke_OverloadedLambda_convert_from_jni(env, key_value.second, TypeId<::smoke::OverloadedLambda>{}));
+    }
+
+    return result;
+}
+
+template<typename K, typename Hash>
+std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>
+com_example_smoke_OverloadedLambda_convert_from_jni(JNIEnv* _env,
+                 const JniReference<jobject>& _jMap,
+                 TypeId<std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>>)
+{
+    return _jMap
+        ? std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>(
+            com_example_smoke_OverloadedLambda_convert_from_jni(_env, _jMap, TypeId<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>{})
+        ) : std::optional<std::unordered_map<K, ::smoke::OverloadedLambda, Hash>>{};
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_StandaloneProducer__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_StandaloneProducer__Conversion.cpp
@@ -1,0 +1,132 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_StandaloneProducer__Conversion.h"
+#include "com_example_smoke_StandaloneProducerImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/StandaloneProducerImpl", com_example_smoke_StandaloneProducer, ::smoke::StandaloneProducer)
+
+void com_example_smoke_StandaloneProducer_createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::smoke::StandaloneProducer& result)
+{
+    std::shared_ptr<com_example_smoke_StandaloneProducer_CppProxy> _nproxy{};
+    CppProxyBase::createProxy<com_example_smoke_StandaloneProducer_CppProxy, com_example_smoke_StandaloneProducer_CppProxy>(env, obj, "com_example_smoke_StandaloneProducer", _nproxy);
+    result = std::bind(&com_example_smoke_StandaloneProducer_CppProxy::operator(), _nproxy);
+}
+
+
+::smoke::StandaloneProducer com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::StandaloneProducer>)
+{
+    ::smoke::StandaloneProducer _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<::smoke::StandaloneProducer*>(long_ptr);
+        }
+    }
+    else
+    {
+        com_example_smoke_StandaloneProducer_createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _jenv, const ::smoke::StandaloneProducer& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    JniReference<jobject> jResult;
+
+    auto &javaClass = CachedJavaClass<::smoke::StandaloneProducer>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) ::smoke::StandaloneProducer(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+
+    return jResult;
+}
+
+std::optional<::smoke::StandaloneProducer>
+com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::StandaloneProducer>>) {
+    return _jobj
+        ? std::optional<::smoke::StandaloneProducer>(com_example_smoke_StandaloneProducer_convert_from_jni(_env, _jobj, TypeId<::smoke::StandaloneProducer>{}))
+        : std::optional<::smoke::StandaloneProducer>{};
+}
+
+JniReference<jobject>
+com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<::smoke::StandaloneProducer>& _ninput) {
+    return _ninput ? com_example_smoke_StandaloneProducer_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
+}
+
+JniReference<jobject>
+com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* const env, const std::vector<::smoke::StandaloneProducer>& input)
+{
+    JavaArrayListAdder list_appender{env};
+
+    for (const auto& element : input)
+    {
+        list_appender.add(com_example_smoke_StandaloneProducer_convert_to_jni(env, element));
+    }
+
+    return list_appender.fetch_container();
+}
+
+JniReference<jobject>
+com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<std::vector<::smoke::StandaloneProducer>>& _ninput) {
+    return _ninput ? com_example_smoke_StandaloneProducer_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
+}
+
+std::vector<::smoke::StandaloneProducer>
+com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* const env, const JniReference<jobject>& array_list, TypeId<std::vector<::smoke::StandaloneProducer>>) {
+    std::vector<::smoke::StandaloneProducer> result{};
+    if (env->IsSameObject(array_list.get(), nullptr))
+    {
+        return result;
+    }
+
+    const JavaListIterator list_iterator(env, array_list);
+
+    const jint length = list_iterator.length();
+
+    result.reserve(length);
+
+    for (jint i = 0; i < length; i++)
+    {
+        result.emplace_back(com_example_smoke_StandaloneProducer_convert_from_jni(
+            env, list_iterator.get(array_list, i), TypeId<::smoke::StandaloneProducer>{}));
+    }
+
+    return result;
+}
+
+std::optional<std::vector<::smoke::StandaloneProducer>>
+com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::StandaloneProducer>>>) {
+    return _arrayList
+        ? std::optional<std::vector<::smoke::StandaloneProducer>>(com_example_smoke_StandaloneProducer_convert_from_jni(_env, _arrayList, TypeId<std::vector<::smoke::StandaloneProducer>>{}))
+        : std::optional<std::vector<::smoke::StandaloneProducer>>{};
+}
+}
+}

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_StandaloneProducer__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/jni/com_example_smoke_StandaloneProducer__Conversion.h
@@ -1,0 +1,97 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/StandaloneProducer.h"
+#include <functional>
+#include "JniCallJavaMethod.h"
+#include "JniJavaContainers.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT ::smoke::StandaloneProducer com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<::smoke::StandaloneProducer>);
+JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _jenv, const ::smoke::StandaloneProducer& _ninput);
+JNIEXPORT std::optional<::smoke::StandaloneProducer> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::optional<::smoke::StandaloneProducer>>);
+JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<::smoke::StandaloneProducer>& _ninput);
+
+// Functions to create ArrayLists from C++ vectors and vice versa, for overloaded lambdas.
+
+JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::vector<::smoke::StandaloneProducer>& _ninput);
+JNIEXPORT JniReference<jobject> com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<std::vector<::smoke::StandaloneProducer>>& _ninput);
+JNIEXPORT std::vector<::smoke::StandaloneProducer> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::vector<::smoke::StandaloneProducer>>);
+JNIEXPORT std::optional<std::vector<::smoke::StandaloneProducer>> com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _arrayList, TypeId<std::optional<std::vector<::smoke::StandaloneProducer>>>);
+
+// Templated functions to create HashMaps from C++ unordered_maps and vice versa, for overloaded lambdas as values.
+
+template <typename K, typename Hash>
+JniReference<jobject>
+com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* const env, const std::unordered_map<K, ::smoke::StandaloneProducer, Hash>& input)
+{
+    JavaHashMapAdder map_adder{env};
+
+    for (const auto& pair : input)
+    {
+        map_adder.add(convert_to_jni(env, pair.first),
+                      com_example_smoke_StandaloneProducer_convert_to_jni(env, pair.second));
+    }
+
+    return map_adder.fetch_hash_map();
+}
+
+template <typename K, typename Hash>
+JniReference<jobject>
+com_example_smoke_StandaloneProducer_convert_to_jni(JNIEnv* _env, const std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>& _ninput)
+{
+    return _ninput ? com_example_smoke_StandaloneProducer_convert_to_jni(_env, *_ninput) : JniReference<jobject>{};
+}
+
+template <typename K, typename Hash>
+std::unordered_map<K, ::smoke::StandaloneProducer, Hash>
+com_example_smoke_StandaloneProducer_convert_from_jni(
+    JNIEnv* const env, const JniReference<jobject>& java_map, TypeId<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>)
+{
+    std::unordered_map<K, ::smoke::StandaloneProducer, Hash> result{};
+
+    if (env->IsSameObject(java_map.get(), nullptr))
+    {
+        return result;
+    }
+
+    const JavaMapIterator map_iterator(env, java_map);
+
+    while(map_iterator.has_next())
+    {
+        const auto& key_value = map_iterator.next();
+        result.emplace(convert_from_jni(env, key_value.first, TypeId<K>{}),
+                       com_example_smoke_StandaloneProducer_convert_from_jni(env, key_value.second, TypeId<::smoke::StandaloneProducer>{}));
+    }
+
+    return result;
+}
+
+template<typename K, typename Hash>
+std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>
+com_example_smoke_StandaloneProducer_convert_from_jni(JNIEnv* _env,
+                 const JniReference<jobject>& _jMap,
+                 TypeId<std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>>)
+{
+    return _jMap
+        ? std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>(
+            com_example_smoke_StandaloneProducer_convert_from_jni(_env, _jMap, TypeId<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>{})
+        ) : std::optional<std::unordered_map<K, ::smoke::StandaloneProducer, Hash>>{};
+}
+
+}
+}


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.