### PR TITLE
Kotlin: implement comments processor

### DIFF
--- a/functional-tests/functional/input/lime/Comments.lime
+++ b/functional-tests/functional/input/lime/Comments.lime
@@ -86,6 +86,7 @@ class comments {
         set
     }
     // @value Some very useful attribute.
+    // @description Some additional description of the property.
     property instanceAttribute: CommentsInstantiable {
         // Some very useful attribute.
         get

--- a/functional-tests/functional/input/lime/DateDefaults.lime
+++ b/functional-tests/functional/input/lime/DateDefaults.lime
@@ -28,6 +28,7 @@ struct DateDefaults {
     static fun getCppDefaults(): DateDefaults
 }
 
+// This is some typealias that references Date type and is used to verify generated documentation.
 typealias DateAlias = Date
 
 struct DateDefaultsAliased {

--- a/functional-tests/functional/input/lime/Lambdas.lime
+++ b/functional-tests/functional/input/lime/Lambdas.lime
@@ -48,6 +48,9 @@ class Lambdas {
     static fun applyNullableConfuser(confuser: NullableConfuser, value: String?): StandaloneProducer?
 }
 
+// This is some lambda named StandaloneProducer.
+// It produces serious data.
+// This sentence is used while validating generated documentation.
 lambda StandaloneProducer = () -> String
 
 @Overloaded

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinCommentsProcessor.kt
@@ -20,19 +20,21 @@
 package com.here.gluecodium.generator.kotlin
 
 import com.here.gluecodium.generator.common.CommentsProcessor
-import com.here.gluecodium.generator.java.JavaDocProcessor.Companion.flexmarkOptions
 import com.here.gluecodium.model.lime.LimeElement
 import com.vladsch.flexmark.ast.LinkRef
-import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.formatter.Formatter
+import com.vladsch.flexmark.util.sequence.CharSubSequence
 
-internal class KotlinCommentsProcessor(private val referenceMap: Map<String, LimeElement>, private val werror: Boolean = true) :
-    CommentsProcessor(HtmlRenderer.builder(flexmarkOptions).build(), werror, flexmarkOptions) {
+internal class KotlinCommentsProcessor(private val referenceMap: Map<String, LimeElement>, werror: Boolean = true) :
+    CommentsProcessor(Formatter.builder().build(), werror) {
     override fun processLink(
         linkNode: LinkRef,
         linkReference: String,
         limeFullName: String,
     ) {
-        // TODO: implement me!
+        linkNode.reference = CharSubSequence.of(linkReference)
+        linkNode.referenceOpeningMarker = CharSubSequence.of("[")
+        linkNode.referenceClosingMarker = CharSubSequence.of("]")
         linkNode.firstChild?.unlink()
     }
 }

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinCommentsProcessor.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinCommentsProcessor.kt
@@ -25,7 +25,7 @@ import com.vladsch.flexmark.ast.LinkRef
 import com.vladsch.flexmark.formatter.Formatter
 import com.vladsch.flexmark.util.sequence.CharSubSequence
 
-internal class KotlinCommentsProcessor(private val referenceMap: Map<String, LimeElement>, werror: Boolean = true) :
+internal class KotlinCommentsProcessor(private val referenceMap: Map<String, LimeElement>, werror: Boolean) :
     CommentsProcessor(Formatter.builder().build(), werror) {
     override fun processLink(
         linkNode: LinkRef,

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGenerator.kt
@@ -58,6 +58,7 @@ internal class KotlinGenerator : Generator {
     private lateinit var cppNameRules: CppNameRules
     private lateinit var kotlinNameRules: KotlinNameRules
     private lateinit var activeTags: Set<String>
+    private lateinit var werror: Set<String>
 
     override val shortName = GENERATOR_NAME
 
@@ -70,6 +71,7 @@ internal class KotlinGenerator : Generator {
         cppNameRules = CppNameRules(rootNamespace, nameRuleSetFromConfig(options.cppNameRules))
         kotlinNameRules = KotlinNameRules(nameRuleSetFromConfig(options.kotlinNameRules))
         activeTags = options.tags
+        werror = options.werror
     }
 
     override fun generate(limeModel: LimeModel): List<GeneratedFile> {
@@ -91,7 +93,8 @@ internal class KotlinGenerator : Generator {
             throw GluecodiumExecutionException("Validation errors found, see log for details.")
         }
 
-        val commentsProcessor = KotlinCommentsProcessor(kotlinFilteredModel.referenceMap)
+        val commentsProcessor =
+            KotlinCommentsProcessor(kotlinFilteredModel.referenceMap, werror.contains(GeneratorOptions.WARNING_DOC_LINKS))
 
         val nameResolver =
             KotlinNameResolver(

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
@@ -33,6 +33,7 @@ import com.here.gluecodium.model.lime.LimeStruct
 internal object KotlinGeneratorPredicates {
     val predicates =
         mapOf(
+            "hasAnyComment" to this::hasAnyComment,
             "hasStaticFunctions" to this::hasStaticFunctions,
             "needsDisposer" to this::needsDisposer,
             "needsCompanionObject" to this::needsCompanionObject,
@@ -43,6 +44,8 @@ internal object KotlinGeneratorPredicates {
             "isExceptionSameForCtorAndHookFun" to this::isExceptionSameForCtorAndHookFun,
             "needsAllFieldsConstructor" to this::needsAllFieldsConstructor,
         )
+
+    private fun hasAnyComment(element: Any) = CommonGeneratorPredicates.hasAnyComment(element, "Kotlin")
 
     private fun needsAllFieldsConstructor(limeStruct: Any): Boolean {
         return when {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
@@ -38,6 +38,8 @@ import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeList
 import com.here.gluecodium.model.lime.LimeMap
 import com.here.gluecodium.model.lime.LimeNamedElement
+import com.here.gluecodium.model.lime.LimeParameter
+import com.here.gluecodium.model.lime.LimeProperty
 import com.here.gluecodium.model.lime.LimeReturnType
 import com.here.gluecodium.model.lime.LimeSet
 import com.here.gluecodium.model.lime.LimeType
@@ -55,6 +57,7 @@ internal class KotlinNameResolver(
     private val basePackages: List<String>,
 ) : ReferenceMapBasedResolver(limeReferenceMap), NameResolver {
     private val kotlinValueResolver = KotlinValueResolver(this)
+    private val limeToKotlinNames: Map<String, String> = buildPathMap()
 
     override fun resolveName(element: Any): String =
         when (element) {
@@ -93,8 +96,12 @@ internal class KotlinNameResolver(
     override fun resolveSetterName(element: Any) = (element as? LimeTypedElement)?.let { kotlinNameRules.getSetterName(it) }
 
     private fun resolveComment(limeComment: LimeComment): String {
-        // TODO: implement me!
-        return ""
+        val commentText = limeComment.getFor("Kotlin")
+        if (commentText.isBlank()) return ""
+
+        val exactElement = limeReferenceMap[limeComment.path.toString()] as? LimeNamedElement
+        val commentedElement = exactElement ?: getParentElement(limeComment.path, withSuffix = true)
+        return commentsProcessor.process(commentedElement.fullName, commentText, limeToKotlinNames, limeLogger)
     }
 
     private fun resolveValue(limeValue: LimeValue): String {
@@ -162,6 +169,54 @@ internal class KotlinNameResolver(
             is LimeLambda -> parentElement.attributes.get(LimeAttributeType.KOTLIN, FUNCTION_NAME) ?: "apply"
             else -> kotlinNameRules.getName(limeFunction)
         }
+    }
+
+    private fun buildPathMap(): Map<String, String> {
+        val result =
+            limeReferenceMap.values
+                .filterIsInstance<LimeNamedElement>()
+                .filterNot { it is LimeFunction || it is LimeParameter }
+                .associateBy({ it.path.toAmbiguousString() }, { resolveFullName(it) })
+                .toMutableMap()
+
+        result +=
+            limeReferenceMap.values.filterIsInstance<LimeParameter>()
+                .associateBy({ it.fullName }, { resolveFullName(it) })
+
+        limeReferenceMap.values.filterIsInstance<LimeFunction>().forEach { function ->
+            val ambiguousKey = function.path.toAmbiguousString()
+            val unambiguousKey =
+                ambiguousKey +
+                    function.parameters.joinToString(prefix = "(", postfix = ")", separator = ",") { it.typeRef.toString() }
+            val fullName = resolveFullName(function)
+
+            result[function.fullName] = fullName
+            result[ambiguousKey] = fullName
+            result[unambiguousKey] = fullName
+        }
+
+        val properties = limeReferenceMap.values.filterIsInstance<LimeProperty>()
+        result += properties.associateBy({ it.path.toAmbiguousString() + ".get" }, { resolveFullName(it) })
+        result +=
+            properties.filter { it.setter != null }
+                .associateBy({ it.path.toAmbiguousString() + ".set" }, { resolveFullName(it) })
+
+        return result
+    }
+
+    private fun resolveFullName(limeElement: LimeNamedElement): String {
+        val elementName = resolveName(limeElement)
+
+        if (!limeElement.path.hasParent) {
+            return (resolvePackageNames(limeElement) + elementName).joinToString(".")
+        }
+
+        val parentElement = getParentElement(limeElement)
+        val prefix = resolveFullName(parentElement)
+
+        val ownName =
+            if (limeElement is LimeFunction && limeElement.isConstructor) resolveName(parentElement) else elementName
+        return "$prefix.$ownName"
     }
 
     fun resolvePackageNames(limeElement: LimeNamedElement) = (basePackages + limeElement.path.head).map { normalizePackageName(it) }

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinAbstractNativeList.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinAbstractNativeList.mustache
@@ -42,13 +42,10 @@ package {{join this delimiter="."}}
 /**
  * <p>Internal base abstract class for List implementations backed by a native object.
  *
- * @hidden
+ * @suppress
  */
 abstract class AbstractNativeList<T> : NativeBase, MutableList<T> {
 
-    /**
-     * @hidden
-     */
     private inner class NativeIterator : MutableListIterator<T> {
         private var index: Int = 0
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -18,6 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 {{resolveName "visibility"}}{{#if this.isOpen}}open {{/if}}class {{resolveName}} : {{!!
 }}{{#if this.parentClass}}{{resolveName this.parentClass "" "ref"}}{{/if}}{{!!
 }}{{#unless this.parentClass}}NativeBase{{/unless}}{{!!
@@ -28,6 +29,7 @@
 {{>kotlin/KotlinContainerContents}}
 
 {{#set classElement=this}}{{#constructors}}
+{{prefixPartial "kotlin/KotlinMethodComment" "    "}}
     {{>kotlinConstructorThrows}}
 {{resolveName "visibility"}}constructor({{!!
 }}{{#parameters}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -48,9 +48,9 @@
     }
 {{/constructors}}{{/set}}
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
@@ -18,4 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 @JvmField final val {{resolveName}}: {{resolveName typeRef}} = {{resolveName value}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinDocComment.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinDocComment.mustache
@@ -1,0 +1,40 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2025 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#ifPredicate "hasAnyComment"}}
+{{#resolveName comment}}{{#unless this.isEmpty}}
+/**
+{{prefix this " * "}}
+{{#if comment.isExcluded}}
+ * @suppress
+{{/if}}
+ */
+{{/unless}}{{/resolveName}}
+{{#unlessPredicate "hasAnyComment"}}
+{{#if comment.isExcluded}}
+/**
+ * @suppress
+ */
+{{/if}}
+{{/unlessPredicate}}
+{{#if attributes.deprecated}}
+@Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
+{{/if}}
+{{/ifPredicate}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinDocComment.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinDocComment.mustache
@@ -22,6 +22,9 @@
 {{#resolveName comment}}{{#unless this.isEmpty}}
 /**
 {{prefix this " * "}}
+{{#property.additionalDescriptionComment}}{{#resolveName this}}{{#unless this.isEmpty}}
+{{prefix this " * "}}
+{{/unless}}{{/resolveName}}{{/property.additionalDescriptionComment}}
 {{#if comment.isExcluded}}
  * @suppress
 {{/if}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinDuration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinDuration.mustache
@@ -41,13 +41,13 @@ package {{join this delimiter="."}}.time
 
 /**
  * Represents duration in time (both positive and negative).
- * <p>
- *     The duration is represented as number of seconds (see {@link #getSeconds()})
- *     and number of nanoseconds in a second (see {@link #getNano()}).
- * <p>
- *     Duration can be created from various units of time by calling on of
- *     {@code of*} methods. The {@code to*} family of methods convert duration
- *     to a value expressed in desired unit of time.
+ *
+ * The duration is represented as number of seconds (see [Duration.getSeconds])
+ * and number of nanoseconds in a second (see [Duration.getNano]).
+ *
+ * Duration can be created from various units of time by calling on of
+ * `of*` methods. The `to*` family of methods convert duration
+ * to a value expressed in desired unit of time.
  */
 public class Duration private constructor(private var mSeconds: Long, private var mNanos: Int) : Comparable<Duration> {
 
@@ -72,7 +72,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      *
      * @return Total number of nanoseconds in this duration.
      * @throws ArithmeticException if the resulting value cannot be represented
-     *                             by {@code long} type.
+     *                             by `long` type.
      */
     @Throws(ArithmeticException::class)
     public fun toNanos(): Long {
@@ -80,7 +80,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
     }
 
     /**
-     * Gets the nanoseconds part of this duration. Equals to {@link #getNano()}.
+     * Gets the nanoseconds part of this duration. Equals to [Duration.getNano].
      *
      * @return The nanoseconds part of this duration, value from 0 to 999999999.
      */
@@ -95,7 +95,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      *
      * @return Total number of milliseconds in this duration.
      * @throws ArithmeticException if the resulting value cannot be represented
-     *                             by {@code long} type.
+     *                             by `long` type.
      */
     @Throws(ArithmeticException::class)
     public fun toMillis(): Long {
@@ -185,7 +185,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
     }
 
     /**
-     * Same as {@link #toDays()}.
+     * Same as [Duration.toDays].
      *
      * @return The number of full days in this duration.
      */

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
@@ -18,6 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 {{resolveName "visibility"}}enum class {{resolveName}}(private val value: Int) {
 {{joinPartial uniqueEnumerators "kotlin/KotlinEnumerator" ",
 "}}{{#if uniqueEnumerators}};{{/if}}{{#if aliasEnumerators}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
@@ -18,6 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#if isAlias}}    @JvmField val {{resolveName}}{{!!
+{{#if comment}}
+{{prefixPartial "kotlin/KotlinDocComment" "    "}}{{/if}}{{!!
+}}{{#if isAlias}}    @JvmField val {{resolveName}}{{!!
 }} = {{resolveName value}}{{/if}}{{!!
 }}{{#unless isAlias}}    {{resolveName}}({{resolveName value}}){{/unless}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
@@ -18,5 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 class {{resolveName}}(@JvmField val error: {{resolveName errorType}}) : Exception(error.toString())
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
@@ -18,8 +18,9 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#thrownType}}@Throws ({{resolveName typeRef}}::class) {{/thrownType}}{{!!
-}}{{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
+{{#unless this.isConstructor}}{{>kotlin/KotlinMethodComment}}{{/unless}}
+{{#thrownType}}@Throws({{resolveName typeRef}}::class){{/thrownType}}
+{{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
 }}{{#unless isInterface}}{{resolveName "visibility"}}external {{/unless}}fun {{resolveName}}({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -18,13 +18,10 @@
   ! License-Filename: LICENSE
   !
   !}}
+/**
+ * @suppress
+ */
 {{resolveName "visibility"}}class {{resolveName}}Impl : NativeBase, {{resolveName}} {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -18,6 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 {{resolveName "visibility"}}interface {{resolveName}} {{!!
 }}{{#if this.parents}}: {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
 {{>kotlin/KotlinContainerContents}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -34,7 +34,9 @@
 {{#set isInterface=true}}
 {{#properties}}
 {{#unless isStatic}}
+{{#set property=this}}{{#property}}
 {{prefixPartial "kotlin/KotlinProperty" "    "}}
+{{/property}}{{/set}}
 {{/unless}}
 {{/properties}}
 {{/set}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
@@ -18,6 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 {{resolveName "visibility"}}fun interface {{resolveName}} {
 {{#set isInterface=true noAttributes=true}}{{!!
 }}{{#asFunction}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinLazyNativeList.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinLazyNativeList.mustache
@@ -18,9 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-/**
- * @hidden
- */
 private class {{resolveName}}LazyNativeList : AbstractNativeList<{{resolveName}}> {
 
     private constructor(nativeHandle: Long, tag: Any?)

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinMethodComment.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinMethodComment.mustache
@@ -1,0 +1,49 @@
+{{!!
+  !
+  ! Copyright (C) 2016-2019 HERE Europe B.V.
+  !
+  ! Licensed under the Apache License, Version 2.0 (the "License");
+  ! you may not use this file except in compliance with the License.
+  ! You may obtain a copy of the License at
+  !
+  !     http://www.apache.org/licenses/LICENSE-2.0
+  !
+  ! Unless required by applicable law or agreed to in writing, software
+  ! distributed under the License is distributed on an "AS IS" BASIS,
+  ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ! See the License for the specific language governing permissions and
+  ! limitations under the License.
+  !
+  ! SPDX-License-Identifier: Apache-2.0
+  ! License-Filename: LICENSE
+  !
+  !}}
+{{#ifPredicate "hasAnyComment"}}
+/**
+{{prefixPartial "combinedComment" " * "}}
+ */{{#if attributes.deprecated}}
+@Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}") {{/if}}{{!!
+}}{{/ifPredicate}}{{!!
+
+}}{{+combinedComment}}{{!!
+}}{{resolveName comment}}{{!!
+}}{{#if comment.isExcluded}}
+{{!!}}@suppress{{!!
+}}{{/if}}{{!!
+}}{{#parameters}}
+{{!!}}@param {{resolveName}} {{#resolveName comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/parameters}}{{!!
+}}{{#unless isConstructor returnType.isVoid logic="and"}}
+{{!!}}@return {{#resolveName returnType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/unless}}{{!!
+}}{{#if thrownType}}
+{{!!}}@throws {{resolveName exception "" "ref"}} {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/if}}{{!!
+}}{{#if isConstructor}}{{#unlessPredicate "isExceptionSameForCtorAndHookFun"}}{{!!
+}}{{#this.attributes.afterconstruction.function.function}}{{!!
+}}{{#if thrownType}}
+{{!!}}@throws {{resolveName exception "" "ref"}} {{#resolveName thrownType.comment}}{{prefix this "    " skipFirstLine=true}}{{/resolveName}}{{!!
+}}{{/if}}{{!!
+}}{{/this.attributes.afterconstruction.function.function}}{{!!
+}}{{/unlessPredicate}}{{/if}}{{!!
+}}{{/combinedComment}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
@@ -18,6 +18,7 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 {{#if isStatic}}@JvmStatic {{/if}}{{!!
 }}{{#if override}}override {{/if}}{{!!
 }}{{#unless isInterface}}{{resolveName "visibility"}}{{/unless}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
@@ -18,13 +18,15 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 {{#unless external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
 }}class {{resolveName}}{{!!
 }}{{#unless external.kotlin.name}}{{!!
 }}{{#if attributes.serializable}} : Parcelable{{/if}}{{!!
 }}{{/unless}} {
 {{#set isImmutable=attributes.immutable}}
-{{#fields}}{{!!
+{{#fields}}
+{{prefixPartial "kotlin/KotlinDocComment" "    "}}{{!!
 }}    @JvmField {{resolveName "visibility"}}{{!!
 }}{{#unless isImmutable}}var {{/unless}}{{!!
 }}{{#if isImmutable}}val {{/if}}{{!!
@@ -40,7 +42,8 @@
 }}
 {{#set self=this}}
 {{#constructors}}
-{{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
+{{prefixPartial "kotlin/KotlinMethodComment" "    "}}
+{{#thrownType}}@Throws({{resolveName typeRef}}::class){{/thrownType}}{{!!
 }}
     {{#unless self.external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
 }}constructor({{!!
@@ -67,6 +70,14 @@
        **Note**: this constructor will not be generated if PositionalDefaults is specified for a given structure,
                  because the constructor generated for positional defaults covers this case.
 }}
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}{{!!
+}}{{#uninitializedFields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/uninitializedFields}}
+     */
+{{/unless}}
     {{#ifPredicate "hasInternalFreeArgsConstructor"}}{{!!
 }}internal {{!!
 }}{{/ifPredicate}}constructor({{!!
@@ -85,6 +96,14 @@
     3. If user did not specify any constructors, field constructor and fields with default values, then
        define a constructor, which allows setting all fields.
 }}
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
+{{#fields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/fields}}
+     */
+{{/unless}}
     {{#ifPredicate "hasInternalAllArgsConstructor"}}{{!!
 }}internal {{!!
 }}{{/ifPredicate}}constructor({{!!
@@ -99,6 +118,21 @@
 
     4. Generate field constructors specified by the user.
 }}{{#set self=this}}{{#fieldConstructors}}
+{{#ifPredicate "hasAnyComment"}}
+    /**
+{{#unless comment.isEmpty}}{{#resolveName comment}}{{prefix this "     * "}}
+{{/resolveName}}{{/unless}}{{!!
+}}{{#if comment.isEmpty}}{{#resolveName constructorComment}}{{#unless this.isEmpty}}{{prefix this "     * "}}
+{{/unless}}{{/resolveName}}{{/if}}{{!!
+}}{{#if comment.isExcluded}}
+     * @suppress
+{{/if}}{{!!
+}}{{#fields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/fields}}
+     */{{#if attributes.deprecated}}
+    @Deprecated("{{#resolveName attributes.deprecated.message}}{{escape this}}{{/resolveName}}")
+{{/if}}{{/ifPredicate}}
 {{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
 }}
     {{#unless self.external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
@@ -116,6 +150,19 @@
     5. Generate positional defaults constructor if it is specified and there are no field constructors.
 }}{{#unless fieldConstructors}}{{!!
 }}{{#if attributes.kotlin.positionalDefaults}}
+{{#unless constructorComment.isEmpty}}
+    /**
+{{#resolveName constructorComment}}{{prefix this "     * "}}{{/resolveName}}
+{{#uninitializedFields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/uninitializedFields}}
+{{#initializedFields}}
+     * @param {{resolveName}} {{#resolveName comment}}{{prefix this "     * " skipFirstLine=true}}{{/resolveName}}
+{{/initializedFields}}
+     */
+{{/unless}}{{#instanceOf attributes.kotlin.positionalDefaults "String"}}
+    @Deprecated("{{attributes.kotlin.positionalDefaults}}")
+{{/instanceOf}}
     {{#if initializedFields}}@JvmOverloads
     {{/if}}{{!!
     }}{{#unless external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinTypeAlias.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinTypeAlias.mustache
@@ -18,4 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
+{{>kotlin/KotlinDocComment}}
 typealias {{resolveName}} = {{resolveName typeRef}}

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
@@ -13,9 +13,9 @@ class BasicTypes : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -30,17 +30,41 @@ class BasicTypes : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun stringFunction(input: String) : String
+
+
         @JvmStatic external fun boolFunction(input: Boolean) : Boolean
+
+
         @JvmStatic external fun floatFunction(input: Float) : Float
+
+
         @JvmStatic external fun doubleFunction(input: Double) : Double
+
+
         @JvmStatic external fun byteFunction(input: Byte) : Byte
+
+
         @JvmStatic external fun shortFunction(input: Short) : Short
+
+
         @JvmStatic external fun intFunction(input: Int) : Int
+
+
         @JvmStatic external fun longFunction(input: Long) : Long
+
+
         @JvmStatic external fun ubyteFunction(input: Short) : Short
+
+
         @JvmStatic external fun ushortFunction(input: Int) : Int
+
+
         @JvmStatic external fun uintFunction(input: Long) : Long
+
+
         @JvmStatic external fun ulongFunction(input: Long) : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
+++ b/gluecodium/src/test/resources/smoke/comments/input/PlatformComments.lime
@@ -25,13 +25,13 @@ class PlatformComments {
         Useful
     }
 
-    // An {@Java @Dart exception}{@Swift error} when something goes wrong.
+    // An {@Java @Kotlin @Dart exception}{@Swift error} when something goes wrong.
     exception SomethingWrong(SomeEnum)
 
-    // This is some very useless method that {@Cpp does nothing}{@Java makes some coffee}{@Swift is very swift}{@Dart cannot have overloads}.
+    // This is some very useless method that {@Cpp does nothing}{@Kotlin makes some tea}{@Java makes some coffee}{@Swift is very swift}{@Dart cannot have overloads}.
     fun doNothing()
 
-    // {@Cpp Cooks very special C++ sauce.}{@Java Makes some coffee.}{@Swift Eats a hip bruschetta.}{@Dart Colors everything in fuchsia.}
+    // {@Cpp Cooks very special C++ sauce.}{@Java Makes some coffee.}{@Kotlin Makes some tea.}{@Swift Eats a hip bruschetta.}{@Dart Colors everything in fuchsia.}
     fun doMagic()
 
     // This is some very useful method that measures the usefulness of its input or \\esc\@pe\{s\}.
@@ -43,7 +43,7 @@ class PlatformComments {
     @Deprecated("A very {@Cpp useful}{@Java @Dart useless}{@Swift awesome} method that is deprecated.")
     fun someDeprecatedMethod()
 
-    // This is a{@Cpp @Java  very}{@Java @Swift  super}{@Swift @Cpp  useful}{@Cpp @Java @Swift  struct}.
+    // This is a{@Cpp @Java  very}{@Java @Swift  super}{@Swift @Cpp  useful}{@Kotlin  great}{@Cpp @Java @Kotlin @Swift  struct}.
     struct something {
         nothing: String
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -9,6 +9,9 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * This is some very useful .
+ */
 class Comments : NativeBase {
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -67,13 +67,33 @@ class Comments : NativeBase {
 
         override external fun apply(p0: String, p1: Int) : Double
 
+        /**
+         * Some very useful property.
+         * Note: without these comments user may not be able to use it correctly.
+         * Note: that's serious.
+         * Therefore, these lines above getter/setter need to be rendered in the output files.
+         */
         override var isSomeProperty: Boolean
             external get
             external set
 
+        /**
+         * OnlyGetterProperty, which does not have a setter.
+         * The generated documentation for this property should only be added to property or getter.
+         */
         override val onlyGetterProperty: Int
             external get
 
+        /**
+         * A flag that determines if [com.example.smoke.Comments.onlyGetterProperty] is visible on the screen.
+         * By default it is set to `false`. In this case the mentioned thing is not visible on the
+         * screen except the case when another flag called [com.example.smoke.Comments.isSomeProperty] forces it.
+         * When set to `true` then it is always visible.
+         *
+         * The additional information about usage of the visibility flag is described here. It contains a lot
+         * of references. For instance, if [com.example.smoke.Comments.isSomeProperty] is
+         * then it is not visible even if flag is set to `true`.
+         */
         override var isIsVisible: Boolean
             external get
             external set
@@ -110,13 +130,33 @@ class Comments : NativeBase {
     external fun oneParameterCommentOnly(undocumented: String, documented: String) : String
     external fun returnCommentOnly(undocumented: String) : String
 
+    /**
+     * Some very useful property.
+     * Note: without these comments user may not be able to use it correctly.
+     * Note: that's serious.
+     * Therefore, these lines above getter/setter need to be rendered in the output files.
+     */
     var isSomeProperty: Boolean
         external get
         external set
 
+    /**
+     * OnlyGetterProperty, which does not have a setter.
+     * The generated documentation for this property should only be added to property or getter.
+     */
     val onlyGetterProperty: Int
         external get
 
+    /**
+     * A flag that determines if [com.example.smoke.Comments.onlyGetterProperty] is visible on the screen.
+     * By default it is set to `false`. In this case the mentioned thing is not visible on the
+     * screen except the case when another flag called [com.example.smoke.Comments.isSomeProperty] forces it.
+     * When set to `true` then it is always visible.
+     *
+     * The additional information about usage of the visibility flag is described here. It contains a lot
+     * of references. For instance, if [com.example.smoke.Comments.isSomeProperty] is
+     * then it is not visible even if flag is set to `true`.
+     */
     var isIsVisible: Boolean
         external get
         external set

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -58,13 +58,10 @@ class Comments : NativeBase {
         fun apply(p0: String, p1: Int) : Double
     }
 
+    /**
+     * @suppress
+     */
     class SomeLambdaImpl : NativeBase, SomeLambda {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -146,9 +146,9 @@ class Comments : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -51,6 +51,9 @@ class Comments : NativeBase {
         }
     }
 
+    /**
+     * This is some very useful lambda that does it.
+     */
     fun interface SomeLambda {
         fun apply(p0: String, p1: Int) : Double
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -11,8 +11,17 @@ import com.example.NativeBase
 
 class Comments : NativeBase {
 
+    /**
+     * This is some very useful enum.
+     */
     enum class SomeEnum(private val value: Int) {
+        /**
+         * Not quite useful
+         */
         USELESS(0),
+        /**
+         * Somewhat useful
+         */
         USEFUL(1);
     }
     class SomethingWrongException(@JvmField val error: Comments.SomeEnum) : Exception(error.toString())

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -1,0 +1,119 @@
+/*
+
+ *
+ */
+
+@file:JvmName("comments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class Comments : NativeBase {
+
+    enum class SomeEnum(private val value: Int) {
+        USELESS(0),
+        USEFUL(1);
+    }
+    class SomethingWrongException(@JvmField val error: Comments.SomeEnum) : Exception(error.toString())
+
+
+    class SomeStruct {
+        @JvmField var someField: Boolean
+        @JvmField var nullableField: String?
+
+
+
+        constructor(someField: Boolean) {
+            this.someField = someField
+            this.nullableField = null
+        }
+
+
+
+        external fun someStructMethod() : Unit
+
+
+        companion object {
+            @JvmStatic external fun someStaticStructMethod() : Unit
+        }
+    }
+
+    fun interface SomeLambda {
+        fun apply(p0: String, p1: Int) : Double
+    }
+
+    class SomeLambdaImpl : NativeBase, SomeLambda {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String, p1: Int) : Double
+
+        override var isSomeProperty: Boolean
+            external get
+            external set
+
+        override val onlyGetterProperty: Int
+            external get
+
+        override var isIsVisible: Boolean
+            external get
+            external set
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    @Throws (Comments.SomethingWrongException::class) external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    external fun someMethodWithInputComments(input: String) : Boolean
+    external fun someMethodWithOutputComments(input: String) : Boolean
+    external fun someMethodWithNoComments(input: String) : Boolean
+    external fun someMethodWithoutReturnTypeWithAllComments(input: String) : Unit
+    external fun someMethodWithoutReturnTypeWithNoComments(input: String) : Unit
+    external fun someMethodWithoutInputParametersWithAllComments() : Boolean
+    external fun someMethodWithoutInputParametersWithNoComments() : Boolean
+    external fun someMethodWithNothing() : Unit
+    external fun someMethodWithoutReturnTypeOrInputParameters() : Unit
+    external fun oneParameterCommentOnly(undocumented: String, documented: String) : String
+    external fun returnCommentOnly(undocumented: String) : String
+
+    var isSomeProperty: Boolean
+        external get
+        external set
+
+    val onlyGetterProperty: Int
+        external get
+
+    var isIsVisible: Boolean
+        external get
+        external set
+
+
+
+
+    companion object {
+        @JvmField final val VERY_USEFUL: Boolean = true
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -113,6 +113,9 @@ class Comments : NativeBase {
 
 
     companion object {
+        /**
+         * This is some very useful constant.
+         */
         @JvmField final val VERY_USEFUL: Boolean = true
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -43,10 +43,18 @@ class Comments : NativeBase {
 
 
 
+        /**
+         * This is some struct method that does nothing.
+         */
+
         external fun someStructMethod() : Unit
 
 
         companion object {
+            /**
+             * This is some static struct method that does nothing.
+             */
+
             @JvmStatic external fun someStaticStructMethod() : Unit
         }
     }
@@ -55,6 +63,13 @@ class Comments : NativeBase {
      * This is some very useful lambda that does it.
      */
     fun interface SomeLambda {
+        /**
+         * This is some very useful lambda that does it.
+         * @param p0 Very useful input parameter
+         * @param p1 Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
+
         fun apply(p0: String, p1: Int) : Double
     }
 
@@ -64,6 +79,13 @@ class Comments : NativeBase {
     class SomeLambdaImpl : NativeBase, SomeLambda {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        /**
+         * This is some very useful lambda that does it.
+         * @param p0 Very useful input parameter
+         * @param p1 Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
 
         override external fun apply(p0: String, p1: Int) : Double
 
@@ -117,17 +139,81 @@ class Comments : NativeBase {
 
 
 
-    @Throws (Comments.SomethingWrongException::class) external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param inputParameter Very useful input parameter
+     * @return Usefulness of the input
+     * @throws Comments.SomethingWrongException Sometimes it happens.
+     */
+    @Throws(Comments.SomethingWrongException::class)
+    external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input Very useful input parameter
+     * @return
+     */
+
     external fun someMethodWithInputComments(input: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input
+     * @return Usefulness of the input
+     */
+
     external fun someMethodWithOutputComments(input: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input
+     * @return
+     */
+
     external fun someMethodWithNoComments(input: String) : Boolean
+    /**
+     * This is some very useful method that does not measure the usefulness of its input.
+     * @param input Very useful input parameter
+     */
+
     external fun someMethodWithoutReturnTypeWithAllComments(input: String) : Unit
+    /**
+     * This is some very useful method that does not measure the usefulness of its input.
+     * @param input
+     */
+
     external fun someMethodWithoutReturnTypeWithNoComments(input: String) : Unit
+    /**
+     * This is some very useful method that measures the usefulness of something.
+     * @return Usefulness of the input
+     */
+
     external fun someMethodWithoutInputParametersWithAllComments() : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of something.
+     * @return
+     */
+
     external fun someMethodWithoutInputParametersWithNoComments() : Boolean
+
+
     external fun someMethodWithNothing() : Unit
+    /**
+     * This is some very useful method that does nothing.
+     */
+
     external fun someMethodWithoutReturnTypeOrInputParameters() : Unit
+    /**
+     *
+     * @param undocumented
+     * @param documented nicely documented
+     * @return
+     */
+
     external fun oneParameterCommentOnly(undocumented: String, documented: String) : String
+    /**
+     *
+     * @param undocumented
+     * @return nicely documented
+     */
+
     external fun returnCommentOnly(undocumented: String) : String
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -33,12 +33,27 @@ class Comments : NativeBase {
     class SomethingWrongException(@JvmField val error: Comments.SomeEnum) : Exception(error.toString())
 
 
+    /**
+     * This is some very useful struct.
+     */
     class SomeStruct {
+        /**
+         * How useful this struct is
+         * remains to be seen
+         */
         @JvmField var someField: Boolean
+        /**
+         * Can be `null`
+         */
         @JvmField var nullableField: String?
 
 
 
+        /**
+         * This is how easy it is to construct.
+         * @param someField How useful this struct is
+         * remains to be seen
+         */
         constructor(someField: Boolean) {
             this.someField = someField
             this.nullableField = null

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/Comments.kt
@@ -24,6 +24,9 @@ class Comments : NativeBase {
          */
         USEFUL(1);
     }
+    /**
+     * This is some very useful exception.
+     */
     class SomethingWrongException(@JvmField val error: Comments.SomeEnum) : Exception(error.toString())
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -52,6 +52,9 @@ interface CommentsInterface {
     fun someMethodWithNothing() : Unit
     fun someMethodWithoutReturnTypeOrInputParameters() : Unit
 
+    /**
+     * Some very useful property.
+     */
     var isSomeProperty: Boolean
         get
         set

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -41,15 +41,55 @@ interface CommentsInterface {
     }
 
 
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input Very useful input parameter
+     * @return Usefulness of the input
+     */
     fun someMethodWithAllComments(input: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input Very useful input parameter
+     * @return
+     */
     fun someMethodWithInputComments(input: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input
+     * @return Usefulness of the input
+     */
     fun someMethodWithOutputComments(input: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input
+     * @return
+     */
     fun someMethodWithNoComments(input: String) : Boolean
+    /**
+     * This is some very useful method that does not measure the usefulness of its input.
+     * @param input Very useful input parameter
+     */
     fun someMethodWithoutReturnTypeWithAllComments(input: String) : Unit
+    /**
+     * This is some very useful method that does not measure the usefulness of its input.
+     * @param input
+     */
     fun someMethodWithoutReturnTypeWithNoComments(input: String) : Unit
+    /**
+     * This is some very useful method that measures the usefulness of something.
+     * @return Usefulness of the input
+     */
     fun someMethodWithoutInputParametersWithAllComments() : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of something.
+     * @return
+     */
     fun someMethodWithoutInputParametersWithNoComments() : Boolean
+
     fun someMethodWithNothing() : Unit
+    /**
+     * This is some very useful method that does nothing.
+     */
     fun someMethodWithoutReturnTypeOrInputParameters() : Unit
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -9,8 +9,17 @@ package com.example.smoke
 
 
 interface CommentsInterface {
+    /**
+     * This is some very useful enum.
+     */
     enum class SomeEnum(private val value: Int) {
+        /**
+         * Not quite useful
+         */
         USELESS(0),
+        /**
+         * Somewhat useful
+         */
         USEFUL(1);
     }
     class SomeStruct {

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -46,6 +46,9 @@ interface CommentsInterface {
 
 
     companion object {
+        /**
+         * This is some very useful constant.
+         */
         @JvmField final val VERY_USEFUL: Boolean = true
     }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -8,6 +8,9 @@
 package com.example.smoke
 
 
+/**
+ * This is some very useful interface.
+ */
 interface CommentsInterface {
     /**
      * This is some very useful enum.

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -25,7 +25,13 @@ interface CommentsInterface {
          */
         USEFUL(1);
     }
+    /**
+     * This is some very useful struct.
+     */
     class SomeStruct {
+        /**
+         * How useful this struct is
+         */
         @JvmField var someField: Boolean
 
 
@@ -46,50 +52,60 @@ interface CommentsInterface {
      * @param input Very useful input parameter
      * @return Usefulness of the input
      */
+
     fun someMethodWithAllComments(input: String) : Boolean
     /**
      * This is some very useful method that measures the usefulness of its input.
      * @param input Very useful input parameter
      * @return
      */
+
     fun someMethodWithInputComments(input: String) : Boolean
     /**
      * This is some very useful method that measures the usefulness of its input.
      * @param input
      * @return Usefulness of the input
      */
+
     fun someMethodWithOutputComments(input: String) : Boolean
     /**
      * This is some very useful method that measures the usefulness of its input.
      * @param input
      * @return
      */
+
     fun someMethodWithNoComments(input: String) : Boolean
     /**
      * This is some very useful method that does not measure the usefulness of its input.
      * @param input Very useful input parameter
      */
+
     fun someMethodWithoutReturnTypeWithAllComments(input: String) : Unit
     /**
      * This is some very useful method that does not measure the usefulness of its input.
      * @param input
      */
+
     fun someMethodWithoutReturnTypeWithNoComments(input: String) : Unit
     /**
      * This is some very useful method that measures the usefulness of something.
      * @return Usefulness of the input
      */
+
     fun someMethodWithoutInputParametersWithAllComments() : Boolean
     /**
      * This is some very useful method that measures the usefulness of something.
      * @return
      */
+
     fun someMethodWithoutInputParametersWithNoComments() : Boolean
+
 
     fun someMethodWithNothing() : Unit
     /**
      * This is some very useful method that does nothing.
      */
+
     fun someMethodWithoutReturnTypeOrInputParameters() : Unit
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsInterface.kt
@@ -1,0 +1,52 @@
+/*
+
+ *
+ */
+
+@file:JvmName("CommentsInterface")
+
+package com.example.smoke
+
+
+interface CommentsInterface {
+    enum class SomeEnum(private val value: Int) {
+        USELESS(0),
+        USEFUL(1);
+    }
+    class SomeStruct {
+        @JvmField var someField: Boolean
+
+
+
+        constructor(someField: Boolean) {
+            this.someField = someField
+        }
+
+
+
+
+
+    }
+
+
+    fun someMethodWithAllComments(input: String) : Boolean
+    fun someMethodWithInputComments(input: String) : Boolean
+    fun someMethodWithOutputComments(input: String) : Boolean
+    fun someMethodWithNoComments(input: String) : Boolean
+    fun someMethodWithoutReturnTypeWithAllComments(input: String) : Unit
+    fun someMethodWithoutReturnTypeWithNoComments(input: String) : Unit
+    fun someMethodWithoutInputParametersWithAllComments() : Boolean
+    fun someMethodWithoutInputParametersWithNoComments() : Boolean
+    fun someMethodWithNothing() : Unit
+    fun someMethodWithoutReturnTypeOrInputParameters() : Unit
+
+    var isSomeProperty: Boolean
+        get
+        set
+
+
+    companion object {
+        @JvmField final val VERY_USEFUL: Boolean = true
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
@@ -1,0 +1,51 @@
+/*
+
+ *
+ */
+
+@file:JvmName("CommentsLinks")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CommentsLinks : NativeBase {
+
+    class RandomStruct {
+        @JvmField var randomField: Comments.SomeStruct
+
+
+
+        constructor(randomField: Comments.SomeStruct) {
+            this.randomField = randomField
+        }
+
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    @Throws (Comments.SomethingWrongException::class) external fun randomMethod(inputParameter: Comments.SomeEnum) : Comments.SomeEnum
+    external fun randomMethod(text: String, flag: Boolean) : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
@@ -20,11 +20,21 @@ import com.example.NativeBase
  */
 class CommentsLinks : NativeBase {
 
+    /**
+     * Links also work in:
+     */
     class RandomStruct {
+        /**
+         * Some random field [com.example.smoke.Comments.SomeStruct]
+         */
         @JvmField var randomField: Comments.SomeStruct
 
 
 
+        /**
+         * constructor comments [com.example.smoke.Comments.SomeStruct]
+         * @param randomField Some random field [com.example.smoke.Comments.SomeStruct]
+         */
         constructor(randomField: Comments.SomeStruct) {
             this.randomField = randomField
         }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
@@ -9,6 +9,15 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * The nested types like [com.example.smoke.CommentsLinks.randomMethod] don't need full name prefix, but it's
+ * possible to references other interfaces like [com.example.smoke.CommentsInterface] or other members
+ * [com.example.smoke.Comments.someMethodWithAllComments].
+ *
+ * Weblinks are not modified like this [example1], [example2](http://www.example.com/2) or <https://www.example.com/3>.
+ *
+ * [example1]: http://example.com/1
+ */
 class CommentsLinks : NativeBase {
 
     class RandomStruct {

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
@@ -47,9 +47,9 @@ class CommentsLinks : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsLinks.kt
@@ -39,7 +39,53 @@ class CommentsLinks : NativeBase {
 
 
 
-    @Throws (Comments.SomethingWrongException::class) external fun randomMethod(inputParameter: Comments.SomeEnum) : Comments.SomeEnum
+    /**
+     * Link types:
+     * * constant: [com.example.smoke.Comments.VERY_USEFUL]
+     * * struct: [com.example.smoke.Comments.SomeStruct]
+     * * struct field: [com.example.smoke.Comments.SomeStruct.someField]
+     * * enum: [com.example.smoke.Comments.SomeEnum]
+     * * enum item: [com.example.smoke.Comments.SomeEnum.USEFUL]
+     * * property: [com.example.smoke.Comments.isSomeProperty]
+     * * property setter: [com.example.smoke.Comments.isSomeProperty]
+     * * property getter: [com.example.smoke.Comments.isSomeProperty]
+     * * method: [com.example.smoke.Comments.someMethodWithAllComments]
+     * * method with signature: [com.example.smoke.Comments.oneParameterCommentOnly]
+     * * method with signature with no spaces: [com.example.smoke.Comments.oneParameterCommentOnly]
+     * * parameter: [com.example.smoke.CommentsLinks.randomMethod.inputParameter]
+     * * top level constant: [com.example.smoke.CommentsTypeCollection.TYPE_COLLECTION_CONSTANT]
+     * * top level struct: [com.example.smoke.CommentsTypeCollection.TypeCollectionStruct]
+     * * top level struct field: [com.example.smoke.CommentsTypeCollection.TypeCollectionStruct.field]
+     * * top level enum: [com.example.smoke.CommentsTypeCollection.TypeCollectionEnum]
+     * * top level enum item: [com.example.smoke.CommentsTypeCollection.TypeCollectionEnum.ITEM]
+     * * error: [com.example.smoke.Comments.SomethingWrongException]
+     * * lambda: [com.example.smoke.Comments.SomeLambda]
+     * * type from aux sources, same package: [com.example.smoke.AuxClass]
+     * * type from aux sources, different package: [com.example.fire.AuxStruct]
+     *   * we can also have
+     *   * nested lists
+     *
+     * Not working for Java:
+     * * typedef: [com.example.smoke.Comments.Usefulness]
+     * * top level typedef: [com.example.smoke.CommentsTypeCollection.TypeCollectionTypedef]
+     *
+     * Not working for Swift:
+     * * named comment: [][com.example.smoke.Comments.VERY_USEFUL]
+     * @param inputParameter Sometimes takes [com.example.smoke.Comments.SomeEnum.USEFUL]
+     * @return Sometimes returns [com.example.smoke.Comments.SomeEnum.USEFUL]
+     * @throws Comments.SomethingWrongException May or may not throw [com.example.smoke.Comments.SomethingWrongException]
+     */
+    @Throws(Comments.SomethingWrongException::class)
+    external fun randomMethod(inputParameter: Comments.SomeEnum) : Comments.SomeEnum
+    /**
+     * Links to method overloads:
+     * * other one: [com.example.smoke.CommentsLinks.randomMethod]
+     * * this one: [com.example.smoke.CommentsLinks.randomMethod]
+     * * ambiguous one: [com.example.smoke.CommentsLinks.randomMethod]
+     * @param text
+     * @param flag
+     */
+
     external fun randomMethod(text: String, flag: Boolean) : Unit
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+@file:JvmName("CommentsMarkdown")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CommentsMarkdown : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
@@ -9,6 +9,32 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * First line.
+ * Second line.
+ *
+ * Another paragraph. **bold** and *italic* and `code`.
+ *
+ * > blockquote
+ *
+ * # Heading one
+ *
+ * ## Heading two
+ *
+ * ### Heading three
+ *
+ * Unordered list:
+ * - A
+ * - B
+ *
+ * Ordered list:
+ * 1. foo
+ * 2. bar
+ *
+ * ---
+ *
+ * [title](https://www.markdownguide.org/cheat-sheet/)
+ */
 class CommentsMarkdown : NativeBase {
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsMarkdown.kt
@@ -39,9 +39,9 @@ class CommentsMarkdown : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
@@ -22,9 +22,9 @@ class CommentsTable : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
@@ -9,6 +9,15 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * Something lorem something ipsum.
+ *
+ * | Tables | Are | Cool |
+ * |----------|:-------------:|------:|
+ * | col 1 is |  left-aligned | $1600 |
+ * | col 2 is |    centered   |   $12 |
+ * | col 3 is | right-aligned |    $1 |
+ */
 class CommentsTable : NativeBase {
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTable.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+@file:JvmName("CommentsTable")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CommentsTable : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+@file:JvmName("CommentsTableLinks")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CommentsTableLinks : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
@@ -22,9 +22,9 @@ class CommentsTableLinks : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CommentsTableLinks.kt
@@ -9,6 +9,15 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * Something lorem something ipsum.
+ *
+ * | Tables | Are | Cool |
+ * |----------|:-------------:|------:|
+ * | col 1 is |  [com.example.smoke.CommentsTable] | $1600 |
+ * | col 2 is |[com.example.smoke.Comments.SomeEnum]|   $12 |
+ * | col 3 is |[com.example.smoke.Comments.SomeEnum.USEFUL]|    $1 |
+ */
 class CommentsTableLinks : NativeBase {
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
@@ -11,7 +11,11 @@ import com.example.NativeBase
 
 class CtorLinks : NativeBase {
 
+    /**
+     * This class has just one constructor [com.example.smoke.CtorLinks.SingleCtor.SingleCtor].
+     */
     class SingleCtor : NativeBase {
+
 
 
         constructor() : this(create(), null as Any?) {
@@ -39,7 +43,11 @@ class CtorLinks : NativeBase {
             @JvmStatic external fun create() : Long
         }
     }
+    /**
+     * This class has just one constructor with one argument [com.example.smoke.CtorLinks.SingleCtorWithOneArgument.SingleCtorWithOneArgument].
+     */
     class SingleCtorWithOneArgument : NativeBase {
+
 
 
         constructor(arg: Int) : this(create(arg), null as Any?) {
@@ -67,7 +75,11 @@ class CtorLinks : NativeBase {
             @JvmStatic external fun create(arg: Int) : Long
         }
     }
+    /**
+     * This class has just one constructor with two argument [com.example.smoke.CtorLinks.SingleCtorWithTwoArgument.SingleCtorWithTwoArgument].
+     */
     class SingleCtorWithTwoArgument : NativeBase {
+
 
 
         constructor(arg: Int, arg2: String) : this(create(arg, arg2), null as Any?) {
@@ -98,9 +110,16 @@ class CtorLinks : NativeBase {
     class OverloadedCtors : NativeBase {
 
 
+
         constructor(input: String) : this(create(input), null as Any?) {
             cacheThisInstance();
         }
+        /**
+         *
+         * @param input
+         * @param flag
+         */
+        @Deprecated("Use [com.example.smoke.CtorLinks.OverloadedCtors.OverloadedCtors] instead.")
         constructor(input: String, flag: Boolean) : this(create(input, flag), null as Any?) {
             cacheThisInstance();
         }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
@@ -1,0 +1,150 @@
+/*
+
+ *
+ */
+
+@file:JvmName("CtorLinks")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class CtorLinks : NativeBase {
+
+    class SingleCtor : NativeBase {
+
+
+        constructor() : this(create(), null as Any?) {
+            cacheThisInstance();
+        }
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        private external fun cacheThisInstance()
+
+
+
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+            @JvmStatic external fun create() : Long
+        }
+    }
+    class SingleCtorWithOneArgument : NativeBase {
+
+
+        constructor(arg: Int) : this(create(arg), null as Any?) {
+            cacheThisInstance();
+        }
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        private external fun cacheThisInstance()
+
+
+
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+            @JvmStatic external fun create(arg: Int) : Long
+        }
+    }
+    class SingleCtorWithTwoArgument : NativeBase {
+
+
+        constructor(arg: Int, arg2: String) : this(create(arg, arg2), null as Any?) {
+            cacheThisInstance();
+        }
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        private external fun cacheThisInstance()
+
+
+
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+            @JvmStatic external fun create(arg: Int, arg2: String) : Long
+        }
+    }
+    class OverloadedCtors : NativeBase {
+
+
+        constructor(input: String) : this(create(input), null as Any?) {
+            cacheThisInstance();
+        }
+        constructor(input: String, flag: Boolean) : this(create(input, flag), null as Any?) {
+            cacheThisInstance();
+        }
+
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        private external fun cacheThisInstance()
+
+
+
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+            @JvmStatic external fun create(input: String) : Long
+            @JvmStatic external fun create(input: String, flag: Boolean) : Long
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/CtorLinks.kt
@@ -22,9 +22,9 @@ class CtorLinks : NativeBase {
             cacheThisInstance();
         }
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
@@ -40,6 +40,7 @@ class CtorLinks : NativeBase {
 
         companion object {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
             @JvmStatic external fun create() : Long
         }
     }
@@ -54,9 +55,9 @@ class CtorLinks : NativeBase {
             cacheThisInstance();
         }
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
@@ -72,6 +73,7 @@ class CtorLinks : NativeBase {
 
         companion object {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
             @JvmStatic external fun create(arg: Int) : Long
         }
     }
@@ -86,9 +88,9 @@ class CtorLinks : NativeBase {
             cacheThisInstance();
         }
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
@@ -104,6 +106,7 @@ class CtorLinks : NativeBase {
 
         companion object {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
             @JvmStatic external fun create(arg: Int, arg2: String) : Long
         }
     }
@@ -124,9 +127,9 @@ class CtorLinks : NativeBase {
             cacheThisInstance();
         }
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
@@ -142,15 +145,17 @@ class CtorLinks : NativeBase {
 
         companion object {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
             @JvmStatic external fun create(input: String) : Long
+
             @JvmStatic external fun create(input: String, flag: Boolean) : Long
         }
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecatedWithNoMessage.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecatedWithNoMessage.kt
@@ -8,6 +8,7 @@
 package com.example.smoke
 
 
+@Deprecated("")
 class DeprecatedWithNoMessage {
     @JvmField var field: String
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecatedWithNoMessage.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecatedWithNoMessage.kt
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+@file:JvmName("DeprecatedWithNoMessage")
+
+package com.example.smoke
+
+
+class DeprecatedWithNoMessage {
+    @JvmField var field: String
+
+
+
+    constructor() {
+        this.field = ""
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -9,7 +9,15 @@ package com.example.smoke
 
 
 interface DeprecationComments {
+    /**
+     * This is some very useful enum.
+     */
+    @Deprecated("Unfortunately, this enum is deprecated. Use [com.example.smoke.Comments.SomeEnum] instead.")
     enum class SomeEnum(private val value: Int) {
+        /**
+         * Not quite useful
+         */
+        @Deprecated("Unfortunately, this item is deprecated.\nUse [com.example.smoke.Comments.SomeEnum.USELESS] instead.")
         USELESS(0);
     }
     class SomethingWrongException(@JvmField val error: DeprecationComments.SomeEnum) : Exception(error.toString())

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -28,7 +28,15 @@ interface DeprecationComments {
     class SomethingWrongException(@JvmField val error: DeprecationComments.SomeEnum) : Exception(error.toString())
 
 
+    /**
+     * This is some very useful struct.
+     */
+    @Deprecated("Unfortunately, this struct is deprecated. Use [com.example.smoke.Comments.SomeStruct] instead.")
     class SomeStruct {
+        /**
+         * How useful this struct is.
+         */
+        @Deprecated("Unfortunately, this field is deprecated.\nUse [com.example.smoke.Comments.SomeStruct.someField] instead.")
         @JvmField var someField: Boolean
 
 
@@ -50,6 +58,7 @@ interface DeprecationComments {
      * @return Usefulness of the input
      */
     @Deprecated("Unfortunately, this method is deprecated.\nUse [com.example.smoke.Comments.someMethodWithAllComments] instead.")
+
     fun someMethodWithAllComments(input: String) : Boolean
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -1,0 +1,49 @@
+/*
+
+ *
+ */
+
+@file:JvmName("DeprecationComments")
+
+package com.example.smoke
+
+
+interface DeprecationComments {
+    enum class SomeEnum(private val value: Int) {
+        USELESS(0);
+    }
+    class SomethingWrongException(@JvmField val error: DeprecationComments.SomeEnum) : Exception(error.toString())
+
+
+    class SomeStruct {
+        @JvmField var someField: Boolean
+
+
+
+        constructor() {
+            this.someField = false
+        }
+
+
+
+
+
+    }
+
+
+    fun someMethodWithAllComments(input: String) : Boolean
+
+    var isSomeProperty: Boolean
+        get
+        set
+
+    var propertyButNotAccessors: String
+        get
+        set
+
+
+    companion object {
+        @JvmField final val VERY_USEFUL: Boolean = true
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -8,6 +8,10 @@
 package com.example.smoke
 
 
+/**
+ * This is some very useful interface.
+ */
+@Deprecated("Unfortunately, this interface is deprecated. Use [com.example.smoke.Comments] instead.")
 interface DeprecationComments {
     /**
      * This is some very useful enum.

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -43,6 +43,10 @@ interface DeprecationComments {
 
 
     companion object {
+        /**
+         * This is some very useful constant.
+         */
+        @Deprecated("Unfortunately, this constant is deprecated. Use [com.example.smoke.Comments.VERY_USEFUL] instead.")
         @JvmField final val VERY_USEFUL: Boolean = true
     }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -46,10 +46,18 @@ interface DeprecationComments {
 
     fun someMethodWithAllComments(input: String) : Boolean
 
+    /**
+     * Some very useful property.
+     */
+    @Deprecated("Unfortunately, this property is deprecated.\nUse [com.example.smoke.Comments.isSomeProperty] instead.")
     var isSomeProperty: Boolean
         get
         set
 
+    /**
+     * Describes the property but not accessors.
+     */
+    @Deprecated("Will be removed in v3.2.1.")
     var propertyButNotAccessors: String
         get
         set

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -44,6 +44,12 @@ interface DeprecationComments {
     }
 
 
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @param input Very useful input parameter
+     * @return Usefulness of the input
+     */
+    @Deprecated("Unfortunately, this method is deprecated.\nUse [com.example.smoke.Comments.someMethodWithAllComments] instead.")
     fun someMethodWithAllComments(input: String) : Boolean
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationComments.kt
@@ -20,6 +20,7 @@ interface DeprecationComments {
         @Deprecated("Unfortunately, this item is deprecated.\nUse [com.example.smoke.Comments.SomeEnum.USELESS] instead.")
         USELESS(0);
     }
+    @Deprecated("Unfortunately, this exception is deprecated, please use [com.example.smoke.Comments.SomethingWrongException] instead.")
     class SomethingWrongException(@JvmField val error: DeprecationComments.SomeEnum) : Exception(error.toString())
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -1,0 +1,42 @@
+/*
+
+ *
+ */
+
+@file:JvmName("DeprecationCommentsOnly")
+
+package com.example.smoke
+
+
+interface DeprecationCommentsOnly {
+    enum class SomeEnum(private val value: Int) {
+        USELESS(0);
+    }
+    class SomeStruct {
+        @JvmField var someField: Boolean
+
+
+
+        constructor() {
+            this.someField = false
+        }
+
+
+
+
+
+    }
+
+
+    fun someMethodWithAllComments(input: String) : Boolean
+
+    var isSomeProperty: Boolean
+        get
+        set
+
+
+    companion object {
+        @JvmField final val VERY_USEFUL: Boolean = true
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -33,6 +33,7 @@ interface DeprecationCommentsOnly {
 
     fun someMethodWithAllComments(input: String) : Boolean
 
+    @Deprecated("Unfortunately, this property is deprecated.")
     var isSomeProperty: Boolean
         get
         set

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -36,6 +36,7 @@ interface DeprecationCommentsOnly {
 
 
     companion object {
+        @Deprecated("Unfortunately, this constant is deprecated.")
         @JvmField final val VERY_USEFUL: Boolean = true
     }
 }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -15,7 +15,9 @@ interface DeprecationCommentsOnly {
         @Deprecated("Unfortunately, this item is deprecated.")
         USELESS(0);
     }
+    @Deprecated("Unfortunately, this struct is deprecated.")
     class SomeStruct {
+        @Deprecated("Unfortunately, this field is deprecated.")
         @JvmField var someField: Boolean
 
 
@@ -37,6 +39,7 @@ interface DeprecationCommentsOnly {
      * @return Usefulness of the input
      */
     @Deprecated("Unfortunately, this method is deprecated.")
+
     fun someMethodWithAllComments(input: String) : Boolean
 
     @Deprecated("Unfortunately, this property is deprecated.")

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -9,7 +9,9 @@ package com.example.smoke
 
 
 interface DeprecationCommentsOnly {
+    @Deprecated("Unfortunately, this enum is deprecated.")
     enum class SomeEnum(private val value: Int) {
+        @Deprecated("Unfortunately, this item is deprecated.")
         USELESS(0);
     }
     class SomeStruct {

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -31,6 +31,12 @@ interface DeprecationCommentsOnly {
     }
 
 
+    /**
+     *
+     * @param input Very useful input parameter
+     * @return Usefulness of the input
+     */
+    @Deprecated("Unfortunately, this method is deprecated.")
     fun someMethodWithAllComments(input: String) : Boolean
 
     @Deprecated("Unfortunately, this property is deprecated.")

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/DeprecationCommentsOnly.kt
@@ -8,6 +8,7 @@
 package com.example.smoke
 
 
+@Deprecated("Unfortunately, this interface is deprecated.")
 interface DeprecationCommentsOnly {
     @Deprecated("Unfortunately, this enum is deprecated.")
     enum class SomeEnum(private val value: Int) {

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -111,9 +111,9 @@ class ExcludedComments : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -9,6 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * This is some very useful class.
+ * @suppress
+ */
 class ExcludedComments : NativeBase {
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -52,13 +52,10 @@ class ExcludedComments : NativeBase {
         fun apply(p0: String, p1: Int) : Double
     }
 
+    /**
+     * @suppress
+     */
     class SomeLambdaImpl : NativeBase, SomeLambda {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -22,6 +22,10 @@ class ExcludedComments : NativeBase {
          */
         USELESS(0);
     }
+    /**
+     * This is some very useful exception.
+     * @suppress
+     */
     class SomethingWrongException(@JvmField val error: ExcludedComments.SomeEnum) : Exception(error.toString())
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -1,0 +1,88 @@
+/*
+
+ *
+ */
+
+@file:JvmName("ExcludedComments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ExcludedComments : NativeBase {
+
+    enum class SomeEnum(private val value: Int) {
+        USELESS(0);
+    }
+    class SomethingWrongException(@JvmField val error: ExcludedComments.SomeEnum) : Exception(error.toString())
+
+
+    class SomeStruct {
+        @JvmField var someField: Boolean
+
+
+
+        constructor(someField: Boolean) {
+            this.someField = someField
+        }
+
+
+
+
+
+    }
+
+    fun interface SomeLambda {
+        fun apply(p0: String, p1: Int) : Double
+    }
+
+    class SomeLambdaImpl : NativeBase, SomeLambda {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String, p1: Int) : Double
+
+        override var isSomeProperty: Boolean
+            external get
+            external set
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    @Throws (ExcludedComments.SomethingWrongException::class) external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    external fun someMethodWithoutReturnTypeOrInputParameters() : Unit
+
+    var isSomeProperty: Boolean
+        external get
+        external set
+
+
+
+
+    companion object {
+        @JvmField final val VERY_USEFUL: Boolean = true
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -49,6 +49,14 @@ class ExcludedComments : NativeBase {
      * @suppress
      */
     fun interface SomeLambda {
+        /**
+         * This is some very useful lambda that does it.
+         * @suppress
+         * @param p0 Very useful input parameter
+         * @param p1 Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
+
         fun apply(p0: String, p1: Int) : Double
     }
 
@@ -58,6 +66,14 @@ class ExcludedComments : NativeBase {
     class SomeLambdaImpl : NativeBase, SomeLambda {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        /**
+         * This is some very useful lambda that does it.
+         * @suppress
+         * @param p0 Very useful input parameter
+         * @param p1 Slightly less useful input parameter
+         * @return Usefulness of the input
+         */
 
         override external fun apply(p0: String, p1: Int) : Double
 
@@ -88,7 +104,20 @@ class ExcludedComments : NativeBase {
 
 
 
-    @Throws (ExcludedComments.SomethingWrongException::class) external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input.
+     * @suppress
+     * @param inputParameter Very useful input parameter
+     * @return Usefulness of the input
+     * @throws ExcludedComments.SomethingWrongException Sometimes it happens.
+     */
+    @Throws(ExcludedComments.SomethingWrongException::class)
+    external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    /**
+     * This is some very useful method that does nothing.
+     * @suppress
+     */
+
     external fun someMethodWithoutReturnTypeOrInputParameters() : Unit
 
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -61,6 +61,10 @@ class ExcludedComments : NativeBase {
 
         override external fun apply(p0: String, p1: Int) : Double
 
+        /**
+         * Some very useful property.
+         * @suppress
+         */
         override var isSomeProperty: Boolean
             external get
             external set
@@ -87,6 +91,10 @@ class ExcludedComments : NativeBase {
     @Throws (ExcludedComments.SomethingWrongException::class) external fun someMethodWithAllComments(inputParameter: String) : Boolean
     external fun someMethodWithoutReturnTypeOrInputParameters() : Unit
 
+    /**
+     * Some very useful property.
+     * @suppress
+     */
     var isSomeProperty: Boolean
         external get
         external set

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -82,6 +82,10 @@ class ExcludedComments : NativeBase {
 
 
     companion object {
+        /**
+         * This is some very useful constant.
+         * @suppress
+         */
         @JvmField final val VERY_USEFUL: Boolean = true
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -33,11 +33,25 @@ class ExcludedComments : NativeBase {
     class SomethingWrongException(@JvmField val error: ExcludedComments.SomeEnum) : Exception(error.toString())
 
 
+    /**
+     * This is some very useful struct.
+     * @suppress
+     */
     class SomeStruct {
+        /**
+         * How useful this struct is
+         * remains to be seen
+         * @suppress
+         */
         @JvmField var someField: Boolean
 
 
 
+        /**
+         * This is how easy it is to construct.
+         * @param someField How useful this struct is
+         * remains to be seen
+         */
         constructor(someField: Boolean) {
             this.someField = someField
         }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -44,6 +44,10 @@ class ExcludedComments : NativeBase {
 
     }
 
+    /**
+     * This is some very useful lambda that does it.
+     * @suppress
+     */
     fun interface SomeLambda {
         fun apply(p0: String, p1: Int) : Double
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedComments.kt
@@ -11,7 +11,15 @@ import com.example.NativeBase
 
 class ExcludedComments : NativeBase {
 
+    /**
+     * This is some very useful enum.
+     * @suppress
+     */
     enum class SomeEnum(private val value: Int) {
+        /**
+         * Not quite useful
+         * @suppress
+         */
         USELESS(0);
     }
     class SomethingWrongException(@JvmField val error: ExcludedComments.SomeEnum) : Exception(error.toString())

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsInterface.kt
@@ -1,0 +1,16 @@
+/*
+
+ *
+ */
+
+@file:JvmName("ExcludedCommentsInterface")
+
+package com.example.smoke
+
+
+interface ExcludedCommentsInterface {
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsInterface.kt
@@ -8,6 +8,10 @@
 package com.example.smoke
 
 
+/**
+ * This is some very useful interface.
+ * @suppress
+ */
 interface ExcludedCommentsInterface {
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
@@ -36,13 +36,10 @@ class ExcludedCommentsOnly : NativeBase {
         fun apply(p0: String, p1: Int) : Double
     }
 
+    /**
+     * @suppress
+     */
     class SomeLambdaImpl : NativeBase, SomeLambda {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
@@ -33,6 +33,14 @@ class ExcludedCommentsOnly : NativeBase {
     }
 
     fun interface SomeLambda {
+        /**
+         *
+         * @suppress
+         * @param p0
+         * @param p1
+         * @return
+         */
+
         fun apply(p0: String, p1: Int) : Double
     }
 
@@ -42,6 +50,14 @@ class ExcludedCommentsOnly : NativeBase {
     class SomeLambdaImpl : NativeBase, SomeLambda {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        /**
+         *
+         * @suppress
+         * @param p0
+         * @param p1
+         * @return
+         */
 
         override external fun apply(p0: String, p1: Int) : Double
 
@@ -68,7 +84,20 @@ class ExcludedCommentsOnly : NativeBase {
 
 
 
-    @Throws (ExcludedCommentsOnly.SomethingWrongException::class) external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    /**
+     *
+     * @suppress
+     * @param inputParameter
+     * @return
+     * @throws ExcludedCommentsOnly.SomethingWrongException
+     */
+    @Throws(ExcludedCommentsOnly.SomethingWrongException::class)
+    external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    /**
+     *
+     * @suppress
+     */
+
     external fun someMethodWithoutReturnTypeOrInputParameters() : Unit
 
     var isSomeProperty: Boolean

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
@@ -1,0 +1,88 @@
+/*
+
+ *
+ */
+
+@file:JvmName("ExcludedCommentsOnly")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class ExcludedCommentsOnly : NativeBase {
+
+    enum class SomeEnum(private val value: Int) {
+        USELESS(0);
+    }
+    class SomethingWrongException(@JvmField val error: ExcludedCommentsOnly.SomeEnum) : Exception(error.toString())
+
+
+    class SomeStruct {
+        @JvmField var someField: Boolean
+
+
+
+        constructor(someField: Boolean) {
+            this.someField = someField
+        }
+
+
+
+
+
+    }
+
+    fun interface SomeLambda {
+        fun apply(p0: String, p1: Int) : Double
+    }
+
+    class SomeLambdaImpl : NativeBase, SomeLambda {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String, p1: Int) : Double
+
+        override var isSomeProperty: Boolean
+            external get
+            external set
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    @Throws (ExcludedCommentsOnly.SomethingWrongException::class) external fun someMethodWithAllComments(inputParameter: String) : Boolean
+    external fun someMethodWithoutReturnTypeOrInputParameters() : Unit
+
+    var isSomeProperty: Boolean
+        external get
+        external set
+
+
+
+
+    companion object {
+        @JvmField final val VERY_USEFUL: Boolean = true
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/ExcludedCommentsOnly.kt
@@ -73,9 +73,9 @@ class ExcludedCommentsOnly : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
@@ -1,0 +1,166 @@
+/*
+
+ *
+ */
+
+@file:JvmName("LambdaComments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class LambdaComments : NativeBase {
+
+    fun interface WithNoNamedParameters {
+        fun apply(p0: String) : String
+    }
+
+    fun interface WithNoDocsForParameters {
+        fun apply(p0: String) : String
+    }
+
+    fun interface WithNamedParameters {
+        fun apply(inputParameter: String) : String
+    }
+
+    fun interface MixedDocNameParameters {
+        fun apply(inputParameter: String, secondInputParameter: String) : String
+    }
+
+    fun interface NoCommentsNoNamedParams {
+        fun apply(p0: String, p1: String) : String
+    }
+
+    fun interface NoCommentsWithNamedParams {
+        fun apply(first: String, second: String) : String
+    }
+
+    class WithNoNamedParametersImpl : NativeBase, WithNoNamedParameters {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class WithNoDocsForParametersImpl : NativeBase, WithNoDocsForParameters {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class WithNamedParametersImpl : NativeBase, WithNamedParameters {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(inputParameter: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class MixedDocNameParametersImpl : NativeBase, MixedDocNameParameters {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(inputParameter: String, secondInputParameter: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class NoCommentsNoNamedParamsImpl : NativeBase, NoCommentsNoNamedParams {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String, p1: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+    class NoCommentsWithNamedParamsImpl : NativeBase, NoCommentsWithNamedParams {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(first: String, second: String) : String
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
@@ -11,18 +11,30 @@ import com.example.NativeBase
 
 class LambdaComments : NativeBase {
 
+    /**
+     * The first line of the doc.
+     */
     fun interface WithNoNamedParameters {
         fun apply(p0: String) : String
     }
 
+    /**
+     * The first line of the doc.
+     */
     fun interface WithNoDocsForParameters {
         fun apply(p0: String) : String
     }
 
+    /**
+     * The first line of the doc.
+     */
     fun interface WithNamedParameters {
         fun apply(inputParameter: String) : String
     }
 
+    /**
+     * The first line of the doc.
+     */
     fun interface MixedDocNameParameters {
         fun apply(inputParameter: String, secondInputParameter: String) : String
     }

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
@@ -47,13 +47,10 @@ class LambdaComments : NativeBase {
         fun apply(first: String, second: String) : String
     }
 
+    /**
+     * @suppress
+     */
     class WithNoNamedParametersImpl : NativeBase, WithNoNamedParameters {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -65,13 +62,10 @@ class LambdaComments : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class WithNoDocsForParametersImpl : NativeBase, WithNoDocsForParameters {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -83,13 +77,10 @@ class LambdaComments : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class WithNamedParametersImpl : NativeBase, WithNamedParameters {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -101,13 +92,10 @@ class LambdaComments : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class MixedDocNameParametersImpl : NativeBase, MixedDocNameParameters {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -119,13 +107,10 @@ class LambdaComments : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class NoCommentsNoNamedParamsImpl : NativeBase, NoCommentsNoNamedParams {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -137,13 +122,10 @@ class LambdaComments : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class NoCommentsWithNamedParamsImpl : NativeBase, NoCommentsWithNamedParams {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
@@ -15,6 +15,11 @@ class LambdaComments : NativeBase {
      * The first line of the doc.
      */
     fun interface WithNoNamedParameters {
+        /**
+         * The first line of the doc.
+         * @param p0 The first input parameter
+         * @return
+         */
         fun apply(p0: String) : String
     }
 
@@ -22,6 +27,11 @@ class LambdaComments : NativeBase {
      * The first line of the doc.
      */
     fun interface WithNoDocsForParameters {
+        /**
+         * The first line of the doc.
+         * @param p0
+         * @return
+         */
         fun apply(p0: String) : String
     }
 
@@ -29,6 +39,11 @@ class LambdaComments : NativeBase {
      * The first line of the doc.
      */
     fun interface WithNamedParameters {
+        /**
+         * The first line of the doc.
+         * @param inputParameter The first input parameter. The second sentence of the first input parameter.
+         * @return The string.
+         */
         fun apply(inputParameter: String) : String
     }
 
@@ -36,14 +51,22 @@ class LambdaComments : NativeBase {
      * The first line of the doc.
      */
     fun interface MixedDocNameParameters {
+        /**
+         * The first line of the doc.
+         * @param inputParameter
+         * @param secondInputParameter
+         * @return The string.
+         */
         fun apply(inputParameter: String, secondInputParameter: String) : String
     }
 
     fun interface NoCommentsNoNamedParams {
+
         fun apply(p0: String, p1: String) : String
     }
 
     fun interface NoCommentsWithNamedParams {
+
         fun apply(first: String, second: String) : String
     }
 
@@ -54,6 +77,11 @@ class LambdaComments : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+        /**
+         * The first line of the doc.
+         * @param p0 The first input parameter
+         * @return
+         */
         override external fun apply(p0: String) : String
 
 
@@ -69,6 +97,11 @@ class LambdaComments : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+        /**
+         * The first line of the doc.
+         * @param p0
+         * @return
+         */
         override external fun apply(p0: String) : String
 
 
@@ -84,6 +117,11 @@ class LambdaComments : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+        /**
+         * The first line of the doc.
+         * @param inputParameter The first input parameter. The second sentence of the first input parameter.
+         * @return The string.
+         */
         override external fun apply(inputParameter: String) : String
 
 
@@ -99,6 +137,12 @@ class LambdaComments : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+        /**
+         * The first line of the doc.
+         * @param inputParameter
+         * @param secondInputParameter
+         * @return The string.
+         */
         override external fun apply(inputParameter: String, secondInputParameter: String) : String
 
 
@@ -114,6 +158,7 @@ class LambdaComments : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
         override external fun apply(p0: String, p1: String) : String
 
 
@@ -128,6 +173,7 @@ class LambdaComments : NativeBase {
     class NoCommentsWithNamedParamsImpl : NativeBase, NoCommentsWithNamedParams {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
         override external fun apply(first: String, second: String) : String
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LambdaComments.kt
@@ -20,6 +20,7 @@ class LambdaComments : NativeBase {
          * @param p0 The first input parameter
          * @return
          */
+
         fun apply(p0: String) : String
     }
 
@@ -32,6 +33,7 @@ class LambdaComments : NativeBase {
          * @param p0
          * @return
          */
+
         fun apply(p0: String) : String
     }
 
@@ -44,6 +46,7 @@ class LambdaComments : NativeBase {
          * @param inputParameter The first input parameter. The second sentence of the first input parameter.
          * @return The string.
          */
+
         fun apply(inputParameter: String) : String
     }
 
@@ -57,15 +60,18 @@ class LambdaComments : NativeBase {
          * @param secondInputParameter
          * @return The string.
          */
+
         fun apply(inputParameter: String, secondInputParameter: String) : String
     }
 
     fun interface NoCommentsNoNamedParams {
 
+
         fun apply(p0: String, p1: String) : String
     }
 
     fun interface NoCommentsWithNamedParams {
+
 
         fun apply(first: String, second: String) : String
     }
@@ -82,6 +88,7 @@ class LambdaComments : NativeBase {
          * @param p0 The first input parameter
          * @return
          */
+
         override external fun apply(p0: String) : String
 
 
@@ -102,6 +109,7 @@ class LambdaComments : NativeBase {
          * @param p0
          * @return
          */
+
         override external fun apply(p0: String) : String
 
 
@@ -122,6 +130,7 @@ class LambdaComments : NativeBase {
          * @param inputParameter The first input parameter. The second sentence of the first input parameter.
          * @return The string.
          */
+
         override external fun apply(inputParameter: String) : String
 
 
@@ -143,6 +152,7 @@ class LambdaComments : NativeBase {
          * @param secondInputParameter
          * @return The string.
          */
+
         override external fun apply(inputParameter: String, secondInputParameter: String) : String
 
 
@@ -157,6 +167,7 @@ class LambdaComments : NativeBase {
     class NoCommentsNoNamedParamsImpl : NativeBase, NoCommentsNoNamedParams {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
         override external fun apply(p0: String, p1: String) : String
@@ -175,6 +186,7 @@ class LambdaComments : NativeBase {
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
+
         override external fun apply(first: String, second: String) : String
 
 
@@ -185,9 +197,9 @@ class LambdaComments : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
@@ -24,6 +24,12 @@ class LongComments : NativeBase {
 
 
 
+    /**
+     * This is very important method. It has very important parameters. It has side effects.
+     * @param input Very useful input parameter. You must not confuse it with the second parameter. But they are similar.
+     * @param ratio Not as useful as the first parameter. But still useful. use a positive value for more happiness.
+     * @return If you provide a useful input and a useful ratio you can expect a useful output. Just kidding do not expect anything from a method until you see its body.
+     */
     external fun someMethodWithLongComment(input: String, ratio: Double) : Float
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
@@ -1,0 +1,35 @@
+/*
+
+ *
+ */
+
+@file:JvmName("LongComments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class LongComments : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun someMethodWithLongComment(input: String, ratio: Double) : Float
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
@@ -9,6 +9,12 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * This is some very useful interface. There is a lot to say about this interface. at least it has a long comment.
+ * This is a placeholder, which has multiple lines. Here we have continuation of the first line.
+ * But this should be rendered in line below.
+ * This too!
+ */
 class LongComments : NativeBase {
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/LongComments.kt
@@ -19,9 +19,9 @@ class LongComments : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -36,6 +36,7 @@ class LongComments : NativeBase {
      * @param ratio Not as useful as the first parameter. But still useful. use a positive value for more happiness.
      * @return If you provide a useful input and a useful ratio you can expect a useful output. Just kidding do not expect anything from a method until you see its body.
      */
+
     external fun someMethodWithLongComment(input: String, ratio: Double) : Float
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
@@ -1,0 +1,58 @@
+/*
+
+ *
+ */
+
+@file:JvmName("MapScene")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class MapScene : NativeBase {
+
+    fun interface LoadSceneCallback {
+        fun apply(p0: String?) : Unit
+    }
+
+    class LoadSceneCallbackImpl : NativeBase, LoadSceneCallback {
+        /*
+         * For internal use only.
+         * @hidden
+         * @param nativeHandle The handle to resources on C++ side.
+         * @param tag Tag used by callers to avoid overload resolution problems.
+         */
+        protected constructor(nativeHandle: Long, tag: Any?)
+            : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+        override external fun apply(p0: String?) : Unit
+
+
+
+        companion object {
+            @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        }
+    }
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun loadScene(mapScheme: Int, callback: MapScene.LoadSceneCallback?) : Unit
+    external fun loadScene(configurationFile: String, callback: MapScene.LoadSceneCallback?) : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
@@ -15,13 +15,10 @@ class MapScene : NativeBase {
         fun apply(p0: String?) : Unit
     }
 
+    /**
+     * @suppress
+     */
     class LoadSceneCallbackImpl : NativeBase, LoadSceneCallback {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
@@ -9,9 +9,13 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * Referencing some type [com.example.smoke.MapScene.loadScene].
+ */
 class MapScene : NativeBase {
 
     fun interface LoadSceneCallback {
+
         fun apply(p0: String?) : Unit
     }
 
@@ -21,6 +25,7 @@ class MapScene : NativeBase {
     class LoadSceneCallbackImpl : NativeBase, LoadSceneCallback {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
         override external fun apply(p0: String?) : Unit
 
@@ -43,7 +48,9 @@ class MapScene : NativeBase {
 
 
 
+
     external fun loadScene(mapScheme: Int, callback: MapScene.LoadSceneCallback?) : Unit
+
     external fun loadScene(configurationFile: String, callback: MapScene.LoadSceneCallback?) : Unit
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MapScene.kt
@@ -16,6 +16,7 @@ class MapScene : NativeBase {
 
     fun interface LoadSceneCallback {
 
+
         fun apply(p0: String?) : Unit
     }
 
@@ -25,6 +26,7 @@ class MapScene : NativeBase {
     class LoadSceneCallbackImpl : NativeBase, LoadSceneCallback {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
         override external fun apply(p0: String?) : Unit
@@ -37,9 +39,9 @@ class MapScene : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -49,7 +51,9 @@ class MapScene : NativeBase {
 
 
 
+
     external fun loadScene(mapScheme: Int, callback: MapScene.LoadSceneCallback?) : Unit
+
 
     external fun loadScene(configurationFile: String, callback: MapScene.LoadSceneCallback?) : Unit
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
@@ -28,9 +28,9 @@ class MultiLineComments : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -54,6 +54,7 @@ class MultiLineComments : NativeBase {
      *     Just kidding do not expect anything from a method until
      *     you see its body.
      */
+
     external fun someMethodWithLongComment(input: String, ratio: Double) : Float
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
@@ -9,6 +9,21 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * This is some very useful interface.
+ * There is a lot to say about this interface.
+ * at least it has multiline comments.
+ *
+ * I am a heading
+ * --------------
+ *
+ * And now comes a list:
+ * * asterisk
+ * * needs
+ * * escaping
+ *
+ * ```Some example code;```
+ */
 class MultiLineComments : NativeBase {
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
@@ -1,0 +1,35 @@
+/*
+
+ *
+ */
+
+@file:JvmName("MultiLineComments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class MultiLineComments : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun someMethodWithLongComment(input: String, ratio: Double) : Float
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/MultiLineComments.kt
@@ -24,6 +24,21 @@ class MultiLineComments : NativeBase {
 
 
 
+    /**
+     * This is very important method.
+     * It has very important parameters.
+     * It has side effects.
+     * @param input Very useful input parameter.
+     *     You must not confuse it with the second parameter.
+     *     But they are similar.
+     * @param ratio Not as useful as the first parameter.
+     *     But still useful.
+     *     use a positive value for more happiness.
+     * @return If you provide a useful input,
+     *     and a useful ratio you can expect a useful output.
+     *     Just kidding do not expect anything from a method until
+     *     you see its body.
+     */
     external fun someMethodWithLongComment(input: String, ratio: Double) : Float
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
@@ -15,6 +15,9 @@ class PlatformComments : NativeBase {
         USELESS(0),
         USEFUL(1);
     }
+    /**
+     * An  when something goes wrong.
+     */
     class SomethingWrongException(@JvmField val error: PlatformComments.SomeEnum) : Exception(error.toString())
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
@@ -41,9 +41,9 @@ class PlatformComments : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
@@ -1,0 +1,60 @@
+/*
+
+ *
+ */
+
+@file:JvmName("PlatformComments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class PlatformComments : NativeBase {
+
+    enum class SomeEnum(private val value: Int) {
+        USELESS(0),
+        USEFUL(1);
+    }
+    class SomethingWrongException(@JvmField val error: PlatformComments.SomeEnum) : Exception(error.toString())
+
+
+    class Something {
+        @JvmField var nothing: String
+
+
+
+        constructor(nothing: String) {
+            this.nothing = nothing
+        }
+
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun doNothing() : Unit
+    external fun doMagic() : Unit
+    @Throws (PlatformComments.SomethingWrongException::class) external fun someMethodWithAllComments(input: String) : Boolean
+    external fun someDeprecatedMethod() : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
@@ -16,11 +16,14 @@ class PlatformComments : NativeBase {
         USEFUL(1);
     }
     /**
-     * An  when something goes wrong.
+     * An exception when something goes wrong.
      */
     class SomethingWrongException(@JvmField val error: PlatformComments.SomeEnum) : Exception(error.toString())
 
 
+    /**
+     * This is a great struct.
+     */
     class Something {
         @JvmField var nothing: String
 
@@ -50,11 +53,13 @@ class PlatformComments : NativeBase {
 
 
     /**
-     * This is some very useless method that .
+     * This is some very useless method that makes some tea.
      */
 
     external fun doNothing() : Unit
-
+    /**
+     * Makes some tea.
+     */
 
     external fun doMagic() : Unit
     /**

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformComments.kt
@@ -49,9 +49,27 @@ class PlatformComments : NativeBase {
 
 
 
+    /**
+     * This is some very useless method that .
+     */
+
     external fun doNothing() : Unit
+
+
     external fun doMagic() : Unit
-    @Throws (PlatformComments.SomethingWrongException::class) external fun someMethodWithAllComments(input: String) : Boolean
+    /**
+     * This is some very useful method that measures the usefulness of its input or \esc@pe{s}.
+     * @param input Very useful parameter that \[\esc@pe{s}\]
+     * @return of the input
+     * @throws PlatformComments.SomethingWrongException Sometimes it happens.
+     */
+    @Throws(PlatformComments.SomethingWrongException::class)
+    external fun someMethodWithAllComments(input: String) : Boolean
+    /**
+     *
+     */
+    @Deprecated("A very  method that is deprecated.")
+
     external fun someDeprecatedMethod() : Unit
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
@@ -9,6 +9,9 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * Text
+ */
 class PlatformCommentsLineBreaks : NativeBase {
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
@@ -16,9 +16,9 @@ class PlatformCommentsLineBreaks : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/PlatformCommentsLineBreaks.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+@file:JvmName("PlatformCommentsLineBreaks")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class PlatformCommentsLineBreaks : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
@@ -24,7 +24,14 @@ class UnicodeComments : NativeBase {
 
 
 
-    @Throws (Comments.SomethingWrongException::class) external fun someMethodWithAllComments(input: String) : Boolean
+    /**
+     * Süßölgefäß
+     * @param input שלום
+     * @return товарищ
+     * @throws Comments.SomethingWrongException ネコ
+     */
+    @Throws(Comments.SomethingWrongException::class)
+    external fun someMethodWithAllComments(input: String) : Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
@@ -13,9 +13,9 @@ class UnicodeComments : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
+++ b/gluecodium/src/test/resources/smoke/comments/output/android-kotlin/com/example/smoke/UnicodeComments.kt
@@ -1,0 +1,35 @@
+/*
+
+ *
+ */
+
+@file:JvmName("UnicodeComments")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class UnicodeComments : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    @Throws (Comments.SomethingWrongException::class) external fun someMethodWithAllComments(input: String) : Boolean
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
@@ -13,9 +13,9 @@ class CollectionConstants : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
@@ -17,9 +17,9 @@ class ConstantsInterface : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
@@ -45,9 +45,9 @@ class StructConstants : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
@@ -20,9 +20,9 @@ class ChildConstructors : Constructors {
         cacheThisInstance();
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -37,7 +37,9 @@ class ChildConstructors : Constructors {
 
 
     companion object {
+
         @JvmStatic external fun createNoArgsChild() : Long
+
         @JvmStatic external fun createCopyFromParent(other: Constructors) : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -51,9 +51,9 @@ open class Constructors : NativeBase {
         cacheThisInstance();
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -19,22 +19,34 @@ open class Constructors : NativeBase {
 
 
 
+
+
     constructor() : this(create(), null as Any?) {
         cacheThisInstance();
     }
+
+
     constructor(other: Constructors) : this(create(other), null as Any?) {
         cacheThisInstance();
     }
+
+
     constructor(foo: String, bar: Long) : this(create(foo, bar), null as Any?) {
         cacheThisInstance();
     }
+
+
     @Throws(Constructors.ConstructorExplodedException::class)
     constructor(input: String) : this(create(input), null as Any?) {
         cacheThisInstance();
     }
+
+
     constructor(input: MutableList<Double>) : this(create(input), null as Any?) {
         cacheThisInstance();
     }
+
+
     constructor(input: Long) : this(create(input), null as Any?) {
         cacheThisInstance();
     }

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -57,11 +57,17 @@ open class Constructors : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun create() : Long
+
         @JvmStatic external fun create(other: Constructors) : Long
+
         @JvmStatic external fun create(foo: String, bar: Long) : Long
-        @Throws (Constructors.ConstructorExplodedException::class) @JvmStatic external fun create(input: String) : Long
+        @Throws(Constructors.ConstructorExplodedException::class)
+        @JvmStatic external fun create(input: String) : Long
+
         @JvmStatic external fun create(input: MutableList<Double>) : Long
+
         @JvmStatic external fun create(input: Long) : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/Dates.kt
+++ b/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/Dates.kt
@@ -31,9 +31,9 @@ class Dates : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -42,7 +42,11 @@ class Dates : NativeBase {
 
 
 
+
+
     external fun dateMethod(input: Date) : Date
+
+
     external fun nullableDateMethod(input: Date?) : Date?
 
     var dateProperty: Date

--- a/gluecodium/src/test/resources/smoke/defaults/input/KotlinPositionalDefaults.lime
+++ b/gluecodium/src/test/resources/smoke/defaults/input/KotlinPositionalDefaults.lime
@@ -17,6 +17,9 @@
 
 package smoke
 
+// This is an important struct that uses positional default annotation.
+// @constructor This is a comment that should be rendered for all struct constructors
+// including positional default one.
 @Kotlin(PositionalDefaults)
 @Java(Skip) @Swift(Skip) @Dart(Skip)
 struct StructWithKotlinPositionalDefaults {

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
@@ -128,9 +128,9 @@ class DefaultValues : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -145,6 +145,8 @@ class DefaultValues : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun processStructWithDefaults(input: DefaultValues.StructWithDefaults) : DefaultValues.StructWithDefaults
     }
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
@@ -8,6 +8,9 @@
 package com.example.smoke
 
 
+/**
+ * This is an important struct that uses positional default annotation.
+ */
 class StructWithKotlinPositionalDefaults {
     @JvmField var firstInitField: Int
     @JvmField var firstFreeField: String
@@ -16,7 +19,15 @@ class StructWithKotlinPositionalDefaults {
     @JvmField var thirdInitField: String
 
 
-
+    /**
+     * This is a comment that should be rendered for all struct constructors
+     * including positional default one.
+     * @param firstFreeField 
+     * @param secondFreeField 
+     * @param firstInitField 
+     * @param secondInitField 
+     * @param thirdInitField 
+     */
     @JvmOverloads
     constructor(firstFreeField: String, secondFreeField: Boolean, firstInitField: Int = 42, secondInitField: Float = 7.2f, thirdInitField: String = "\\Jonny \"Magic\" Smith\n") {
         this.firstInitField = firstInitField

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
@@ -29,9 +29,9 @@ class DurationMilliseconds : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -40,7 +40,11 @@ class DurationMilliseconds : NativeBase {
 
 
 
+
+
     external fun durationFunction(input: Duration) : Duration
+
+
     external fun nullableDurationFunction(input: Duration?) : Duration?
 
     var durationProperty: Duration

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
@@ -29,9 +29,9 @@ class DurationSeconds : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -40,7 +40,11 @@ class DurationSeconds : NativeBase {
 
 
 
+
+
     external fun durationFunction(input: Duration) : Duration
+
+
     external fun nullableDurationFunction(input: Duration?) : Duration?
 
     var durationProperty: Duration

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/time/Duration.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/time/Duration.kt
@@ -21,13 +21,13 @@ package com.example.time
 
 /**
  * Represents duration in time (both positive and negative).
- * <p>
- *     The duration is represented as number of seconds (see {@link #getSeconds()})
- *     and number of nanoseconds in a second (see {@link #getNano()}).
- * <p>
- *     Duration can be created from various units of time by calling on of
- *     {@code of*} methods. The {@code to*} family of methods convert duration
- *     to a value expressed in desired unit of time.
+ *
+ * The duration is represented as number of seconds (see [Duration.getSeconds])
+ * and number of nanoseconds in a second (see [Duration.getNano]).
+ *
+ * Duration can be created from various units of time by calling on of
+ * `of*` methods. The `to*` family of methods convert duration
+ * to a value expressed in desired unit of time.
  */
 public class Duration private constructor(private var mSeconds: Long, private var mNanos: Int) : Comparable<Duration> {
 
@@ -52,7 +52,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      *
      * @return Total number of nanoseconds in this duration.
      * @throws ArithmeticException if the resulting value cannot be represented
-     *                             by {@code long} type.
+     *                             by `long` type.
      */
     @Throws(ArithmeticException::class)
     public fun toNanos(): Long {
@@ -60,7 +60,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
     }
 
     /**
-     * Gets the nanoseconds part of this duration. Equals to {@link #getNano()}.
+     * Gets the nanoseconds part of this duration. Equals to [Duration.getNano].
      *
      * @return The nanoseconds part of this duration, value from 0 to 999999999.
      */
@@ -75,7 +75,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      *
      * @return Total number of milliseconds in this duration.
      * @throws ArithmeticException if the resulting value cannot be represented
-     *                             by {@code long} type.
+     *                             by `long` type.
      */
     @Throws(ArithmeticException::class)
     public fun toMillis(): Long {
@@ -165,7 +165,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
     }
 
     /**
-     * Same as {@link #toDays()}.
+     * Same as [Duration.toDays].
      *
      * @return The number of full days in this duration.
      */

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
@@ -38,9 +38,9 @@ class Enums : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -55,9 +55,17 @@ class Enums : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun methodWithEnumeration(input: Enums.SimpleEnum) : Enums.SimpleEnum
+
+
         @JvmStatic external fun flipEnumValue(input: Enums.InternalErrorCode) : Enums.InternalErrorCode
+
+
         @JvmStatic external fun extractEnumFromStruct(input: Enums.ErrorStruct) : Enums.InternalErrorCode
+
+
         @JvmStatic external fun createStructWithEnumInside(type: Enums.InternalErrorCode, message: String) : Enums.ErrorStruct
     }
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
@@ -13,9 +13,9 @@ class EnumsInTypeCollectionInterface : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -30,6 +30,8 @@ class EnumsInTypeCollectionInterface : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun flipEnumValue(input: EnumsInTypeCollection.TCEnum) : EnumsInTypeCollection.TCEnum
     }
 }

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
@@ -59,9 +59,9 @@ class EquatableClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableInterfaceImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class EquatableInterfaceImpl : NativeBase, EquatableInterface {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -28,9 +28,9 @@ class Errors : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -45,10 +45,20 @@ class Errors : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
-        @Throws (Errors.InternalException::class) @JvmStatic external fun methodWithErrors() : Unit
-        @Throws (Errors.ExternalException::class) @JvmStatic external fun methodWithExternalErrors() : Unit
-        @Throws (Errors.InternalException::class) @JvmStatic external fun methodWithErrorsAndReturnValue() : String
-        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadError() : Unit
-        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
+
+        @Throws(Errors.InternalException::class)
+        @JvmStatic external fun methodWithErrors() : Unit
+
+        @Throws(Errors.ExternalException::class)
+        @JvmStatic external fun methodWithExternalErrors() : Unit
+
+        @Throws(Errors.InternalException::class)
+        @JvmStatic external fun methodWithErrorsAndReturnValue() : String
+
+        @Throws(WithPayloadException::class)
+        @JvmStatic external fun methodWithPayloadError() : Unit
+
+        @Throws(WithPayloadException::class)
+        @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
     }
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -25,18 +25,28 @@ interface ErrorsInterface {
 
 
 
-    @Throws (ErrorsInterface.InternalException::class) fun methodWithErrors() : Unit
-    @Throws (ErrorsInterface.ExternalException::class) fun methodWithExternalErrors() : Unit
-    @Throws (ErrorsInterface.InternalException::class) fun methodWithErrorsAndReturnValue() : String
+
+    @Throws(ErrorsInterface.InternalException::class)
+    fun methodWithErrors() : Unit
+
+    @Throws(ErrorsInterface.ExternalException::class)
+    fun methodWithExternalErrors() : Unit
+
+    @Throws(ErrorsInterface.InternalException::class)
+    fun methodWithErrorsAndReturnValue() : String
 
 
     companion object {
         @JvmField final val ERROR_MESSAGE: String = "Some error message constant"
-        @Throws (WithPayloadException::class) @JvmStatic fun methodWithPayloadError() : Unit {
+
+        @Throws(WithPayloadException::class)
+        @JvmStatic fun methodWithPayloadError() : Unit {
             ErrorsInterfaceImpl.methodWithPayloadError()
         }
 
-        @Throws (WithPayloadException::class) @JvmStatic fun methodWithPayloadErrorAndReturnValue() : String {
+
+        @Throws(WithPayloadException::class)
+        @JvmStatic fun methodWithPayloadErrorAndReturnValue() : String {
             return ErrorsInterfaceImpl.methodWithPayloadErrorAndReturnValue()
         }
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class ErrorsInterfaceImpl : NativeBase, ErrorsInterface {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
@@ -16,15 +16,25 @@ class ErrorsInterfaceImpl : NativeBase, ErrorsInterface {
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
-    @Throws (ErrorsInterface.InternalException::class) override external fun methodWithErrors() : Unit
-    @Throws (ErrorsInterface.ExternalException::class) override external fun methodWithExternalErrors() : Unit
-    @Throws (ErrorsInterface.InternalException::class) override external fun methodWithErrorsAndReturnValue() : String
+
+    @Throws(ErrorsInterface.InternalException::class)
+    override external fun methodWithErrors() : Unit
+
+    @Throws(ErrorsInterface.ExternalException::class)
+    override external fun methodWithExternalErrors() : Unit
+
+    @Throws(ErrorsInterface.InternalException::class)
+    override external fun methodWithErrorsAndReturnValue() : String
 
 
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
-        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadError() : Unit
-        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
+
+        @Throws(WithPayloadException::class)
+        @JvmStatic external fun methodWithPayloadError() : Unit
+
+        @Throws(WithPayloadException::class)
+        @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
     }
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
@@ -28,7 +28,9 @@ class Class : NativeBase, Interface {
     private external fun cacheThisInstance()
 
 
-    @Throws (Types.ExceptionException::class) external fun Fun(double: MutableList<Types.Struct>) : Types.Struct
+
+    @Throws(Types.ExceptionException::class)
+    external fun Fun(double: MutableList<Types.Struct>) : Types.Struct
 
     var Property: Types.Enum
         external get
@@ -39,6 +41,7 @@ class Class : NativeBase, Interface {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun Constructor() : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
@@ -12,13 +12,14 @@ import com.example.NativeBase
 class Class : NativeBase, Interface {
 
 
+
     constructor() : this(Constructor(), null as Any?) {
         cacheThisInstance();
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalTypes.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalTypes.kt
@@ -13,9 +13,9 @@ class UseKotlinExternalTypes : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -30,12 +30,26 @@ class UseKotlinExternalTypes : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun currencyRoundTrip(input: java.util.Currency) : java.util.Currency
+
+
         @JvmStatic external fun timeZoneRoundTrip(input: java.util.SimpleTimeZone) : java.util.SimpleTimeZone
+
+
         @JvmStatic external fun monthRoundTrip(input: java.time.Month) : java.time.Month
+
+
         @JvmStatic external fun colorRoundTrip(input: kotlin.Int?) : kotlin.Int?
+
+
         @JvmStatic external fun seasonRoundTrip(input: kotlin.String) : kotlin.String
+
+
         @JvmStatic external fun structRoundTrip(input: KotlinExternalTypesStruct) : KotlinExternalTypesStruct
+
+
         @JvmStatic external fun veryBooleanUnbox(input: kotlin.Boolean?) : Boolean
     }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
@@ -21,9 +21,9 @@ class Enums : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -38,6 +38,8 @@ class Enums : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun methodWithExternalEnum(input: Enums.ExternalEnum) : Unit
     }
 }

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
@@ -31,14 +31,16 @@ class ExternalClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterfaceImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class ExternalInterfaceImpl : NativeBase, ExternalInterface {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
@@ -49,9 +49,9 @@ class Structs : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -66,7 +66,11 @@ class Structs : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun getExternalStruct() : Structs.ExternalStruct
+
+
         @JvmStatic external fun getAnotherExternalStruct() : Structs.AnotherExternalStruct
     }
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
+++ b/gluecodium/src/test/resources/smoke/field_constructors/input/FieldConstructors.lime
@@ -21,6 +21,8 @@ struct FieldConstructorsPartialDefaults {
     stringField: String
     intField: Int
     boolField: Boolean = true
+    // This is some field constructor with two parameters.
+    // It is very important.
     @Dart("withTrue")
     field constructor(intField, stringField)
     @Dart(Default)

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsPartialDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsPartialDefaults.kt
@@ -16,6 +16,12 @@ class FieldConstructorsPartialDefaults {
 
 
 
+    /**
+     * This is some field constructor with two parameters.
+     * It is very important.
+     * @param intField 
+     * @param stringField 
+     */
     constructor(intField: Int, stringField: String) {
         this.intField = intField
         this.stringField = stringField

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsPartialDefaults.java
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android/com/example/smoke/FieldConstructorsPartialDefaults.java
@@ -1,21 +1,35 @@
 /*
+
  *
  */
+
 package com.example.smoke;
+
 import android.support.annotation.NonNull;
+
 public final class FieldConstructorsPartialDefaults {
     @NonNull
     public String stringField;
     public int intField;
     public boolean boolField;
+    /**
+     * <p>This is some field constructor with two parameters.
+     * It is very important.
+     * @param intField 
+     * @param stringField 
+     */
     public FieldConstructorsPartialDefaults(final int intField, @NonNull final String stringField) {
         this.intField = intField;
         this.stringField = stringField;
         this.boolField = true;
     }
+
     public FieldConstructorsPartialDefaults(final boolean boolField, final int intField, @NonNull final String stringField) {
         this.boolField = boolField;
         this.intField = intField;
         this.stringField = stringField;
     }
+
+
 }
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_partial_defaults.dart
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/dart/lib/src/smoke/field_constructors_partial_defaults.dart
@@ -1,15 +1,29 @@
+
+
 import 'dart:ffi';
 import 'package:library/src/_library_context.dart' as __lib;
 import 'package:library/src/builtin_types__conversion.dart';
+
+
 class FieldConstructorsPartialDefaults {
   String stringField;
+
   int intField;
+
   bool boolField;
+
+  /// This is some field constructor with two parameters.
+  /// It is very important.
+  /// [intField] 
+  /// [stringField] 
   FieldConstructorsPartialDefaults.withTrue(this.intField, this.stringField)
       : boolField = true;
   FieldConstructorsPartialDefaults(this.boolField, this.intField, this.stringField);
 }
+
+
 // FieldConstructorsPartialDefaults "private" section, not exported.
+
 final _smokeFieldconstructorspartialdefaultsCreateHandle = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>, Int32, Uint8),
     Pointer<Void> Function(Pointer<Void>, int, int)
@@ -30,32 +44,41 @@ final _smokeFieldconstructorspartialdefaultsGetFieldboolField = __lib.catchArgum
     Uint8 Function(Pointer<Void>),
     int Function(Pointer<Void>)
   >('library_smoke_FieldConstructorsPartialDefaults_get_field_boolField'));
+
+
+
 Pointer<Void> smokeFieldconstructorspartialdefaultsToFfi(FieldConstructorsPartialDefaults value) {
   final _stringFieldHandle = stringToFfi(value.stringField);
   final _intFieldHandle = (value.intField);
   final _boolFieldHandle = booleanToFfi(value.boolField);
   final _result = _smokeFieldconstructorspartialdefaultsCreateHandle(_stringFieldHandle, _intFieldHandle, _boolFieldHandle);
   stringReleaseFfiHandle(_stringFieldHandle);
+  
   booleanReleaseFfiHandle(_boolFieldHandle);
   return _result;
 }
+
 FieldConstructorsPartialDefaults smokeFieldconstructorspartialdefaultsFromFfi(Pointer<Void> handle) {
   final _stringFieldHandle = _smokeFieldconstructorspartialdefaultsGetFieldstringField(handle);
   final _intFieldHandle = _smokeFieldconstructorspartialdefaultsGetFieldintField(handle);
   final _boolFieldHandle = _smokeFieldconstructorspartialdefaultsGetFieldboolField(handle);
   try {
     return FieldConstructorsPartialDefaults(
-      booleanFromFfi(_boolFieldHandle),
-      (_intFieldHandle),
+      booleanFromFfi(_boolFieldHandle), 
+      (_intFieldHandle), 
       stringFromFfi(_stringFieldHandle)
     );
   } finally {
     stringReleaseFfiHandle(_stringFieldHandle);
+    
     booleanReleaseFfiHandle(_boolFieldHandle);
   }
 }
+
 void smokeFieldconstructorspartialdefaultsReleaseFfiHandle(Pointer<Void> handle) => _smokeFieldconstructorspartialdefaultsReleaseHandle(handle);
+
 // Nullable FieldConstructorsPartialDefaults
+
 final _smokeFieldconstructorspartialdefaultsCreateHandleNullable = __lib.catchArgumentError(() => __lib.nativeLibrary.lookupFunction<
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
@@ -68,6 +91,7 @@ final _smokeFieldconstructorspartialdefaultsGetValueNullable = __lib.catchArgume
     Pointer<Void> Function(Pointer<Void>),
     Pointer<Void> Function(Pointer<Void>)
   >('library_smoke_FieldConstructorsPartialDefaults_get_value_nullable'));
+
 Pointer<Void> smokeFieldconstructorspartialdefaultsToFfiNullable(FieldConstructorsPartialDefaults? value) {
   if (value == null) return Pointer<Void>.fromAddress(0);
   final _handle = smokeFieldconstructorspartialdefaultsToFfi(value);
@@ -75,6 +99,7 @@ Pointer<Void> smokeFieldconstructorspartialdefaultsToFfiNullable(FieldConstructo
   smokeFieldconstructorspartialdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 FieldConstructorsPartialDefaults? smokeFieldconstructorspartialdefaultsFromFfiNullable(Pointer<Void> handle) {
   if (handle.address == 0) return null;
   final _handle = _smokeFieldconstructorspartialdefaultsGetValueNullable(handle);
@@ -82,6 +107,10 @@ FieldConstructorsPartialDefaults? smokeFieldconstructorspartialdefaultsFromFfiNu
   smokeFieldconstructorspartialdefaultsReleaseFfiHandle(_handle);
   return result;
 }
+
 void smokeFieldconstructorspartialdefaultsReleaseFfiHandleNullable(Pointer<Void> handle) =>
   _smokeFieldconstructorspartialdefaultsReleaseHandleNullable(handle);
+
 // End of FieldConstructorsPartialDefaults "private" section.
+
+

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsPartialDefaults.swift
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/swift/smoke/FieldConstructorsPartialDefaults.swift
@@ -1,26 +1,45 @@
 //
+
 //
+
 import Foundation
+
 public struct FieldConstructorsPartialDefaults {
+
     public var stringField: String
+
     public var intField: Int32
+
     public var boolField: Bool
+    /// This is some field constructor with two parameters.
+    /// It is very important.
+    /// - Parameters
+    ///   - intField: 
+    ///   - stringField: 
+
+
     public init(intField: Int32, stringField: String) {
         self.intField = intField
         self.stringField = stringField
         self.boolField = true
     }
+
+
     public init(boolField: Bool, intField: Int32, stringField: String) {
         self.boolField = boolField
         self.intField = intField
         self.stringField = stringField
     }
+
     internal init(cHandle: _baseRef) {
         stringField = moveFromCType(smoke_FieldConstructorsPartialDefaults_stringField_get(cHandle))
         intField = moveFromCType(smoke_FieldConstructorsPartialDefaults_intField_get(cHandle))
         boolField = moveFromCType(smoke_FieldConstructorsPartialDefaults_boolField_get(cHandle))
     }
 }
+
+
+
 internal func copyFromCType(_ handle: _baseRef) -> FieldConstructorsPartialDefaults {
     return FieldConstructorsPartialDefaults(cHandle: handle)
 }
@@ -30,6 +49,7 @@ internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsPartialDefau
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: FieldConstructorsPartialDefaults) -> RefHolder {
     let c_stringField = moveToCType(swiftType.stringField)
     let c_intField = moveToCType(swiftType.intField)
@@ -52,6 +72,7 @@ internal func moveFromCType(_ handle: _baseRef) -> FieldConstructorsPartialDefau
     }
     return copyFromCType(handle)
 }
+
 internal func copyToCType(_ swiftType: FieldConstructorsPartialDefaults?) -> RefHolder {
     guard let swiftType = swiftType else {
         return RefHolder(0)
@@ -64,3 +85,6 @@ internal func copyToCType(_ swiftType: FieldConstructorsPartialDefaults?) -> Ref
 internal func moveToCType(_ swiftType: FieldConstructorsPartialDefaults?) -> RefHolder {
     return RefHolder(ref: copyToCType(swiftType).ref, release: smoke_FieldConstructorsPartialDefaults_release_optional_handle)
 }
+
+
+

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/AbstractNativeList.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/AbstractNativeList.kt
@@ -22,13 +22,10 @@ package com.example
 /**
  * <p>Internal base abstract class for List implementations backed by a native object.
  *
- * @hidden
+ * @suppress
  */
 abstract class AbstractNativeList<T> : NativeBase, MutableList<T> {
 
-    /**
-     * @hidden
-     */
     private inner class NativeIterator : MutableListIterator<T> {
         private var index: Int = 0
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
@@ -32,9 +32,9 @@ class GenericTypesWithBasicTypes : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -43,11 +43,23 @@ class GenericTypesWithBasicTypes : NativeBase {
 
 
 
+
+
     external fun methodWithList(input: MutableList<Int>) : MutableList<Int>
+
+
     external fun methodWithMap(input: MutableMap<Int, Boolean>) : MutableMap<Int, Boolean>
+
+
     external fun methodWithSet(input: MutableSet<Int>) : MutableSet<Int>
+
+
     external fun methodWithListTypeAlias(input: MutableList<String>) : MutableList<String>
+
+
     external fun methodWithMapTypeAlias(input: MutableMap<String, String>) : MutableMap<String, String>
+
+
     external fun methodWithSetTypeAlias(input: MutableSet<String>) : MutableSet<String>
 
     var listProperty: MutableList<Float>

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
@@ -51,9 +51,9 @@ class GenericTypesWithCompoundTypes : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -62,13 +62,29 @@ class GenericTypesWithCompoundTypes : NativeBase {
 
 
 
+
+
     external fun methodWithStructList(input: MutableList<GenericTypesWithCompoundTypes.BasicStruct>) : MutableList<GenericTypesWithCompoundTypes.ExternalStruct>
+
+
     external fun methodWithStructMap(input: MutableMap<String, GenericTypesWithCompoundTypes.BasicStruct>) : MutableMap<String, GenericTypesWithCompoundTypes.ExternalStruct>
+
+
     external fun methodWithEnumList(input: MutableList<GenericTypesWithCompoundTypes.SomeEnum>) : MutableList<GenericTypesWithCompoundTypes.ExternalEnum>
+
+
     external fun methodWithEnumMapKey(input: MutableMap<GenericTypesWithCompoundTypes.SomeEnum, Boolean>) : MutableMap<GenericTypesWithCompoundTypes.ExternalEnum, Boolean>
+
+
     external fun methodWithEnumMapValue(input: MutableMap<Int, GenericTypesWithCompoundTypes.SomeEnum>) : MutableMap<Int, GenericTypesWithCompoundTypes.ExternalEnum>
+
+
     external fun methodWithEnumSet(input: MutableSet<GenericTypesWithCompoundTypes.SomeEnum>) : MutableSet<GenericTypesWithCompoundTypes.ExternalEnum>
+
+
     external fun methodWithInstancesList(input: MutableList<DummyClass>) : MutableList<DummyInterface>
+
+
     external fun methodWithInstancesMap(input: MutableMap<Int, DummyClass>) : MutableMap<Int, DummyInterface>
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
@@ -13,9 +13,9 @@ class GenericTypesWithGenericTypes : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -24,12 +24,26 @@ class GenericTypesWithGenericTypes : NativeBase {
 
 
 
+
+
     external fun methodWithListOfLists(input: MutableList<MutableList<Int>>) : MutableList<MutableList<Int>>
+
+
     external fun methodWithMapOfMaps(input: MutableMap<Int, MutableMap<Int, Boolean>>) : MutableMap<MutableMap<Int, Boolean>, Boolean>
+
+
     external fun methodWithSetOfSets(input: MutableSet<MutableSet<Int>>) : MutableSet<MutableSet<Int>>
+
+
     external fun methodWithListAndMap(input: MutableList<MutableMap<Int, Boolean>>) : MutableMap<Int, MutableList<Int>>
+
+
     external fun methodWithListAndSet(input: MutableList<MutableSet<Int>>) : MutableSet<MutableList<Int>>
+
+
     external fun methodWithMapAndSet(input: MutableMap<Int, MutableSet<Int>>) : MutableSet<MutableMap<Int, Boolean>>
+
+
     external fun methodWithMapGenericKeys(input: MutableMap<MutableSet<Int>, Boolean>) : MutableMap<MutableList<Int>, Boolean>
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
@@ -28,9 +28,6 @@ class UseOptimizedList : NativeBase {
 
 
 
-    /**
-     * @hidden
-     */
     private class UnreasonablyLazyClassLazyNativeList : AbstractNativeList<UnreasonablyLazyClass> {
 
         private constructor(nativeHandle: Long, tag: Any?)
@@ -45,9 +42,6 @@ class UseOptimizedList : NativeBase {
 
     }
 
-    /**
-     * @hidden
-     */
     private class VeryBigStructLazyNativeList : AbstractNativeList<VeryBigStruct> {
 
         private constructor(nativeHandle: Long, tag: Any?)

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
@@ -14,9 +14,9 @@ class UseOptimizedList : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -59,6 +59,8 @@ class UseOptimizedList : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun fetchTheBigOnes() : MutableList<VeryBigStruct>
         @JvmStatic val lazyOnes: MutableList<UnreasonablyLazyClass>
             external get

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
@@ -23,9 +23,6 @@ class UseOptimizedListStruct {
 
 
 
-    /**
-     * @hidden
-     */
     private class VeryBigStructLazyNativeList : AbstractNativeList<VeryBigStruct> {
 
         private constructor(nativeHandle: Long, tag: Any?)
@@ -40,9 +37,6 @@ class UseOptimizedListStruct {
 
     }
 
-    /**
-     * @hidden
-     */
     private class UnreasonablyLazyClassLazyNativeList : AbstractNativeList<UnreasonablyLazyClass> {
 
         private constructor(nativeHandle: Long, tag: Any?)

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleClass.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleClass.kt
@@ -13,9 +13,9 @@ class SimpleClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -24,7 +24,11 @@ class SimpleClass : NativeBase {
 
 
 
+
+
     external fun getStringValue() : String
+
+
     external fun useSimpleClass(input: SimpleClass) : SimpleClass
 
 

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterfaceImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class SimpleInterfaceImpl : NativeBase, SimpleInterface {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
@@ -15,6 +15,9 @@ class Lambdas : NativeBase {
         fun apply() : String
     }
 
+    /**
+     * Should confuse everyone thoroughly
+     */
     fun interface Confounder {
         fun confuse(p0: String) : Lambdas.Producer
     }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
@@ -34,13 +34,10 @@ class Lambdas : NativeBase {
         fun apply(p0: String?) : Lambdas.Producer?
     }
 
+    /**
+     * @suppress
+     */
     class ProducerImpl : NativeBase, Producer {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -52,13 +49,10 @@ class Lambdas : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class ConfounderImpl : NativeBase, Confounder {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -70,13 +64,10 @@ class Lambdas : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class ConsumerImpl : NativeBase, Consumer {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -88,13 +79,10 @@ class Lambdas : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class IndexerImpl : NativeBase, Indexer {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -106,13 +94,10 @@ class Lambdas : NativeBase {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class NullableConfuserImpl : NativeBase, NullableConfuser {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
@@ -12,6 +12,8 @@ import com.example.NativeBase
 class Lambdas : NativeBase {
 
     fun interface Producer {
+
+
         fun apply() : String
     }
 
@@ -19,18 +21,30 @@ class Lambdas : NativeBase {
      * Should confuse everyone thoroughly
      */
     fun interface Confounder {
+        /**
+         * Should confuse everyone thoroughly
+         * @param p0
+         * @return
+         */
+
         fun confuse(p0: String) : Lambdas.Producer
     }
 
     fun interface Consumer {
+
+
         fun apply(p0: String) : Unit
     }
 
     fun interface Indexer {
+
+
         fun apply(p0: String, idx: Float) : Int
     }
 
     fun interface NullableConfuser {
+
+
         fun apply(p0: String?) : Lambdas.Producer?
     }
 
@@ -40,6 +54,8 @@ class Lambdas : NativeBase {
     class ProducerImpl : NativeBase, Producer {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
         override external fun apply() : String
 
@@ -56,6 +72,12 @@ class Lambdas : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+        /**
+         * Should confuse everyone thoroughly
+         * @param p0
+         * @return
+         */
+
         override external fun confuse(p0: String) : Lambdas.Producer
 
 
@@ -70,6 +92,8 @@ class Lambdas : NativeBase {
     class ConsumerImpl : NativeBase, Consumer {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
         override external fun apply(p0: String) : Unit
 
@@ -86,6 +110,8 @@ class Lambdas : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
         override external fun apply(p0: String, idx: Float) : Int
 
 
@@ -100,6 +126,8 @@ class Lambdas : NativeBase {
     class NullableConfuserImpl : NativeBase, NullableConfuser {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
         override external fun apply(p0: String?) : Lambdas.Producer?
 
@@ -122,6 +150,8 @@ class Lambdas : NativeBase {
 
 
 
+
+
     external fun deconfuse(value: String, confuser: Lambdas.Confounder) : Lambdas.Producer
 
 
@@ -129,6 +159,8 @@ class Lambdas : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun fuse(items: MutableList<String>, callback: Lambdas.Indexer) : MutableMap<Int, String>
     }
 }

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/Lambdas.kt
@@ -139,9 +139,9 @@ class Lambdas : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/LambdasInterface.kt
@@ -14,13 +14,10 @@ interface LambdasInterface {
         fun apply(p0: ByteArray?) : Unit
     }
 
+    /**
+     * @suppress
+     */
     class TakeScreenshotCallbackImpl : NativeBase, TakeScreenshotCallback {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/lambdas/output/android-kotlin/com/example/smoke/StandaloneProducerImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class StandaloneProducerImpl : NativeBase, StandaloneProducer {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
@@ -13,9 +13,9 @@ class Calculator : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -30,7 +30,11 @@ class Calculator : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun registerListener(listener: CalculatorListener) : Unit
+
+
         @JvmStatic external fun unregisterListener(listener: CalculatorListener) : Unit
     }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class CalculatorListenerImpl : NativeBase, CalculatorListener {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class InterfaceWithStaticImpl : NativeBase, InterfaceWithStatic {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 internal class InternalListenerImpl : NativeBase, InternalListener {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class ListenerWithNullableImpl : NativeBase, ListenerWithNullable {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class ListenerWithPropertiesImpl : NativeBase, ListenerWithProperties {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class ListenersWithReturnValuesImpl : NativeBase, ListenersWithReturnValues {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
@@ -8,6 +8,9 @@
 package com.example.smoke
 
 
+/**
+ * Observer interface for monitoring changes in thermometer ("Observer of subject").
+ */
 interface TemperatureObserver {
 
     fun onTemperatureUpdate(thermometer: Thermometer) : Unit

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -19,17 +19,18 @@ class Thermometer : NativeBase {
         ERROR_NONE(0),
         ERROR_FATAL(1);
     }
-
     /**
      * This error indicates problems with notification of observers.
      * May be thrown if observers cannot be notified.
      */
     class NotificationException(@JvmField val error: String) : Exception(error.toString())
 
+
     /**
      * This error indicates other problems with notification of observers.
      */
     class AnotherNotificationException(@JvmField val error: Thermometer.SomeThermometerErrorCode) : Exception(error.toString())
+
 
 
     constructor(interval: Duration, observers: MutableList<TemperatureObserver>) : this(makeWithDuration(interval, observers), null as Any?) {
@@ -68,9 +69,17 @@ class Thermometer : NativeBase {
     private external fun cacheThisInstance()
 
 
+
+
     external fun forceUpdate() : Unit
+
+
     external fun getCelsius() : Double
+
+
     external fun getKelvin() : Double
+
+
     external fun getFahrenheit() : Double
 
 
@@ -78,13 +87,27 @@ class Thermometer : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun makeWithDuration(interval: Duration, observers: MutableList<TemperatureObserver>) : Long
+
         @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
-        @Throws (Thermometer.NotificationException::class) @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
+        @Throws(Thermometer.NotificationException::class)
+        @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
+
         @JvmStatic external fun nothrowMake(label: String, niceObservers: MutableList<TemperatureObserver>) : Long
-        @Throws (Thermometer.AnotherNotificationException::class) @JvmStatic external fun anotherThrowingMake(dummy: Boolean, observers: MutableList<TemperatureObserver>) : Long
+        @Throws(Thermometer.AnotherNotificationException::class)
+        @JvmStatic external fun anotherThrowingMake(dummy: Boolean, observers: MutableList<TemperatureObserver>) : Long
+
+
         @JvmStatic external fun notifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
-        @Throws (Thermometer.NotificationException::class) @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
+        /**
+         * Function used to notify observers.
+         * @param thermometer subject that has changed state
+         * @param someObservers observers to be notified
+         * @throws Thermometer.NotificationException if notification of observers failed
+         */
+        @Throws(Thermometer.NotificationException::class)
+        @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -10,6 +10,10 @@ package com.example.smoke
 import com.example.NativeBase
 import com.example.time.Duration
 
+/**
+ * A class, which reads temperature and updates observers according to the given interval.
+ * "Subject" in observer design pattern.
+ */
 class Thermometer : NativeBase {
 
     /**
@@ -33,24 +37,57 @@ class Thermometer : NativeBase {
 
 
 
+    /**
+     * A constructor, which makes the thermometer with readout interval.
+     * @param interval readout interval
+     * @param observers observers of temperature changes
+     */
+
     constructor(interval: Duration, observers: MutableList<TemperatureObserver>) : this(makeWithDuration(interval, observers), null as Any?) {
         cacheThisInstance();
         notifyObservers(this, observers)
     }
+    /**
+     * A constructor, which makes the thermometer with default readout interval (1 second).
+     * @param observers observers of temperature changes
+     */
+
     constructor(observers: MutableList<TemperatureObserver>) : this(makeWithoutDuration(observers), null as Any?) {
         cacheThisInstance();
         notifyObservers(this, observers)
     }
+    /**
+     * A throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * @param id identification of this thermometer
+     * @param observers observers of temperature changes
+     * @throws Thermometer.NotificationException if identification number is invalid
+     */
+
     @Throws(Thermometer.NotificationException::class)
     constructor(id: Int, observers: MutableList<TemperatureObserver>) : this(throwingMake(id, observers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }
+    /**
+     * A non-throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * @param label some identification label
+     * @param niceObservers observers of temperature changes
+     * @throws Thermometer.NotificationException if notification of observers failed
+     */
+
     @Throws(Thermometer.NotificationException::class)
     constructor(label: String, niceObservers: MutableList<TemperatureObserver>) : this(nothrowMake(label, niceObservers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, niceObservers)
     }
+    /**
+     * A throwing constructor, which makes the thermometer with default readout interval (1 second).
+     * @param dummy some dummy boolean flag
+     * @param observers observers of temperature changes
+     * @throws Thermometer.AnotherNotificationException if some problem occurs
+     * @throws Thermometer.NotificationException if notification of observers failed
+     */
+
     @Throws(Thermometer.AnotherNotificationException::class, Thermometer.NotificationException::class)
     constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
         cacheThisInstance();

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -12,6 +12,9 @@ import com.example.time.Duration
 
 class Thermometer : NativeBase {
 
+    /**
+     * Some error code for thermometer.
+     */
     enum class SomeThermometerErrorCode(private val value: Int) {
         ERROR_NONE(0),
         ERROR_FATAL(1);

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -19,11 +19,17 @@ class Thermometer : NativeBase {
         ERROR_NONE(0),
         ERROR_FATAL(1);
     }
+
+    /**
+     * This error indicates problems with notification of observers.
+     * May be thrown if observers cannot be notified.
+     */
     class NotificationException(@JvmField val error: String) : Exception(error.toString())
 
-
+    /**
+     * This error indicates other problems with notification of observers.
+     */
     class AnotherNotificationException(@JvmField val error: Thermometer.SomeThermometerErrorCode) : Exception(error.toString())
-
 
 
     constructor(interval: Duration, observers: MutableList<TemperatureObserver>) : this(makeWithDuration(interval, observers), null as Any?) {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -94,9 +94,9 @@ class Thermometer : NativeBase {
         throwingNotifyObservers(this, observers)
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
@@ -29,14 +29,16 @@ class Locales : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsClassClass.kt
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsClassClass.kt
@@ -12,9 +12,9 @@ class FirstParentIsClassClass : ParentClass, ParentNarrowOne {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -23,11 +23,15 @@ class FirstParentIsClassClass : ParentClass, ParentNarrowOne {
 
 
 
+
+
     external fun childFunction() : Unit
 
     var childProperty: String
         external get
         external set
+
+
 
 
     override external fun parentFunctionOne() : Unit

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -52,7 +52,9 @@ class NAME_RULES_KT : NativeBase {
     private external fun cacheThisInstance()
 
 
-    @Throws (NAME_RULES_KT.ExampleException::class) external fun some_method(someArgument: NAME_RULES_KT.EXAMPLE_STRUCT_KT) : Double
+
+    @Throws(NAME_RULES_KT.ExampleException::class)
+    external fun some_method(someArgument: NAME_RULES_KT.EXAMPLE_STRUCT_KT) : Double
 
     var intProperty: Long
         external get
@@ -71,6 +73,7 @@ class NAME_RULES_KT : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun create() : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -36,13 +36,14 @@ class NAME_RULES_KT : NativeBase {
     }
 
 
+
     constructor() : this(create(), null as Any?) {
         cacheThisInstance();
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
@@ -33,20 +33,24 @@ class LevelOne : NativeBase {
 
                 companion object {
                     @JvmField final val FOO: Boolean = false
+
+
                     @JvmStatic external fun fooFactory() : LevelOne.LevelTwo.LevelThree.LevelFour
                 }
             }
 
 
 
-            /*
+            /**
              * For internal use only.
-             * @hidden
+             * @suppress
              * @param nativeHandle The handle to resources on C++ side.
              * @param tag Tag used by callers to avoid overload resolution problems.
              */
             protected constructor(nativeHandle: Long, tag: Any?)
                 : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 
@@ -61,9 +65,9 @@ class LevelOne : NativeBase {
         }
 
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
@@ -82,9 +86,9 @@ class LevelOne : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
@@ -28,14 +28,16 @@ class NestedReferences : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
@@ -15,14 +15,16 @@ class OuterClass : NativeBase {
 
 
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 
@@ -37,6 +39,8 @@ class OuterClass : NativeBase {
     }
     interface InnerInterface {
 
+
+
         fun foo(input: String) : String
 
 
@@ -49,6 +53,8 @@ class OuterClass : NativeBase {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
         override external fun foo(input: String) : String
 
 
@@ -59,14 +65,16 @@ class OuterClass : NativeBase {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
@@ -42,13 +42,10 @@ class OuterClass : NativeBase {
 
     }
 
+    /**
+     * @suppress
+     */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
@@ -42,13 +42,10 @@ class OuterClassWithInheritance : ParentClass {
 
     }
 
+    /**
+     * @suppress
+     */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
@@ -15,14 +15,16 @@ class OuterClassWithInheritance : ParentClass {
 
 
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 
@@ -37,6 +39,8 @@ class OuterClassWithInheritance : ParentClass {
     }
     interface InnerInterface {
 
+
+
         fun baz(input: String) : String
 
 
@@ -49,6 +53,8 @@ class OuterClassWithInheritance : ParentClass {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
         override external fun baz(input: String) : String
 
 
@@ -59,14 +65,16 @@ class OuterClassWithInheritance : ParentClass {
     }
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, tag) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
@@ -41,13 +41,10 @@ interface OuterInterface {
 
     }
 
+    /**
+     * @suppress
+     */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
@@ -14,14 +14,16 @@ interface OuterInterface {
 
 
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 
@@ -36,6 +38,8 @@ interface OuterInterface {
     }
     interface InnerInterface {
 
+
+
         fun foo(input: String) : String
 
 
@@ -48,6 +52,8 @@ interface OuterInterface {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
+
+
         override external fun foo(input: String) : String
 
 
@@ -56,6 +62,8 @@ interface OuterInterface {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+
+
 
     fun foo(input: String) : String
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -32,6 +32,8 @@ class OuterStruct {
 
 
 
+
+
         external fun doSomething() : Unit
 
 
@@ -49,6 +51,8 @@ class OuterStruct {
          */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 
@@ -80,7 +84,11 @@ class OuterStruct {
         private external fun cacheThisInstance()
 
 
+
+
         external fun field(value: String) : OuterStruct.Builder
+
+
         external fun build() : OuterStruct
 
 
@@ -88,10 +96,13 @@ class OuterStruct {
 
         companion object {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
             @JvmStatic external fun create() : Long
         }
     }
     interface InnerInterface {
+
+
 
         fun barBaz() : MutableMap<String, ByteArray>
 
@@ -99,6 +110,8 @@ class OuterStruct {
     }
 
     fun interface InnerLambda {
+
+
         fun apply() : Unit
     }
 
@@ -108,6 +121,8 @@ class OuterStruct {
     class InnerInterfaceImpl : NativeBase, InnerInterface {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
         override external fun barBaz() : MutableMap<String, ByteArray>
 
@@ -123,6 +138,8 @@ class OuterStruct {
     class InnerLambdaImpl : NativeBase, InnerLambda {
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
         override external fun apply() : Unit
 
@@ -140,8 +157,9 @@ class OuterStruct {
 
 
 
-    @Throws (OuterStruct.InstantiationException::class) external fun doNothing() : Unit
 
+    @Throws(OuterStruct.InstantiationException::class)
+    external fun doNothing() : Unit
 
 
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -102,13 +102,10 @@ class OuterStruct {
         fun apply() : Unit
     }
 
+    /**
+     * @suppress
+     */
     class InnerInterfaceImpl : NativeBase, InnerInterface {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -120,13 +117,10 @@ class OuterStruct {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
     }
+    /**
+     * @suppress
+     */
     class InnerLambdaImpl : NativeBase, InnerLambda {
-        /*
-         * For internal use only.
-         * @hidden
-         * @param nativeHandle The handle to resources on C++ side.
-         * @param tag Tag used by callers to avoid overload resolution problems.
-         */
         protected constructor(nativeHandle: Long, tag: Any?)
             : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
@@ -147,6 +141,7 @@ class OuterStruct {
 
 
     @Throws (OuterStruct.InstantiationException::class) external fun doNothing() : Unit
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -43,9 +43,9 @@ class OuterStruct {
 
 
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */
@@ -68,13 +68,14 @@ class OuterStruct {
     class Builder : NativeBase {
 
 
+
         constructor() : this(create(), null as Any?) {
             cacheThisInstance();
         }
 
-        /*
+        /**
          * For internal use only.
-         * @hidden
+         * @suppress
          * @param nativeHandle The handle to resources on C++ side.
          * @param tag Tag used by callers to avoid overload resolution problems.
          */

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
@@ -14,9 +14,9 @@ class UseFreeTypes : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
@@ -25,7 +25,9 @@ class UseFreeTypes : NativeBase {
 
 
 
-    @Throws (FreeException::class) external fun doStuff(point: FreePoint, mode: FreeEnum) : Date
+
+    @Throws(FreeException::class)
+    external fun doStuff(point: FreePoint, mode: FreeEnum) : Date
 
 
 

--- a/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
@@ -16,14 +16,16 @@ class NoCacheClass : NativeBase {
     constructor() : this(make(), null as Any?) {
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 
@@ -34,6 +36,7 @@ class NoCacheClass : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun make() : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
@@ -92,9 +92,9 @@ class Nullable : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -103,15 +103,35 @@ class Nullable : NativeBase {
 
 
 
+
+
     external fun methodWithString(input: String?) : String?
+
+
     external fun methodWithBoolean(input: Boolean?) : Boolean?
+
+
     external fun methodWithDouble(input: Double?) : Double?
+
+
     external fun methodWithInt(input: Long?) : Long?
+
+
     external fun methodWithSomeStruct(input: Nullable.SomeStruct?) : Nullable.SomeStruct?
+
+
     external fun methodWithSomeEnum(input: Nullable.SomeEnum?) : Nullable.SomeEnum?
+
+
     external fun methodWithSomeArray(input: MutableList<String>?) : MutableList<String>?
+
+
     external fun methodWithInlineArray(input: MutableList<String>?) : MutableList<String>?
+
+
     external fun methodWithSomeMap(input: MutableMap<Long, String>?) : MutableMap<Long, String>?
+
+
     external fun methodWithInstance(input: SomeInterface?) : SomeInterface?
 
     var stringProperty: String?

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
@@ -28,9 +28,9 @@ class NestedPackages : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -45,6 +45,8 @@ class NestedPackages : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun basicMethod(input: NestedPackages.SomeStruct) : NestedPackages.SomeStruct
     }
 }

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
@@ -13,9 +13,9 @@ class UnderscorePackage : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -30,6 +30,8 @@ class UnderscorePackage : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun basicMethod(inputString: String) : String
     }
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
@@ -19,9 +19,9 @@ class dodoInterface : NativeBase {
         cacheThisInstance();
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -29,6 +29,8 @@ class dodoInterface : NativeBase {
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
     private external fun cacheThisInstance()
+
+
 
 
     external fun DodoMethod(DodoParameter: String) : dodoTypes.dodoStruct
@@ -42,6 +44,7 @@ class dodoInterface : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun make(makeParameter: String) : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class dodoListenerImpl : NativeBase, dodoListener {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
@@ -13,9 +13,9 @@ class CachedProperties : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
@@ -32,9 +32,9 @@ class Properties : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class PropertiesInterfaceImpl : NativeBase, PropertiesInterface {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
@@ -28,9 +28,9 @@ class ClassWithStructWithSkipLambdaInPlatform : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
@@ -13,9 +13,9 @@ class EnableIfEnabled : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -30,12 +30,26 @@ class EnableIfEnabled : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun enableIfUnquoted() : Unit
+
+
         @JvmStatic external fun enableIfUnquotedList() : Unit
+
+
         @JvmStatic external fun enableIfQuoted() : Unit
+
+
         @JvmStatic external fun enableIfQuotedList() : Unit
+
+
         @JvmStatic external fun enableIfTagged() : Unit
+
+
         @JvmStatic external fun enableIfTaggedList() : Unit
+
+
         @JvmStatic external fun enableIfMixedList() : Unit
     }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
@@ -13,9 +13,9 @@ class EnableIfSkipped : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 class InheritFromSkippedImpl : NativeBase, InheritFromSkipped {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
@@ -13,9 +13,9 @@ class SkipFunctions : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -30,8 +30,14 @@ class SkipFunctions : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun notInJava(input: String) : String
+
+
         @JvmStatic external fun notInSwift(input: Boolean) : Boolean
+
+
         @JvmStatic external fun notInDart(input: Float) : Float
     }
 }

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
@@ -13,9 +13,9 @@ class SkipTagsOnly : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
@@ -58,9 +58,9 @@ class SkipTypes : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
@@ -14,14 +14,16 @@ class SomeSkippedClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/input/Structs.lime
+++ b/gluecodium/src/test/resources/smoke/structs/input/Structs.lime
@@ -22,6 +22,7 @@ class Structs {
         x: Double
         y: Double
 
+        // This is some constructor, which constructs Point from polar coordinates.
         constructor fromPolar(phi: Double, r: Double)
     }
     struct Line {

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
@@ -21,6 +21,12 @@ class Structs : NativeBase {
 
 
 
+        /**
+         * This is some constructor, which constructs Point from polar coordinates.
+         * @param phi
+         * @param r
+         */
+
         constructor(phi: Double, r: Double) {
             val _other = fromPolar(phi, r)
             this.x = _other.x
@@ -212,9 +218,13 @@ class Structs : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun swapPointCoordinates(input: Structs.Point) : Structs.Point
+
         @JvmStatic external fun returnAllTypesStruct(input: Structs.AllTypesStruct) : Structs.AllTypesStruct
+
         @JvmStatic external fun createPoint(x: Double, y: Double) : TypeCollection.Point
+
         @JvmStatic external fun modifyAllTypesStruct(input: TypeCollection.AllTypesStruct) : TypeCollection.AllTypesStruct
     }
 }

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
@@ -20,12 +20,12 @@ class Structs : NativeBase {
         @JvmField var y: Double
 
 
-
         /**
          * This is some constructor, which constructs Point from polar coordinates.
          * @param phi
          * @param r
          */
+
 
         constructor(phi: Double, r: Double) {
             val _other = fromPolar(phi, r)
@@ -39,6 +39,7 @@ class Structs : NativeBase {
 
 
         companion object {
+
             @JvmStatic external fun fromPolar(phi: Double, r: Double) : Point
         }
     }
@@ -201,9 +202,9 @@ class Structs : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -219,11 +220,15 @@ class Structs : NativeBase {
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
 
+
         @JvmStatic external fun swapPointCoordinates(input: Structs.Point) : Structs.Point
+
 
         @JvmStatic external fun returnAllTypesStruct(input: Structs.AllTypesStruct) : Structs.AllTypesStruct
 
+
         @JvmStatic external fun createPoint(x: Double, y: Double) : TypeCollection.Point
+
 
         @JvmStatic external fun modifyAllTypesStruct(input: TypeCollection.AllTypesStruct) : TypeCollection.AllTypesStruct
     }

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
@@ -48,9 +48,9 @@ class StructsWithConstantsInterface : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
@@ -31,14 +31,22 @@ class StructsWithMethods {
 
 
 
+
+
         external fun distanceTo(other: StructsWithMethods.Vector) : Double
+
+
         external fun add(other: StructsWithMethods.Vector) : StructsWithMethods.Vector
 
 
         companion object {
+
+
             @JvmStatic external fun validate(x: Double, y: Double) : Boolean
+
             @JvmStatic external fun create(x: Double, y: Double) : Vector
-            @Throws (ValidationUtils.ValidationException::class) @JvmStatic external fun create(other: StructsWithMethods.Vector) : Vector
+            @Throws(ValidationUtils.ValidationException::class)
+            @JvmStatic external fun create(other: StructsWithMethods.Vector) : Vector
         }
     }
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
@@ -16,12 +16,16 @@ class StructsWithMethods {
 
 
 
+
+
         constructor(x: Double, y: Double) {
             val _other = create(x, y)
             this.x = _other.x
             this.y = _other.y
         }
-    @Throws (ValidationUtils.ValidationException::class)
+
+
+    @Throws(ValidationUtils.ValidationException::class)
         constructor(other: StructsWithMethods.Vector) {
             val _other = create(other)
             this.x = _other.x

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -35,14 +35,22 @@ class StructsWithMethodsInterface : NativeBase {
 
 
 
+
+
         external fun distanceTo(other: StructsWithMethodsInterface.Vector3) : Double
+
+
         external fun add(other: StructsWithMethodsInterface.Vector3) : StructsWithMethodsInterface.Vector3
 
 
         companion object {
+
+
             @JvmStatic external fun validate(x: Double, y: Double, z: Double) : Boolean
+
             @JvmStatic external fun create(input: String) : Vector3
-            @Throws (ValidationUtils.ValidationException::class) @JvmStatic external fun create(other: StructsWithMethodsInterface.Vector3) : Vector3
+            @Throws(ValidationUtils.ValidationException::class)
+            @JvmStatic external fun create(other: StructsWithMethodsInterface.Vector3) : Vector3
         }
     }
 
@@ -56,6 +64,8 @@ class StructsWithMethodsInterface : NativeBase {
 
 
         companion object {
+
+
             @JvmStatic external fun doStuff() : Unit
         }
     }

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -18,13 +18,17 @@ class StructsWithMethodsInterface : NativeBase {
 
 
 
+
+
         constructor(input: String) {
             val _other = create(input)
             this.x = _other.x
             this.y = _other.y
             this.z = _other.z
         }
-    @Throws (ValidationUtils.ValidationException::class)
+
+
+    @Throws(ValidationUtils.ValidationException::class)
         constructor(other: StructsWithMethodsInterface.Vector3) {
             val _other = create(other)
             this.x = _other.x

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -76,9 +76,9 @@ class StructsWithMethodsInterface : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
+++ b/gluecodium/src/test/resources/smoke/structs/output/android/com/example/smoke/Structs.java
@@ -26,7 +26,11 @@ public final class Structs extends NativeBase {
     public static final class Point {
         public double x;
         public double y;
-
+        /**
+         * <p>This is some constructor, which constructs Point from polar coordinates.
+         * @param phi
+         * @param r
+         */
 
         public Point(final double phi, final double r) {
             Point _other = fromPolar(phi, r);

--- a/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
+++ b/gluecodium/src/test/resources/smoke/structs/output/cpp/include/smoke/Structs.h
@@ -36,6 +36,12 @@ public:
         Point( );
         Point( double x, double y );
 
+        /**
+         * This is some constructor, which constructs Point from polar coordinates.
+         * \param[in] phi
+         * \param[in] r
+         * \return
+         */
         static ::smoke::Structs::Point from_polar( const double phi, const double r );
 
     };

--- a/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
+++ b/gluecodium/src/test/resources/smoke/structs/output/dart/lib/src/smoke/structs.dart
@@ -96,7 +96,8 @@ class Structs_Point {
   double y;
 
   Structs_Point._(this.x, this.y);
-
+  /// This is some constructor, which constructs Point from polar coordinates.
+  ///
   factory Structs_Point(double phi, double r) => $prototype.fromPolar(phi, r);
 
   /// @nodoc

--- a/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
+++ b/gluecodium/src/test/resources/smoke/structs/output/swift/smoke/Structs.swift
@@ -39,6 +39,10 @@ public class Structs {
             x = moveFromCType(smoke_Structs_Point_x_get(cHandle))
             y = moveFromCType(smoke_Structs_Point_y_get(cHandle))
         }
+        /// This is some constructor, which constructs Point from polar coordinates.
+        /// - Parameters:
+        ///   - phi:
+        ///   - r:
 
         public init(phi: Double, r: Double) {
             let _result_handle = Structs.Point.fromPolar(phi: phi, r: r)

--- a/gluecodium/src/test/resources/smoke/typedefs/input/TypeDefs.lime
+++ b/gluecodium/src/test/resources/smoke/typedefs/input/TypeDefs.lime
@@ -54,7 +54,10 @@ class TypeDefs {
     property primitiveTypeProperty: List<PrimitiveTypeDef>
 }
 
+// This is some standalone list typedef.
 typealias GlobalListTypeDef = List<Float>
+
+// This is some standalone map typedef.
 typealias GlobalMapTypeDef = Map<Int, String>
 
 struct TypeCollection {

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalListTypeDef.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalListTypeDef.kt
@@ -8,4 +8,7 @@
 package com.example.smoke
 
 
+/**
+ * This is some standalone list typedef.
+ */
 typealias GlobalListTypeDef = MutableList<Float>

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalMapTypeDef.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalMapTypeDef.kt
@@ -8,4 +8,7 @@
 package com.example.smoke
 
 
+/**
+ * This is some standalone map typedef.
+ */
 typealias GlobalMapTypeDef = MutableMap<Int, String>

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
@@ -43,9 +43,9 @@ class TypeDefs : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -64,11 +64,23 @@ class TypeDefs : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
+
         @JvmStatic external fun methodWithPrimitiveTypeDef(input: Double) : Double
+
+
         @JvmStatic external fun methodWithComplexTypeDef(input: MutableList<TypeDefs.TestStruct>) : MutableList<TypeDefs.TestStruct>
+
+
         @JvmStatic external fun returnNestedIntTypeDef(input: Double) : Double
+
+
         @JvmStatic external fun returnTestStructTypeDef(input: TypeDefs.TestStruct) : TypeDefs.TestStruct
+
+
         @JvmStatic external fun returnNestedStructTypeDef(input: TypeDefs.TestStruct) : TypeDefs.TestStruct
+
+
         @JvmStatic external fun returnTypeDefPointFromTypeCollection(input: TypeCollection.Point) : TypeCollection.Point
     }
 }

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalListTypeDef.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalListTypeDef.h
@@ -11,6 +11,10 @@
 #include <vector>
 
 namespace smoke {
+/**
+ * This is some standalone list typedef.
+
+ */
 using GlobalListTypeDef = ::std::vector< float >;
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalMapTypeDef.h
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/cpp/include/smoke/GlobalMapTypeDef.h
@@ -13,6 +13,10 @@
 #include <unordered_map>
 
 namespace smoke {
+/**
+ * This is some standalone map typedef.
+
+ */
 using GlobalMapTypeDef = ::std::unordered_map< int32_t, ::std::string >;
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalListTypeDef.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalListTypeDef.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+/// This is some standalone list typedef.
 public typealias GlobalListTypeDef = [Float]
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalMapTypeDef.swift
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/swift/smoke/GlobalMapTypeDef.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+/// This is some standalone map typedef.
 public typealias GlobalMapTypeDef = [Int32: String]
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
@@ -13,14 +13,16 @@ internal class InternalClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
@@ -13,14 +13,16 @@ internal class InternalClassInherits : NativeBase, InternalInterfaceParent {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
@@ -21,9 +21,9 @@ internal class InternalClassWithFunctions : NativeBase {
         cacheThisInstance();
     }
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
@@ -33,6 +33,8 @@ internal class InternalClassWithFunctions : NativeBase {
     private external fun cacheThisInstance()
 
 
+
+
     external fun fooBar() : Unit
 
 
@@ -40,7 +42,9 @@ internal class InternalClassWithFunctions : NativeBase {
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+
         @JvmStatic external fun make() : Long
+
         @JvmStatic external fun make(foo: String) : Long
     }
 }

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
@@ -13,9 +13,9 @@ internal class InternalClassWithStaticProperty : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 internal class InternalInterfaceImpl : NativeBase, InternalInterface {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
@@ -9,13 +9,10 @@ package com.example.smoke
 
 import com.example.NativeBase
 
+/**
+ * @suppress
+ */
 internal class InternalLambdaImpl : NativeBase, InternalLambda {
-    /*
-     * For internal use only.
-     * @hidden
-     * @param nativeHandle The handle to resources on C++ side.
-     * @param tag Tag used by callers to avoid overload resolution problems.
-     */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
@@ -13,9 +13,9 @@ class InternalPropertyOnly : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
@@ -64,14 +64,16 @@ class PublicClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
@@ -13,9 +13,9 @@ internal class KotlinInternalClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
@@ -13,9 +13,9 @@ internal class KotlinInternalClassRev : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinPublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinPublicClass.kt
@@ -13,9 +13,9 @@ class KotlinPublicClass : NativeBase {
 
 
 
-    /*
+    /**
      * For internal use only.
-     * @hidden
+     * @suppress
      * @param nativeHandle The handle to resources on C++ side.
      * @param tag Tag used by callers to avoid overload resolution problems.
      */


### PR DESCRIPTION
---------- Motivation ----------
The initial commit, which introduced Kotlin support
did not implement 'KotlinCommentsProcessor' class.
Moreover, mustache files for Kotlin generator did not
render documentation comments.

---------- Comments processor ----------
Unlike JavaDoc, the documentation syntax for Kotlin,
which is called KDoc uses markdown for inline markup.
    
Therefore, the renderer passed to the base 'CommentsProcessor'
is changed from 'HtmlRenderer' to 'Formatter'. Moreover,
custom links processing uses markdown syntax -- it does not
require any special annotations. Thus, the body of 'processLink()'
function looks exactly like in the case of DartCommentsProcessor.

This change implements also 'KotlinNameResolver.resolveComment()'
function. It is important to note that KDoc does not support referencing
given function overload -- instead, when a link is used then whole section
with all overloads of given method is opened.

---------- Mustache files ----------
The mustache files for Kotlin generator have been adjusted to render
KDoc comments when the input LIME files contain specify them.

Co-author:  Vladyslav Tsymbal (@VladyslavTsymbal).