### PR TITLE
Handle throwing function used in `AfterConstruction` attribute

### DIFF
--- a/docs/lime_attributes.md
+++ b/docs/lime_attributes.md
@@ -59,8 +59,7 @@ element is skipped (not generated). Custom tags are case-insensitive.
 It specifies a function that should be called after the constructor call finishes and the object is properly created and cached.
 It is required when `this` object needs to be passed to some platform method during construction. The function call inside
 `@AfterConstructed()` annotation can use any of parameters of the constructor in any order. In order to refer to this/self
-object `this` keyword should be used in LIME file. Note: the parameter of static function in Swift needs to be named `self`
-in order to ensure that the code compiles.
+object `this` keyword should be used in LIME file.
 To understand the purpose of the usage let's consider the following situation:
   * we have a constructor, which takes an interface: `constructor(someInterface: SomeInterface)`
   * we want to call a method of the interface from the constructor with the newly created object: `someInterface.doSomething(this)`

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
@@ -90,4 +90,17 @@ class ListenerAsConstructorParamTest {
         }
         assertEquals("BAD THING HAPPENED!", exception.error)
     }
+
+    @org.junit.Test
+    fun testThrowingAfterConstructionFunctionFromCtorThatMayThrowTwoTypesOfExceptions() {
+        // Given temperature observer, which receives updates about temperature.
+        val observer: CelsiusObserver = CelsiusObserver()
+        val observers: MutableList<TemperatureObserver> = mutableListOf(observer)
+
+        // Then throwing after-construction function raises exception.
+        val exception = assertThrows(Thermometer.NotificationException::class.java) {
+            Thermometer(true, observers)
+        }
+        assertEquals("BAD THING HAPPENED!", exception.error)
+    }
 }

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
@@ -77,4 +77,17 @@ class ListenerAsConstructorParamTest {
         }
         assertEquals("BAD THING HAPPENED!", exception.error)
     }
+
+    @org.junit.Test
+    fun testThrowingAfterConstructionFunctionFromNonthrowingConstructor() {
+        // Given temperature observer, which receives updates about temperature.
+        val observer: CelsiusObserver = CelsiusObserver()
+        val observers: MutableList<TemperatureObserver> = mutableListOf(observer)
+
+        // Then throwing after-construction function raises exception.
+        val exception = assertThrows(Thermometer.NotificationException::class.java) {
+            Thermometer("DUMMY LABEL", observers)
+        }
+        assertEquals("BAD THING HAPPENED!", exception.error)
+    }
 }

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ListenerAsConstructorParamTest.kt
@@ -19,12 +19,12 @@
 package com.here.android.test
 
 import com.here.android.RobolectricApplication
-import org.junit.runner.RunWith
+import com.here.android.lorem.ipsum.time.Duration
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-
-import com.here.android.lorem.ipsum.time.Duration
 
 @RunWith(RobolectricTestRunner::class)
 @Config(application = RobolectricApplication::class)
@@ -63,5 +63,18 @@ class ListenerAsConstructorParamTest {
         // Then subject informed about its state during creation.
         assertEquals(observer.getUpdatesCount(), 2)
         assertEquals(observer.getLastCelsiusTemperature(), anotherThermometer.getCelsius(), delta)
+    }
+
+    @org.junit.Test
+    fun testThrowingAfterConstructionFunction() {
+        // Given temperature observer, which receives updates about temperature.
+        val observer: CelsiusObserver = CelsiusObserver()
+        val observers: MutableList<TemperatureObserver> = mutableListOf(observer)
+
+        // Then throwing after-construction function raises exception.
+        val exception = assertThrows(Thermometer.NotificationException::class.java) {
+            Thermometer(77, observers)
+        }
+        assertEquals("BAD THING HAPPENED!", exception.error)
     }
 }

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
@@ -19,6 +19,7 @@
 package com.here.android.test;
 
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import android.os.Build;
 import com.here.android.lorem.ipsum.time.Duration;
@@ -74,5 +75,21 @@ public class ListenerAsConstructorParamTest {
     // Then subject informed about its state during creation.
     assertEquals(observer.getUpdatesCount(), 2);
     assertEquals(observer.getLastCelsius(), anotherThermometer.getCelsius(), delta);
+  }
+
+  @Test
+  public void testThrowingAfterConstructionFunction() {
+    // Given temperature observer, which receives updates about temperature.
+    CelsiusObserver observer = new CelsiusObserver();
+
+    ArrayList<TemperatureObserver> observers = new ArrayList();
+    observers.add(observer);
+
+    // Then throwing after-construction function raises exception.
+    Thermometer.NotificationException exception = assertThrows(Thermometer.NotificationException.class, () -> {
+      new Thermometer(77, observers);
+    });
+
+    assertEquals("BAD THING HAPPENED!", exception.error);
   }
 }

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
@@ -92,4 +92,20 @@ public class ListenerAsConstructorParamTest {
 
     assertEquals("BAD THING HAPPENED!", exception.error);
   }
+
+  @Test
+  public void testThrowingAfterConstructionFunctionFromNonthrowingConstructor() {
+    // Given temperature observer, which receives updates about temperature.
+    CelsiusObserver observer = new CelsiusObserver();
+
+    ArrayList<TemperatureObserver> observers = new ArrayList();
+    observers.add(observer);
+
+    // Then throwing after-construction function raises exception.
+    Thermometer.NotificationException exception = assertThrows(Thermometer.NotificationException.class, () -> {
+      new Thermometer("SOME DUMMY LABEL", observers);
+    });
+
+    assertEquals("BAD THING HAPPENED!", exception.error);
+  }
 }

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ListenerAsConstructorParamTest.java
@@ -108,4 +108,20 @@ public class ListenerAsConstructorParamTest {
 
     assertEquals("BAD THING HAPPENED!", exception.error);
   }
+
+  @Test
+  public void testThrowingAfterConstructionFunctionFromCtorThatMayThrowTwoTypesOfExceptions() {
+    // Given temperature observer, which receives updates about temperature.
+    CelsiusObserver observer = new CelsiusObserver();
+
+    ArrayList<TemperatureObserver> observers = new ArrayList();
+    observers.add(observer);
+
+    // Then throwing after-construction function raises exception.
+    Thermometer.NotificationException exception = assertThrows(Thermometer.NotificationException.class, () -> {
+      new Thermometer(true, observers);
+    });
+
+    assertEquals("BAD THING HAPPENED!", exception.error);
+  }
 }

--- a/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
+++ b/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
@@ -55,4 +55,22 @@ void main() {
       expect(observer.updatesCount, equals(2));
       expect(observer.lastReadTemperature, equals(anotherThermometer.getCelsius()));
   });
+
+  _testSuite.test("Exception is propagated when after construction function throws", () {
+      // Given temperature observer, which receives updates about temperature.
+      var observer = CelsiusObserver();
+      var observers = [observer];
+
+      // Then throwing after-construction function raises exception.
+      expect(
+          () => Thermometer.throwingMake(77, observers),
+          throwsA(
+              isA<ThermometerNotificationException>().having(
+                  (e) => e.error,
+                  "Correct error message is thrown",
+                  "BAD THING HAPPENED!",
+              )
+          ),
+      );
+  });
 }

--- a/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
+++ b/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
@@ -73,4 +73,22 @@ void main() {
           ),
       );
   });
+
+  _testSuite.test("Exception is propagated when after construction function throws even for non throwing ctor", () {
+      // Given temperature observer, which receives updates about temperature.
+      var observer = CelsiusObserver();
+      var observers = [observer];
+
+      // Then throwing after-construction function raises exception.
+      expect(
+          () => Thermometer.nothrowMake("DUMMY LABEL", observers),
+          throwsA(
+              isA<ThermometerNotificationException>().having(
+                  (e) => e.error,
+                  "Correct error message is thrown",
+                  "BAD THING HAPPENED!",
+              )
+          ),
+      );
+  });
 }

--- a/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
+++ b/functional-tests/functional/dart/test/ListenerAsConstructorParam_test.dart
@@ -91,4 +91,22 @@ void main() {
           ),
       );
   });
+
+  _testSuite.test("Exception is propagated when after construction function throws from ctor that can throw 2 error types", () {
+      // Given temperature observer, which receives updates about temperature.
+      var observer = CelsiusObserver();
+      var observers = [observer];
+
+      // Then throwing after-construction function raises exception.
+      expect(
+          () => Thermometer.anotherThrowingMake(true, observers),
+          throwsA(
+              isA<ThermometerNotificationException>().having(
+                  (e) => e.error,
+                  "Correct error message is thrown",
+                  "BAD THING HAPPENED!",
+              )
+          ),
+      );
+  });
 }

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -20,7 +20,14 @@ package test
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
+    enum SomeThermometerErrorCode {
+        ERROR_NONE,
+        ERROR_FATAL
+    }
+
     exception Notification(String)
+
+    exception AnotherNotification(SomeThermometerErrorCode)
 
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
@@ -33,6 +40,9 @@ class Thermometer {
 
     @AfterConstruction("throwingNotifyObservers(this, niceObservers)")
     constructor nothrowMake(label: String, niceObservers: List<TemperatureObserver>)
+
+    @AfterConstruction("throwingNotifyObservers(this, observers)")
+    constructor anotherThrowingMake(dummy: Boolean, observers: List<TemperatureObserver>) throws AnotherNotification
 
     static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -20,32 +20,56 @@ package test
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
+    // Some error code for thermometer.
     enum SomeThermometerErrorCode {
         ERROR_NONE,
         ERROR_FATAL
     }
 
+    // This error indicates problems with notification of observers.
+    // May be thrown if observers cannot be notified.
     exception Notification(String)
 
+    // This error indicates other problems with notification of observers.
     exception AnotherNotification(SomeThermometerErrorCode)
 
+    // A constructor, which makes the thermometer with readout interval.
+    // @param[interval] readout interval
+    // @param[observers] observers of temperature changes
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
 
+    // A constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[observers] observers of temperature changes
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithoutDuration(observers: List<TemperatureObserver>)
 
+    // A throwing constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[id] identification of this thermometer
+    // @param[observers] observers of temperature changes
+    // @throws if identification number is invalid
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
 
+    // A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[label] some identification label
+    // @param[niceObservers] observers of temperature changes
     @AfterConstruction("throwingNotifyObservers(this, niceObservers)")
     constructor nothrowMake(label: String, niceObservers: List<TemperatureObserver>)
 
+    // A throwing constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[dummy] some dummy boolean flag
+    // @param[observers] observers of temperature changes
+    // @throws if some problem occurs
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor anotherThrowingMake(dummy: Boolean, observers: List<TemperatureObserver>) throws AnotherNotification
 
     static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 
+    // Function used to notify observers.
+    // @param[thermometer] subject that has changed state
+    // @param[someObservers] observers to be notified
+    // @throws if notification of observers failed
     static fun throwingNotifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>) throws Notification
 
     fun forceUpdate()

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -31,6 +31,9 @@ class Thermometer {
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
 
+    @AfterConstruction("throwingNotifyObservers(this, niceObservers)")
+    constructor nothrowMake(label: String, niceObservers: List<TemperatureObserver>)
+
     static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 
     static fun throwingNotifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>) throws Notification

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -31,9 +31,9 @@ class Thermometer {
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
 
-    static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
+    static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 
-    static fun throwingNotifyObservers(self: Thermometer, observers: List<TemperatureObserver>) throws Notification
+    static fun throwingNotifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>) throws Notification
 
     fun forceUpdate()
 

--- a/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
+++ b/functional-tests/functional/input/lime/ListenerAsConstructorParam.lime
@@ -20,13 +20,20 @@ package test
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
+    exception Notification(String)
+
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
 
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithoutDuration(observers: List<TemperatureObserver>)
 
+    @AfterConstruction("throwingNotifyObservers(this, observers)")
+    constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
+
     static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
+
+    static fun throwingNotifyObservers(self: Thermometer, observers: List<TemperatureObserver>) throws Notification
 
     fun forceUpdate()
 

--- a/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
+++ b/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
@@ -117,4 +117,14 @@ void Thermometer::notify_observers(
     return {self};
 }
 
+::std::shared_ptr<::test::Thermometer> Thermometer::nothrow_make(
+    [[maybe_unused]] const std::string& label,
+    const ::std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers
+) {
+    auto self = std::make_shared<ThermometerImpl>(observers);
+    self->force_update();
+
+    return self;
+}
+
 } // namespace test

--- a/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
+++ b/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
@@ -76,6 +76,18 @@ void Thermometer::notify_observers(
     }
 }
 
+::lorem_ipsum::test::Return<void, ::std::string> Thermometer::throwing_notify_observers(
+    const ::std::shared_ptr< ::test::Thermometer >& self,
+    const std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers
+) {
+    for (auto& observer: observers) {
+        observer->on_temperature_update(self);
+    }
+
+    const std::string error_message{"BAD THING HAPPENED!"};
+    return {error_message};
+}
+
 ::std::shared_ptr<::test::Thermometer> Thermometer::make_with_duration(
     const ::std::chrono::seconds interval,
     const ::std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers
@@ -93,6 +105,16 @@ void Thermometer::notify_observers(
     self->force_update();
 
     return self;
+}
+
+::lorem_ipsum::test::Return<::std::shared_ptr<::test::Thermometer>, std::string> Thermometer::throwing_make(
+    [[maybe_unused]] int id,
+    const ::std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers
+) {
+    auto self = std::make_shared<ThermometerImpl>(observers);
+    self->force_update();
+
+    return {self};
 }
 
 } // namespace test

--- a/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
+++ b/functional-tests/functional/input/src/cpp/ListenerAsConstructorParam.cpp
@@ -117,6 +117,16 @@ void Thermometer::notify_observers(
     return {self};
 }
 
+::lorem_ipsum::test::Return<::std::shared_ptr<::test::Thermometer>, ::std::error_code> Thermometer::another_throwing_make(
+    [[maybe_unused]] bool dummy_flag,
+    const ::std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers
+) {
+    auto self = std::make_shared<ThermometerImpl>(observers);
+    self->force_update();
+
+    return {self};
+}
+
 ::std::shared_ptr<::test::Thermometer> Thermometer::nothrow_make(
     [[maybe_unused]] const std::string& label,
     const ::std::vector<::std::shared_ptr<::test::TemperatureObserver>>& observers

--- a/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
+++ b/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
@@ -60,7 +60,19 @@ class ListenerAsConstructorParamTest: XCTestCase {
       XCTAssertEqual(anotherThermometer.getCelsius(), observer.getLastCelsius(), accuracy: 0.000001)
     }
 
+    func testThrowingAfterConstructionFunction() {
+        // Given temperature observer, which receives updates about temperature.
+        let observer = CelsiusObserver()
+        let observers = [observer]
+
+        // Then throwing after-construction function raises exception.
+        XCTAssertThrowsError(try Thermometer(id: 77, observers: observers)) { (error) in
+            XCTAssertEqual(error as? Thermometer.NotificationError, "BAD THING HAPPENED!")
+        }
+    }
+
     static var allTests = [
-      ("testObserverUpdateWhenAfterConstructedUsed", testObserverUpdateWhenAfterConstructedUsed)
+      ("testObserverUpdateWhenAfterConstructedUsed", testObserverUpdateWhenAfterConstructedUsed),
+      ("testThrowingAfterConstructionFunction", testThrowingAfterConstructionFunction)
     ]
 }

--- a/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
+++ b/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
@@ -71,8 +71,20 @@ class ListenerAsConstructorParamTest: XCTestCase {
         }
     }
 
+    func testThrowingAfterConstructionFunctionFromNonThrowingConstructor() {
+        // Given temperature observer, which receives updates about temperature.
+        let observer = CelsiusObserver()
+        let observers = [observer]
+
+        // Then throwing after-construction function raises exception.
+        XCTAssertThrowsError(try Thermometer(label: "DUMMY", niceObservers: observers)) { (error) in
+            XCTAssertEqual(error as? Thermometer.NotificationError, "BAD THING HAPPENED!")
+        }
+    }
+
     static var allTests = [
       ("testObserverUpdateWhenAfterConstructedUsed", testObserverUpdateWhenAfterConstructedUsed),
-      ("testThrowingAfterConstructionFunction", testThrowingAfterConstructionFunction)
+      ("testThrowingAfterConstructionFunction", testThrowingAfterConstructionFunction),
+      ("testThrowingAfterConstructionFunctionFromNonThrowingConstructor", testThrowingAfterConstructionFunctionFromNonThrowingConstructor)
     ]
 }

--- a/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
+++ b/functional-tests/functional/swift/Tests/ListenerAsConstructorParamTest.swift
@@ -82,9 +82,21 @@ class ListenerAsConstructorParamTest: XCTestCase {
         }
     }
 
+    func testThrowingAfterConstructionFunctionFromCtorThatMayThrowTwoTypesOfExceptions() {
+        // Given temperature observer, which receives updates about temperature.
+        let observer = CelsiusObserver()
+        let observers = [observer]
+
+        // Then throwing after-construction function raises exception.
+        XCTAssertThrowsError(try Thermometer(dummy: true, observers: observers)) { (error) in
+            XCTAssertEqual(error as? Thermometer.NotificationError, "BAD THING HAPPENED!")
+        }
+    }
+
     static var allTests = [
       ("testObserverUpdateWhenAfterConstructedUsed", testObserverUpdateWhenAfterConstructedUsed),
       ("testThrowingAfterConstructionFunction", testThrowingAfterConstructionFunction),
-      ("testThrowingAfterConstructionFunctionFromNonThrowingConstructor", testThrowingAfterConstructionFunctionFromNonThrowingConstructor)
+      ("testThrowingAfterConstructionFunctionFromNonThrowingConstructor", testThrowingAfterConstructionFunctionFromNonThrowingConstructor),
+      ("testThrowingAfterConstructionFunctionFromCtorThatMayThrowTwoTypesOfExceptions", testThrowingAfterConstructionFunctionFromCtorThatMayThrowTwoTypesOfExceptions)
     ]
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -114,16 +114,17 @@ internal object CommonGeneratorPredicates {
         else -> limeElement.attributes.have(LimeAttributeType.INTERNAL)
     }
 
-    fun isExceptionSameForCtorAndHookFun(ctor: LimeFunction) : Boolean{
+    fun isExceptionSameForCtorAndHookFun(ctor: LimeFunction): Boolean {
         if (!ctor.isConstructor || ctor.thrownType == null || !ctor.attributes.have(LimeAttributeType.AFTER_CONSTRUCTION)) {
             return false
         }
 
-        val hookFun = ctor.attributes.get(
-            LimeAttributeType.AFTER_CONSTRUCTION,
-            LimeAttributeValueType.FUNCTION,
-            LimeLazyFunctionCall::class.java
-        )?.function
+        val hookFun =
+            ctor.attributes.get(
+                LimeAttributeType.AFTER_CONSTRUCTION,
+                LimeAttributeValueType.FUNCTION,
+                LimeLazyFunctionCall::class.java,
+            )?.function
 
         if (hookFun == null) {
             return false

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/CommonGeneratorPredicates.kt
@@ -28,6 +28,7 @@ import com.here.gluecodium.model.lime.LimeField
 import com.here.gluecodium.model.lime.LimeFieldConstructor
 import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLazyFunctionCall
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
@@ -111,6 +112,24 @@ internal object CommonGeneratorPredicates {
         limeElement.attributes.have(platformAttribute, LimeAttributeValueType.PUBLIC) -> false
         limeElement.attributes.have(platformAttribute, LimeAttributeValueType.INTERNAL) -> true
         else -> limeElement.attributes.have(LimeAttributeType.INTERNAL)
+    }
+
+    fun isExceptionSameForCtorAndHookFun(ctor: LimeFunction) : Boolean{
+        if (!ctor.isConstructor || ctor.thrownType == null || !ctor.attributes.have(LimeAttributeType.AFTER_CONSTRUCTION)) {
+            return false
+        }
+
+        val hookFun = ctor.attributes.get(
+            LimeAttributeType.AFTER_CONSTRUCTION,
+            LimeAttributeValueType.FUNCTION,
+            LimeLazyFunctionCall::class.java
+        )?.function
+
+        if (hookFun == null) {
+            return false
+        }
+
+        return hookFun.exception?.path == ctor.exception?.path
     }
 
     private fun getAllFieldTypes(limeType: LimeType) = getAllFieldTypesRec(getLeafType(limeType), mutableSetOf())

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/dart/DartGeneratorPredicates.kt
@@ -30,6 +30,7 @@ import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeExternalDescriptor
 import com.here.gluecodium.model.lime.LimeField
+import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeNamedElement
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeType
@@ -63,6 +64,12 @@ internal class DartGeneratorPredicates(
             },
             "fieldHasDefaultValue" to { limeField: Any ->
                 limeField is LimeField && limeField.defaultValue != null
+            },
+            "isExceptionSameForCtorAndHookFun" to { constructor: Any ->
+                when (constructor) {
+                    is LimeFunction -> CommonGeneratorPredicates.isExceptionSameForCtorAndHookFun(constructor)
+                    else -> false
+                }
             },
             "isInternal" to { element: Any ->
                 when (element) {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/java/JavaGeneratorPredicates.kt
@@ -25,6 +25,7 @@ import com.here.gluecodium.model.lime.LimeAttributeType.JAVA
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeExternalDescriptor
+import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeInterface
 import com.here.gluecodium.model.lime.LimeStruct
 import com.here.gluecodium.model.lime.LimeTypeRef
@@ -56,6 +57,12 @@ internal object JavaGeneratorPredicates {
                     limeInterface !is LimeInterface -> false
                     limeInterface.functions.any { it.isStatic } -> true
                     limeInterface.properties.any { it.isStatic } -> true
+                    else -> false
+                }
+            },
+            "isExceptionSameForCtorAndHookFun" to { constructor: Any ->
+                when (constructor) {
+                    is LimeFunction -> CommonGeneratorPredicates.isExceptionSameForCtorAndHookFun(constructor)
                     else -> false
                 }
             },

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -50,18 +50,6 @@ internal class SwiftGeneratorPredicates(
 ) {
     val predicates =
         mapOf(
-            "afterConstructionFunctionThrows" to { limeFunction: Any ->
-                if (limeFunction is LimeFunction) {
-                    val exactFunction = limeReferenceMap[limeFunction.path.toString()] as? LimeFunction
-                    if (exactFunction == null) {
-                        false
-                    } else {
-                        exactFunction.thrownType != null
-                    }
-                } else {
-                    false
-                }
-            },
             "hasAnyComment" to { limeElement: Any ->
                 CommonGeneratorPredicates.hasAnyComment(limeElement, "Swift")
             },

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -50,6 +50,18 @@ internal class SwiftGeneratorPredicates(
 ) {
     val predicates =
         mapOf(
+            "afterConstructionFunctionThrows" to { limeFunction: Any ->
+                if (limeFunction is LimeFunction) {
+                    val exactFunction = limeReferenceMap[limeFunction.path.toString()] as? LimeFunction
+                    if (exactFunction == null) {
+                        false
+                    } else {
+                        exactFunction.thrownType != null
+                    }
+                } else {
+                    false
+                }
+            },
             "hasAnyComment" to { limeElement: Any ->
                 CommonGeneratorPredicates.hasAnyComment(limeElement, "Swift")
             },

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/swift/SwiftGeneratorPredicates.kt
@@ -83,6 +83,12 @@ internal class SwiftGeneratorPredicates(
                     limeStruct.fields.any { CommonGeneratorPredicates.isInternal(it, SWIFT) }
             },
             "hasTypeRepository" to { CommonGeneratorPredicates.hasTypeRepository(it) },
+            "isExceptionSameForCtorAndHookFun" to { constructor: Any ->
+                when (constructor) {
+                    is LimeFunction -> CommonGeneratorPredicates.isExceptionSameForCtorAndHookFun(constructor)
+                    else -> false
+                }
+            },
             "isInternal" to { it is LimeNamedElement && CommonGeneratorPredicates.isInternal(it, SWIFT) },
             "isNestedInternal" to { limeElement: Any ->
                 limeElement is LimeNamedElement &&

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -183,6 +183,7 @@ void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
 {{#unless parent.attributes.nocache}}
   __lib.cacheInstance(_result_handle, _result);
 {{/unless}}
+  _{{resolveName parent "Ffi"}}RegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
 {{#this.attributes.afterconstruction}}
   {{resolveName function}}({{!!
 }}{{#function.parameters}}{{!!
@@ -190,7 +191,6 @@ void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
 }}{{#isNotEq this.name "this"}}{{resolveName}}{{/isNotEq}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/function.parameters}});
 {{/this.attributes.afterconstruction}}
-  _{{resolveName parent "Ffi"}}RegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
   return _result;
 }
 {{/dartConstructor}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartClass.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartClass.mustache
@@ -185,7 +185,7 @@ void {{resolveName "Ffi"}}ReleaseFfiHandleNullable(Pointer<Void> handle) =>
 {{/unless}}
   _{{resolveName parent "Ffi"}}RegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
 {{#this.attributes.afterconstruction}}
-  {{resolveName function}}({{!!
+  {{resolveName function.function}}({{!!
 }}{{#function.parameters}}{{!!
 }}{{#isEq this.name "this"}}_result{{/isEq}}{{!!
 }}{{#isNotEq this.name "this"}}{{resolveName}}{{/isNotEq}}{{#if iter.hasNext}}, {{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
+++ b/gluecodium/src/main/resources/templates/dart/DartFunctionDocs.mustache
@@ -29,6 +29,15 @@
 }}{{#if thrownType}}{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}
 /// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}
 ///{{/unless}}{{/resolveName}}{{/if}}{{!!
+}}{{#if isConstructor}}{{#unlessPredicate "isExceptionSameForCtorAndHookFun"}}{{!!
+}}{{#this.attributes.afterconstruction.function.function}}{{!!
+}}{{#if thrownType}}
+{{#resolveName thrownType.comment}}{{#unless this.isEmpty}}
+/// Throws [{{resolveName exception}}]. {{prefix this "/// " skipFirstLine=true}}
+///{{/unless}}{{/resolveName}}{{!!
+}}{{/if}}{{!!
+}}{{/this.attributes.afterconstruction.function.function}}{{!!
+}}{{/unlessPredicate}}{{/if}}{{!!
 }}{{#ifPredicate "needsNoDoc"}}
 /// @nodoc{{/ifPredicate}}{{!!
 }}{{#if attributes.deprecated}}

--- a/gluecodium/src/main/resources/templates/java/JavaClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaClass.mustache
@@ -36,7 +36,7 @@
         cacheThisInstance();
 {{/unless}}
 {{#this.attributes.afterconstruction}}
-        {{resolveName function}}({{!!
+        {{resolveName function.function}}({{!!
 }}{{#function.parameters}}{{!!
 }}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/function.parameters}});

--- a/gluecodium/src/main/resources/templates/java/JavaClass.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaClass.mustache
@@ -30,7 +30,7 @@
 {{#set classElement=this}}{{#constructors}}
 {{prefixPartial "java/JavaMethodComment" "    "}}
     {{resolveName "visibility"}}{{resolveName classElement}}({{joinPartial parameters "java/JavaParameter" ", "}}){{!!
-    }}{{#thrownType}} throws {{resolveName typeRef}}{{/thrownType}} {
+    }}{{>javaConstructorThrows}}{{>javaConstructorExceptions}} {
         this({{resolveName}}({{#parameters}}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{/parameters}}), (Object)null);
 {{#unless classElement.attributes.nocache}}
         cacheThisInstance();
@@ -103,3 +103,25 @@
 {{#elementType}}{{prefixPartial "java/LazyNativeList" "    "}}{{/elementType}}
 {{/this}}{{/eval}}
 }
+{{!!
+
+}}{{+javaConstructorThrows}}{{!!
+}}{{#if thrownType}} throws {{/if}}{{!!
+}}{{#unless thrownType}}{{!!
+}}{{#this.attributes.afterconstruction.function}}{{!!
+}}{{#if function.thrownType}} throws {{/if}}{{!!
+}}{{/this.attributes.afterconstruction.function}}{{!!
+}}{{/unless}}{{!!
+}}{{/javaConstructorThrows}}{{!!
+
+}}{{+javaConstructorExceptions}}{{!!
+}}{{#thrownType}}{{resolveName typeRef}}{{/thrownType}}{{!!
+}}{{#unlessPredicate "isExceptionSameForCtorAndHookFun"}}{{!!
+}}{{#if thrownType this.attributes.afterconstruction.function.function.thrownType}}, {{/if}}{{!!
+}}{{#this.attributes.afterconstruction.function}}{{!!
+}}{{#function.thrownType}}{{resolveName typeRef}}{{/function.thrownType}}{{!!
+}}{{/this.attributes.afterconstruction.function}}{{!!
+}}{{/unlessPredicate}}{{!!
+}}{{/javaConstructorExceptions}}{{!!
+
+}}

--- a/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/java/JavaMethodComment.mustache
@@ -45,4 +45,11 @@
 }}{{#if thrownType}}
 {{!!}}@throws {{resolveName exception "" "ref"}} {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
 }}{{/if}}{{!!
+}}{{#if isConstructor}}{{#unlessPredicate "isExceptionSameForCtorAndHookFun"}}{{!!
+}}{{#this.attributes.afterconstruction.function.function}}{{!!
+}}{{#if thrownType}}
+{{!!}}@throws {{resolveName exception "" "ref"}} {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/if}}{{!!
+}}{{/this.attributes.afterconstruction.function.function}}{{!!
+}}{{/unlessPredicate}}{{/if}}{{!!
 }}{{/combinedComment}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -37,7 +37,7 @@
         cacheThisInstance();
 {{/unless}}
 {{#this.attributes.afterconstruction}}
-        {{resolveName function}}({{!!
+        {{resolveName function.function}}({{!!
 }}{{#function.parameters}}{{!!
 }}{{resolveName}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/function.parameters}})

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -50,10 +50,12 @@
 {{#this.attributes.afterconstruction}}
         {{#function.function.thrownType}}try {{/function.function.thrownType}}{{!!
 }}{{resolveName class}}.{{resolveName function.function}}({{!!
-}}{{#function.parameters}}{{!!
-}}{{#isEq this.name "this"}}self: self{{/isEq}}{{!!
-}}{{#isNotEq this.name "this"}}{{resolveName}}: {{resolveName}}{{/isNotEq}}{{#if iter.hasNext}}, {{/if}}{{!!
-}}{{/function.parameters}});
+}}{{#set funCall=function originalFun=function.function}}{{#funCall.parameters}}{{!!
+}}{{#eval "originalFun.parameters" iter.position}}{{resolveName}}{{/eval}}{{!!
+}}{{#isEq this.name "this"}}: self{{/isEq}}{{!!
+}}{{#isNotEq this.name "this"}}: {{resolveName}}{{/isNotEq}}{{!!
+}}{{#if iter.hasNext}}, {{/if}}{{!!
+}}{{/funCall.parameters}}{{/set}});
 {{/this.attributes.afterconstruction}}
     }
 

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -48,7 +48,8 @@
         {{resolveName class "CBridge"}}_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
 {{/unless}}
 {{#this.attributes.afterconstruction}}
-        {{resolveName class }}.{{resolveName function}}({{!!
+        {{#ifPredicate function "afterConstructionFunctionThrows"}}try {{/ifPredicate}}{{!!
+}}{{resolveName class}}.{{resolveName function}}({{!!
 }}{{#function.parameters}}{{!!
 }}{{#isEq this.name "this"}}self: self{{/isEq}}{{!!
 }}{{#isNotEq this.name "this"}}{{resolveName}}: {{resolveName}}{{/isNotEq}}{{#if iter.hasNext}}, {{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -34,7 +34,7 @@
 {{#set class=this}}{{#constructors}}
 {{prefixPartial "swift/SwiftFunctionComment" "    "}}
     {{resolveName "visibility"}} {{#ifPredicate "isOverriding"}}override {{/ifPredicate}}{{!!
-    }}init({{>swift/SwiftFunctionParameters}}){{#if thrownType}} throws{{/if}} {
+    }}init({{>swift/SwiftFunctionParameters}}){{>swiftConstructorThrows}} {
         let _result = {{#if thrownType}}try {{/if}}{{resolveName class "" "ref"}}.{{resolveName}}({{#parameters}}{{!!
 }}{{#if attributes.swift.label}}{{#isNotEq attributes.swift.label "_"}}{{attributes.swift.label}}: {{/isNotEq}}{{/if}}{{!!
 }}{{#unless attributes.swift.label}}{{resolveName}}: {{/unless}}{{!!
@@ -66,4 +66,15 @@
 
 {{#interfaces}}
 {{>swift/SwiftInterfaceDefinition}}
-{{/interfaces}}
+{{/interfaces}}{{!!
+
+}}{{+swiftConstructorThrows}}{{!!
+}}{{#if thrownType}} throws{{/if}}{{!!
+}}{{#unless thrownType}}{{!!
+}}{{#this.attributes.afterconstruction.function}}{{!!
+}}{{#if function.thrownType}} throws{{/if}}{{!!
+}}{{/this.attributes.afterconstruction.function}}{{!!
+}}{{/unless}}{{!!
+}}{{/swiftConstructorThrows}}{{!!
+
+}}

--- a/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftClassDefinition.mustache
@@ -48,8 +48,8 @@
         {{resolveName class "CBridge"}}_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
 {{/unless}}
 {{#this.attributes.afterconstruction}}
-        {{#ifPredicate function "afterConstructionFunctionThrows"}}try {{/ifPredicate}}{{!!
-}}{{resolveName class}}.{{resolveName function}}({{!!
+        {{#function.function.thrownType}}try {{/function.function.thrownType}}{{!!
+}}{{resolveName class}}.{{resolveName function.function}}({{!!
 }}{{#function.parameters}}{{!!
 }}{{#isEq this.name "this"}}self: self{{/isEq}}{{!!
 }}{{#isNotEq this.name "this"}}{{resolveName}}: {{resolveName}}{{/isNotEq}}{{#if iter.hasNext}}, {{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/swift/SwiftFunctionComment.mustache
+++ b/gluecodium/src/main/resources/templates/swift/SwiftFunctionComment.mustache
@@ -37,4 +37,11 @@
 - Returns: {{#resolveName returnType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{/unless}}{{!!
 }}{{#if thrownType}}
 - Throws: `{{resolveName exception "" "ref"}}` {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{/if}}{{!!
-}}{{/combinedComment}}
+}}{{!!
+}}{{#if isConstructor}}{{#unlessPredicate "isExceptionSameForCtorAndHookFun"}}{{!!
+}}{{#this.attributes.afterconstruction.function.function}}{{!!
+}}{{#if thrownType}}
+- Throws: `{{resolveName exception "" "ref"}}` {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/if}}{{!!
+}}{{/this.attributes.afterconstruction.function.function}}{{!!
+}}{{/unlessPredicate}}{{/if}}{{/combinedComment}}

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -66,6 +66,10 @@ class Thermometer {
 
     static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 
+    // Function used to notify observers.
+    // @param[thermometer] subject that has changed state
+    // @param[someObservers] observers to be notified
+    // @throws if notification of observers failed
     static fun throwingNotifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>) throws Notification
 
     fun forceUpdate()

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -31,6 +31,9 @@ class Thermometer {
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
 
+    @AfterConstruction("throwingNotifyObservers(this, niceObservers)")
+    constructor nothrowMake(label: String, niceObservers: List<TemperatureObserver>)
+
     static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 
     static fun throwingNotifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>) throws Notification

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -31,9 +31,9 @@ class Thermometer {
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
 
-    static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
+    static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 
-    static fun throwingNotifyObservers(self: Thermometer, observers: List<TemperatureObserver>) throws Notification
+    static fun throwingNotifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>) throws Notification
 
     fun forceUpdate()
 

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -20,13 +20,20 @@ package smoke
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
+    exception Notification(String)
+
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
 
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithoutDuration(observers: List<TemperatureObserver>)
 
+    @AfterConstruction("throwingNotifyObservers(this, observers)")
+    constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
+
     static fun notifyObservers(self: Thermometer, observers: List<TemperatureObserver>)
+
+    static fun throwingNotifyObservers(self: Thermometer, observers: List<TemperatureObserver>) throws Notification
 
     fun forceUpdate()
 

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -20,7 +20,14 @@ package smoke
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
+    enum SomeThermometerErrorCode {
+        ERROR_NONE,
+        ERROR_FATAL
+    }
+
     exception Notification(String)
+
+    exception AnotherNotification(SomeThermometerErrorCode)
 
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
@@ -33,6 +40,9 @@ class Thermometer {
 
     @AfterConstruction("throwingNotifyObservers(this, niceObservers)")
     constructor nothrowMake(label: String, niceObservers: List<TemperatureObserver>)
+
+    @AfterConstruction("throwingNotifyObservers(this, observers)")
+    constructor anotherThrowingMake(dummy: Boolean, observers: List<TemperatureObserver>) throws AnotherNotification
 
     static fun notifyObservers(thermometer: Thermometer, someObservers: List<TemperatureObserver>)
 

--- a/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
+++ b/gluecodium/src/test/resources/smoke/listeners/input/ListenerAsConstructorParam.lime
@@ -20,27 +20,47 @@ package smoke
 // A class, which reads temperature and updates observers according to the given interval.
 // "Subject" in observer design pattern.
 class Thermometer {
+    // Some error code for thermometer.
     enum SomeThermometerErrorCode {
         ERROR_NONE,
         ERROR_FATAL
     }
 
+    // This error indicates problems with notification of observers.
+    // May be thrown if observers cannot be notified.
     exception Notification(String)
 
+    // This error indicates other problems with notification of observers.
     exception AnotherNotification(SomeThermometerErrorCode)
 
+    // A constructor, which makes the thermometer with readout interval.
+    // @param[interval] readout interval
+    // @param[observers] observers of temperature changes
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithDuration(interval: Duration, observers: List<TemperatureObserver>)
 
+    // A constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[observers] observers of temperature changes
     @AfterConstruction("notifyObservers(this, observers)")
     constructor makeWithoutDuration(observers: List<TemperatureObserver>)
 
+    // A throwing constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[id] identification of this thermometer
+    // @param[observers] observers of temperature changes
+    // @throws if identification number is invalid
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor throwingMake(id: Int, observers: List<TemperatureObserver>) throws Notification
 
+    // A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[label] some identification label
+    // @param[niceObservers] observers of temperature changes
     @AfterConstruction("throwingNotifyObservers(this, niceObservers)")
     constructor nothrowMake(label: String, niceObservers: List<TemperatureObserver>)
 
+    // A throwing constructor, which makes the thermometer with default readout interval (1 second).
+    // @param[dummy] some dummy boolean flag
+    // @param[observers] observers of temperature changes
+    // @throws if some problem occurs
     @AfterConstruction("throwingNotifyObservers(this, observers)")
     constructor anotherThrowingMake(dummy: Boolean, observers: List<TemperatureObserver>) throws AnotherNotification
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -10,6 +10,9 @@ import com.example.time.Duration
 
 class Thermometer : NativeBase {
 
+    class NotificationException(val error: String) : Exception(error.toString())
+
+
 
     constructor(interval: Duration, observers: MutableList<TemperatureObserver>) : this(makeWithDuration(interval, observers), null as Any?) {
         cacheThisInstance();
@@ -18,6 +21,10 @@ class Thermometer : NativeBase {
     constructor(observers: MutableList<TemperatureObserver>) : this(makeWithoutDuration(observers), null as Any?) {
         cacheThisInstance();
         notifyObservers(this, observers)
+    }
+    constructor(id: Int, observers: MutableList<TemperatureObserver>) : this(throwingMake(id, observers), null as Any?) {
+        cacheThisInstance();
+        throwingNotifyObservers(this, observers)
     }
 
     /*
@@ -44,6 +51,8 @@ class Thermometer : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         @JvmStatic external fun makeWithDuration(interval: Duration, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
+        @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun notifyObservers(self: Thermometer, observers: MutableList<TemperatureObserver>) : Unit
+        @JvmStatic external fun throwingNotifyObservers(self: Thermometer, observers: MutableList<TemperatureObserver>) : Unit
     }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -52,7 +52,7 @@ class Thermometer : NativeBase {
         @JvmStatic external fun makeWithDuration(interval: Duration, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
-        @JvmStatic external fun notifyObservers(self: Thermometer, observers: MutableList<TemperatureObserver>) : Unit
-        @JvmStatic external fun throwingNotifyObservers(self: Thermometer, observers: MutableList<TemperatureObserver>) : Unit
+        @JvmStatic external fun notifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
+        @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
     }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -10,7 +10,14 @@ import com.example.time.Duration
 
 class Thermometer : NativeBase {
 
+    enum class SomeThermometerErrorCode(private val value: Int) {
+        ERROR_NONE(0),
+        ERROR_FATAL(1);
+    }
     class NotificationException(val error: String) : Exception(error.toString())
+
+
+    class AnotherNotificationException(val error: Thermometer.SomeThermometerErrorCode) : Exception(error.toString())
 
 
 
@@ -29,6 +36,10 @@ class Thermometer : NativeBase {
     constructor(label: String, niceObservers: MutableList<TemperatureObserver>) : this(nothrowMake(label, niceObservers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, niceObservers)
+    }
+    constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
+        cacheThisInstance();
+        throwingNotifyObservers(this, observers)
     }
 
     /*
@@ -57,6 +68,7 @@ class Thermometer : NativeBase {
         @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun nothrowMake(label: String, niceObservers: MutableList<TemperatureObserver>) : Long
+        @JvmStatic external fun anotherThrowingMake(dummy: Boolean, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun notifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
         @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -26,6 +26,10 @@ class Thermometer : NativeBase {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }
+    constructor(label: String, niceObservers: MutableList<TemperatureObserver>) : this(nothrowMake(label, niceObservers), null as Any?) {
+        cacheThisInstance();
+        throwingNotifyObservers(this, niceObservers)
+    }
 
     /*
      * For internal use only.
@@ -52,6 +56,7 @@ class Thermometer : NativeBase {
         @JvmStatic external fun makeWithDuration(interval: Duration, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
+        @JvmStatic external fun nothrowMake(label: String, niceObservers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun notifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
         @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
@@ -121,32 +121,32 @@ Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstanc
 }
 
 void
-Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers)
 
 {
 
 
 
-    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jself),
+    ::std::shared_ptr< ::smoke::Thermometer > thermometer = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jthermometer),
             ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
 
 
 
-    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > someObservers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jsomeObservers),
             ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
 
 
 
 
 
-    ::smoke::Thermometer::notify_observers(self,observers);
+    ::smoke::Thermometer::notify_observers(thermometer,someObservers);
 
 }
 
 void
-Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers)
 
 {
 
@@ -154,21 +154,21 @@ Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobjec
 
 
 
-    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jself),
+    ::std::shared_ptr< ::smoke::Thermometer > thermometer = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jthermometer),
             ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
 
 
 
-    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > someObservers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jsomeObservers),
             ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
 
 
 
 
 
-    auto nativeCallResult = ::smoke::Thermometer::throwing_notify_observers(self,observers);
+    auto nativeCallResult = ::smoke::Thermometer::throwing_notify_observers(thermometer,someObservers);
 
 
     if (!nativeCallResult.has_value())

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
@@ -120,6 +120,38 @@ Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstanc
     return reinterpret_cast<jlong>(nSharedPtr);
 }
 
+jlong
+Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance, jstring jlabel, jobject jniceObservers)
+
+{
+
+
+
+    ::std::string label = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jlabel),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > niceObservers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jniceObservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto _result = ::smoke::Thermometer::nothrow_make(label,niceObservers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
 void
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers)
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
@@ -5,6 +5,7 @@
 
 #include "com_example_smoke_TemperatureObserver__Conversion.h"
 #include "com_example_smoke_Thermometer.h"
+#include "com_example_smoke_Thermometer_SomeThermometerErrorCode__Conversion.h"
 #include "com_example_smoke_Thermometer__Conversion.h"
 #include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
@@ -142,6 +143,54 @@ Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance
 
 
     auto _result = ::smoke::Thermometer::nothrow_make(label,niceObservers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+jlong
+Java_com_example_smoke_Thermometer_anotherThrowingMake(JNIEnv* _jenv, jobject _jinstance, jboolean jdummy, jobject jobservers)
+
+{
+
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
+
+
+
+    bool dummy = jdummy;
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto nativeCallResult = ::smoke::Thermometer::another_throwing_make(dummy,observers);
+
+
+    auto errorCode = nativeCallResult.error();
+    if (!nativeCallResult.has_value())
+    {
+        auto nErrorValue = static_cast<::smoke::Thermometer::SomeThermometerErrorCode>(errorCode.value());
+        auto jErrorValue = ::gluecodium::jni::convert_to_jni(_jenv, nErrorValue);
+
+        auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Thermometer$AnotherNotificationException");
+        auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Thermometer$SomeThermometerErrorCode;)V");
+        auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
+        _throw_exception.register_exception(std::move(exception));
+        return 0;
+    }
+    auto _result = nativeCallResult.unsafe_value();
+
 
     auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
     if (nSharedPtr == nullptr)

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.cpp
@@ -6,6 +6,7 @@
 #include "com_example_smoke_TemperatureObserver__Conversion.h"
 #include "com_example_smoke_Thermometer.h"
 #include "com_example_smoke_Thermometer__Conversion.h"
+#include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniNativeHandle.h"
@@ -73,6 +74,52 @@ Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _j
     return reinterpret_cast<jlong>(nSharedPtr);
 }
 
+jlong
+Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers)
+
+{
+
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
+
+
+
+    int32_t id = jid;
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto nativeCallResult = ::smoke::Thermometer::throwing_make(id,observers);
+
+
+    if (!nativeCallResult.has_value())
+    {
+        auto jErrorValue = ::gluecodium::jni::convert_to_jni(_jenv, nativeCallResult.error());
+
+        auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Thermometer$NotificationException");
+        auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Ljava/lang/String;)V");
+        auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
+        _throw_exception.register_exception(std::move(exception));
+        return 0;
+    }
+    auto _result = nativeCallResult.unsafe_value();
+
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
 void
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
 
@@ -95,6 +142,45 @@ Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinst
 
 
     ::smoke::Thermometer::notify_observers(self,observers);
+
+}
+
+void
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+
+{
+
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
+
+
+
+    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jself),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto nativeCallResult = ::smoke::Thermometer::throwing_notify_observers(self,observers);
+
+
+    if (!nativeCallResult.has_value())
+    {
+        auto jErrorValue = ::gluecodium::jni::convert_to_jni(_jenv, nativeCallResult.error());
+
+        auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Thermometer$NotificationException");
+        auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Ljava/lang/String;)V");
+        auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
+        _throw_exception.register_exception(std::move(exception));
+    }
+
 
 }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
@@ -19,6 +19,8 @@ JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance, jstring jlabel, jobject jniceObservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_anotherThrowingMake(JNIEnv* _jenv, jobject _jinstance, jboolean jdummy, jobject jobservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
@@ -17,6 +17,8 @@ JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers);
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance, jstring jlabel, jobject jniceObservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
@@ -15,8 +15,12 @@ JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_makeWithDuration(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers);
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance);
 JNIEXPORT jdouble JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer.h
@@ -18,9 +18,9 @@ Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _j
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
 JNIEXPORT void JNICALL
-Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL
-Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance);
 JNIEXPORT jdouble JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/jni/com_example_smoke_Thermometer__Conversion.h
@@ -7,6 +7,7 @@
 
 #include "smoke/Thermometer.h"
 #include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer_SomeThermometerErrorCode__Conversion.h"
 #include "JniReference.h"
 #include "JniTypeId.h"
 #include <memory>

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -15,6 +15,21 @@ import java.util.List;
  * &quot;Subject&quot; in observer design pattern.
  */
 public final class Thermometer extends NativeBase {
+    public static final class NotificationException extends Exception {
+        /**
+         * @hidden
+         * @param error The error.
+         */
+        public NotificationException(final String error) {
+            super(error.toString());
+            this.error = error;
+        }
+
+        /**
+         * @hidden
+         */
+        public final String error;
+    }
 
 
     public Thermometer(@NonNull final Duration interval, @NonNull final List<TemperatureObserver> observers) {
@@ -28,6 +43,13 @@ public final class Thermometer extends NativeBase {
         this(makeWithoutDuration(observers), (Object)null);
         cacheThisInstance();
         notifyObservers(this, observers);
+    }
+
+
+    public Thermometer(final int id, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException {
+        this(throwingMake(id, observers), (Object)null);
+        cacheThisInstance();
+        throwingNotifyObservers(this, observers);
     }
 
     /**
@@ -53,8 +75,13 @@ public final class Thermometer extends NativeBase {
 
     private static native long makeWithoutDuration(@NonNull final List<TemperatureObserver> observers);
 
+    private static native long throwingMake(final int id, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException;
+
 
     public static native void notifyObservers(@NonNull final Thermometer self, @NonNull final List<TemperatureObserver> observers);
+
+
+    public static native void throwingNotifyObservers(@NonNull final Thermometer self, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException;
 
 
     public native void forceUpdate();

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -104,6 +104,7 @@ public final class Thermometer extends NativeBase {
      * <p>A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
      * @param label <p>some identification label
      * @param niceObservers <p>observers of temperature changes
+     * @throws Thermometer.NotificationException <p>if notification of observers failed
      */
 
     public Thermometer(@NonNull final String label, @NonNull final List<TemperatureObserver> niceObservers) throws Thermometer.NotificationException {
@@ -116,6 +117,7 @@ public final class Thermometer extends NativeBase {
      * @param dummy <p>some dummy boolean flag
      * @param observers <p>observers of temperature changes
      * @throws Thermometer.AnotherNotificationException <p>if some problem occurs
+     * @throws Thermometer.NotificationException <p>if notification of observers failed
      */
 
     public Thermometer(final boolean dummy, @NonNull final List<TemperatureObserver> observers) throws Thermometer.AnotherNotificationException, Thermometer.NotificationException {
@@ -156,7 +158,12 @@ public final class Thermometer extends NativeBase {
 
     public static native void notifyObservers(@NonNull final Thermometer thermometer, @NonNull final List<TemperatureObserver> someObservers);
 
-
+    /**
+     * <p>Function used to notify observers.
+     * @param thermometer <p>subject that has changed state
+     * @param someObservers <p>observers to be notified
+     * @throws Thermometer.NotificationException <p>if notification of observers failed
+     */
     public static native void throwingNotifyObservers(@NonNull final Thermometer thermometer, @NonNull final List<TemperatureObserver> someObservers) throws Thermometer.NotificationException;
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -15,6 +15,18 @@ import java.util.List;
  * &quot;Subject&quot; in observer design pattern.
  */
 public final class Thermometer extends NativeBase {
+    public enum SomeThermometerErrorCode {
+        ERROR_NONE(0),
+        ERROR_FATAL(1);
+        /**
+         * @hidden
+         */
+        public final int value;
+
+        SomeThermometerErrorCode(final int value) {
+            this.value = value;
+        }
+    }
     public static final class NotificationException extends Exception {
         /**
          * @hidden
@@ -29,6 +41,21 @@ public final class Thermometer extends NativeBase {
          * @hidden
          */
         public final String error;
+    }
+    public static final class AnotherNotificationException extends Exception {
+        /**
+         * @hidden
+         * @param error The error.
+         */
+        public AnotherNotificationException(final Thermometer.SomeThermometerErrorCode error) {
+            super(error.toString());
+            this.error = error;
+        }
+
+        /**
+         * @hidden
+         */
+        public final Thermometer.SomeThermometerErrorCode error;
     }
 
 
@@ -59,6 +86,13 @@ public final class Thermometer extends NativeBase {
         throwingNotifyObservers(this, niceObservers);
     }
 
+
+    public Thermometer(final boolean dummy, @NonNull final List<TemperatureObserver> observers) throws Thermometer.AnotherNotificationException, Thermometer.NotificationException {
+        this(anotherThrowingMake(dummy, observers), (Object)null);
+        cacheThisInstance();
+        throwingNotifyObservers(this, observers);
+    }
+
     /**
      * For internal use only.
      * @hidden
@@ -85,6 +119,8 @@ public final class Thermometer extends NativeBase {
     private static native long throwingMake(final int id, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException;
 
     private static native long nothrowMake(@NonNull final String label, @NonNull final List<TemperatureObserver> niceObservers);
+
+    private static native long anotherThrowingMake(final boolean dummy, @NonNull final List<TemperatureObserver> observers) throws Thermometer.AnotherNotificationException;
 
 
     public static native void notifyObservers(@NonNull final Thermometer thermometer, @NonNull final List<TemperatureObserver> someObservers);

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -15,6 +15,9 @@ import java.util.List;
  * &quot;Subject&quot; in observer design pattern.
  */
 public final class Thermometer extends NativeBase {
+    /**
+     * <p>Some error code for thermometer.
+     */
     public enum SomeThermometerErrorCode {
         ERROR_NONE(0),
         ERROR_FATAL(1);
@@ -27,6 +30,10 @@ public final class Thermometer extends NativeBase {
             this.value = value;
         }
     }
+    /**
+     * <p>This error indicates problems with notification of observers.
+     * May be thrown if observers cannot be notified.
+     */
     public static final class NotificationException extends Exception {
         /**
          * @hidden
@@ -42,6 +49,9 @@ public final class Thermometer extends NativeBase {
          */
         public final String error;
     }
+    /**
+     * <p>This error indicates other problems with notification of observers.
+     */
     public static final class AnotherNotificationException extends Exception {
         /**
          * @hidden
@@ -57,35 +67,56 @@ public final class Thermometer extends NativeBase {
          */
         public final Thermometer.SomeThermometerErrorCode error;
     }
-
+    /**
+     * <p>A constructor, which makes the thermometer with readout interval.
+     * @param interval <p>readout interval
+     * @param observers <p>observers of temperature changes
+     */
 
     public Thermometer(@NonNull final Duration interval, @NonNull final List<TemperatureObserver> observers) {
         this(makeWithDuration(interval, observers), (Object)null);
         cacheThisInstance();
         notifyObservers(this, observers);
     }
-
+    /**
+     * <p>A constructor, which makes the thermometer with default readout interval (1 second).
+     * @param observers <p>observers of temperature changes
+     */
 
     public Thermometer(@NonNull final List<TemperatureObserver> observers) {
         this(makeWithoutDuration(observers), (Object)null);
         cacheThisInstance();
         notifyObservers(this, observers);
     }
-
+    /**
+     * <p>A throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * @param id <p>identification of this thermometer
+     * @param observers <p>observers of temperature changes
+     * @throws Thermometer.NotificationException <p>if identification number is invalid
+     */
 
     public Thermometer(final int id, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException {
         this(throwingMake(id, observers), (Object)null);
         cacheThisInstance();
         throwingNotifyObservers(this, observers);
     }
-
+    /**
+     * <p>A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * @param label <p>some identification label
+     * @param niceObservers <p>observers of temperature changes
+     */
 
     public Thermometer(@NonNull final String label, @NonNull final List<TemperatureObserver> niceObservers) throws Thermometer.NotificationException {
         this(nothrowMake(label, niceObservers), (Object)null);
         cacheThisInstance();
         throwingNotifyObservers(this, niceObservers);
     }
-
+    /**
+     * <p>A throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * @param dummy <p>some dummy boolean flag
+     * @param observers <p>observers of temperature changes
+     * @throws Thermometer.AnotherNotificationException <p>if some problem occurs
+     */
 
     public Thermometer(final boolean dummy, @NonNull final List<TemperatureObserver> observers) throws Thermometer.AnotherNotificationException, Thermometer.NotificationException {
         this(anotherThrowingMake(dummy, observers), (Object)null);

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -52,6 +52,13 @@ public final class Thermometer extends NativeBase {
         throwingNotifyObservers(this, observers);
     }
 
+
+    public Thermometer(@NonNull final String label, @NonNull final List<TemperatureObserver> niceObservers) {
+        this(nothrowMake(label, niceObservers), (Object)null);
+        cacheThisInstance();
+        throwingNotifyObservers(this, niceObservers);
+    }
+
     /**
      * For internal use only.
      * @hidden
@@ -76,6 +83,8 @@ public final class Thermometer extends NativeBase {
     private static native long makeWithoutDuration(@NonNull final List<TemperatureObserver> observers);
 
     private static native long throwingMake(final int id, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException;
+
+    private static native long nothrowMake(@NonNull final String label, @NonNull final List<TemperatureObserver> niceObservers);
 
 
     public static native void notifyObservers(@NonNull final Thermometer thermometer, @NonNull final List<TemperatureObserver> someObservers);

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -53,7 +53,7 @@ public final class Thermometer extends NativeBase {
     }
 
 
-    public Thermometer(@NonNull final String label, @NonNull final List<TemperatureObserver> niceObservers) {
+    public Thermometer(@NonNull final String label, @NonNull final List<TemperatureObserver> niceObservers) throws Thermometer.NotificationException {
         this(nothrowMake(label, niceObservers), (Object)null);
         cacheThisInstance();
         throwingNotifyObservers(this, niceObservers);

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/com/example/smoke/Thermometer.java
@@ -78,10 +78,10 @@ public final class Thermometer extends NativeBase {
     private static native long throwingMake(final int id, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException;
 
 
-    public static native void notifyObservers(@NonNull final Thermometer self, @NonNull final List<TemperatureObserver> observers);
+    public static native void notifyObservers(@NonNull final Thermometer thermometer, @NonNull final List<TemperatureObserver> someObservers);
 
 
-    public static native void throwingNotifyObservers(@NonNull final Thermometer self, @NonNull final List<TemperatureObserver> observers) throws Thermometer.NotificationException;
+    public static native void throwingNotifyObservers(@NonNull final Thermometer thermometer, @NonNull final List<TemperatureObserver> someObservers) throws Thermometer.NotificationException;
 
 
     public native void forceUpdate();

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
@@ -121,32 +121,32 @@ Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstanc
 }
 
 void
-Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers)
 
 {
 
 
 
-    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jself),
+    ::std::shared_ptr< ::smoke::Thermometer > thermometer = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jthermometer),
             ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
 
 
 
-    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > someObservers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jsomeObservers),
             ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
 
 
 
 
 
-    ::smoke::Thermometer::notify_observers(self,observers);
+    ::smoke::Thermometer::notify_observers(thermometer,someObservers);
 
 }
 
 void
-Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers)
 
 {
 
@@ -154,21 +154,21 @@ Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobjec
 
 
 
-    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jself),
+    ::std::shared_ptr< ::smoke::Thermometer > thermometer = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jthermometer),
             ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
 
 
 
-    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
-            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > someObservers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jsomeObservers),
             ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
 
 
 
 
 
-    auto nativeCallResult = ::smoke::Thermometer::throwing_notify_observers(self,observers);
+    auto nativeCallResult = ::smoke::Thermometer::throwing_notify_observers(thermometer,someObservers);
 
 
     if (!nativeCallResult.has_value())

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
@@ -120,6 +120,38 @@ Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstanc
     return reinterpret_cast<jlong>(nSharedPtr);
 }
 
+jlong
+Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance, jstring jlabel, jobject jniceObservers)
+
+{
+
+
+
+    ::std::string label = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jlabel),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > niceObservers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jniceObservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto _result = ::smoke::Thermometer::nothrow_make(label,niceObservers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
 void
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers)
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
@@ -5,6 +5,7 @@
 
 #include "com_example_smoke_TemperatureObserver__Conversion.h"
 #include "com_example_smoke_Thermometer.h"
+#include "com_example_smoke_Thermometer_SomeThermometerErrorCode__Conversion.h"
 #include "com_example_smoke_Thermometer__Conversion.h"
 #include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
@@ -142,6 +143,54 @@ Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance
 
 
     auto _result = ::smoke::Thermometer::nothrow_make(label,niceObservers);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+jlong
+Java_com_example_smoke_Thermometer_anotherThrowingMake(JNIEnv* _jenv, jobject _jinstance, jboolean jdummy, jobject jobservers)
+
+{
+
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
+
+
+
+    bool dummy = jdummy;
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto nativeCallResult = ::smoke::Thermometer::another_throwing_make(dummy,observers);
+
+
+    auto errorCode = nativeCallResult.error();
+    if (!nativeCallResult.has_value())
+    {
+        auto nErrorValue = static_cast<::smoke::Thermometer::SomeThermometerErrorCode>(errorCode.value());
+        auto jErrorValue = ::gluecodium::jni::convert_to_jni(_jenv, nErrorValue);
+
+        auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Thermometer$AnotherNotificationException");
+        auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Lcom/example/smoke/Thermometer$SomeThermometerErrorCode;)V");
+        auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
+        _throw_exception.register_exception(std::move(exception));
+        return 0;
+    }
+    auto _result = nativeCallResult.unsafe_value();
+
 
     auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
     if (nSharedPtr == nullptr)

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.cpp
@@ -6,6 +6,7 @@
 #include "com_example_smoke_TemperatureObserver__Conversion.h"
 #include "com_example_smoke_Thermometer.h"
 #include "com_example_smoke_Thermometer__Conversion.h"
+#include "JniExceptionThrower.h"
 #include "ArrayConversionUtils.h"
 #include "JniClassCache.h"
 #include "JniNativeHandle.h"
@@ -73,6 +74,52 @@ Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _j
     return reinterpret_cast<jlong>(nSharedPtr);
 }
 
+jlong
+Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers)
+
+{
+
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
+
+
+
+    int32_t id = jid;
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto nativeCallResult = ::smoke::Thermometer::throwing_make(id,observers);
+
+
+    if (!nativeCallResult.has_value())
+    {
+        auto jErrorValue = ::gluecodium::jni::convert_to_jni(_jenv, nativeCallResult.error());
+
+        auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Thermometer$NotificationException");
+        auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Ljava/lang/String;)V");
+        auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
+        _throw_exception.register_exception(std::move(exception));
+        return 0;
+    }
+    auto _result = nativeCallResult.unsafe_value();
+
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::Thermometer >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
 void
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
 
@@ -95,6 +142,45 @@ Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinst
 
 
     ::smoke::Thermometer::notify_observers(self,observers);
+
+}
+
+void
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers)
+
+{
+
+    ::gluecodium::jni::JniExceptionThrower _throw_exception(_jenv);
+
+
+
+    ::std::shared_ptr< ::smoke::Thermometer > self = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jself),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::Thermometer >>{});
+
+
+
+    ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > > observers = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jobservers),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >>{});
+
+
+
+
+
+    auto nativeCallResult = ::smoke::Thermometer::throwing_notify_observers(self,observers);
+
+
+    if (!nativeCallResult.has_value())
+    {
+        auto jErrorValue = ::gluecodium::jni::convert_to_jni(_jenv, nativeCallResult.error());
+
+        auto exceptionClass = ::gluecodium::jni::find_class(_jenv, "com/example/smoke/Thermometer$NotificationException");
+        auto theConstructor = _jenv->GetMethodID(exceptionClass.get(), "<init>", "(Ljava/lang/String;)V");
+        auto exception = ::gluecodium::jni::new_object(_jenv, exceptionClass, theConstructor, jErrorValue);
+        _throw_exception.register_exception(std::move(exception));
+    }
+
 
 }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
@@ -19,6 +19,8 @@ JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance, jstring jlabel, jobject jniceObservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_anotherThrowingMake(JNIEnv* _jenv, jobject _jinstance, jboolean jdummy, jobject jobservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
@@ -17,6 +17,8 @@ JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers);
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_nothrowMake(JNIEnv* _jenv, jobject _jinstance, jstring jlabel, jobject jniceObservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
@@ -15,8 +15,12 @@ JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_makeWithDuration(JNIEnv* _jenv, jobject _jinstance, jobject jinterval, jobject jobservers);
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _jinstance, jobject jobservers);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance);
 JNIEXPORT jdouble JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer.h
@@ -18,9 +18,9 @@ Java_com_example_smoke_Thermometer_makeWithoutDuration(JNIEnv* _jenv, jobject _j
 JNIEXPORT jlong JNICALL
 Java_com_example_smoke_Thermometer_throwingMake(JNIEnv* _jenv, jobject _jinstance, jint jid, jobject jobservers);
 JNIEXPORT void JNICALL
-Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
+Java_com_example_smoke_Thermometer_notifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL
-Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jself, jobject jobservers);
+Java_com_example_smoke_Thermometer_throwingNotifyObservers(JNIEnv* _jenv, jobject _jinstance, jobject jthermometer, jobject jsomeObservers);
 JNIEXPORT void JNICALL
 Java_com_example_smoke_Thermometer_forceUpdate(JNIEnv* _jenv, jobject _jinstance);
 JNIEXPORT jdouble JNICALL

--- a/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android/jni/com_example_smoke_Thermometer__Conversion.h
@@ -7,6 +7,7 @@
 
 #include "smoke/Thermometer.h"
 #include "com_example_smoke_TemperatureObserver__Conversion.h"
+#include "com_example_smoke_Thermometer_SomeThermometerErrorCode__Conversion.h"
 #include "JniReference.h"
 #include "JniTypeId.h"
 #include <memory>

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -60,17 +60,17 @@ public:
     static ::gluecodium::Return< ::std::shared_ptr< ::smoke::Thermometer >, ::std::string > throwing_make( const int32_t id, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     /**
      *
-     * \param[in] self @NotNull
-     * \param[in] observers
+     * \param[in] thermometer @NotNull
+     * \param[in] some_observers
      */
-    static void notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& self, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    static void notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& thermometer, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& some_observers );
     /**
      *
-     * \param[in] self @NotNull
-     * \param[in] observers
+     * \param[in] thermometer @NotNull
+     * \param[in] some_observers
      * \retval ::::String
      */
-    static ::gluecodium::Return< void, ::std::string > throwing_notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& self, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    static ::gluecodium::Return< void, ::std::string > throwing_notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& thermometer, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& some_observers );
     virtual void force_update(  ) = 0;
     virtual double get_celsius(  ) = 0;
     virtual double get_kelvin(  ) = 0;

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -8,9 +8,12 @@
 
 #include "gluecodium/DurationHash.h"
 #include "gluecodium/ExportGluecodiumCpp.h"
+#include "gluecodium/Return.h"
 #include "gluecodium/VectorHash.h"
 #include <chrono>
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 
@@ -49,10 +52,25 @@ public:
     static ::std::shared_ptr< ::smoke::Thermometer > make_without_duration( const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     /**
      *
+     * \param[in] id
+     * \param[in] observers
+     * \return @NotNull
+     * \retval ::::String
+     */
+    static ::gluecodium::Return< ::std::shared_ptr< ::smoke::Thermometer >, ::std::string > throwing_make( const int32_t id, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    /**
+     *
      * \param[in] self @NotNull
      * \param[in] observers
      */
     static void notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& self, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    /**
+     *
+     * \param[in] self @NotNull
+     * \param[in] observers
+     * \retval ::::String
+     */
+    static ::gluecodium::Return< void, ::std::string > throwing_notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& self, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     virtual void force_update(  ) = 0;
     virtual double get_celsius(  ) = 0;
     virtual double get_kelvin(  ) = 0;

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <system_error>
 #include <vector>
 
 
@@ -34,6 +35,13 @@ class _GLUECODIUM_CPP_EXPORT Thermometer {
 public:
     Thermometer();
     virtual ~Thermometer();
+
+
+public:
+    enum class SomeThermometerErrorCode {
+        ERROR_NONE,
+        ERROR_FATAL
+    };
 
 
 public:
@@ -67,6 +75,14 @@ public:
     static ::std::shared_ptr< ::smoke::Thermometer > nothrow_make( const ::std::string& label, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& nice_observers );
     /**
      *
+     * \param[in] dummy
+     * \param[in] observers
+     * \return @NotNull
+     * \retval ::smoke::Thermometer::SomeThermometerErrorCode
+     */
+    static ::gluecodium::Return< ::std::shared_ptr< ::smoke::Thermometer >, ::std::error_code > another_throwing_make( const bool dummy, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
+    /**
+     *
      * \param[in] thermometer @NotNull
      * \param[in] some_observers
      */
@@ -85,4 +101,11 @@ public:
 };
 
 
+_GLUECODIUM_CPP_EXPORT ::std::error_code make_error_code( ::smoke::Thermometer::SomeThermometerErrorCode value ) noexcept;
+}
+
+namespace std
+{
+template <>
+struct is_error_code_enum< ::smoke::Thermometer::SomeThermometerErrorCode > : public std::true_type { };
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -92,10 +92,10 @@ public:
      */
     static void notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& thermometer, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& some_observers );
     /**
-     *
-     * \param[in] thermometer @NotNull
-     * \param[in] some_observers
-     * \retval ::::String
+     * Function used to notify observers.
+     * \param[in] thermometer @NotNull subject that has changed state
+     * \param[in] some_observers observers to be notified
+     * \retval ::::String if notification of observers failed
      */
     static ::gluecodium::Return< void, ::std::string > throwing_notify_observers( const ::std::shared_ptr< ::smoke::Thermometer >& thermometer, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& some_observers );
     virtual void force_update(  ) = 0;

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -38,6 +38,10 @@ public:
 
 
 public:
+    /**
+     * Some error code for thermometer.
+
+     */
     enum class SomeThermometerErrorCode {
         ERROR_NONE,
         ERROR_FATAL
@@ -46,39 +50,39 @@ public:
 
 public:
     /**
-     *
-     * \param[in] interval
-     * \param[in] observers
+     * A constructor, which makes the thermometer with readout interval.
+     * \param[in] interval readout interval
+     * \param[in] observers observers of temperature changes
      * \return @NotNull
      */
     static ::std::shared_ptr< ::smoke::Thermometer > make_with_duration( const ::std::chrono::seconds interval, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     /**
-     *
-     * \param[in] observers
+     * A constructor, which makes the thermometer with default readout interval (1 second).
+     * \param[in] observers observers of temperature changes
      * \return @NotNull
      */
     static ::std::shared_ptr< ::smoke::Thermometer > make_without_duration( const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     /**
-     *
-     * \param[in] id
-     * \param[in] observers
+     * A throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * \param[in] id identification of this thermometer
+     * \param[in] observers observers of temperature changes
      * \return @NotNull
-     * \retval ::::String
+     * \retval ::::String if identification number is invalid
      */
     static ::gluecodium::Return< ::std::shared_ptr< ::smoke::Thermometer >, ::std::string > throwing_make( const int32_t id, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     /**
-     *
-     * \param[in] label
-     * \param[in] nice_observers
+     * A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * \param[in] label some identification label
+     * \param[in] nice_observers observers of temperature changes
      * \return @NotNull
      */
     static ::std::shared_ptr< ::smoke::Thermometer > nothrow_make( const ::std::string& label, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& nice_observers );
     /**
-     *
-     * \param[in] dummy
-     * \param[in] observers
+     * A throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * \param[in] dummy some dummy boolean flag
+     * \param[in] observers observers of temperature changes
      * \return @NotNull
-     * \retval ::smoke::Thermometer::SomeThermometerErrorCode
+     * \retval ::smoke::Thermometer::SomeThermometerErrorCode if some problem occurs
      */
     static ::gluecodium::Return< ::std::shared_ptr< ::smoke::Thermometer >, ::std::error_code > another_throwing_make( const bool dummy, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     /**

--- a/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
+++ b/gluecodium/src/test/resources/smoke/listeners/output/cpp/include/smoke/Thermometer.h
@@ -60,6 +60,13 @@ public:
     static ::gluecodium::Return< ::std::shared_ptr< ::smoke::Thermometer >, ::std::string > throwing_make( const int32_t id, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& observers );
     /**
      *
+     * \param[in] label
+     * \param[in] nice_observers
+     * \return @NotNull
+     */
+    static ::std::shared_ptr< ::smoke::Thermometer > nothrow_make( const ::std::string& label, const ::std::vector< ::std::shared_ptr< ::smoke::TemperatureObserver > >& nice_observers );
+    /**
+     *
      * \param[in] thermometer @NotNull
      * \param[in] some_observers
      */

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -13,15 +13,42 @@ import 'package:meta/meta.dart';
 ///
 /// "Subject" in observer design pattern.
 abstract class Thermometer implements Finalizable {
-
+  /// A constructor, which makes the thermometer with readout interval.
+  ///
+  /// [interval] readout interval
+  ///
+  /// [observers] observers of temperature changes
+  ///
   factory Thermometer.makeWithDuration(Duration interval, List<TemperatureObserver> observers) => $prototype.makeWithDuration(interval, observers);
-
+  /// A constructor, which makes the thermometer with default readout interval (1 second).
+  ///
+  /// [observers] observers of temperature changes
+  ///
   factory Thermometer.makeWithoutDuration(List<TemperatureObserver> observers) => $prototype.makeWithoutDuration(observers);
-
+  /// A throwing constructor, which makes the thermometer with default readout interval (1 second).
+  ///
+  /// [id] identification of this thermometer
+  ///
+  /// [observers] observers of temperature changes
+  ///
+  /// Throws [Thermometer_NotificationException]. if identification number is invalid
+  ///
   factory Thermometer.throwingMake(int id, List<TemperatureObserver> observers) => $prototype.throwingMake(id, observers);
-
+  /// A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
+  ///
+  /// [label] some identification label
+  ///
+  /// [niceObservers] observers of temperature changes
+  ///
   factory Thermometer.nothrowMake(String label, List<TemperatureObserver> niceObservers) => $prototype.nothrowMake(label, niceObservers);
-
+  /// A throwing constructor, which makes the thermometer with default readout interval (1 second).
+  ///
+  /// [dummy] some dummy boolean flag
+  ///
+  /// [observers] observers of temperature changes
+  ///
+  /// Throws [Thermometer_AnotherNotificationException]. if some problem occurs
+  ///
   factory Thermometer.anotherThrowingMake(bool dummy, List<TemperatureObserver> observers) => $prototype.anotherThrowingMake(dummy, observers);
 
 
@@ -42,6 +69,7 @@ abstract class Thermometer implements Finalizable {
   static dynamic $prototype = Thermometer$Impl(Pointer<Void>.fromAddress(0));
 }
 
+/// Some error code for thermometer.
 enum Thermometer_SomeThermometerErrorCode {
     errorNone,
     errorFatal
@@ -104,10 +132,14 @@ void smokeThermometerSomethermometererrorcodeReleaseFfiHandleNullable(Pointer<Vo
   _smokeThermometerSomethermometererrorcodeReleaseHandleNullable(handle);
 
 // End of Thermometer_SomeThermometerErrorCode "private" section.
+/// This error indicates problems with notification of observers.
+///
+/// May be thrown if observers cannot be notified.
 class Thermometer_NotificationException implements Exception {
   final String error;
   Thermometer_NotificationException(this.error);
 }
+/// This error indicates other problems with notification of observers.
 class Thermometer_AnotherNotificationException implements Exception {
   final Thermometer_SomeThermometerErrorCode error;
   Thermometer_AnotherNotificationException(this.error);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -20,6 +20,8 @@ abstract class Thermometer implements Finalizable {
 
   factory Thermometer.throwingMake(int id, List<TemperatureObserver> observers) => $prototype.throwingMake(id, observers);
 
+  factory Thermometer.nothrowMake(String label, List<TemperatureObserver> niceObservers) => $prototype.nothrowMake(label, niceObservers);
+
 
   static void notifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) => $prototype.notifyObservers(thermometer, someObservers);
 
@@ -77,6 +79,7 @@ final _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserver
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_Thermometer_throwingMake__Int_ListOf_smoke_TemperatureObserver_return_has_error'));
+
 
 
 
@@ -147,6 +150,20 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     return _result;
   }
 
+
+  Thermometer nothrowMake(String label, List<TemperatureObserver> niceObservers) {
+    final _result_handle = _nothrowMake(label, niceObservers);
+    final _result = Thermometer$Impl(_result_handle);
+
+    __lib.cacheInstance(_result_handle, _result);
+
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+
+    throwingNotifyObservers(_result, niceObservers);
+
+    return _result;
+  }
+
   static Pointer<Void> _makeWithDuration(Duration interval, List<TemperatureObserver> observers) {
     final _makeWithDurationFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Thermometer_makeWithDuration__Duration_ListOf_smoke_TemperatureObserver'));
     final _intervalHandle = durationToFfi(interval);
@@ -183,6 +200,16 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     }
     final __resultHandle = _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnGetResult(__callResultHandle);
     _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);
+    return __resultHandle;
+  }
+
+  static Pointer<Void> _nothrowMake(String label, List<TemperatureObserver> niceObservers) {
+    final _nothrowMakeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Thermometer_nothrowMake__String_ListOf_smoke_TemperatureObserver'));
+    final _labelHandle = stringToFfi(label);
+    final _niceObserversHandle = foobarListofSmokeTemperatureobserverToFfi(niceObservers);
+    final __resultHandle = _nothrowMakeFfi(__lib.LibraryContext.isolateId, _labelHandle, _niceObserversHandle);
+    stringReleaseFfiHandle(_labelHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_niceObserversHandle);
     return __resultHandle;
   }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -18,8 +18,12 @@ abstract class Thermometer implements Finalizable {
 
   factory Thermometer.makeWithoutDuration(List<TemperatureObserver> observers) => $prototype.makeWithoutDuration(observers);
 
+  factory Thermometer.throwingMake(int id, List<TemperatureObserver> observers) => $prototype.throwingMake(id, observers);
+
 
   static void notifyObservers(Thermometer self, List<TemperatureObserver> observers) => $prototype.notifyObservers(self, observers);
+
+  static void throwingNotifyObservers(Thermometer self, List<TemperatureObserver> observers) => $prototype.throwingNotifyObservers(self, observers);
 
   void forceUpdate();
 
@@ -34,6 +38,10 @@ abstract class Thermometer implements Finalizable {
   static dynamic $prototype = Thermometer$Impl(Pointer<Void>.fromAddress(0));
 }
 
+class Thermometer_NotificationException implements Exception {
+  final String error;
+  Thermometer_NotificationException(this.error);
+}
 
 // Thermometer "private" section, not exported.
 
@@ -52,6 +60,38 @@ final _smokeThermometerReleaseHandle = __lib.catchArgumentError(() => __lib.nati
 
 
 
+
+final _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Thermometer_throwingMake__Int_ListOf_smoke_TemperatureObserver_return_release_handle'));
+final _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Thermometer_throwingMake__Int_ListOf_smoke_TemperatureObserver_return_get_result'));
+final _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Thermometer_throwingMake__Int_ListOf_smoke_TemperatureObserver_return_get_error'));
+final _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Thermometer_throwingMake__Int_ListOf_smoke_TemperatureObserver_return_has_error'));
+
+
+
+final _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Thermometer_throwingNotifyObservers__Thermometer_ListOf_smoke_TemperatureObserver_return_release_handle'));
+final _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Thermometer_throwingNotifyObservers__Thermometer_ListOf_smoke_TemperatureObserver_return_get_error'));
+final _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Thermometer_throwingNotifyObservers__Thermometer_ListOf_smoke_TemperatureObserver_return_has_error'));
 
 
 
@@ -93,6 +133,20 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     return _result;
   }
 
+
+  Thermometer throwingMake(int id, List<TemperatureObserver> observers) {
+    final _result_handle = _throwingMake(id, observers);
+    final _result = Thermometer$Impl(_result_handle);
+
+    __lib.cacheInstance(_result_handle, _result);
+
+
+    throwingNotifyObservers(_result, observers);
+
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+    return _result;
+  }
+
   static Pointer<Void> _makeWithDuration(Duration interval, List<TemperatureObserver> observers) {
     final _makeWithDurationFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Thermometer_makeWithDuration__Duration_ListOf_smoke_TemperatureObserver'));
     final _intervalHandle = durationToFfi(interval);
@@ -111,6 +165,27 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     return __resultHandle;
   }
 
+  static Pointer<Void> _throwingMake(int id, List<TemperatureObserver> observers) {
+    final _throwingMakeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Int32, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Thermometer_throwingMake__Int_ListOf_smoke_TemperatureObserver'));
+    final _idHandle = (id);
+    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
+    final __callResultHandle = _throwingMakeFfi(__lib.LibraryContext.isolateId, _idHandle, _observersHandle);
+
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+    if (_throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnGetError(__callResultHandle);
+        _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);
+        try {
+          throw Thermometer_NotificationException(stringFromFfi(__errorHandle));
+        } finally {
+          stringReleaseFfiHandle(__errorHandle);
+        }
+    }
+    final __resultHandle = _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnGetResult(__callResultHandle);
+    _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);
+    return __resultHandle;
+  }
+
   void notifyObservers(Thermometer self, List<TemperatureObserver> observers) {
     final _notifyObserversFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>, Pointer<Void>), void Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Thermometer_notifyObservers__Thermometer_ListOf_smoke_TemperatureObserver'));
     final _selfHandle = smokeThermometerToFfi(self);
@@ -118,6 +193,26 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     _notifyObserversFfi(__lib.LibraryContext.isolateId, _selfHandle, _observersHandle);
     smokeThermometerReleaseFfiHandle(_selfHandle);
     foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+
+  }
+
+  void throwingNotifyObservers(Thermometer self, List<TemperatureObserver> observers) {
+    final _throwingNotifyObserversFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Thermometer_throwingNotifyObservers__Thermometer_ListOf_smoke_TemperatureObserver'));
+    final _selfHandle = smokeThermometerToFfi(self);
+    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
+    final __callResultHandle = _throwingNotifyObserversFfi(__lib.LibraryContext.isolateId, _selfHandle, _observersHandle);
+    smokeThermometerReleaseFfiHandle(_selfHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+    if (_throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnGetError(__callResultHandle);
+        _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);
+        try {
+          throw Thermometer_NotificationException(stringFromFfi(__errorHandle));
+        } finally {
+          stringReleaseFfiHandle(__errorHandle);
+        }
+    }
+    _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);
 
   }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -40,6 +40,8 @@ abstract class Thermometer implements Finalizable {
   ///
   /// [niceObservers] observers of temperature changes
   ///
+  /// Throws [Thermometer_NotificationException]. if notification of observers failed
+  ///
   factory Thermometer.nothrowMake(String label, List<TemperatureObserver> niceObservers) => $prototype.nothrowMake(label, niceObservers);
   /// A throwing constructor, which makes the thermometer with default readout interval (1 second).
   ///
@@ -49,11 +51,20 @@ abstract class Thermometer implements Finalizable {
   ///
   /// Throws [Thermometer_AnotherNotificationException]. if some problem occurs
   ///
+  /// Throws [Thermometer_NotificationException]. if notification of observers failed
+  ///
   factory Thermometer.anotherThrowingMake(bool dummy, List<TemperatureObserver> observers) => $prototype.anotherThrowingMake(dummy, observers);
 
 
   static void notifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) => $prototype.notifyObservers(thermometer, someObservers);
-
+  /// Function used to notify observers.
+  ///
+  /// [thermometer] subject that has changed state
+  ///
+  /// [someObservers] observers to be notified
+  ///
+  /// Throws [Thermometer_NotificationException]. if notification of observers failed
+  ///
   static void throwingNotifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) => $prototype.throwingNotifyObservers(thermometer, someObservers);
 
   void forceUpdate();

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -112,10 +112,10 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
 
     __lib.cacheInstance(_result_handle, _result);
 
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
 
     notifyObservers(_result, observers);
 
-    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
 
@@ -126,10 +126,10 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
 
     __lib.cacheInstance(_result_handle, _result);
 
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
 
     notifyObservers(_result, observers);
 
-    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
 
@@ -140,10 +140,10 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
 
     __lib.cacheInstance(_result_handle, _result);
 
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
 
     throwingNotifyObservers(_result, observers);
 
-    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
     return _result;
   }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -21,9 +21,9 @@ abstract class Thermometer implements Finalizable {
   factory Thermometer.throwingMake(int id, List<TemperatureObserver> observers) => $prototype.throwingMake(id, observers);
 
 
-  static void notifyObservers(Thermometer self, List<TemperatureObserver> observers) => $prototype.notifyObservers(self, observers);
+  static void notifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) => $prototype.notifyObservers(thermometer, someObservers);
 
-  static void throwingNotifyObservers(Thermometer self, List<TemperatureObserver> observers) => $prototype.throwingNotifyObservers(self, observers);
+  static void throwingNotifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) => $prototype.throwingNotifyObservers(thermometer, someObservers);
 
   void forceUpdate();
 
@@ -186,23 +186,23 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     return __resultHandle;
   }
 
-  void notifyObservers(Thermometer self, List<TemperatureObserver> observers) {
+  void notifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) {
     final _notifyObserversFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Void Function(Int32, Pointer<Void>, Pointer<Void>), void Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Thermometer_notifyObservers__Thermometer_ListOf_smoke_TemperatureObserver'));
-    final _selfHandle = smokeThermometerToFfi(self);
-    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
-    _notifyObserversFfi(__lib.LibraryContext.isolateId, _selfHandle, _observersHandle);
-    smokeThermometerReleaseFfiHandle(_selfHandle);
-    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+    final _thermometerHandle = smokeThermometerToFfi(thermometer);
+    final _someObserversHandle = foobarListofSmokeTemperatureobserverToFfi(someObservers);
+    _notifyObserversFfi(__lib.LibraryContext.isolateId, _thermometerHandle, _someObserversHandle);
+    smokeThermometerReleaseFfiHandle(_thermometerHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_someObserversHandle);
 
   }
 
-  void throwingNotifyObservers(Thermometer self, List<TemperatureObserver> observers) {
+  void throwingNotifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) {
     final _throwingNotifyObserversFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Pointer<Void>, Pointer<Void>), Pointer<Void> Function(int, Pointer<Void>, Pointer<Void>)>('library_smoke_Thermometer_throwingNotifyObservers__Thermometer_ListOf_smoke_TemperatureObserver'));
-    final _selfHandle = smokeThermometerToFfi(self);
-    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
-    final __callResultHandle = _throwingNotifyObserversFfi(__lib.LibraryContext.isolateId, _selfHandle, _observersHandle);
-    smokeThermometerReleaseFfiHandle(_selfHandle);
-    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+    final _thermometerHandle = smokeThermometerToFfi(thermometer);
+    final _someObserversHandle = foobarListofSmokeTemperatureobserverToFfi(someObservers);
+    final __callResultHandle = _throwingNotifyObserversFfi(__lib.LibraryContext.isolateId, _thermometerHandle, _someObserversHandle);
+    smokeThermometerReleaseFfiHandle(_thermometerHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_someObserversHandle);
     if (_throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnHasError(__callResultHandle) != 0) {
         final __errorHandle = _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnGetError(__callResultHandle);
         _throwingNotifyObserverssmokeThermometerThrowingnotifyobserversThermometerListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);

--- a/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
+++ b/gluecodium/src/test/resources/smoke/listeners/output/dart/lib/src/smoke/thermometer.dart
@@ -22,6 +22,8 @@ abstract class Thermometer implements Finalizable {
 
   factory Thermometer.nothrowMake(String label, List<TemperatureObserver> niceObservers) => $prototype.nothrowMake(label, niceObservers);
 
+  factory Thermometer.anotherThrowingMake(bool dummy, List<TemperatureObserver> observers) => $prototype.anotherThrowingMake(dummy, observers);
+
 
   static void notifyObservers(Thermometer thermometer, List<TemperatureObserver> someObservers) => $prototype.notifyObservers(thermometer, someObservers);
 
@@ -40,9 +42,75 @@ abstract class Thermometer implements Finalizable {
   static dynamic $prototype = Thermometer$Impl(Pointer<Void>.fromAddress(0));
 }
 
+enum Thermometer_SomeThermometerErrorCode {
+    errorNone,
+    errorFatal
+}
+
+// Thermometer_SomeThermometerErrorCode "private" section, not exported.
+
+int smokeThermometerSomethermometererrorcodeToFfi(Thermometer_SomeThermometerErrorCode value) {
+  switch (value) {
+  case Thermometer_SomeThermometerErrorCode.errorNone:
+    return 0;
+  case Thermometer_SomeThermometerErrorCode.errorFatal:
+    return 1;
+  }
+}
+
+Thermometer_SomeThermometerErrorCode smokeThermometerSomethermometererrorcodeFromFfi(int handle) {
+  switch (handle) {
+  case 0:
+    return Thermometer_SomeThermometerErrorCode.errorNone;
+  case 1:
+    return Thermometer_SomeThermometerErrorCode.errorFatal;
+  default:
+    throw StateError("Invalid numeric value $handle for Thermometer_SomeThermometerErrorCode enum.");
+  }
+}
+
+void smokeThermometerSomethermometererrorcodeReleaseFfiHandle(int handle) {}
+
+final _smokeThermometerSomethermometererrorcodeCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Uint32),
+    Pointer<Void> Function(int)
+  >('library_smoke_Thermometer_SomeThermometerErrorCode_create_handle_nullable'));
+final _smokeThermometerSomethermometererrorcodeReleaseHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Thermometer_SomeThermometerErrorCode_release_handle_nullable'));
+final _smokeThermometerSomethermometererrorcodeGetValueNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Thermometer_SomeThermometerErrorCode_get_value_nullable'));
+
+Pointer<Void> smokeThermometerSomethermometererrorcodeToFfiNullable(Thermometer_SomeThermometerErrorCode? value) {
+  if (value == null) return Pointer<Void>.fromAddress(0);
+  final _handle = smokeThermometerSomethermometererrorcodeToFfi(value);
+  final result = _smokeThermometerSomethermometererrorcodeCreateHandleNullable(_handle);
+  smokeThermometerSomethermometererrorcodeReleaseFfiHandle(_handle);
+  return result;
+}
+
+Thermometer_SomeThermometerErrorCode? smokeThermometerSomethermometererrorcodeFromFfiNullable(Pointer<Void> handle) {
+  if (handle.address == 0) return null;
+  final _handle = _smokeThermometerSomethermometererrorcodeGetValueNullable(handle);
+  final result = smokeThermometerSomethermometererrorcodeFromFfi(_handle);
+  smokeThermometerSomethermometererrorcodeReleaseFfiHandle(_handle);
+  return result;
+}
+
+void smokeThermometerSomethermometererrorcodeReleaseFfiHandleNullable(Pointer<Void> handle) =>
+  _smokeThermometerSomethermometererrorcodeReleaseHandleNullable(handle);
+
+// End of Thermometer_SomeThermometerErrorCode "private" section.
 class Thermometer_NotificationException implements Exception {
   final String error;
   Thermometer_NotificationException(this.error);
+}
+class Thermometer_AnotherNotificationException implements Exception {
+  final Thermometer_SomeThermometerErrorCode error;
+  Thermometer_AnotherNotificationException(this.error);
 }
 
 // Thermometer "private" section, not exported.
@@ -80,6 +148,24 @@ final _throwingMakesmokeThermometerThrowingmakeIntListofSmokeTemperatureobserver
     int Function(Pointer<Void>)
   >('library_smoke_Thermometer_throwingMake__Int_ListOf_smoke_TemperatureObserver_return_has_error'));
 
+
+
+final _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnReleaseHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('library_smoke_Thermometer_anotherThrowingMake__Boolean_ListOf_smoke_TemperatureObserver_return_release_handle'));
+final _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnGetResult = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>),
+    Pointer<Void> Function(Pointer<Void>)
+  >('library_smoke_Thermometer_anotherThrowingMake__Boolean_ListOf_smoke_TemperatureObserver_return_get_result'));
+final _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnGetError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Thermometer_anotherThrowingMake__Boolean_ListOf_smoke_TemperatureObserver_return_get_error'));
+final _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnHasError = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
+    Uint8 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('library_smoke_Thermometer_anotherThrowingMake__Boolean_ListOf_smoke_TemperatureObserver_return_has_error'));
 
 
 
@@ -164,6 +250,20 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     return _result;
   }
 
+
+  Thermometer anotherThrowingMake(bool dummy, List<TemperatureObserver> observers) {
+    final _result_handle = _anotherThrowingMake(dummy, observers);
+    final _result = Thermometer$Impl(_result_handle);
+
+    __lib.cacheInstance(_result_handle, _result);
+
+    _smokeThermometerRegisterFinalizer(_result_handle, __lib.LibraryContext.isolateId, _result);
+
+    throwingNotifyObservers(_result, observers);
+
+    return _result;
+  }
+
   static Pointer<Void> _makeWithDuration(Duration interval, List<TemperatureObserver> observers) {
     final _makeWithDurationFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint64, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Thermometer_makeWithDuration__Duration_ListOf_smoke_TemperatureObserver'));
     final _intervalHandle = durationToFfi(interval);
@@ -210,6 +310,27 @@ class Thermometer$Impl extends __lib.NativeBase implements Thermometer {
     final __resultHandle = _nothrowMakeFfi(__lib.LibraryContext.isolateId, _labelHandle, _niceObserversHandle);
     stringReleaseFfiHandle(_labelHandle);
     foobarListofSmokeTemperatureobserverReleaseFfiHandle(_niceObserversHandle);
+    return __resultHandle;
+  }
+
+  static Pointer<Void> _anotherThrowingMake(bool dummy, List<TemperatureObserver> observers) {
+    final _anotherThrowingMakeFfi = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<Pointer<Void> Function(Int32, Uint8, Pointer<Void>), Pointer<Void> Function(int, int, Pointer<Void>)>('library_smoke_Thermometer_anotherThrowingMake__Boolean_ListOf_smoke_TemperatureObserver'));
+    final _dummyHandle = booleanToFfi(dummy);
+    final _observersHandle = foobarListofSmokeTemperatureobserverToFfi(observers);
+    final __callResultHandle = _anotherThrowingMakeFfi(__lib.LibraryContext.isolateId, _dummyHandle, _observersHandle);
+    booleanReleaseFfiHandle(_dummyHandle);
+    foobarListofSmokeTemperatureobserverReleaseFfiHandle(_observersHandle);
+    if (_anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnHasError(__callResultHandle) != 0) {
+        final __errorHandle = _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnGetError(__callResultHandle);
+        _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);
+        try {
+          throw Thermometer_AnotherNotificationException(smokeThermometerSomethermometererrorcodeFromFfi(__errorHandle));
+        } finally {
+          smokeThermometerSomethermometererrorcodeReleaseFfiHandle(__errorHandle);
+        }
+    }
+    final __resultHandle = _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnGetResult(__callResultHandle);
+    _anotherThrowingMakesmokeThermometerAnotherthrowingmakeBooleanListofSmokeTemperatureobserverReturnReleaseHandle(__callResultHandle);
     return __resultHandle;
   }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -44,6 +44,17 @@ public class Thermometer {
     }
 
 
+    public init(label: String, niceObservers: [TemperatureObserver]) {
+        let _result = Thermometer.nothrowMake(label: label, niceObservers: niceObservers)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+        try Thermometer.throwingNotifyObservers(thermometer: self, someObservers: niceObservers);
+    }
+
+
     let c_instance : _baseRef
 
     init(cThermometer: _baseRef) {
@@ -77,6 +88,12 @@ public class Thermometer {
             throw moveFromCType(RESULT.error_value) as Thermometer.NotificationError
         }
         let c_result_handle = RESULT.returned_value
+        return moveFromCType(c_result_handle)
+    }
+    private static func nothrowMake(label: String, niceObservers: [TemperatureObserver]) -> _baseRef {
+        let c_label = moveToCType(label)
+        let c_niceObservers = foobar_moveToCType(niceObservers)
+        let c_result_handle = smoke_Thermometer_nothrowMake(c_label.ref, c_niceObservers.ref)
         return moveFromCType(c_result_handle)
     }
     public static func notifyObservers(thermometer: Thermometer, someObservers: [TemperatureObserver]) -> Void {

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -18,7 +18,7 @@ public class Thermometer {
         }
         c_instance = _result
         smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
-        Thermometer.notifyObservers(self: self, observers: observers);
+        Thermometer.notifyObservers(thermometer: self, someObservers: observers);
     }
 
 
@@ -29,7 +29,7 @@ public class Thermometer {
         }
         c_instance = _result
         smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
-        Thermometer.notifyObservers(self: self, observers: observers);
+        Thermometer.notifyObservers(thermometer: self, someObservers: observers);
     }
 
 
@@ -40,7 +40,7 @@ public class Thermometer {
         }
         c_instance = _result
         smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
-        try Thermometer.throwingNotifyObservers(self: self, observers: observers);
+        try Thermometer.throwingNotifyObservers(thermometer: self, someObservers: observers);
     }
 
 
@@ -79,15 +79,15 @@ public class Thermometer {
         let c_result_handle = RESULT.returned_value
         return moveFromCType(c_result_handle)
     }
-    public static func notifyObservers(self: Thermometer, observers: [TemperatureObserver]) -> Void {
-        let c_self = moveToCType(self)
-        let c_observers = foobar_moveToCType(observers)
-        smoke_Thermometer_notifyObservers(c_self.ref, c_observers.ref)
+    public static func notifyObservers(thermometer: Thermometer, someObservers: [TemperatureObserver]) -> Void {
+        let c_thermometer = moveToCType(thermometer)
+        let c_someObservers = foobar_moveToCType(someObservers)
+        smoke_Thermometer_notifyObservers(c_thermometer.ref, c_someObservers.ref)
     }
-    public static func throwingNotifyObservers(self: Thermometer, observers: [TemperatureObserver]) throws -> Void {
-        let c_self = moveToCType(self)
-        let c_observers = foobar_moveToCType(observers)
-        let RESULT = smoke_Thermometer_throwingNotifyObservers(c_self.ref, c_observers.ref)
+    public static func throwingNotifyObservers(thermometer: Thermometer, someObservers: [TemperatureObserver]) throws -> Void {
+        let c_thermometer = moveToCType(thermometer)
+        let c_someObservers = foobar_moveToCType(someObservers)
+        let RESULT = smoke_Thermometer_throwingNotifyObservers(c_thermometer.ref, c_someObservers.ref)
         if (!RESULT.has_value) {
             throw moveFromCType(RESULT.error_value) as Thermometer.NotificationError
         }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -10,6 +10,8 @@ public class Thermometer {
 
     public typealias NotificationError = String
 
+    public typealias AnotherNotificationError = Thermometer.SomeThermometerErrorCode
+
 
     public init(interval: TimeInterval, observers: [TemperatureObserver]) {
         let _result = Thermometer.makeWithDuration(interval: interval, observers: observers)
@@ -55,6 +57,17 @@ public class Thermometer {
     }
 
 
+    public init(dummy: Bool, observers: [TemperatureObserver]) throws {
+        let _result = try Thermometer.anotherThrowingMake(dummy: dummy, observers: observers)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+        try Thermometer.throwingNotifyObservers(thermometer: self, someObservers: observers);
+    }
+
+
     let c_instance : _baseRef
 
     init(cThermometer: _baseRef) {
@@ -69,6 +82,12 @@ public class Thermometer {
         smoke_Thermometer_release_handle(c_instance)
     }
 
+    public enum SomeThermometerErrorCode : UInt32, CaseIterable, Codable {
+
+        case errorNone
+
+        case errorFatal
+    }
     private static func makeWithDuration(interval: TimeInterval, observers: [TemperatureObserver]) -> _baseRef {
         let c_interval = moveToCType(interval)
         let c_observers = foobar_moveToCType(observers)
@@ -94,6 +113,16 @@ public class Thermometer {
         let c_label = moveToCType(label)
         let c_niceObservers = foobar_moveToCType(niceObservers)
         let c_result_handle = smoke_Thermometer_nothrowMake(c_label.ref, c_niceObservers.ref)
+        return moveFromCType(c_result_handle)
+    }
+    private static func anotherThrowingMake(dummy: Bool, observers: [TemperatureObserver]) throws -> _baseRef {
+        let c_dummy = moveToCType(dummy)
+        let c_observers = foobar_moveToCType(observers)
+        let RESULT = smoke_Thermometer_anotherThrowingMake(c_dummy.ref, c_observers.ref)
+        if (!RESULT.has_value) {
+            throw moveFromCType(RESULT.error_value) as Thermometer.AnotherNotificationError
+        }
+        let c_result_handle = RESULT.returned_value
         return moveFromCType(c_result_handle)
     }
     public static func notifyObservers(thermometer: Thermometer, someObservers: [TemperatureObserver]) -> Void {
@@ -205,7 +234,42 @@ internal func moveToCType(_ swiftClass: Thermometer?) -> RefHolder {
     return getRef(swiftClass, owning: true)
 }
 
+internal func copyToCType(_ swiftEnum: Thermometer.SomeThermometerErrorCode) -> PrimitiveHolder<UInt32> {
+    return PrimitiveHolder(swiftEnum.rawValue)
+}
+internal func moveToCType(_ swiftEnum: Thermometer.SomeThermometerErrorCode) -> PrimitiveHolder<UInt32> {
+    return copyToCType(swiftEnum)
+}
+
+internal func copyToCType(_ swiftEnum: Thermometer.SomeThermometerErrorCode?) -> RefHolder {
+    return copyToCType(swiftEnum?.rawValue)
+}
+internal func moveToCType(_ swiftEnum: Thermometer.SomeThermometerErrorCode?) -> RefHolder {
+    return moveToCType(swiftEnum?.rawValue)
+}
+
+internal func copyFromCType(_ cValue: UInt32) -> Thermometer.SomeThermometerErrorCode {
+    return Thermometer.SomeThermometerErrorCode(rawValue: cValue)!
+}
+internal func moveFromCType(_ cValue: UInt32) -> Thermometer.SomeThermometerErrorCode {
+    return copyFromCType(cValue)
+}
+
+internal func copyFromCType(_ handle: _baseRef) -> Thermometer.SomeThermometerErrorCode? {
+    guard handle != 0 else {
+        return nil
+    }
+    return Thermometer.SomeThermometerErrorCode(rawValue: uint32_t_value_get(handle))!
+}
+internal func moveFromCType(_ handle: _baseRef) -> Thermometer.SomeThermometerErrorCode? {
+    defer {
+        uint32_t_release_handle(handle)
+    }
+    return copyFromCType(handle)
+}
 
 
 extension String : Error {
+}
+extension Thermometer.SomeThermometerErrorCode : Error {
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -63,6 +63,7 @@ public class Thermometer {
     /// - Parameters:
     ///   - label: some identification label
     ///   - niceObservers: observers of temperature changes
+    /// - Throws: `Thermometer.NotificationError` if notification of observers failed
 
     public init(label: String, niceObservers: [TemperatureObserver]) throws {
         let _result = Thermometer.nothrowMake(label: label, niceObservers: niceObservers)
@@ -79,6 +80,7 @@ public class Thermometer {
     ///   - dummy: some dummy boolean flag
     ///   - observers: observers of temperature changes
     /// - Throws: `Thermometer.AnotherNotificationError` if some problem occurs
+    /// - Throws: `Thermometer.NotificationError` if notification of observers failed
 
     public init(dummy: Bool, observers: [TemperatureObserver]) throws {
         let _result = try Thermometer.anotherThrowingMake(dummy: dummy, observers: observers)
@@ -154,6 +156,11 @@ public class Thermometer {
         let c_someObservers = foobar_moveToCType(someObservers)
         smoke_Thermometer_notifyObservers(c_thermometer.ref, c_someObservers.ref)
     }
+    /// Function used to notify observers.
+    /// - Parameters:
+    ///   - thermometer: subject that has changed state
+    ///   - someObservers: observers to be notified
+    /// - Throws: `Thermometer.NotificationError` if notification of observers failed
     public static func throwingNotifyObservers(thermometer: Thermometer, someObservers: [TemperatureObserver]) throws -> Void {
         let c_thermometer = moveToCType(thermometer)
         let c_someObservers = foobar_moveToCType(someObservers)

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -44,7 +44,7 @@ public class Thermometer {
     }
 
 
-    public init(label: String, niceObservers: [TemperatureObserver]) {
+    public init(label: String, niceObservers: [TemperatureObserver]) throws {
         let _result = Thermometer.nothrowMake(label: label, niceObservers: niceObservers)
         guard _result != 0 else {
             fatalError("Nullptr value is not supported for initializers")

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -8,10 +8,17 @@ import Foundation
 /// "Subject" in observer design pattern.
 public class Thermometer {
 
+    /// This error indicates problems with notification of observers.
+    /// May be thrown if observers cannot be notified.
     public typealias NotificationError = String
 
+    /// This error indicates other problems with notification of observers.
     public typealias AnotherNotificationError = Thermometer.SomeThermometerErrorCode
 
+    /// A constructor, which makes the thermometer with readout interval.
+    /// - Parameters:
+    ///   - interval: readout interval
+    ///   - observers: observers of temperature changes
 
     public init(interval: TimeInterval, observers: [TemperatureObserver]) {
         let _result = Thermometer.makeWithDuration(interval: interval, observers: observers)
@@ -23,6 +30,8 @@ public class Thermometer {
         Thermometer.notifyObservers(thermometer: self, someObservers: observers);
     }
 
+    /// A constructor, which makes the thermometer with default readout interval (1 second).
+    /// - Parameter observers: observers of temperature changes
 
     public init(observers: [TemperatureObserver]) {
         let _result = Thermometer.makeWithoutDuration(observers: observers)
@@ -34,6 +43,11 @@ public class Thermometer {
         Thermometer.notifyObservers(thermometer: self, someObservers: observers);
     }
 
+    /// A throwing constructor, which makes the thermometer with default readout interval (1 second).
+    /// - Parameters:
+    ///   - id: identification of this thermometer
+    ///   - observers: observers of temperature changes
+    /// - Throws: `Thermometer.NotificationError` if identification number is invalid
 
     public init(id: Int32, observers: [TemperatureObserver]) throws {
         let _result = try Thermometer.throwingMake(id: id, observers: observers)
@@ -45,6 +59,10 @@ public class Thermometer {
         try Thermometer.throwingNotifyObservers(thermometer: self, someObservers: observers);
     }
 
+    /// A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
+    /// - Parameters:
+    ///   - label: some identification label
+    ///   - niceObservers: observers of temperature changes
 
     public init(label: String, niceObservers: [TemperatureObserver]) throws {
         let _result = Thermometer.nothrowMake(label: label, niceObservers: niceObservers)
@@ -56,6 +74,11 @@ public class Thermometer {
         try Thermometer.throwingNotifyObservers(thermometer: self, someObservers: niceObservers);
     }
 
+    /// A throwing constructor, which makes the thermometer with default readout interval (1 second).
+    /// - Parameters:
+    ///   - dummy: some dummy boolean flag
+    ///   - observers: observers of temperature changes
+    /// - Throws: `Thermometer.AnotherNotificationError` if some problem occurs
 
     public init(dummy: Bool, observers: [TemperatureObserver]) throws {
         let _result = try Thermometer.anotherThrowingMake(dummy: dummy, observers: observers)
@@ -82,6 +105,7 @@ public class Thermometer {
         smoke_Thermometer_release_handle(c_instance)
     }
 
+    /// Some error code for thermometer.
     public enum SomeThermometerErrorCode : UInt32, CaseIterable, Codable {
 
         case errorNone

--- a/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
+++ b/gluecodium/src/test/resources/smoke/listeners/output/swift/smoke/Thermometer.swift
@@ -8,6 +8,8 @@ import Foundation
 /// "Subject" in observer design pattern.
 public class Thermometer {
 
+    public typealias NotificationError = String
+
 
     public init(interval: TimeInterval, observers: [TemperatureObserver]) {
         let _result = Thermometer.makeWithDuration(interval: interval, observers: observers)
@@ -28,6 +30,17 @@ public class Thermometer {
         c_instance = _result
         smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
         Thermometer.notifyObservers(self: self, observers: observers);
+    }
+
+
+    public init(id: Int32, observers: [TemperatureObserver]) throws {
+        let _result = try Thermometer.throwingMake(id: id, observers: observers)
+        guard _result != 0 else {
+            fatalError("Nullptr value is not supported for initializers")
+        }
+        c_instance = _result
+        smoke_Thermometer_cache_swift_object_wrapper(c_instance, Unmanaged<AnyObject>.passUnretained(self).toOpaque())
+        try Thermometer.throwingNotifyObservers(self: self, observers: observers);
     }
 
 
@@ -56,10 +69,28 @@ public class Thermometer {
         let c_result_handle = smoke_Thermometer_makeWithoutDuration(c_observers.ref)
         return moveFromCType(c_result_handle)
     }
+    private static func throwingMake(id: Int32, observers: [TemperatureObserver]) throws -> _baseRef {
+        let c_id = moveToCType(id)
+        let c_observers = foobar_moveToCType(observers)
+        let RESULT = smoke_Thermometer_throwingMake(c_id.ref, c_observers.ref)
+        if (!RESULT.has_value) {
+            throw moveFromCType(RESULT.error_value) as Thermometer.NotificationError
+        }
+        let c_result_handle = RESULT.returned_value
+        return moveFromCType(c_result_handle)
+    }
     public static func notifyObservers(self: Thermometer, observers: [TemperatureObserver]) -> Void {
         let c_self = moveToCType(self)
         let c_observers = foobar_moveToCType(observers)
         smoke_Thermometer_notifyObservers(c_self.ref, c_observers.ref)
+    }
+    public static func throwingNotifyObservers(self: Thermometer, observers: [TemperatureObserver]) throws -> Void {
+        let c_self = moveToCType(self)
+        let c_observers = foobar_moveToCType(observers)
+        let RESULT = smoke_Thermometer_throwingNotifyObservers(c_self.ref, c_observers.ref)
+        if (!RESULT.has_value) {
+            throw moveFromCType(RESULT.error_value) as Thermometer.NotificationError
+        }
     }
     public func forceUpdate() -> Void {
         smoke_Thermometer_forceUpdate(self.c_instance)
@@ -159,3 +190,5 @@ internal func moveToCType(_ swiftClass: Thermometer?) -> RefHolder {
 
 
 
+extension String : Error {
+}

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -30,7 +30,9 @@ import com.here.gluecodium.model.lime.LimeAttributeType.SWIFT
 import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeComment
+import com.here.gluecodium.model.lime.LimeElement
 import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeLazyFunctionCall
 import com.here.gluecodium.model.lime.LimeLazyTypeRef
 import com.here.gluecodium.model.lime.LimeParameter
 import com.here.gluecodium.model.lime.LimePath
@@ -70,11 +72,12 @@ internal object AntlrLimeConverter {
         annotations: List<LimeParser.AnnotationContext>,
         classTypeRef: LimeLazyTypeRef,
         parameters: List<LimeParameter>,
+        referenceMap: Map<String, LimeElement>,
     ): LimeAttributes {
         val attributes = convertAnnotationsToBuilder(limePath, annotations)
         if (attributes.have(LimeAttributeType.AFTER_CONSTRUCTION)) {
             val rawString = attributes.get(LimeAttributeType.AFTER_CONSTRUCTION, LimeAttributeValueType.FUNCTION) as String
-            val limeFunction = createAfterConstructionFunction(rawString, limePath, classTypeRef, parameters)
+            val limeFunction = createAfterConstructionFunction(rawString, limePath, classTypeRef, parameters, referenceMap)
             attributes.overwriteAttribute(
                 LimeAttributeType.AFTER_CONSTRUCTION,
                 LimeAttributeValueType.FUNCTION,
@@ -90,14 +93,15 @@ internal object AntlrLimeConverter {
         path: LimePath,
         classTypeRef: LimeLazyTypeRef,
         constructorParams: List<LimeParameter>,
-    ): LimeFunction {
+        referenceMap: Map<String, LimeElement>,
+    ): LimeLazyFunctionCall {
         val functionName = extractFunctionName(raw)
         val afterConstructionFunPath = path.parent.child(functionName)
         val params = extractFunctionParameters(raw, afterConstructionFunPath, classTypeRef, constructorParams)
-        return LimeFunction(
-            path = afterConstructionFunPath,
+        return LimeLazyFunctionCall(
+            elementFullName = afterConstructionFunPath.toString(),
+            referenceMap = referenceMap,
             parameters = params,
-            isStatic = true,
         )
     }
 

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeConverter.kt
@@ -31,7 +31,6 @@ import com.here.gluecodium.model.lime.LimeAttributeValueType
 import com.here.gluecodium.model.lime.LimeAttributes
 import com.here.gluecodium.model.lime.LimeComment
 import com.here.gluecodium.model.lime.LimeElement
-import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeLazyFunctionCall
 import com.here.gluecodium.model.lime.LimeLazyTypeRef
 import com.here.gluecodium.model.lime.LimeParameter

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -219,7 +219,7 @@ internal class AntlrLimeModelBuilder(
             LimeFunction(
                 path = currentPath,
                 comment = structuredCommentsStack.peek().description,
-                attributes = AntlrLimeConverter.convertAnnotationsForConstructor(currentPath, ctx.annotation(), classTypeRef, parameters),
+                attributes = AntlrLimeConverter.convertAnnotationsForConstructor(currentPath, ctx.annotation(), classTypeRef, parameters,  referenceResolver.referenceMap),
                 returnType = LimeReturnType(classTypeRef),
                 parameters = parameters,
                 thrownType = exceptionType,

--- a/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
+++ b/lime-loader/src/main/java/com/here/gluecodium/loader/AntlrLimeModelBuilder.kt
@@ -219,7 +219,14 @@ internal class AntlrLimeModelBuilder(
             LimeFunction(
                 path = currentPath,
                 comment = structuredCommentsStack.peek().description,
-                attributes = AntlrLimeConverter.convertAnnotationsForConstructor(currentPath, ctx.annotation(), classTypeRef, parameters,  referenceResolver.referenceMap),
+                attributes =
+                    AntlrLimeConverter.convertAnnotationsForConstructor(
+                        currentPath,
+                        ctx.annotation(),
+                        classTypeRef,
+                        parameters,
+                        referenceResolver.referenceMap,
+                    ),
                 returnType = LimeReturnType(classTypeRef),
                 parameters = parameters,
                 thrownType = exceptionType,

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyFunctionCall.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyFunctionCall.kt
@@ -19,9 +19,10 @@
 
 package com.here.gluecodium.model.lime
 
-class LimeLazyFunctionCall(private val elementFullName: String,
-                           private val referenceMap: Map<String, LimeElement>,
-                           val parameters: List<LimeParameter>,
+class LimeLazyFunctionCall(
+    private val elementFullName: String,
+    private val referenceMap: Map<String, LimeElement>,
+    val parameters: List<LimeParameter>,
 ) {
     val function by lazy {
         referenceMap[elementFullName] as? LimeFunction

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyFunctionCall.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeLazyFunctionCall.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.model.lime
+
+class LimeLazyFunctionCall(private val elementFullName: String,
+                           private val referenceMap: Map<String, LimeElement>,
+                           val parameters: List<LimeParameter>,
+) {
+    val function by lazy {
+        referenceMap[elementFullName] as? LimeFunction
+            ?: throw LimeModelLoaderException("LimeFunction $elementFullName was not found")
+    }
+}


### PR DESCRIPTION
The mentioned case was not tested. It did not compile for Swift.

This commit:
- introduces `LimeLazyFunctionCall` to LimeModel to be able to get all the information about called function including the original parameter names and exceptions
- adjusts the code generators to correctly propagate the exception even when the constructor is not explicitly marked as throwing, but after-constructed function throws
- removes the requirements related to the same parameters naming for Swift -- since now constructor and static function may use different parameter names and 'this' object does not need to be named 'self'
- ensures that the generated documentation comment for constructor contains information about exceptions from `AfterConstructed` annotation
- adds new smoke tests
- adds new functional tests