### PR TITLE
Kotlin: correctly handle types with duplicated names

### DIFF
--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -511,7 +511,7 @@ feature(Locales cpp android android-kotlin swift dart SOURCES
     input/lime/LocaleDefaults.lime
 )
 
-feature(CrossPackageNameClash cpp android swift dart SOURCES
+feature(CrossPackageNameClash cpp android android-kotlin swift dart SOURCES
     input/lime/CrossPackageNameClashA.lime
     input/lime/CrossPackageNameClashB.lime
     input/lime/CrossPackageNameClashC.lime

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinImportResolver.kt
@@ -130,6 +130,8 @@ internal class KotlinImportResolver(
     }
 
     fun createTopElementImport(limeType: LimeType): String? {
+        if (nameResolver.typesWithDuplicateNames.contains(limeType.fullName)) return null
+
         val topElement =
             generateSequence(limeType) {
                 limeReferenceMap[it.path.parent.toString()] as? LimeType

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToRead.kt
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToRead.kt
@@ -1,0 +1,28 @@
+/*
+
+ *
+ */
+
+@file:JvmName("LearnToRead")
+
+package com.example.smoke
+
+import com.example.smoke.foo.Alphabet
+
+class LearnToRead {
+    @JvmField var fieldA: Alphabet
+    @JvmField var fieldB: Alphabet
+
+
+
+    constructor() {
+        this.fieldA = Alphabet.A
+        this.fieldB = Alphabet.BETA
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToRead.kt
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToRead.kt
@@ -7,17 +7,16 @@
 
 package com.example.smoke
 
-import com.example.smoke.foo.Alphabet
 
 class LearnToRead {
-    @JvmField var fieldA: Alphabet
-    @JvmField var fieldB: Alphabet
+    @JvmField var fieldA: com.example.smoke.Alphabet
+    @JvmField var fieldB: com.example.smoke.foo.Alphabet
 
 
 
     constructor() {
-        this.fieldA = Alphabet.A
-        this.fieldB = Alphabet.BETA
+        this.fieldA = com.example.smoke.Alphabet.A
+        this.fieldB = com.example.smoke.foo.Alphabet.BETA
     }
 
 

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToReadAgain.kt
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToReadAgain.kt
@@ -1,0 +1,29 @@
+/*
+
+ *
+ */
+
+@file:JvmName("LearnToReadAgain")
+
+package com.example.smoke
+
+import com.example.smoke.bar.Alphabet
+import com.example.smoke.foo.Alphabet
+
+class LearnToReadAgain {
+    @JvmField var fieldB: Alphabet
+    @JvmField var fieldC: Alphabet
+
+
+
+    constructor() {
+        this.fieldB = Alphabet.BETA
+        this.fieldC = Alphabet.GIMEL
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToReadAgain.kt
+++ b/gluecodium/src/test/resources/smoke/duplicate_names/output/android-kotlin/com/example/smoke/LearnToReadAgain.kt
@@ -7,18 +7,16 @@
 
 package com.example.smoke
 
-import com.example.smoke.bar.Alphabet
-import com.example.smoke.foo.Alphabet
 
 class LearnToReadAgain {
-    @JvmField var fieldB: Alphabet
-    @JvmField var fieldC: Alphabet
+    @JvmField var fieldB: com.example.smoke.foo.Alphabet
+    @JvmField var fieldC: com.example.smoke.bar.Alphabet
 
 
 
     constructor() {
-        this.fieldB = Alphabet.BETA
-        this.fieldC = Alphabet.GIMEL
+        this.fieldB = com.example.smoke.foo.Alphabet.BETA
+        this.fieldC = com.example.smoke.bar.Alphabet.GIMEL
     }
 
 


### PR DESCRIPTION
This change enables 'CrossPackageNameClash' functional test
suite for Kotlin generator tests.

Moreover, this change adds handling of types with duplicated names.
It ensurers that 'cross-package-name-clash' test suite passes without problems.
    
Without this change Kotlin generator was creating multiple
imports of type with the same name. With this commit it does
not generate imports if there are types with duplicated names
and references them with full path.