### PR TITLE
Conditionally warn about android attributes mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Features
  * Dart/Flutter: the generated code is now compatible with Flutter 3.29 and above. When the user invokes the callback created for lambda/interface from the thread that is the main isolate thread, but outside of isolate context then it is correclty executed. Before this release the thread would deadlock. Now the generated code identifies such case and enters the isolate context before invoking the callback.
+ * Java/Kotlin: in order to ease transition from Java to Kotlin the possibility to conditionally warn about mismatch in attributes used for Java/Kotlin is implemented. The following new CLI parameter is available `-enableandroidattributesmismatchwarning` as well as `GLUECODIUM_ENABLE_ANDROID_ATTRIBUTES_MISMATCH_WARNING` CMake parameter.
 
 ## 13.12.0
 Release date 2025-03-24

--- a/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
+++ b/cmake/modules/gluecodium/gluecodium/KnownOptionalProperties.cmake
@@ -238,6 +238,15 @@ _gluecodium_define_target_property(
 )
 
 _gluecodium_define_target_property(
+  GLUECODIUM_ENABLE_ANDROID_ATTRIBUTES_MISMATCH_WARNING
+  BRIEF_DOCS "Enables generation of warnings when attributes for Java and Kotlin do not match."
+  FULL_DOCS
+    "Enables generation of warnings when attributes for Java and Kotlin do not match. "
+    "Option used to ease adjustments of LIME files needed to transition from Java to Kotlin. "
+    "This property is initialized by the value of the GLUECODIUM_ENABLE_ANDROID_ATTRIBUTES_MISMATCH_WARNING_DEFAULT variable if it is set when the function gluecodium_add_generate_command is called."
+)
+
+_gluecodium_define_target_property(
   GLUECODIUM_DART_NAMERULES
   BRIEF_DOCS "The path to a file with name rules for Dart"
   FULL_DOCS

--- a/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
+++ b/cmake/modules/gluecodium/gluecodium/details/runGenerate.cmake
@@ -151,6 +151,7 @@ function(_prepare_gluecodium_config_file file_path placeholder_file)
   _append_boolean_value(swiftexpose "${GLUECODIUM_SWIFT_EXPOSE_INTERNALS}")
   _append_boolean_value(strict "${GLUECODIUM_STRICT_VALIDATION}")
   _append_boolean_value(dartdisablefinalizablemarker "${GLUECODIUM_DART_DISABLE_FINALIZABLE_MARKER}")
+  _append_boolean_value(enableandroidattributesmismatchwarning "${GLUECODIUM_ENABLE_ANDROID_ATTRIBUTES_MISMATCH_WARNING}")
 
   _append_list_option(generators GLUECODIUM_GENERATORS)
   _append_list_option(werror GLUECODIUM_WERROR)

--- a/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/CMakeLists.txt
+++ b/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (C) 2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+cmake_minimum_required(VERSION 3.12)
+
+project(gluecodium.test)
+set(CMAKE_CXX_STANDARD 17)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
+list(APPEND CMAKE_MODULE_PATH "${GLUECODIUM_CMAKE_DIR}/modules")
+include(gluecodium/Gluecodium)
+
+include(${GLUECODIUM_CMAKE_TESTS_DIR}/utils/get_supported_gluecodium_generators.cmake)
+
+add_library(dummySharedLibrary SHARED "${CMAKE_CURRENT_LIST_DIR}/cpp/FooImpl.cpp")
+target_link_libraries(dummySharedLibrary PRIVATE Threads::Threads)
+
+get_supported_gluecodium_generators(_gluecodium_generator)
+
+gluecodium_generate(dummySharedLibrary GENERATORS ${_gluecodium_generator})
+gluecodium_target_lime_sources(dummySharedLibrary
+                               PRIVATE "${CMAKE_CURRENT_LIST_DIR}/lime/foo.lime")
+
+set_target_properties(dummySharedLibrary
+                      PROPERTIES GLUECODIUM_ENABLE_ANDROID_ATTRIBUTES_MISMATCH_WARNING "ON")

--- a/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/cpp/FooImpl.cpp
+++ b/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/cpp/FooImpl.cpp
@@ -1,0 +1,19 @@
+// -------------------------------------------------------------------------------------------------
+// Copyright (C) 2016-2025 HERE Europe B.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+// License-Filename: LICENSE
+//
+// -------------------------------------------------------------------------------------------------

--- a/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/lime/foo.lime
+++ b/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/lime/foo.lime
@@ -1,0 +1,26 @@
+# Copyright (C) 2016-2025 HERE Europe B.V.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+package unit.test
+
+# This class uses function with type that does not exist.
+# It is done this way to force CMake to print Gluecodium logs
+# to the output to be able to match it.
+@Java(Skip)
+class Foo {
+    fun foo(): SomeTypeThatDoesNotExits
+}

--- a/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/successful.regex
+++ b/cmake/tests/unit/gluecodium_generate/enable-android-attributes-mismatch-warning-XFAIL/successful.regex
@@ -1,0 +1,1 @@
+element unit.test.Foo: Attributes missing in Kotlin, but present in Java: \[Skip\]

--- a/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/Gluecodium.kt
@@ -34,6 +34,7 @@ import com.here.gluecodium.generator.common.templates.TemplateEngine
 import com.here.gluecodium.model.lime.LimeModel
 import com.here.gluecodium.model.lime.LimeModelLoader
 import com.here.gluecodium.model.lime.LimeModelLoaderException
+import com.here.gluecodium.validator.LimeAndroidAttributesMismatchValidator
 import com.here.gluecodium.validator.LimeAsyncValidator
 import com.here.gluecodium.validator.LimeConstantRefsValidator
 import com.here.gluecodium.validator.LimeExternalTypesValidator
@@ -178,6 +179,9 @@ class Gluecodium(
             getIndependentValidators(limeLogger) +
                 if (typeRefsValidationResult) getTypeRefDependentValidators(limeLogger) else emptyList()
         val validationResults = validators.map { it.invoke(filteredModel) }
+        if (generatorOptions.enableAndroidAttributesMismatchWarning) {
+            LimeAndroidAttributesMismatchValidator(limeLogger).validate(filteredModel)
+        }
         return typeRefsValidationResult && !validationResults.contains(false)
     }
 

--- a/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/cli/OptionReader.kt
@@ -129,6 +129,12 @@ object OptionReader {
                     "'Finalizable' marker)",
             )
             addOption(
+                "enableandroidattributesmismatchwarning",
+                false,
+                "Enables generation of warnings when attributes for Java and Kotlin do not match. " +
+                    "Option used to ease adjustments of LIME files needed to transition from Java to Kotlin.",
+            )
+            addOption(
                 "werror",
                 "warning-as-error",
                 true,
@@ -233,6 +239,7 @@ object OptionReader {
         getStringValue("dartlookuperrormessage")?.let { generatorOptions.dartLookupErrorMessage = it }
         getStringListValue("werror")?.let { generatorOptions.werror = it.toSet() }
 
+        generatorOptions.enableAndroidAttributesMismatchWarning = getFlagValue("enableandroidattributesmismatchwarning")
         generatorOptions.dartDisableFinalizableMarker = getFlagValue("dartdisablefinalizablemarker")
         generatorOptions.swiftExposeInternals = getFlagValue("swiftexpose")
 

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/common/GeneratorOptions.kt
@@ -38,6 +38,7 @@ data class GeneratorOptions(
     var cppExportCommon: String? = null,
     var internalPrefix: String? = null,
     var libraryName: String = "library",
+    var enableAndroidAttributesMismatchWarning: Boolean = false,
     var dartDisableFinalizableMarker: Boolean = false,
     var dartLookupErrorMessage: String =
         "Failed to resolve an FFI function. Perhaps `LibraryContext.init()` was not called.",

--- a/gluecodium/src/main/java/com/here/gluecodium/validator/LimeAndroidAttributesMismatchValidator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/validator/LimeAndroidAttributesMismatchValidator.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimeNamedElement
+
+class LimeAndroidAttributesMismatchValidator(private val limeLogger: LimeLogger) {
+    fun validate(limeModel: LimeModel) {
+        val allElements = limeModel.referenceMap.values
+        allElements.filterIsInstance<LimeNamedElement>().forEach { element ->
+            val javaAttributes = element.attributes.getAllAttributeValueTypes(LimeAttributeType.JAVA)
+            val kotlinAttributes = element.attributes.getAllAttributeValueTypes(LimeAttributeType.KOTLIN)
+            val commonAttributes = kotlinAttributes intersect javaAttributes
+
+            val attributesMissingInJava = kotlinAttributes subtract commonAttributes
+            if (attributesMissingInJava.isNotEmpty()) {
+                logAttributesMismatch(
+                    element = element,
+                    attributes = attributesMissingInJava,
+                    present = "Kotlin",
+                    missing = "Java",
+                )
+            }
+
+            val attributesMissingInKotlin = javaAttributes subtract commonAttributes
+            if (attributesMissingInKotlin.isNotEmpty()) {
+                logAttributesMismatch(
+                    element = element,
+                    attributes = attributesMissingInKotlin,
+                    present = "Java",
+                    missing = "Kotlin",
+                )
+            }
+        }
+    }
+
+    private fun logAttributesMismatch(
+        element: LimeNamedElement,
+        attributes: Set<LimeAttributeValueType>,
+        present: String,
+        missing: String,
+    ) {
+        val warningMessage = "Attributes missing in $missing, but present in $present: $attributes"
+        limeLogger.warning(element, warningMessage)
+    }
+}

--- a/gluecodium/src/test/java/com/here/gluecodium/validator/LimeAndroidAttributesMismatchValidatorTest.kt
+++ b/gluecodium/src/test/java/com/here/gluecodium/validator/LimeAndroidAttributesMismatchValidatorTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2016-2025 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package com.here.gluecodium.validator
+
+import com.here.gluecodium.common.LimeLogger
+import com.here.gluecodium.model.lime.LimeAttributeType
+import com.here.gluecodium.model.lime.LimeAttributeValueType
+import com.here.gluecodium.model.lime.LimeAttributes
+import com.here.gluecodium.model.lime.LimeElement
+import com.here.gluecodium.model.lime.LimeModel
+import com.here.gluecodium.model.lime.LimePath
+import com.here.gluecodium.model.lime.LimeStruct
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+
+class LimeAndroidAttributesMismatchValidatorTest {
+    private val allElements = mutableMapOf<String, LimeElement>()
+    private val limeModel = LimeModel(allElements, emptyList())
+    private val somePath = LimePath(emptyList(), listOf("foo", "bar"))
+
+    @Test
+    fun elementWithoutAttributesDoesNotGenerateWarning() {
+        val limeStruct = LimeStruct(path = somePath)
+        allElements[somePath.toString()] = limeStruct
+
+        val logger: LimeLogger = mockk()
+        val validator = LimeAndroidAttributesMismatchValidator(logger)
+        validator.validate(limeModel)
+
+        verify(exactly = 0) { logger.warning(limeStruct, any()) }
+    }
+
+    @Test
+    fun elementWithSameAttributesForJavaAndKotlinDoesNotGenerateWarning() {
+        val attributes =
+            LimeAttributes.Builder()
+                .addAttribute(LimeAttributeType.KOTLIN, LimeAttributeValueType.SKIP)
+                .addAttribute(LimeAttributeType.JAVA, LimeAttributeValueType.SKIP)
+                .build()
+
+        val limeStruct = LimeStruct(path = somePath, attributes = attributes)
+        allElements[somePath.toString()] = limeStruct
+
+        val logger: LimeLogger = mockk()
+        val validator = LimeAndroidAttributesMismatchValidator(logger)
+        validator.validate(limeModel)
+
+        verify(exactly = 0) { logger.warning(limeStruct, any()) }
+    }
+
+    @Test
+    fun elementWithAttributeOnlyForJavaGeneratesWarning() {
+        val attributes =
+            LimeAttributes.Builder()
+                .addAttribute(LimeAttributeType.JAVA, LimeAttributeValueType.SKIP)
+                .build()
+
+        val limeStruct = LimeStruct(path = somePath, attributes = attributes)
+        allElements[somePath.toString()] = limeStruct
+
+        val logger: LimeLogger = mockk()
+        justRun { logger.warning(limeStruct, any()) }
+
+        val validator = LimeAndroidAttributesMismatchValidator(logger)
+        validator.validate(limeModel)
+
+        verify(exactly = 1) { logger.warning(limeStruct, "Attributes missing in Kotlin, but present in Java: [Skip]") }
+    }
+
+    @Test
+    fun elementWithAttributesOnlyForKotlinGeneratesWarning() {
+        val attributes =
+            LimeAttributes.Builder()
+                .addAttribute(LimeAttributeType.KOTLIN, LimeAttributeValueType.SKIP)
+                .build()
+
+        val limeStruct = LimeStruct(path = somePath, attributes = attributes)
+        allElements[somePath.toString()] = limeStruct
+
+        val logger: LimeLogger = mockk()
+        justRun { logger.warning(limeStruct, any()) }
+
+        val validator = LimeAndroidAttributesMismatchValidator(logger)
+        validator.validate(limeModel)
+
+        verify(exactly = 1) { logger.warning(limeStruct, "Attributes missing in Java, but present in Kotlin: [Skip]") }
+    }
+
+    @Test
+    fun mismatchForTwoPlatformsGeneratesTwoWarnings() {
+        val attributes =
+            LimeAttributes.Builder()
+                .addAttribute(LimeAttributeType.JAVA, LimeAttributeValueType.SKIP)
+                .addAttribute(LimeAttributeType.KOTLIN, LimeAttributeValueType.INTERNAL)
+                .build()
+
+        val limeStruct = LimeStruct(path = somePath, attributes = attributes)
+        allElements[somePath.toString()] = limeStruct
+
+        val logger: LimeLogger = mockk()
+        justRun { logger.warning(limeStruct, any()) }
+
+        val validator = LimeAndroidAttributesMismatchValidator(logger)
+        validator.validate(limeModel)
+
+        verify(exactly = 1) { logger.warning(limeStruct, "Attributes missing in Kotlin, but present in Java: [Skip]") }
+        verify(exactly = 1) { logger.warning(limeStruct, "Attributes missing in Java, but present in Kotlin: [Internal]") }
+    }
+}

--- a/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributes.kt
+++ b/lime-runtime/src/main/java/com/here/gluecodium/model/lime/LimeAttributes.kt
@@ -38,6 +38,8 @@ class LimeAttributes private constructor(
         else -> true
     }
 
+    fun getAllAttributeValueTypes(type: LimeAttributeType) = attributes[type]?.keys ?: emptySet()
+
     fun <T> get(
         attributeType: LimeAttributeType,
         valueType: LimeAttributeValueType,


### PR DESCRIPTION
In order to ease transition from Java to Kotlin
the users have the possibility to enable warnings
about mismatch in attributes for elements.
    
The following new CLI parameter is available
`-enableandroidattributesmismatchwarning` as well as
`GLUECODIUM_ENABLE_ANDROID_ATTRIBUTES_MISMATCH_WARNING`
CMake parameter.
    
When flag is set to true and an element from LIME file uses
annotations for Java, but it does not use the matching annotation
for Kotlin then the warning is generated (and vice versa).
    
Signed-off-by: Patryk Wrobel <183546751+pwrobeldev@users.noreply.github.com>