### PR TITLE
Implement validation rules for LimeDoc comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Features
  * Dart/Flutter: the generated code is now compatible with Flutter 3.29 and above. When the user invokes the callback created for lambda/interface from the thread that is the main isolate thread, but outside of isolate context then it is correclty executed. Before this release the thread would deadlock. Now the generated code identifies such case and enters the isolate context before invoking the callback.
  * Java/Kotlin: in order to ease transition from Java to Kotlin the possibility to conditionally warn about mismatch in attributes used for Java/Kotlin is implemented. The following new CLI parameter is available `-enableandroidattributesmismatchwarning` as well as `GLUECODIUM_ENABLE_ANDROID_ATTRIBUTES_MISMATCH_WARNING` CMake parameter.
+ * Common: introduced LIME DOC validation rules. Users may use the new CLI parameter called `-docsvalidationrules` or CMake parameter `GLUECODIUM_DOCS_VALIDATION_RULES`, which allow specifying JSON file with regular expressions used to validate comments for certain LIME elements. More information can be found in `lime_markdown.md`.
 
 ## 13.12.0
 Release date 2025-03-24

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ buildscript {
     }
 }
 plugins {
+    alias libs.plugins.kotlinx.serialization
     alias libs.plugins.nebula.lint
 }
 
@@ -56,6 +57,7 @@ allprojects {
 
     apply plugin: 'java'
     apply plugin: 'org.jetbrains.kotlin.jvm'
+    apply plugin: 'kotlinx-serialization'
 
     compileJava {
         options.encoding = "UTF-8"

--- a/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
@@ -333,6 +333,14 @@ _gluecodium_define_target_property(
     "This property is initialized by the value of the GLUECODIUM_DOCS_PLACEHOLDERS_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
 )
 
+_gluecodium_define_target_property(
+  GLUECODIUM_DOCS_VALIDATION_RULES
+  BRIEF_DOCS "The path to file with rules used to validate documentation comments."
+  FULL_DOCS
+    "File with rules used to validate documentation comments. Each rule contains list of elements, that need to match certain regular expression."
+    "This property is initialized by the value of the GLUECODIUM_DOCS_VALIDATION_RULES_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
 # TODO: Add read-only properties
 
 function(_gluecodium_get_default_value_for_variable result _property)

--- a/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
@@ -186,6 +186,7 @@ function(_prepare_gluecodium_config_file file_path placeholder_file)
   _append_path_option(swiftnamerules GLUECODIUM_SWIFT_NAMERULES)
   _append_path_option(dartnamerules GLUECODIUM_DART_NAMERULES)
   _append_path_option(docsplaceholderslist placeholder_file)
+  _append_path_option(docsvalidationrules GLUECODIUM_DOCS_VALIDATION_RULES)
 
   _append_option(output GLUECODIUM_OUTPUT_MAIN)
   _append_option(commonoutput GLUECODIUM_OUTPUT_COMMON)

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_VALIDATION_RULES "${CMAKE_CURRENT_LIST_DIR}/docs_validation_rules.json")

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/docs_validation_rules.json
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/docs_validation_rules.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "Availability rule",
+    "limeElements": ["class"],
+    "regex": "This class is available (offline | online)\\."
+  }
+]

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/lime/bar.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/lime/bar.lime
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+class Bar {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/lime/foo.lime
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+class Foo {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/successful.regex
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-basic-validation-XFAIL/successful.regex
@@ -1,0 +1,1 @@
+element unit.test.Foo: LimeDocValidationRule 'Availability rule' failed for unit.test.Foo for platform '(Dart|Java|Kotlin|Swift)'

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_PLACEHOLDERS_FILES "${CMAKE_CURRENT_LIST_DIR}/placeholders.properties"
+                                 GLUECODIUM_DOCS_VALIDATION_RULES "${CMAKE_CURRENT_LIST_DIR}/docs_validation_rules.json")

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/docs_validation_rules.json
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/docs_validation_rules.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Availability rule",
+    "limeElements": ["class"],
+    "regex": "@Placeholder (AvailableOnline|AvailableOffline)",
+    "resolvePlaceholders": false
+  }
+]

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/lime/bar.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/lime/bar.lime
@@ -1,0 +1,24 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+// This is very important 'Bar' class.
+// {@Placeholder AvailableOffline}
+class Bar {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/lime/foo.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+// This is very important 'Foo' class.
+class Foo {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/placeholders.properties
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/placeholders.properties
@@ -1,0 +1,2 @@
+AvailableOnline="This type is available online."
+AvailableOffline="This type is available offline."

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/successful.regex
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-fails-placeholders-validation-XFAIL/successful.regex
@@ -1,0 +1,1 @@
+element unit.test.Foo: LimeDocValidationRule 'Availability rule' failed for unit.test.Foo for platform '(Dart|Java|Kotlin|Swift)'

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_VALIDATION_RULES "${CMAKE_CURRENT_LIST_DIR}/docs_validation_rules.json")

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/docs_validation_rules.json
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/docs_validation_rules.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "Availability rule",
+    "limeElements": ["class"],
+    "regex": "This class is available (offline|online)\\."
+  }
+]

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/lime/bar.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/lime/bar.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+// This class is available offline.
+class Bar {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-basic-validation/lime/foo.lime
@@ -1,0 +1,23 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+// This class is available online.
+class Foo {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_PLACEHOLDERS_FILES "${CMAKE_CURRENT_LIST_DIR}/placeholders.properties"
+                                 GLUECODIUM_DOCS_VALIDATION_RULES "${CMAKE_CURRENT_LIST_DIR}/docs_validation_rules.json")

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/docs_validation_rules.json
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/docs_validation_rules.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "Availability rule",
+    "limeElements": ["class"],
+    "regex": "@Placeholder (AvailableOnline|AvailableOffline)",
+    "resolvePlaceholders": false
+  }
+]

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/lime/bar.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/lime/bar.lime
@@ -1,0 +1,24 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+// This is very important 'Bar' class.
+// {@Placeholder AvailableOffline}
+class Bar {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/lime/foo.lime
@@ -1,0 +1,25 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+// This is very important 'Foo' class.
+// {@Placeholder AvailableOnline}
+// Some additional notes about availability can be put here.
+class Foo {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/placeholders.properties
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-input-lime-passes-placeholders-validation/placeholders.properties
@@ -1,0 +1,2 @@
+AvailableOnline="This type is available online."
+AvailableOffline="This type is available offline."

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_VALIDATION_RULES "${CMAKE_CURRENT_LIST_DIR}/docs_validation_rules.json")

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/docs_validation_rules.json
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/docs_validation_rules.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name" "Online/Offline availability rule",
+    "limeElements": ["class", "struct", "enum"],
+    "regex": "This class is available (offline | online | both offline and online).",
+  }
+]

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/lime/foo.lime
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+class Foo {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/successful.regex
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-invalid-content-of-json-file-XFAIL/successful.regex
@@ -1,0 +1,1 @@
+Failed reading options: File .*/docs_validation_rules.json is not a valid rules file! Parsing JSON failed:.*

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_DOCS_VALIDATION_RULES "${CMAKE_CURRENT_LIST_DIR}/docs_validation_rules.json")

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/lime/foo.lime
@@ -1,0 +1,22 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+class Foo {
+
+}

--- a/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/successful.regex
+++ b/cmake/tests/unit/gluecodium_generate/docsvalidationrules-nonexistent-file-XFAIL/successful.regex
@@ -1,0 +1,1 @@
+Failed reading options: Rules file .*/docs_validation_rules.json does not exist

--- a/docs/lime_markdown.md
+++ b/docs/lime_markdown.md
@@ -239,3 +239,43 @@ Excluding an element from documentation
 Documentation comments support a special `@exclude` tag. This tag is converted into a language-appropriate "exclude from
 the documentation" tag in the generated code. When using this tag, it should be placed on a separate line of its own
 within the IDL documentation comment.
+
+Validation rules for documentation comments
+---------------------------------------
+
+Sometimes certain elements must contain given required information. For instance, about module to which given public interface belongs or
+online/offline availability. In order to add custom validation of comments, a dedicated JSON file with rules can be used. The file can be
+specified via `-docsvalidationrules` CLI option or `GLUECODIUM_DOCS_VALIDATION_RULES` CMake parameter. The JSON file must contain a list
+of rules. Each rule consists of required fields:
+- **name** - the name of the rule, which must be unique within the file
+- **limeElements** - the list of LIME elements to which the rule applies. The supported elements are: `class`, `struct`,
+`interface`, `lambda`, `enum`, `function` and `property`.
+- **regex** - the regular expression used to validate the comment.
+
+Moreover, the following optional fields may be used for a rule:
+- **isWarningOnly** - by default it is set to `false`. This field is used to control the behavior of validator that is triggered
+when the rule is not respected. When this field is set to `true` then only warning is raised instead of an error.
+- **resolvePlaceholders** - by default it is set to `true`. This field is used to ease creation of validation rules that want to
+check if placeholder is used in the body of comment. When this flag is set to `false` then validation rule may look only for
+`@Placeholder <NAME>`.
+- **platforms** - by default a rule is checked for all generated platforms. However, there may be a need to create platform-specific
+rule e.g. respected only for Java, Swift, Kotlin or Dart. In such a case `platforms` field can be used - it is a list of platforms
+specified as string. When this field is set the rule is applied only for the specified platforms.
+
+The example input JSON with rules can be found below:
+```
+[
+  {
+    "name": "Availability rule",
+    "limeElements": ["class", "interface"],
+    "regex": "@Placeholder (AvailableOnline|AvailableOffline)",
+    "resolvePlaceholders": false
+  },
+  {
+    "name": "Module belonging",
+    "limeElements": ["class", "struct", "interface", "lambda", "enum"],
+    "regex": "This type belongs to modules: .*"
+  },
+]
+```
+ 

--- a/gluecodium/build.gradle
+++ b/gluecodium/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation libs.slf4j.api
     implementation libs.slf4j.log4j12
     implementation libs.trimou.core
+    implementation libs.kotlinx.serialization.json
 
     testImplementation files({ project(":lime-runtime").sourceSets.test.output })
     testImplementation libs.bundles.mockk

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -37,6 +37,7 @@ import com.here.gluecodium.model.lime.LimeModelLoaderException
 import com.here.gluecodium.validator.LimeAndroidAttributesMismatchValidator
 import com.here.gluecodium.validator.LimeAsyncValidator
 import com.here.gluecodium.validator.LimeConstantRefsValidator
+import com.here.gluecodium.validator.LimeDocRulesValidator
 import com.here.gluecodium.validator.LimeExternalTypesValidator
 import com.here.gluecodium.validator.LimeFieldConstructorsValidator
 import com.here.gluecodium.validator.LimeFunctionsValidator
@@ -196,6 +197,7 @@ class Gluecodium(
             { LimeOptimizedListsValidator(limeLogger).validate(it) },
             { LimeFieldConstructorsValidator(limeLogger).validate(it) },
             { LimeValuesValidator(limeLogger).validate(it) },
+            { LimeDocRulesValidator(limeLogger, gluecodiumOptions.docsValidationRules).validate(it) },
         )
 
     private fun getIndependentValidators(limeLogger: LimeLogger) =

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -197,7 +197,7 @@ class Gluecodium(
             { LimeOptimizedListsValidator(limeLogger).validate(it) },
             { LimeFieldConstructorsValidator(limeLogger).validate(it) },
             { LimeValuesValidator(limeLogger).validate(it) },
-            { LimeDocRulesValidator(limeLogger, gluecodiumOptions.docsValidationRules).validate(it) },
+            { LimeDocRulesValidator(limeLogger, gluecodiumOptions.docsValidationRules, discoverGenerators()).validate(it) },
         )
 
     private fun getIndependentValidators(limeLogger: LimeLogger) =

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 HERE Europe B.V.
+ * Copyright (C) 2016-2025 HERE Europe B.V.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import com.here.gluecodium.GluecodiumOptions
 import com.here.gluecodium.common.CaseInsensitiveSet
 import com.here.gluecodium.generator.common.Generator
 import com.here.gluecodium.generator.common.GeneratorOptions
+import com.here.gluecodium.validator.LimeDocValidationRule
 import com.natpryce.konfig.Configuration
 import com.natpryce.konfig.ConfigurationProperties
 import com.natpryce.konfig.Key
@@ -30,6 +31,8 @@ import com.natpryce.konfig.booleanType
 import com.natpryce.konfig.listType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.HelpFormatter
 import org.apache.commons.cli.Option
@@ -170,6 +173,12 @@ object OptionReader {
                     "The placeholders file should follow '.properties' file format and enclose text with \"\" as follows: " +
                     "my_placeholder_name=\"This will be injected instead of my_placeholder\"",
             )
+            addOption(
+                "docsvalidationrules",
+                true,
+                "File with rules used to validate documentation comments. Each rule contains list of elements, that need " +
+                    "to match certain regular expression.",
+            )
         }
 
     @Throws(OptionReaderException::class)
@@ -219,6 +228,7 @@ object OptionReader {
         gluecodiumOptions.isEnableCaching = getFlagValue("output") && getFlagValue("cache")
         gluecodiumOptions.isStrictMode = getFlagValue("strict")
         gluecodiumOptions.docsPlaceholders = readPlaceholdersFile(getStringValue("docsplaceholderslist"))
+        gluecodiumOptions.docsValidationRules = readDocsValidationRulesFile(getStringValue("docsvalidationrules"))
 
         val generatorOptions = GeneratorOptions()
 
@@ -286,6 +296,26 @@ object OptionReader {
 
             it.key to it.value.removeSurrounding("\"", "\"")
         }.toMap()
+    }
+
+    private fun readDocsValidationRulesFile(path: String?): List<LimeDocValidationRule> {
+        if (path == null) {
+            return emptyList()
+        }
+
+        val rulesFile = File(path)
+        if (!rulesFile.exists()) {
+            val currentDir = Paths.get("").toAbsolutePath()
+            throw OptionReaderException("Rules file $path does not exist in $currentDir")
+        }
+
+        try {
+            return Json.decodeFromString<List<LimeDocValidationRule>>(rulesFile.readText())
+        } catch (e: Exception) {
+            throw OptionReaderException(
+                "File $path is not a valid rules file! Parsing JSON failed: ${e.message}",
+            )
+        }
     }
 
     @Throws(OptionReaderException::class)

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocRulesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocRulesValidator.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.cli.OptionReaderException
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeContainerWithInheritance
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeStruct
+import java.util.regex.PatternSyntaxException
+
+class LimeDocRulesValidator(private val logger: LimeLogger, docValidationRules: List<LimeDocValidationRule>) {
+    private val ruleToRegex: Map<String, Regex> = createRuleToRegexMapping(docValidationRules)
+    private val elementToRules: Map<String, List<LimeDocValidationRule>> = createElementToRulesMapping(docValidationRules)
+
+    fun validate(limeModel: LimeModel): Boolean {
+        val allElements = limeModel.referenceMap.values
+        val validationResults =
+            elementToRules.map {
+                when (it.key) {
+                    "class" -> applyRules(allElements.filterIsInstance<LimeClass>(), it.value)
+                    "struct" -> applyRules(allElements.filterIsInstance<LimeStruct>(), it.value)
+                    "interface" -> applyRules(allElements.filterIsInstance<LimeInterface>(), it.value)
+                    "lambda" -> applyRules(allElements.filterIsInstance<LimeLambda>(), it.value)
+                    "enum" -> applyRules(allElements.filterIsInstance<LimeEnumeration>(), it.value)
+                    "function" -> applyRules(allElements.filterIsInstance<LimeFunction>(), it.value)
+                    "property" ->
+                        applyRules(
+                            allElements.filterIsInstance<LimeContainerWithInheritance>().flatMap {
+                                    container ->
+                                container.properties
+                            },
+                            it.value,
+                        )
+                    else -> throw OptionReaderException("Unknown lime element type for docs validation rules '${it.key}'")
+                }
+            }
+        return !validationResults.contains(false)
+    }
+
+    private fun applyRules(
+        elements: List<LimeNamedElement>,
+        rules: List<LimeDocValidationRule>,
+    ): Boolean {
+        return !elements.map { element ->
+            !rules.map { rule -> applySingleRule(element, rule) }.contains(false)
+        }.contains(false)
+    }
+
+    private fun applySingleRule(
+        element: LimeNamedElement,
+        rule: LimeDocValidationRule,
+    ): Boolean {
+        val regex = ruleToRegex[rule.name]!!
+        val applyResult = regex.containsMatchIn(element.comment.toString())
+
+        if (!applyResult) {
+            logRuleApplicationFailed(rule, element)
+        }
+
+        return rule.isWarningOnly || applyResult
+    }
+
+    private fun logRuleApplicationFailed(
+        rule: LimeDocValidationRule,
+        element: LimeNamedElement,
+    ) {
+        val errorMessage = "LimeDocValidationRule '${rule.name}' failed for ${element.fullName}"
+        if (rule.isWarningOnly) {
+            logger.warning(element, errorMessage)
+        } else {
+            logger.error(element, errorMessage)
+        }
+    }
+
+    companion object {
+        private fun createRuleToRegexMapping(docValidationRules: List<LimeDocValidationRule>): Map<String, Regex> {
+            val mapping: MutableMap<String, Regex> = mutableMapOf()
+            for (rule in docValidationRules) {
+                if (mapping.contains(rule.name)) {
+                    throw OptionReaderException("Multiple doc validation rules with the same name = '${rule.name}'")
+                }
+
+                try {
+                    mapping[rule.name] = Regex(rule.regex)
+                } catch (e: PatternSyntaxException) {
+                    throw OptionReaderException("Cannot compile regex for doc validation rule '${rule.name}'. Exception = '${e.message}'")
+                }
+            }
+            return mapping
+        }
+
+        private fun createElementToRulesMapping(docValidationRules: List<LimeDocValidationRule>): Map<String, List<LimeDocValidationRule>> {
+            val mapping: MutableMap<String, MutableList<LimeDocValidationRule>> = mutableMapOf()
+            for (rule in docValidationRules) {
+                if (rule.limeElements.isEmpty()) {
+                    throw OptionReaderException("No lime elements specified for doc validation rule: '${rule.name}'")
+                }
+
+                for (elementType in rule.limeElements) {
+                    if (!isKnownElementType(elementType)) {
+                        throw OptionReaderException("Unknown element type '$elementType' for rule '${rule.name}'")
+                    }
+
+                    if (!mapping.contains(elementType)) {
+                        mapping[elementType] = mutableListOf(rule)
+                    } else {
+                        mapping[elementType]!!.add(rule)
+                    }
+                }
+            }
+            return mapping
+        }
+
+        private fun isKnownElementType(elementType: String): Boolean {
+            return LIME_ELEMENTS.contains(elementType)
+        }
+
+        private val LIME_ELEMENTS: Set<String> =
+            setOf(
+                "class",
+                "struct",
+                "interface",
+                "lambda",
+                "enum",
+                "function",
+                "property",
+            )
+    }
+}

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocRulesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocRulesValidator.kt
@@ -87,7 +87,14 @@ class LimeDocRulesValidator(
                 continue
             }
 
-            val applyResult = regex.containsMatchIn(element.comment.getFor(platform))
+            val validatedComment =
+                if (rule.resolvePlaceholders) {
+                    element.comment.getFor(platform)
+                } else {
+                    element.comment.getForWithoutResolvingPlaceholder(platform)
+                }
+
+            val applyResult = regex.containsMatchIn(validatedComment)
             if (!applyResult) {
                 logRuleApplicationFailed(rule, element, platform)
                 result = false

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocRulesValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocRulesValidator.kt
@@ -41,6 +41,16 @@ class LimeDocRulesValidator(
     private val elementToRules: Map<String, List<LimeDocValidationRule>> = createElementToRulesMapping(docValidationRules)
     private val platforms: List<String> = discoverPlatforms(generators)
 
+    init {
+        for (rule in docValidationRules) {
+            for (platform in rule.platforms) {
+                if (!ACCEPTED_PLATFORMS.contains(platform)) {
+                    throw OptionReaderException("Unknown platform '$platform' in docs validation rule '${rule.name}'")
+                }
+            }
+        }
+    }
+
     fun validate(limeModel: LimeModel): Boolean {
         val allElements = limeModel.referenceMap.values
         val validationResults =
@@ -182,5 +192,7 @@ class LimeDocRulesValidator(
                 "function",
                 "property",
             )
+
+        private val ACCEPTED_PLATFORMS: Set<String> = setOf("Java", "Dart", "Kotlin", "Swift")
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
@@ -26,7 +26,7 @@ data class LimeDocValidationRule(
     val name: String,
     val limeElements: List<String>,
     val regex: String,
-    val isWarningOnly: Boolean,
+    val isWarningOnly: Boolean = false,
     val resolvePlaceholders: Boolean = true,
     val platforms: List<String> = listOf(),
 )

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
@@ -27,5 +27,6 @@ data class LimeDocValidationRule(
     val limeElements: List<String>,
     val regex: String,
     val isWarningOnly: Boolean,
+    val resolvePlaceholders: Boolean = true,
     val platforms: List<String> = listOf(),
 )

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
@@ -17,19 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package com.here.gluecodium
+package com.here.gluecodium.validator
 
-import com.here.gluecodium.validator.LimeDocValidationRule
+import kotlinx.serialization.Serializable
 
-data class GluecodiumOptions(
-    var idlSources: List<String> = emptyList(),
-    var auxiliaryIdlSources: List<String> = emptyList(),
-    var outputDir: String = "",
-    var commonOutputDir: String = "",
-    var generators: Set<String> = setOf(),
-    var isValidatingOnly: Boolean = false,
-    var isEnableCaching: Boolean = false,
-    var isStrictMode: Boolean = false,
-    var docsPlaceholders: Map<String, String> = emptyMap(),
-    var docsValidationRules: List<LimeDocValidationRule> = emptyList(),
+@Serializable
+data class LimeDocValidationRule(
+    val name: String,
+    val limeElements: List<String>,
+    val regex: String,
+    val isWarningOnly: Boolean,
 )

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeDocValidationRule.kt
@@ -27,4 +27,5 @@ data class LimeDocValidationRule(
     val limeElements: List<String>,
     val regex: String,
     val isWarningOnly: Boolean,
+    val platforms: List<String> = listOf(),
 )

--- a/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/cli/OptionReaderTest.kt
@@ -209,6 +209,19 @@ class OptionReaderTest {
         assertTrue(exception.message!!.startsWith("File $path does not exist"))
     }
 
+    @Test
+    fun docsValidationRulesMissingFile() {
+        // Arrange, Act
+        val path = "rulesFileThatDoesNotExist.json"
+        val exception =
+            assertThrows(OptionReaderException::class.java, {
+                OptionReader.read(arrayOf("-docsvalidationrules", path))
+            })
+
+        // Assert
+        assertTrue(exception.message!!.startsWith("Rules file $path does not exist"))
+    }
+
     private fun prepareToRead(
         optionName: String,
         optionValue: String,

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
@@ -899,7 +899,7 @@ class LimeDocRulesValidatorTest {
     }
 
     @Test
-    fun validationOfCommentWithResolvedPlaceholder() {
+    fun validationPassesForCommentWithResolvedPlaceholder() {
         // Given a class in LimeModel, which obeys the rules.
         allElements[outerTypePath.toString()] =
             LimeClass(
@@ -916,7 +916,7 @@ class LimeDocRulesValidatorTest {
                     ),
             )
 
-        // And given a correct validation rule for classes that uses the placeholder.
+        // And given a correct validation rule for classes.
         val docValidationRules: List<LimeDocValidationRule> =
             listOf(
                 LimeDocValidationRule(
@@ -935,6 +935,82 @@ class LimeDocRulesValidatorTest {
 
         // Then validation passes.
         assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationPassesForCommentWithoutResolvedPlaceholder() {
+        // Given a class in LimeModel, which obeys the rules.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type class. ",
+                                "Placeholder" to "AvailableOnline",
+                            ),
+                        placeholders = mapOf("AvailableOnline" to LimeComment("This type is available only online")),
+                    ),
+            )
+
+        // And given a correct validation rule for classes that uses the placeholder but does not resolve it.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "@Placeholder AvailableOnline",
+                    isWarningOnly = false,
+                    resolvePlaceholders = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForCommentWithoutResolvedPlaceholder() {
+        // Given a class in LimeModel, which does not obey the rules.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf("" to "This is some important outer type class. "),
+                    ),
+            )
+
+        // And given a correct validation rule for classes that uses the placeholder but does not resolve it.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "@Placeholder AvailableOnline",
+                    isWarningOnly = false,
+                    resolvePlaceholders = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
     }
 
     @Test

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
@@ -79,6 +79,30 @@ class LimeDocRulesValidatorTest {
     }
 
     @Test
+    fun creationFailsForRuleWithUnknownPlatform() {
+        // Given two a rule with unknown platform.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class", "struct"),
+                    regex = "It is a special type",
+                    isWarningOnly = false,
+                    platforms = listOf("Python")
+                )
+            )
+
+        // When constructing validator.
+        val exception =
+            assertThrows(OptionReaderException::class.java) {
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
+            }
+
+        // Then error is raised.
+        assertTrue(exception.message!!.startsWith("Unknown platform 'Python' in docs validation rule 'SPECIAL_RULE'"))
+    }
+
+    @Test
     fun creationFailsForRuleWithRegexThatDoesNotCompile() {
         // Given a validation rule with invalid regex [missing ')']
         val docValidationRules: List<LimeDocValidationRule> =

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
@@ -111,7 +111,6 @@ class LimeDocRulesValidatorTest {
                     name = "MY_RULE",
                     limeElements = listOf("class", "struct"),
                     regex = "(a|b",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -134,7 +133,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = emptyList(),
                     regex = "It is a special type",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -157,7 +155,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class", "mixin"),
                     regex = "It is a special type",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -209,7 +206,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "It is a special type",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -261,7 +257,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "It is a special type",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -313,7 +308,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "It is a (STRONG|WEAK) type",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -351,7 +345,6 @@ class LimeDocRulesValidatorTest {
                     name = "Plain old data structure",
                     limeElements = listOf("struct"),
                     regex = "@POD_STRUCT",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -388,7 +381,6 @@ class LimeDocRulesValidatorTest {
                     name = "Plain old data structure",
                     limeElements = listOf("struct"),
                     regex = "@POD_STRUCT",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -426,7 +418,6 @@ class LimeDocRulesValidatorTest {
                     name = "Public interface",
                     limeElements = listOf("interface"),
                     regex = "@PUBLIC_INTERFACE",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -463,7 +454,6 @@ class LimeDocRulesValidatorTest {
                     name = "Public interface",
                     limeElements = listOf("interface"),
                     regex = "@PUBLIC_INTERFACE",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -501,7 +491,6 @@ class LimeDocRulesValidatorTest {
                     name = "Error code",
                     limeElements = listOf("enum"),
                     regex = "@ERROR_CODE",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -538,7 +527,6 @@ class LimeDocRulesValidatorTest {
                     name = "Error code",
                     limeElements = listOf("enum"),
                     regex = "@ERROR_CODE",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -580,7 +568,6 @@ class LimeDocRulesValidatorTest {
                     name = "Standard calling convention",
                     limeElements = listOf("function"),
                     regex = "@CallingConvention\\('Standard'\\)",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -618,7 +605,6 @@ class LimeDocRulesValidatorTest {
                     name = "Standard calling convention",
                     limeElements = listOf("function"),
                     regex = "@CallingConvention\\('Standard'\\)",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -656,7 +642,6 @@ class LimeDocRulesValidatorTest {
                     name = "Available only online",
                     limeElements = listOf("lambda"),
                     regex = "Available only in online mode",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -690,7 +675,6 @@ class LimeDocRulesValidatorTest {
                     name = "Available only online",
                     limeElements = listOf("lambda"),
                     regex = "Available only in online mode",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -776,13 +760,11 @@ class LimeDocRulesValidatorTest {
                     name = "Available online/offline",
                     limeElements = listOf("class", "struct", "lambda"),
                     regex = "Available only in (offline|online) mode",
-                    isWarningOnly = false,
                 ),
                 LimeDocValidationRule(
                     name = "Standard calling convention",
                     limeElements = listOf("function"),
                     regex = "@CallingConvention\\('Standard'\\)",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -862,7 +844,6 @@ class LimeDocRulesValidatorTest {
                     name = "PROPERTY_RULE",
                     limeElements = listOf("property"),
                     regex = "It is a (special|normal) property",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -908,7 +889,6 @@ class LimeDocRulesValidatorTest {
                     name = "PROPERTY_RULE",
                     limeElements = listOf("property"),
                     regex = "It is a (special|normal) property",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -947,7 +927,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "This type is available only online",
-                    isWarningOnly = false,
                 ),
             )
 
@@ -986,7 +965,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "@Placeholder AvailableOnline",
-                    isWarningOnly = false,
                     resolvePlaceholders = false,
                 ),
             )
@@ -1022,7 +1000,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "@Placeholder AvailableOnline",
-                    isWarningOnly = false,
                     resolvePlaceholders = false,
                 ),
             )
@@ -1064,7 +1041,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "It is a (SPECIAL|NORMAL) type",
-                    isWarningOnly = false,
                     platforms = listOf("Java", "Dart"),
                 ),
             )
@@ -1105,7 +1081,6 @@ class LimeDocRulesValidatorTest {
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
                     regex = "It is a NORMAL type",
-                    isWarningOnly = false,
                     platforms = listOf("Swift"),
                 ),
             )

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
@@ -47,6 +47,7 @@ class LimeDocRulesValidatorTest {
     private val limeModel = LimeModel(allElements, emptyList())
     private val outerTypePath = LimePath(emptyList(), listOf("SomeOuterType"))
     private val innerTypePath = outerTypePath.child("SomeInnerType")
+    private val allGenerators = setOf("android", "android-kotlin", "cpp", "dart", "swift")
 
     @Test
     fun creationFailsForTwoRulesWithTheSameName() {
@@ -70,7 +71,7 @@ class LimeDocRulesValidatorTest {
         // When constructing validator.
         val exception =
             assertThrows(OptionReaderException::class.java) {
-                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
             }
 
         // Then error is raised.
@@ -93,7 +94,7 @@ class LimeDocRulesValidatorTest {
         // When constructing validator.
         val exception =
             assertThrows(OptionReaderException::class.java) {
-                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
             }
 
         // Then error is raised.
@@ -116,7 +117,7 @@ class LimeDocRulesValidatorTest {
         // When constructing validator.
         val exception =
             assertThrows(OptionReaderException::class.java) {
-                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
             }
 
         // Then error is raised.
@@ -139,7 +140,7 @@ class LimeDocRulesValidatorTest {
         // When constructing validator.
         val exception =
             assertThrows(OptionReaderException::class.java) {
-                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
             }
 
         // Then error is raised.
@@ -189,7 +190,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -241,7 +242,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -293,7 +294,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -331,7 +332,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -368,7 +369,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -406,7 +407,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -443,7 +444,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -481,7 +482,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -518,7 +519,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -560,7 +561,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -598,7 +599,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -636,7 +637,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -670,7 +671,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -762,7 +763,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -796,7 +797,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -842,7 +843,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -888,7 +889,7 @@ class LimeDocRulesValidatorTest {
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
@@ -898,7 +899,7 @@ class LimeDocRulesValidatorTest {
     }
 
     @Test
-    fun validationOfCommentWithPlaceholders() {
+    fun validationOfCommentWithResolvedPlaceholder() {
         // Given a class in LimeModel, which obeys the rules.
         allElements[outerTypePath.toString()] =
             LimeClass(
@@ -921,18 +922,101 @@ class LimeDocRulesValidatorTest {
                 LimeDocValidationRule(
                     name = "SPECIAL_RULE",
                     limeElements = listOf("class"),
-                    regex = "\\{@Placeholder AvailableOnline\\}",
+                    regex = "This type is available only online",
                     isWarningOnly = false,
                 ),
             )
 
         // And given correctly constructed validator.
-        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
 
         // When trying to verify if rules are obeyed.
         val validationResult = validator.validate(limeModel)
 
         // Then validation passes.
         assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationPassesForRuleForTwoPlatforms() {
+        // Given a class in LimeModel, which obeys the rules.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type class. ",
+                                "" to "It is a ",
+                                "Java" to "SPECIAL",
+                                "Dart" to "NORMAL",
+                                "" to " type",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for classes for Java and Dart.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "It is a (SPECIAL|NORMAL) type",
+                    isWarningOnly = false,
+                    platforms = listOf("Java", "Dart"),
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForRuleForOnePlatform() {
+        // Given a class in LimeModel, which obeys the rules except for Swift.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type class. ",
+                                "" to "It is a ",
+                                "Swift" to "SPECIAL",
+                                "" to " type",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for classes for Swift.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "It is a NORMAL type",
+                    isWarningOnly = false,
+                    platforms = listOf("Swift"),
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules, allGenerators)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
     }
 }

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
@@ -88,8 +88,8 @@ class LimeDocRulesValidatorTest {
                     limeElements = listOf("class", "struct"),
                     regex = "It is a special type",
                     isWarningOnly = false,
-                    platforms = listOf("Python")
-                )
+                    platforms = listOf("Python"),
+                ),
             )
 
         // When constructing validator.

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeDocRulesValidatorTest.kt
@@ -1,0 +1,938 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.cli.OptionReaderException
+import com.here.gluecodium.model.lime.LimeBasicTypeRef
+import com.here.gluecodium.model.lime.LimeClass
+import com.here.gluecodium.model.lime.LimeComment
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeEnumeration
+import com.here.gluecodium.model.lime.LimeFunction
+import com.here.gluecodium.model.lime.LimeInterface
+import com.here.gluecodium.model.lime.LimeLambda
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimeProperty
+import com.here.gluecodium.model.lime.LimeReturnType
+import com.here.gluecodium.model.lime.LimeStruct
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class LimeDocRulesValidatorTest {
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+    private val outerTypePath = LimePath(emptyList(), listOf("SomeOuterType"))
+    private val innerTypePath = outerTypePath.child("SomeInnerType")
+
+    @Test
+    fun creationFailsForTwoRulesWithTheSameName() {
+        // Given two validation rules with the same name.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class", "struct"),
+                    regex = "It is a special type",
+                    isWarningOnly = false,
+                ),
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("interface", "class", "struct"),
+                    regex = "@SPECIAL_TYPE",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // When constructing validator.
+        val exception =
+            assertThrows(OptionReaderException::class.java) {
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+            }
+
+        // Then error is raised.
+        assertTrue(exception.message!!.startsWith("Multiple doc validation rules with the same name = 'SPECIAL_RULE'"))
+    }
+
+    @Test
+    fun creationFailsForRuleWithRegexThatDoesNotCompile() {
+        // Given a validation rule with invalid regex [missing ')']
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "MY_RULE",
+                    limeElements = listOf("class", "struct"),
+                    regex = "(a|b",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // When constructing validator.
+        val exception =
+            assertThrows(OptionReaderException::class.java) {
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+            }
+
+        // Then error is raised.
+        assertTrue(exception.message!!.startsWith("Cannot compile regex for doc validation rule 'MY_RULE'. Exception ="))
+    }
+
+    @Test
+    fun creationFailsForRuleWithoutLimeElementsDefined() {
+        // Given a validation rule without specified lime elements.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = emptyList(),
+                    regex = "It is a special type",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // When constructing validator.
+        val exception =
+            assertThrows(OptionReaderException::class.java) {
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+            }
+
+        // Then error is raised.
+        assertTrue(exception.message!!.startsWith("No lime elements specified for doc validation rule: 'SPECIAL_RULE'"))
+    }
+
+    @Test
+    fun creationFailsForRuleWithUnknownElementTypeDefined() {
+        // Given a validation rule with unknown lime element specified.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class", "mixin"),
+                    regex = "It is a special type",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // When constructing validator.
+        val exception =
+            assertThrows(OptionReaderException::class.java) {
+                LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+            }
+
+        // Then error is raised.
+        assertTrue(exception.message!!.startsWith("Unknown element type 'mixin' for rule 'SPECIAL_RULE'"))
+    }
+
+    @Test
+    fun validationPassesForClassMatchingSimpleRule() {
+        // Given two classes in LimeModel, that are obeying the rules.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type class. ",
+                                "" to "It is a special type",
+                            ),
+                    ),
+            )
+
+        allElements[innerTypePath.toString()] =
+            LimeClass(
+                path = innerTypePath,
+                comment =
+                    LimeComment(
+                        path = innerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important inner type class. ",
+                                "" to "It is a special type",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for classes.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "It is a special type",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForClassNotMatchingRule() {
+        // Given two classes in LimeModel, where one does not comply with the rule.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type class. ",
+                                "" to "It is a special type",
+                            ),
+                    ),
+            )
+
+        allElements[innerTypePath.toString()] =
+            LimeClass(
+                path = innerTypePath,
+                comment =
+                    LimeComment(
+                        path = innerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important inner type class. ",
+                                "" to "It is a normal type",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for classes.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "It is a special type",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
+    }
+
+    @Test
+    fun validationPassesForClassesMatchingComplexRule() {
+        // Given two classes in LimeModel, that are obeying the rules.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type class. ",
+                                "" to "It is a STRONG type",
+                            ),
+                    ),
+            )
+
+        allElements[innerTypePath.toString()] =
+            LimeClass(
+                path = innerTypePath,
+                comment =
+                    LimeComment(
+                        path = innerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important inner type class. ",
+                                "" to "It is a WEAK type",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for classes.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "It is a (STRONG|WEAK) type",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationPassesForStructMatchingRule() {
+        // Given a struct in LimeModel, which obeys the rules.
+        allElements[outerTypePath.toString()] =
+            LimeStruct(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type struct. ",
+                                "" to "@POD_STRUCT",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for structs.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Plain old data structure",
+                    limeElements = listOf("struct"),
+                    regex = "@POD_STRUCT",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForStructNotMatchingRule() {
+        // Given a struct in LimeModel, which does not obey the rules.
+        allElements[outerTypePath.toString()] =
+            LimeStruct(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type struct. ",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for structs.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Plain old data structure",
+                    limeElements = listOf("struct"),
+                    regex = "@POD_STRUCT",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
+    }
+
+    @Test
+    fun validationPassesForInterfaceMatchingRule() {
+        // Given an interface in LimeModel, which obeys the rules.
+        allElements[outerTypePath.toString()] =
+            LimeInterface(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type interface. ",
+                                "" to "@PUBLIC_INTERFACE",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for interfaces.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Public interface",
+                    limeElements = listOf("interface"),
+                    regex = "@PUBLIC_INTERFACE",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForInterfaceNotMatchingRule() {
+        // Given an interface in LimeModel, which does not obey the rules.
+        allElements[outerTypePath.toString()] =
+            LimeInterface(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type interface. ",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for interfaces.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Public interface",
+                    limeElements = listOf("interface"),
+                    regex = "@PUBLIC_INTERFACE",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
+    }
+
+    @Test
+    fun validationPassesForEnumMatchingRule() {
+        // Given an enumeration in LimeModel, which obeys the rules.
+        allElements[outerTypePath.toString()] =
+            LimeEnumeration(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type enumeration. ",
+                                "" to "@ERROR_CODE",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for enumerations.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Error code",
+                    limeElements = listOf("enum"),
+                    regex = "@ERROR_CODE",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForEnumNotMatchingRule() {
+        // Given an enumeration in LimeModel, which does not obey the rules.
+        allElements[outerTypePath.toString()] =
+            LimeEnumeration(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type enumeration. ",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for enumerations.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Error code",
+                    limeElements = listOf("enum"),
+                    regex = "@ERROR_CODE",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
+    }
+
+    @Test
+    fun validationPassesForFunctionMatchingRule() {
+        // Given a class with function in LimeModel, which obeys the rules.
+        val functionPath = outerTypePath.child("someFunction")
+        val function =
+            LimeFunction(
+                path = functionPath,
+                comment =
+                    LimeComment(
+                        path = functionPath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important function. ",
+                                "" to "@CallingConvention('Standard')",
+                            ),
+                    ),
+            )
+
+        allElements[functionPath.toString()] = function
+        allElements[outerTypePath.toString()] = LimeClass(path = outerTypePath, functions = listOf(function))
+
+        // And given a correct validation rule for functions.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Standard calling convention",
+                    limeElements = listOf("function"),
+                    regex = "@CallingConvention\\('Standard'\\)",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForFunctionNotMatchingRule() {
+        // Given a class with function in LimeModel, which does not obey the rules.
+        val functionPath = outerTypePath.child("someFunction")
+        val function =
+            LimeFunction(
+                path = functionPath,
+                comment =
+                    LimeComment(
+                        path = functionPath.child("comment"),
+                        taggedSections = listOf("" to "This is some important function. "),
+                    ),
+            )
+
+        allElements[functionPath.toString()] = function
+        allElements[outerTypePath.toString()] = LimeClass(path = outerTypePath, functions = listOf(function))
+
+        // And given a correct validation rule for functions.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Standard calling convention",
+                    limeElements = listOf("function"),
+                    regex = "@CallingConvention\\('Standard'\\)",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
+    }
+
+    @Test
+    fun validationPassesForLambdaMatchingRule() {
+        // Given a lambda in LimeModel, which obeys the rules.
+        allElements[outerTypePath.toString()] =
+            LimeLambda(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important lambda. ",
+                                "" to "Available only in online mode",
+                            ),
+                    ),
+            )
+
+        // And given a correct validation rule for lambdas.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Available only online",
+                    limeElements = listOf("lambda"),
+                    regex = "Available only in online mode",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForLambdaNotMatchingRule() {
+        // Given a lambda in LimeModel, which does not obey the rules.
+        allElements[outerTypePath.toString()] =
+            LimeLambda(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections = listOf("" to "This is some important lambda. "),
+                    ),
+            )
+
+        // And given a correct validation rule for lambdas.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Available only online",
+                    limeElements = listOf("lambda"),
+                    regex = "Available only in online mode",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
+    }
+
+    @Test
+    fun validationPassesForMultipleRulesForMultipleElements() {
+        // Given a few elements in LimeModel, which obey the rules.
+        val lambdaPath = LimePath(emptyList(), listOf("SomeLambda"))
+        val classPath = LimePath(emptyList(), listOf("SomeClass"))
+        val structPath = LimePath(emptyList(), listOf("SomeStruct"))
+        val functionPath = classPath.child("someFunction")
+
+        val function =
+            LimeFunction(
+                path = functionPath,
+                comment =
+                    LimeComment(
+                        path = functionPath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important function. ",
+                                "" to "@CallingConvention('Standard')",
+                            ),
+                    ),
+            )
+
+        allElements[classPath.toString()] =
+            LimeClass(
+                path = classPath,
+                comment =
+                    LimeComment(
+                        path = classPath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important class. ",
+                                "" to "Available only in offline mode",
+                            ),
+                    ),
+                functions = listOf(function),
+            )
+
+        allElements[lambdaPath.toString()] =
+            LimeLambda(
+                path = lambdaPath,
+                comment =
+                    LimeComment(
+                        path = lambdaPath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important lambda. ",
+                                "" to "Available only in online mode",
+                            ),
+                    ),
+            )
+
+        allElements[structPath.toString()] =
+            LimeStruct(
+                path = structPath,
+                comment =
+                    LimeComment(
+                        path = structPath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important struct. ",
+                                "" to "Available only in online mode",
+                            ),
+                    ),
+            )
+
+        // And given correct validation rules.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Available online/offline",
+                    limeElements = listOf("class", "struct", "lambda"),
+                    regex = "Available only in (offline|online) mode",
+                    isWarningOnly = false,
+                ),
+                LimeDocValidationRule(
+                    name = "Standard calling convention",
+                    limeElements = listOf("function"),
+                    regex = "@CallingConvention\\('Standard'\\)",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun whenRuleIsNotObeyedButWarningOnlyFlagIsSetThenValidationResultIsPositive() {
+        // Given a lambda in LimeModel, which does not obey the rules.
+        allElements[outerTypePath.toString()] =
+            LimeLambda(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections = listOf("" to "This is some important lambda. "),
+                    ),
+            )
+
+        // And given a correct validation rule for lambdas that generates only warnings.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "Available only online",
+                    limeElements = listOf("lambda"),
+                    regex = "Available only in online mode",
+                    isWarningOnly = true,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes (because of isWarningOnly = true).
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationPassesForPropertiesMatchingRule() {
+        // Given a class with property in LimeModel, which obeys the rules.
+        val propertyPath = outerTypePath.child("someProperty")
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                properties =
+                    listOf(
+                        LimeProperty(
+                            path = propertyPath,
+                            typeRef = LimeBasicTypeRef.INT,
+                            getter =
+                                LimeFunction(
+                                    path = propertyPath.child("get"), returnType = LimeReturnType(LimeBasicTypeRef.INT),
+                                ),
+                            comment =
+                                LimeComment(
+                                    path = outerTypePath.child("comment"),
+                                    taggedSections = listOf("" to "It is a normal property"),
+                                ),
+                        ),
+                    ),
+            )
+
+        // And given a correct validation rule for properties.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "PROPERTY_RULE",
+                    limeElements = listOf("property"),
+                    regex = "It is a (special|normal) property",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+
+    @Test
+    fun validationFailsForPropertiesNotMatchingRule() {
+        // Given a class with property in LimeModel, which does not obey the rules.
+        val propertyPath = outerTypePath.child("someProperty")
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                properties =
+                    listOf(
+                        LimeProperty(
+                            path = propertyPath,
+                            typeRef = LimeBasicTypeRef.INT,
+                            getter =
+                                LimeFunction(
+                                    path = propertyPath.child("get"), returnType = LimeReturnType(LimeBasicTypeRef.INT),
+                                ),
+                            comment =
+                                LimeComment(
+                                    path = outerTypePath.child("comment"),
+                                    taggedSections = listOf("" to "This is some random property"),
+                                ),
+                        ),
+                    ),
+            )
+
+        // And given a correct validation rule for properties.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "PROPERTY_RULE",
+                    limeElements = listOf("property"),
+                    regex = "It is a (special|normal) property",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation fails.
+        assertFalse(validationResult)
+    }
+
+    @Test
+    fun validationOfCommentWithPlaceholders() {
+        // Given a class in LimeModel, which obeys the rules.
+        allElements[outerTypePath.toString()] =
+            LimeClass(
+                path = outerTypePath,
+                comment =
+                    LimeComment(
+                        path = outerTypePath.child("comment"),
+                        taggedSections =
+                            listOf(
+                                "" to "This is some important outer type class. ",
+                                "Placeholder" to "AvailableOnline",
+                            ),
+                        placeholders = mapOf("AvailableOnline" to LimeComment("This type is available only online")),
+                    ),
+            )
+
+        // And given a correct validation rule for classes that uses the placeholder.
+        val docValidationRules: List<LimeDocValidationRule> =
+            listOf(
+                LimeDocValidationRule(
+                    name = "SPECIAL_RULE",
+                    limeElements = listOf("class"),
+                    regex = "\\{@Placeholder AvailableOnline\\}",
+                    isWarningOnly = false,
+                ),
+            )
+
+        // And given correctly constructed validator.
+        val validator = LimeDocRulesValidator(mockk(relaxed = true), docValidationRules)
+
+        // When trying to verify if rules are obeyed.
+        val validationResult = validator.validate(limeModel)
+
+        // Then validation passes.
+        assertTrue(validationResult)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ powermock-reflect = "2.0.9"
 robolectric = "4.11.1"
 natpryce-konfig = "1.6.10.0"
 kotlin = "1.9.22"
+kotlinx-serialization-json = "1.6.3"
 build-info-extractor-gradle = "5.1.13"
 spotless-plugin-gradle = "6.23.3"
 android-tools-build-gradle = "8.2.0"
@@ -39,6 +40,7 @@ natpryce-konfig = { module = "com.natpryce:konfig", version.ref = "natpryce-konf
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 build-info-extractor-gradle = { module = "org.jfrog.buildinfo:build-info-extractor-gradle", version.ref = "build-info-extractor-gradle" }
 spotless-plugin-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-plugin-gradle" }
 android-tools-build-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-tools-build-gradle" }
@@ -55,6 +57,7 @@ slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 slf4j-log4j12 = { module = "org.slf4j:slf4j-log4j12", version.ref = "slf4j" }
 
 [plugins]
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 nebula-lint = { id = "nebula.lint", version.ref = "nebula-lint" }
 lazan-dependency-export = { id = "com.lazan.dependency-export", version.ref = "lazan-dependency-export" }
 

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeComment.kt
@@ -51,6 +51,18 @@ class LimeComment(
             .joinToString("") { if (!isPlaceholder(it.first)) it.second else resolvePlaceholder(it.second, platform) }
             .trim()
 
+    fun getForWithoutResolvingPlaceholder(platform: String) =
+        taggedSections
+            .filter { it.first == "" || it.first == platform || isPlaceholder(it.first) }
+            .joinToString("") {
+                if (!isPlaceholder(it.first)) {
+                    it.second
+                } else {
+                    "{ @Placeholder ${it.second} }"
+                }
+            }
+            .trim()
+
     fun withPath(newPath: LimePath) = LimeComment(newPath, taggedSections, isExcluded, placeholders)
 
     fun withExcluded(newExcluded: Boolean): LimeComment {


### PR DESCRIPTION
------------------- Motivation -------------------
Sometimes the documentation of certain elements must contain given required information.
For instance, about module to which given public interface belongs or online/offline availability.
If the required information is missing then Gluecodium must generate warning or error.

------------------- Implemented solution -------------------
In order to add custom validation of comments, a dedicated JSON file with rules can be used.
The file can be specified via `-docsvalidationrules` CLI option or `GLUECODIUM_DOCS_VALIDATION_RULES`
CMake parameter. The JSON file must contain a list of rules.

Each rule consists of required fields:
 - `name` - the name of the rule, which must be unique within the file
 - `limeElements` - the list of LIME elements to which the rule applies. The supported elements are: `class`, `struct`, `interface`, `lambda`, `enum`, `function` and `property`.
- `regex` - the regular expression used to validate the comment.

Moreover, the following optional fields may be used for a rule:
 - `isWarningOnly` - by default it is set to false. This field is used to control the behavior of validator that is triggered when the rule is not respected. When this field is set to true then only warning is raised instead of an error.
 - `resolvePlaceholders` - by default it is set to true. This field is used to ease creation of validation rules that want to check if placeholder is used in the body of comment. When this flag is set to false then validation rule may look only for `@Placeholder <NAME>`.
- `platforms` - by default a rule is checked for all generated platforms. However, there may be a need to create platform-specific rule e.g. respected only for Java, Swift, Kotlin or Dart. In such a case platforms field can be used - it is a list of platforms specified as string. When this field is set the rule is applied only for the specified platforms.