### PR TITLE
CI: use Ubuntu 22.04

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install GCC
         uses: egor-tensin/setup-gcc@v1
         with:
-          version: 8
+          version: 9
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.7
         with:
@@ -138,7 +138,7 @@ jobs:
       - name: Install GCC
         uses: egor-tensin/setup-gcc@v1
         with:
-          version: 8
+          version: 9
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.7
         with:

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   cpp:
     name: C++
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -56,7 +56,7 @@ jobs:
 
   android:
     name: Android
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -118,7 +118,7 @@ jobs:
 
   android-kotlin:
     name: Android-Kotlin
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -173,7 +173,7 @@ jobs:
 
   swift:
     name: Swift on Linux
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -210,9 +210,9 @@ jobs:
         run: sudo apt install -y libcurl4
       - name: Install Swift SDK
         run: |
-          SWIFT_BRANCH=swift-5.4.3-release
-          SWIFT_VERSION=swift-5.4.3-RELEASE
-          SWIFT_PLATFORM=ubuntu20.04
+          SWIFT_BRANCH=swift-5.7.3-release
+          SWIFT_VERSION=swift-5.7.3-RELEASE
+          SWIFT_PLATFORM=ubuntu22.04
           SWIFT_ARCHIVE_NAME=${SWIFT_VERSION}-${SWIFT_PLATFORM}.tar.gz
           if [ ! -d "${HOME}/swift-sdk" ]; then
             mkdir ~/swift-sdk
@@ -284,7 +284,7 @@ jobs:
 
   dart:
     name: Dart
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -323,7 +323,7 @@ jobs:
 
   dart-asan:
     name: Dart with AddressSanitizer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2
@@ -387,7 +387,7 @@ jobs:
 
   cmake-tests:
     name: CMake toolchain tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build:
     name: Create release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build and unit tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v2

--- a/functional-tests/scripts/valgrind_suppressions
+++ b/functional-tests/scripts/valgrind_suppressions
@@ -320,3 +320,19 @@
    fun:__swift_instantiateConcreteTypeFromMangledName
    fun:*
 }
+{
+   False positive from XCTest library on Linux (see: https://github.com/swiftlang/swift-corelibs-xctest/issues/342)
+
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:_ZN5swift9RefCountsINS_13RefCountBitsTILNS_19RefCountInlinednessE1EEEE17formWeakReferenceEv
+   fun:swift_weakAssign
+   fun:$s6XCTest9XCTWaiterC4wait3for7timeout12enforceOrder4file4lineAC6ResultOSayAA0A11ExpectationCG_SdSbs12StaticStringVSitF
+   fun:$s6XCTest9XCTWaiterC4wait3for7timeout12enforceOrder4file4lineAC6ResultOSayAA0A11ExpectationCG_SdSbs12StaticStringVSitFZ
+   fun:$s6XCTest21awaitUsingExpectationyyyyYaKcKF
+   fun:$s6XCTest0A4CaseC10invokeTestyyF
+   fun:$s6XCTest0A4CaseC7performyyAA0A3RunCF
+   fun:$s6XCTestAAC3runyyF
+   fun:$s6XCTest0A5SuiteC7performyyAA0A3RunCF
+}

--- a/functional-tests/scripts/valgrind_suppressions
+++ b/functional-tests/scripts/valgrind_suppressions
@@ -31,6 +31,25 @@
    fun:*
 }
 {
+   getForeignTypeMetadata
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:swift_getForeignTypeMetadata
+   fun:*
+}
+{
+   pthreadCreate_allocateStack
+
+   Memcheck:Leak
+   match-leak-kinds: possible
+   ...
+   fun:allocate_stack
+   fun:pthread_create@@GLIBC_2.34
+   fun:*
+}
+{
    instantiateCPGenericMetadata
 
    Memcheck:Leak


### PR DESCRIPTION
The CI workflows were running jobs using Ubuntu 20.04.
The mentioned version has been unsupported since 2025-04-15.

Therefore, the workflow files are adjusted to use Ubuntu 22.04.
Moreover, Swift SDK's version is raised from 5.4.3 to 5.7.3, because
the older version is not available for Ubuntu 22.04.

g++ version has been upgraded from 8 to 9, because Ubuntu 22.04
does not support the old package.
