### PR TITLE
Kotlin: introduce usage of JvmField annotation

### DIFF
--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/AttributesInterfaceTest.kt
@@ -53,10 +53,10 @@ class AttributesInterfaceTest {
     @org.junit.Test
     fun setGetStaticAttributes() {
         assertEquals(AttributesInterface.LABEL, "SOME CONSTANT LABEL")
-        assertEquals(AttributesInterface.someStaticProperty, "MY STATIC PROPERTY")
+        assertEquals(AttributesInterface.getSomeStaticProperty(), "MY STATIC PROPERTY")
 
-        AttributesInterface.someStaticProperty = "NEW VALUE OF PROPERTY"
-        assertEquals(AttributesInterface.someStaticProperty, "NEW VALUE OF PROPERTY")
+        AttributesInterface.setSomeStaticProperty("NEW VALUE OF PROPERTY")
+        assertEquals(AttributesInterface.getSomeStaticProperty(), "NEW VALUE OF PROPERTY")
 
         assertEquals(AttributesInterface.staticFunction(), "Some magic string!");
     }

--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InterfaceWithStaticTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/InterfaceWithStaticTest.kt
@@ -41,15 +41,14 @@ class InterfaceWithStaticTest {
 
     @org.junit.Test
     fun callStaticPropertyGetter() {
-        val result: String = InterfaceWithStatic.staticProperty
-        assertEquals("bar2", result)
+        assertEquals("bar2", InterfaceWithStatic.getStaticProperty())
     }
 
     @org.junit.Test
     fun callStaticPropertySetter() {
-        InterfaceWithStatic.staticProperty = "wizz1"
+        InterfaceWithStatic.setStaticProperty("wizz1")
 
-        val result: String = InterfaceWithStatic.staticProperty
+        val result: String = InterfaceWithStatic.getStaticProperty()
         UseInterfaceWithStatic.resetStaticValue()
 
         assertEquals("wizz1", result)

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
@@ -89,6 +89,7 @@ internal class KotlinNameResolver(
     }
 
     override fun resolveGetterName(element: Any) = (element as? LimeTypedElement)?.let { kotlinNameRules.getGetterName(it) }
+
     override fun resolveSetterName(element: Any) = (element as? LimeTypedElement)?.let { kotlinNameRules.getSetterName(it) }
 
     private fun resolveComment(limeComment: LimeComment): String {

--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinNameResolver.kt
@@ -89,6 +89,7 @@ internal class KotlinNameResolver(
     }
 
     override fun resolveGetterName(element: Any) = (element as? LimeTypedElement)?.let { kotlinNameRules.getGetterName(it) }
+    override fun resolveSetterName(element: Any) = (element as? LimeTypedElement)?.let { kotlinNameRules.getSetterName(it) }
 
     private fun resolveComment(limeComment: LimeComment): String {
         // TODO: implement me!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinConstant.mustache
@@ -18,4 +18,4 @@
   ! License-Filename: LICENSE
   !
   !}}
-val {{resolveName}}: {{resolveName typeRef}} = {{resolveName value}}
+@JvmField final val {{resolveName}}: {{resolveName typeRef}} = {{resolveName value}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumerator.mustache
@@ -18,6 +18,6 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#if isAlias}}    val {{resolveName}}{{!!
+{{#if isAlias}}    @JvmField val {{resolveName}}{{!!
 }} = {{resolveName value}}{{/if}}{{!!
 }}{{#unless isAlias}}    {{resolveName}}({{resolveName value}}){{/unless}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinException.mustache
@@ -18,5 +18,5 @@
   ! License-Filename: LICENSE
   !
   !}}
-class {{resolveName}}(val error: {{resolveName errorType}}) : Exception(error.toString())
+class {{resolveName}}(@JvmField val error: {{resolveName errorType}}) : Exception(error.toString())
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -57,13 +57,13 @@
 {{#set property=this}}
 {{#property}}
 {{#if isStatic}}
-{{#if setter}}        @JvmStatic var{{/if}}{{!!
-}}{{#unless setter}}        @JvmStatic val{{/unless}}{{!!
-}} {{resolveName}}: {{resolveName typeRef}}
-            get() = {{resolveName interface}}Impl.{{resolveName property}}{{#setter}}
-            set(value) {
-                {{resolveName interface}}Impl.{{resolveName property}} = value
-            }{{/setter}}
+        @JvmStatic fun {{resolveName property "" "getter"}}(): {{resolveName typeRef}} {
+            return {{resolveName interface}}Impl.{{resolveName property}}
+        }
+
+        @JvmStatic fun {{resolveName property "" "setter"}}(value: {{resolveName typeRef}}) {
+            {{resolveName interface}}Impl.{{resolveName property}} = value
+        }
 {{/if}}
 {{/property}}
 {{/set}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
@@ -25,7 +25,7 @@
 }}{{/unless}} {
 {{#set isImmutable=attributes.immutable}}
 {{#fields}}{{!!
-}}    {{resolveName "visibility"}}{{!!
+}}    @JvmField {{resolveName "visibility"}}{{!!
 }}{{#unless isImmutable}}var {{/unless}}{{!!
 }}{{#if isImmutable}}val {{/if}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{!!

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
@@ -29,10 +29,10 @@ class CollectionConstants : NativeBase {
 
 
     companion object {
-        val LIST_CONSTANT: MutableList<String> = mutableListOf("foo", "bar")
-        val SET_CONSTANT: MutableSet<String> = mutableSetOf("foo", "bar")
-        val MAP_CONSTANT: MutableMap<String, String> = mutableMapOf("foo" to "bar")
-        val MIXED_CONSTANT: MutableMap<MutableList<String>, MutableSet<String>> = mutableMapOf(mutableListOf("foo") to mutableSetOf("bar"))
+        @JvmField final val LIST_CONSTANT: MutableList<String> = mutableListOf("foo", "bar")
+        @JvmField final val SET_CONSTANT: MutableSet<String> = mutableSetOf("foo", "bar")
+        @JvmField final val MAP_CONSTANT: MutableMap<String, String> = mutableMapOf("foo" to "bar")
+        @JvmField final val MIXED_CONSTANT: MutableMap<MutableList<String>, MutableSet<String>> = mutableMapOf(mutableListOf("foo") to mutableSetOf("bar"))
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
@@ -22,13 +22,13 @@ class Constants {
 
 
     companion object {
-        val BOOL_CONSTANT: Boolean = true
-        val INT_CONSTANT: Int = -11
-        val UINT_CONSTANT: Long = 4294967295L
-        val FLOAT_CONSTANT: Float = 2.71f
-        val DOUBLE_CONSTANT: Double = -3.14
-        val STRING_CONSTANT: String = "Foo bar"
-        val ENUM_CONSTANT: Constants.StateEnum = Constants.StateEnum.ON
+        @JvmField final val BOOL_CONSTANT: Boolean = true
+        @JvmField final val INT_CONSTANT: Int = -11
+        @JvmField final val UINT_CONSTANT: Long = 4294967295L
+        @JvmField final val FLOAT_CONSTANT: Float = 2.71f
+        @JvmField final val DOUBLE_CONSTANT: Double = -3.14
+        @JvmField final val STRING_CONSTANT: String = "Foo bar"
+        @JvmField final val ENUM_CONSTANT: Constants.StateEnum = Constants.StateEnum.ON
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
@@ -33,13 +33,13 @@ class ConstantsInterface : NativeBase {
 
 
     companion object {
-        val BOOL_CONSTANT: Boolean = true
-        val INT_CONSTANT: Int = -11
-        val UINT_CONSTANT: Long = 4294967295L
-        val FLOAT_CONSTANT: Float = 2.71f
-        val DOUBLE_CONSTANT: Double = -3.14
-        val STRING_CONSTANT: String = "Foo bar"
-        val ENUM_CONSTANT: ConstantsInterface.StateEnum = ConstantsInterface.StateEnum.ON
+        @JvmField final val BOOL_CONSTANT: Boolean = true
+        @JvmField final val INT_CONSTANT: Int = -11
+        @JvmField final val UINT_CONSTANT: Long = 4294967295L
+        @JvmField final val FLOAT_CONSTANT: Float = 2.71f
+        @JvmField final val DOUBLE_CONSTANT: Double = -3.14
+        @JvmField final val STRING_CONSTANT: String = "Foo bar"
+        @JvmField final val ENUM_CONSTANT: ConstantsInterface.StateEnum = ConstantsInterface.StateEnum.ON
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
@@ -12,8 +12,8 @@ import com.example.NativeBase
 class StructConstants : NativeBase {
 
     class SomeStruct {
-        var stringField: String
-        var floatField: Float
+        @JvmField var stringField: String
+        @JvmField var floatField: Float
 
 
 
@@ -29,7 +29,7 @@ class StructConstants : NativeBase {
     }
 
     class NestingStruct {
-        var structField: StructConstants.SomeStruct
+        @JvmField var structField: StructConstants.SomeStruct
 
 
 

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
@@ -61,8 +61,8 @@ class StructConstants : NativeBase {
 
 
     companion object {
-        val STRUCT_CONSTANT: StructConstants.SomeStruct = StructConstants.SomeStruct("bar Buzz", 1.41f)
-        val NESTING_STRUCT_CONSTANT: StructConstants.NestingStruct = StructConstants.NestingStruct(StructConstants.SomeStruct("nonsense", -2.82f))
+        @JvmField final val STRUCT_CONSTANT: StructConstants.SomeStruct = StructConstants.SomeStruct("bar Buzz", 1.41f)
+        @JvmField final val NESTING_STRUCT_CONSTANT: StructConstants.NestingStruct = StructConstants.NestingStruct(StructConstants.SomeStruct("nonsense", -2.82f))
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
     }
 }

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -15,7 +15,7 @@ open class Constructors : NativeBase {
         NONE(0),
         CRASHED(1);
     }
-    class ConstructorExplodedException(val error: Constructors.ErrorEnum) : Exception(error.toString())
+    class ConstructorExplodedException(@JvmField val error: Constructors.ErrorEnum) : Exception(error.toString())
 
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/BlobDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/BlobDefaults.kt
@@ -9,8 +9,8 @@ package com.example.smoke
 
 
 class BlobDefaults {
-    var emptyList: ByteArray
-    var deadBeef: ByteArray
+    @JvmField var emptyList: ByteArray
+    @JvmField var deadBeef: ByteArray
 
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
@@ -12,12 +12,12 @@ import com.example.NativeBase
 class DefaultValues : NativeBase {
 
     class StructWithDefaults {
-        var intField: Int
-        var uintField: Long
-        var floatField: Float
-        var doubleField: Double
-        var boolField: Boolean
-        var stringField: String
+        @JvmField var intField: Int
+        @JvmField var uintField: Long
+        @JvmField var floatField: Float
+        @JvmField var doubleField: Double
+        @JvmField var boolField: Boolean
+        @JvmField var stringField: String
 
 
 
@@ -37,11 +37,11 @@ class DefaultValues : NativeBase {
     }
 
     class NullableStructWithDefaults {
-        var intField: Int?
-        var uintField: Long?
-        var floatField: Float?
-        var boolField: Boolean?
-        var stringField: String?
+        @JvmField var intField: Int?
+        @JvmField var uintField: Long?
+        @JvmField var floatField: Float?
+        @JvmField var boolField: Boolean?
+        @JvmField var stringField: String?
 
 
 
@@ -60,12 +60,12 @@ class DefaultValues : NativeBase {
     }
 
     class StructWithSpecialDefaults {
-        var floatNanField: Float
-        var floatInfinityField: Float
-        var floatNegativeInfinityField: Float
-        var doubleNanField: Double
-        var doubleInfinityField: Double
-        var doubleNegativeInfinityField: Double
+        @JvmField var floatNanField: Float
+        @JvmField var floatInfinityField: Float
+        @JvmField var floatNegativeInfinityField: Float
+        @JvmField var doubleNanField: Double
+        @JvmField var doubleInfinityField: Double
+        @JvmField var doubleNegativeInfinityField: Double
 
 
 
@@ -85,11 +85,11 @@ class DefaultValues : NativeBase {
     }
 
     class StructWithEmptyDefaults {
-        var intsField: MutableList<Int>
-        var floatsField: MutableList<Float>
-        var mapField: MutableMap<Long, String>
-        var structField: DefaultValues.StructWithDefaults
-        var setTypeField: MutableSet<String>
+        @JvmField var intsField: MutableList<Int>
+        @JvmField var floatsField: MutableList<Float>
+        @JvmField var mapField: MutableMap<Long, String>
+        @JvmField var structField: DefaultValues.StructWithDefaults
+        @JvmField var setTypeField: MutableSet<String>
 
 
 
@@ -108,9 +108,9 @@ class DefaultValues : NativeBase {
     }
 
     class StructWithTypedefDefaults {
-        var longField: Long
-        var boolField: Boolean
-        var stringField: String
+        @JvmField var longField: Long
+        @JvmField var boolField: Boolean
+        @JvmField var stringField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
@@ -9,11 +9,11 @@ package com.example.smoke
 
 
 class StructWithKotlinPositionalDefaults {
-    var firstInitField: Int
-    var firstFreeField: String
-    var secondInitField: Float
-    var secondFreeField: Boolean
-    var thirdInitField: String
+    @JvmField var firstInitField: Int
+    @JvmField var firstFreeField: String
+    @JvmField var secondInitField: Float
+    @JvmField var secondFreeField: Boolean
+    @JvmField var thirdInitField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationDefaults.kt
@@ -10,13 +10,13 @@ package com.example.smoke
 import com.example.time.Duration
 
 class DurationDefaults {
-    var dayz: Duration
-    var hourz: Duration
-    var minutez: Duration
-    var secondz: Duration
-    var milliz: Duration
-    var microz: Duration
-    var nanoz: Duration
+    @JvmField var dayz: Duration
+    @JvmField var hourz: Duration
+    @JvmField var minutez: Duration
+    @JvmField var secondz: Duration
+    @JvmField var milliz: Duration
+    @JvmField var microz: Duration
+    @JvmField var nanoz: Duration
 
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
@@ -13,7 +13,7 @@ import com.example.time.Duration
 class DurationMilliseconds : NativeBase {
 
     class DurationStruct {
-        var durationField: Duration
+        @JvmField var durationField: Duration
 
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
@@ -13,7 +13,7 @@ import com.example.time.Duration
 class DurationSeconds : NativeBase {
 
     class DurationStruct {
-        var durationField: Duration
+        @JvmField var durationField: Duration
 
 
 

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
@@ -14,8 +14,8 @@ enum class EnumWithAlias(private val value: Int) {
     THREE(4);
 
     companion object {
-        val FIRST = EnumWithAlias.ONE
-        val THE_BEST = EnumWithAlias.FIRST
+        @JvmField val FIRST = EnumWithAlias.ONE
+        @JvmField val THE_BEST = EnumWithAlias.FIRST
     }
 
 }

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
@@ -20,8 +20,8 @@ class Enums : NativeBase {
         ERROR_FATAL(999);
     }
     class ErrorStruct {
-        var type: Enums.InternalErrorCode
-        var message: String
+        @JvmField var type: Enums.InternalErrorCode
+        @JvmField var message: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/Equatable.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/Equatable.kt
@@ -15,16 +15,16 @@ class Equatable {
         BAR(1);
     }
     class EquatableStruct {
-        var boolField: Boolean
-        var intField: Int
-        var longField: Long
-        var floatField: Float
-        var doubleField: Double
-        var stringField: String
-        var structField: Equatable.NestedEquatableStruct
-        var enumField: Equatable.SomeEnum
-        var arrayField: MutableList<String>
-        var mapField: MutableMap<Int, String>
+        @JvmField var boolField: Boolean
+        @JvmField var intField: Int
+        @JvmField var longField: Long
+        @JvmField var floatField: Float
+        @JvmField var doubleField: Double
+        @JvmField var stringField: String
+        @JvmField var structField: Equatable.NestedEquatableStruct
+        @JvmField var enumField: Equatable.SomeEnum
+        @JvmField var arrayField: MutableList<String>
+        @JvmField var mapField: MutableMap<Int, String>
 
 
 
@@ -85,15 +85,15 @@ class Equatable {
     }
 
     class EquatableNullableStruct {
-        var boolField: Boolean?
-        var intField: Int?
-        var uintField: Int?
-        var floatField: Float?
-        var stringField: String?
-        var structField: Equatable.NestedEquatableStruct?
-        var enumField: Equatable.SomeEnum?
-        var arrayField: MutableList<String>?
-        var mapField: MutableMap<Int, String>?
+        @JvmField var boolField: Boolean?
+        @JvmField var intField: Int?
+        @JvmField var uintField: Int?
+        @JvmField var floatField: Float?
+        @JvmField var stringField: String?
+        @JvmField var structField: Equatable.NestedEquatableStruct?
+        @JvmField var enumField: Equatable.SomeEnum?
+        @JvmField var arrayField: MutableList<String>?
+        @JvmField var mapField: MutableMap<Int, String>?
 
 
 
@@ -151,7 +151,7 @@ class Equatable {
     }
 
     class NestedEquatableStruct {
-        var fooField: String
+        @JvmField var fooField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
@@ -12,10 +12,10 @@ import com.example.NativeBase
 class EquatableClass : NativeBase {
 
     class EquatableStruct {
-        var intField: Int
-        var stringField: String
-        var nestedEquatableInstance: EquatableClass
-        var nestedPointerEquatableInstance: PointerEquatableClass
+        @JvmField var intField: Int
+        @JvmField var stringField: String
+        @JvmField var nestedEquatableInstance: EquatableClass
+        @JvmField var nestedPointerEquatableInstance: PointerEquatableClass
 
 
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/SimpleEquatableStruct.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/SimpleEquatableStruct.kt
@@ -9,10 +9,10 @@ package com.example.smoke
 
 
 class SimpleEquatableStruct {
-    var classField: NonEquatableClass
-    var interfaceField: NonEquatableInterface
-    var nullableClassField: NonEquatableClass?
-    var nullableInterfaceField: NonEquatableInterface?
+    @JvmField var classField: NonEquatableClass
+    @JvmField var interfaceField: NonEquatableInterface
+    @JvmField var nullableClassField: NonEquatableClass?
+    @JvmField var nullableInterfaceField: NonEquatableInterface?
 
 
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -20,10 +20,10 @@ class Errors : NativeBase {
         BOOM(1),
         BUST(2);
     }
-    class InternalException(val error: Errors.InternalErrorCode) : Exception(error.toString())
+    class InternalException(@JvmField val error: Errors.InternalErrorCode) : Exception(error.toString())
 
 
-    class ExternalException(val error: Errors.ExternalErrors) : Exception(error.toString())
+    class ExternalException(@JvmField val error: Errors.ExternalErrors) : Exception(error.toString())
 
 
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -18,10 +18,10 @@ interface ErrorsInterface {
         BOOM(1),
         BUST(2);
     }
-    class InternalException(val error: ErrorsInterface.InternalError) : Exception(error.toString())
+    class InternalException(@JvmField val error: ErrorsInterface.InternalError) : Exception(error.toString())
 
 
-    class ExternalException(val error: ErrorsInterface.ExternalErrors) : Exception(error.toString())
+    class ExternalException(@JvmField val error: ErrorsInterface.ExternalErrors) : Exception(error.toString())
 
 
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -31,7 +31,7 @@ interface ErrorsInterface {
 
 
     companion object {
-        val ERROR_MESSAGE: String = "Some error message constant"
+        @JvmField final val ERROR_MESSAGE: String = "Some error message constant"
         @Throws (WithPayloadException::class) @JvmStatic fun methodWithPayloadError() : Unit {
             ErrorsInterfaceImpl.methodWithPayloadError()
         }

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
@@ -14,7 +14,7 @@ class SomeTypeCollection {
         ERROR_A(0),
         ERROR_B(1);
     }
-    class SomeException(val error: SomeTypeCollection.SomeTypeCollectionError) : Exception(error.toString())
+    class SomeException(@JvmField val error: SomeTypeCollection.SomeTypeCollectionError) : Exception(error.toString())
 
 
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/WithPayloadException.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/WithPayloadException.kt
@@ -8,6 +8,6 @@
 package com.example.smoke
 
 
-class WithPayloadException(val error: Payload) : Exception(error.toString())
+class WithPayloadException(@JvmField val error: Payload) : Exception(error.toString())
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/ExternalMarkedAsSerializable.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/ExternalMarkedAsSerializable.kt
@@ -11,7 +11,7 @@ import android.os.Parcel
 import android.os.Parcelable
 
 class ExternalMarkedAsSerializable {
-    var field: Int
+    @JvmField var field: Int
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/KotlinExternalTypesStruct.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/KotlinExternalTypesStruct.kt
@@ -9,11 +9,11 @@ package com.example.kotlinsmoke
 
 
 class KotlinExternalTypesStruct {
-    var currency: java.util.Currency
-    var timeZone: java.util.SimpleTimeZone
-    var month: java.time.Month
-    var color: kotlin.Int?
-    var season: kotlin.String
+    @JvmField var currency: java.util.Currency
+    @JvmField var timeZone: java.util.SimpleTimeZone
+    @JvmField var month: java.time.Month
+    @JvmField var color: kotlin.Int?
+    @JvmField var season: kotlin.String
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SerializableStructWithExternalField.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SerializableStructWithExternalField.kt
@@ -11,7 +11,7 @@ import android.os.Parcel
 import android.os.Parcelable
 
 class SerializableStructWithExternalField : Parcelable {
-    var someStruct: com.here.android.test.AnExternalStruct
+    @JvmField var someStruct: com.here.android.test.AnExternalStruct
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SystemColor.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SystemColor.kt
@@ -9,10 +9,10 @@ package com.example.kotlinsmoke
 
 
 class SystemColor {
-    var red: Float
-    var green: Float
-    var blue: Float
-    var alpha: Float
+    @JvmField var red: Float
+    @JvmField var green: Float
+    @JvmField var blue: Float
+    @JvmField var alpha: Float
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalConst.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalConst.kt
@@ -22,7 +22,7 @@ class UseKotlinExternalConst {
 
 
     companion object {
-        val DEFAULT_TRUTH: kotlin.Boolean? = true
+        @JvmField final val DEFAULT_TRUTH: kotlin.Boolean? = true
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalConst.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalConst.kt
@@ -9,7 +9,7 @@ package com.example.kotlinsmoke
 
 
 class UseKotlinExternalConst {
-    var stringField: String
+    @JvmField var stringField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/VeryBoolean.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/VeryBoolean.kt
@@ -9,7 +9,7 @@ package com.example.kotlinsmoke
 
 
 class VeryBoolean {
-    var value: Boolean
+    @JvmField var value: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
@@ -15,7 +15,7 @@ class ExternalClass : NativeBase {
         SOME_VALUE(0);
     }
     class SomeStruct {
-        var someField: String
+        @JvmField var someField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterface.kt
@@ -13,7 +13,7 @@ interface ExternalInterface {
         SOME_VALUE(0);
     }
     class SomeStruct {
-        var someField: String
+        @JvmField var someField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
@@ -12,10 +12,10 @@ import com.example.NativeBase
 class Structs : NativeBase {
 
     class ExternalStruct {
-        var stringField: String
-        var externalStringField: String
-        var externalArrayField: MutableList<Byte>
-        var externalStructField: Structs.AnotherExternalStruct
+        @JvmField var stringField: String
+        @JvmField var externalStringField: String
+        @JvmField var externalArrayField: MutableList<Byte>
+        @JvmField var externalStructField: Structs.AnotherExternalStruct
 
 
 
@@ -33,7 +33,7 @@ class Structs : NativeBase {
     }
 
     class AnotherExternalStruct {
-        var intField: Byte
+        @JvmField var intField: Byte
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsAllDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsAllDefaults.kt
@@ -9,9 +9,9 @@ package com.example.smoke
 
 
 class FieldConstructorsAllDefaults {
-    var stringField: String
-    var intField: Int
-    var boolField: Boolean
+    @JvmField var stringField: String
+    @JvmField var intField: Int
+    @JvmField var boolField: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsPartialDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsPartialDefaults.kt
@@ -9,9 +9,9 @@ package com.example.smoke
 
 
 class FieldConstructorsPartialDefaults {
-    var stringField: String
-    var intField: Int
-    var boolField: Boolean
+    @JvmField var stringField: String
+    @JvmField var intField: Int
+    @JvmField var boolField: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldCustomConstructorsMix.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldCustomConstructorsMix.kt
@@ -9,9 +9,9 @@ package com.example.smoke
 
 
 class FieldCustomConstructorsMix {
-    var stringField: String
-    var intField: Int
-    var boolField: Boolean
+    @JvmField var stringField: String
+    @JvmField var intField: Int
+    @JvmField var boolField: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructNoClash.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructNoClash.kt
@@ -9,9 +9,9 @@ package com.example.smoke
 
 
 class ImmutableStructNoClash {
-    val stringField: String
-    val intField: Int
-    val boolField: Boolean
+    @JvmField val stringField: String
+    @JvmField val intField: Int
+    @JvmField val boolField: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructWithClash.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructWithClash.kt
@@ -9,9 +9,9 @@ package com.example.smoke
 
 
 class ImmutableStructWithClash {
-    val stringField: String
-    val intField: Int
-    val boolField: Boolean
+    @JvmField val stringField: String
+    @JvmField val intField: Int
+    @JvmField val boolField: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/MutableStructNoClash.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/MutableStructNoClash.kt
@@ -9,9 +9,9 @@ package com.example.smoke
 
 
 class MutableStructNoClash {
-    var stringField: String
-    var intField: Int
-    var boolField: Boolean
+    @JvmField var stringField: String
+    @JvmField var intField: Int
+    @JvmField var boolField: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/OuterStructWithFieldConstructor.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/OuterStructWithFieldConstructor.kt
@@ -9,10 +9,10 @@ package com.example.smoke
 
 
 class OuterStructWithFieldConstructor {
-    var outerStructField: OuterStructWithFieldConstructor.InnerStructWithDefaults
+    @JvmField var outerStructField: OuterStructWithFieldConstructor.InnerStructWithDefaults
 
     class InnerStructWithDefaults {
-        var innerStructField: Double
+        @JvmField var innerStructField: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 import java.util.EnumSet
 
 class EnumSets {
-    var enumSetField: MutableSet<GenericTypesWithCompoundTypes.SomeEnum>
+    @JvmField var enumSetField: MutableSet<GenericTypesWithCompoundTypes.SomeEnum>
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
@@ -23,7 +23,7 @@ class EnumSets {
 
 
     companion object {
-        val ENUM_SET_CONST: MutableSet<GenericTypesWithCompoundTypes.SomeEnum> = EnumSet.of(GenericTypesWithCompoundTypes.SomeEnum.FOO, GenericTypesWithCompoundTypes.SomeEnum.BAR)
+        @JvmField final val ENUM_SET_CONST: MutableSet<GenericTypesWithCompoundTypes.SomeEnum> = EnumSet.of(GenericTypesWithCompoundTypes.SomeEnum.FOO, GenericTypesWithCompoundTypes.SomeEnum.BAR)
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
@@ -12,9 +12,9 @@ import com.example.NativeBase
 class GenericTypesWithBasicTypes : NativeBase {
 
     class StructWithGenerics {
-        var numbersList: MutableList<Short>
-        var numbersMap: MutableMap<Short, String>
-        var numbersSet: MutableSet<Short>
+        @JvmField var numbersList: MutableList<Short>
+        @JvmField var numbersMap: MutableMap<Short, String>
+        @JvmField var numbersSet: MutableSet<Short>
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
@@ -20,7 +20,7 @@ class GenericTypesWithCompoundTypes : NativeBase {
         OFF(1);
     }
     class BasicStruct {
-        var value: Double
+        @JvmField var value: Double
 
 
 
@@ -35,7 +35,7 @@ class GenericTypesWithCompoundTypes : NativeBase {
     }
 
     class ExternalStruct {
-        var string: String
+        @JvmField var string: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
@@ -10,8 +10,8 @@ package com.example.smoke
 import com.example.AbstractNativeList
 
 class UseOptimizedListStruct {
-    val structs: MutableList<VeryBigStruct>
-    val classes: MutableList<UnreasonablyLazyClass>
+    @JvmField val structs: MutableList<VeryBigStruct>
+    @JvmField val classes: MutableList<UnreasonablyLazyClass>
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListener.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListener.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 
 interface CalculatorListener {
     class ResultStruct {
-        var result: Double
+        @JvmField var result: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStatic.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStatic.kt
@@ -22,11 +22,13 @@ interface InterfaceWithStatic {
             return InterfaceWithStaticImpl.staticFunction()
         }
 
-        @JvmStatic var staticProperty: String
-            get() = InterfaceWithStaticImpl.staticProperty
-            set(value) {
-                InterfaceWithStaticImpl.staticProperty = value
-            }
+        @JvmStatic fun getStaticProperty(): String {
+            return InterfaceWithStaticImpl.staticProperty
+        }
+
+        @JvmStatic fun setStaticProperty(value: String) {
+            InterfaceWithStaticImpl.staticProperty = value
+        }
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
@@ -14,7 +14,7 @@ interface ListenerWithProperties {
         RESULT(1);
     }
     class ResultStruct {
-        var result: Double
+        @JvmField var result: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
@@ -14,7 +14,7 @@ interface ListenersWithReturnValues {
         RESULT(1);
     }
     class ResultStruct {
-        var result: Double
+        @JvmField var result: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -16,10 +16,10 @@ class Thermometer : NativeBase {
         ERROR_NONE(0),
         ERROR_FATAL(1);
     }
-    class NotificationException(val error: String) : Exception(error.toString())
+    class NotificationException(@JvmField val error: String) : Exception(error.toString())
 
 
-    class AnotherNotificationException(val error: Thermometer.SomeThermometerErrorCode) : Exception(error.toString())
+    class AnotherNotificationException(@JvmField val error: Thermometer.SomeThermometerErrorCode) : Exception(error.toString())
 
 
 

--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/LocaleDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/LocaleDefaults.kt
@@ -10,12 +10,12 @@ package com.example.smoke
 import java.util.Locale
 
 class LocaleDefaults {
-    var english: Locale
-    var latAmSpanish: Locale
-    var romanshSursilvan: Locale
-    var serbianCyrillic: Locale
-    var traditionalChineseTaiwan: Locale
-    var zuerichGerman: Locale
+    @JvmField var english: Locale
+    @JvmField var latAmSpanish: Locale
+    @JvmField var romanshSursilvan: Locale
+    @JvmField var serbianCyrillic: Locale
+    @JvmField var traditionalChineseTaiwan: Locale
+    @JvmField var zuerichGerman: Locale
 
 
 

--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
@@ -13,7 +13,7 @@ import java.util.Locale
 class Locales : NativeBase {
 
     class LocaleStruct {
-        var localeField: Locale
+        @JvmField var localeField: Locale
 
 
 

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -19,8 +19,8 @@ class NAME_RULES_KT : NativeBase {
 
 
     class EXAMPLE_STRUCT_KT {
-        var value: Double
-        var int_value: MutableList<Long>
+        @JvmField var value: Double
+        @JvmField var int_value: MutableList<Long>
 
 
 

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -15,7 +15,7 @@ class NAME_RULES_KT : NativeBase {
         NONE(0),
         FATAL(1);
     }
-    class ExampleException(val error: NAME_RULES_KT.EXAMPLE_ERROR_CODE_KT) : Exception(error.toString())
+    class ExampleException(@JvmField val error: NAME_RULES_KT.EXAMPLE_ERROR_CODE_KT) : Exception(error.toString())
 
 
     class EXAMPLE_STRUCT_KT {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeException.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeException.kt
@@ -8,6 +8,6 @@
 package com.example.smoke
 
 
-class FreeException(val error: FreeEnum) : Exception(error.toString())
+class FreeException(@JvmField val error: FreeEnum) : Exception(error.toString())
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
@@ -25,7 +25,7 @@ class FreePoint {
 
 
     companion object {
-        val A_BAR: FreeEnum = FreeEnum.BAR
+        @JvmField final val A_BAR: FreeEnum = FreeEnum.BAR
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
@@ -9,8 +9,8 @@ package com.example.smoke
 
 
 class FreePoint {
-    var x: Double
-    var y: Double
+    @JvmField var x: Double
+    @JvmField var y: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
@@ -32,7 +32,7 @@ class LevelOne : NativeBase {
 
 
                 companion object {
-                    val FOO: Boolean = false
+                    @JvmField final val FOO: Boolean = false
                     @JvmStatic external fun fooFactory() : LevelOne.LevelTwo.LevelThree.LevelFour
                 }
             }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
@@ -19,7 +19,7 @@ class LevelOne : NativeBase {
                 NONE(0);
             }
             class LevelFour {
-                var stringField: String
+                @JvmField var stringField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 class NestedReferences : NativeBase {
 
     class NestedReferences {
-        var stringField: String
+        @JvmField var stringField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -18,7 +18,7 @@ class OuterStruct {
         FOO(0),
         BAR(1);
     }
-    class InstantiationException(val error: OuterStruct.InnerEnum) : Exception(error.toString())
+    class InstantiationException(@JvmField val error: OuterStruct.InnerEnum) : Exception(error.toString())
 
 
     class InnerStruct {
@@ -62,7 +62,6 @@ class OuterStruct {
         }
     }
     class Builder : NativeBase {
-
 
 
         constructor() : this(create(), null as Any?) {
@@ -148,7 +147,6 @@ class OuterStruct {
 
 
     @Throws (OuterStruct.InstantiationException::class) external fun doNothing() : Unit
-
 
 
 }

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -12,7 +12,7 @@ import java.util.Date
 import java.util.Locale
 
 class OuterStruct {
-    var field: String
+    @JvmField var field: String
 
     enum class InnerEnum(private val value: Int) {
         FOO(0),
@@ -22,7 +22,7 @@ class OuterStruct {
 
 
     class InnerStruct {
-        var otherField: MutableList<Date>
+        @JvmField var otherField: MutableList<Date>
 
 
 
@@ -148,6 +148,7 @@ class OuterStruct {
 
 
     @Throws (OuterStruct.InstantiationException::class) external fun doNothing() : Unit
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
@@ -16,7 +16,7 @@ class Nullable : NativeBase {
         OFF(1);
     }
     class SomeStruct {
-        var stringField: String
+        @JvmField var stringField: String
 
 
 
@@ -31,15 +31,15 @@ class Nullable : NativeBase {
     }
 
     class NullableStruct {
-        var stringField: String?
-        var boolField: Boolean?
-        var doubleField: Double?
-        var structField: Nullable.SomeStruct?
-        var enumField: Nullable.SomeEnum?
-        var arrayField: MutableList<String>?
-        var inlineArrayField: MutableList<String>?
-        var mapField: MutableMap<Long, String>?
-        var instanceField: SomeInterface?
+        @JvmField var stringField: String?
+        @JvmField var boolField: Boolean?
+        @JvmField var doubleField: Double?
+        @JvmField var structField: Nullable.SomeStruct?
+        @JvmField var enumField: Nullable.SomeEnum?
+        @JvmField var arrayField: MutableList<String>?
+        @JvmField var inlineArrayField: MutableList<String>?
+        @JvmField var mapField: MutableMap<Long, String>?
+        @JvmField var instanceField: SomeInterface?
 
 
 
@@ -62,14 +62,14 @@ class Nullable : NativeBase {
     }
 
     class NullableIntsStruct {
-        var int8Field: Byte?
-        var int16Field: Short?
-        var int32Field: Int?
-        var int64Field: Long?
-        var uint8Field: Short?
-        var uint16Field: Int?
-        var uint32Field: Long?
-        var uint64Field: Long?
+        @JvmField var int8Field: Byte?
+        @JvmField var int16Field: Short?
+        @JvmField var int32Field: Int?
+        @JvmField var int64Field: Long?
+        @JvmField var uint8Field: Short?
+        @JvmField var uint16Field: Int?
+        @JvmField var uint32Field: Long?
+        @JvmField var uint64Field: Long?
 
 
 

--- a/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/NullableCollectionsStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/NullableCollectionsStruct.kt
@@ -10,8 +10,8 @@ package com.example.smoke
 import java.util.Date
 
 class NullableCollectionsStruct {
-    var dates: MutableList<Date?>
-    var structs: MutableMap<Int, Nullable.SomeStruct?>
+    @JvmField var dates: MutableList<Date?>
+    @JvmField var structs: MutableMap<Int, Nullable.SomeStruct?>
 
 
 

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 class NestedPackages : NativeBase {
 
     class SomeStruct {
-        var someField: String
+        @JvmField var someField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
@@ -15,7 +15,7 @@ class dodoTypes {
         DODO_ITEM(0);
     }
     class dodoStruct {
-        var DODO_FIELD: String
+        @JvmField var DODO_FIELD: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
@@ -16,7 +16,7 @@ class Properties : NativeBase {
         ERROR_FATAL(999);
     }
     class ExampleStruct {
-        var value: Double
+        @JvmField var value: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterface.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 
 interface PropertiesInterface {
     class ExampleStruct {
-        var value: Double
+        @JvmField var value: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
+++ b/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
@@ -18,22 +18,22 @@ class Serialization {
         BAR(7);
     }
     class SerializableStruct : Parcelable {
-        var boolField: Boolean
-        var byteField: Byte
-        var shortField: Short
-        var intField: Int
-        var longField: Long
-        var floatField: Float
-        var doubleField: Double
-        var stringField: String
-        var structField: Serialization.NestedSerializableStruct
-        var byteBufferField: ByteArray
-        var arrayField: MutableList<String>
-        var structArrayField: MutableList<Serialization.NestedSerializableStruct>
-        var mapField: MutableMap<Int, String>
-        var setField: MutableSet<String>
-        var enumSetField: MutableSet<Serialization.SomeEnum>
-        var enumField: Serialization.SomeEnum
+        @JvmField var boolField: Boolean
+        @JvmField var byteField: Byte
+        @JvmField var shortField: Short
+        @JvmField var intField: Int
+        @JvmField var longField: Long
+        @JvmField var floatField: Float
+        @JvmField var doubleField: Double
+        @JvmField var stringField: String
+        @JvmField var structField: Serialization.NestedSerializableStruct
+        @JvmField var byteBufferField: ByteArray
+        @JvmField var arrayField: MutableList<String>
+        @JvmField var structArrayField: MutableList<Serialization.NestedSerializableStruct>
+        @JvmField var mapField: MutableMap<Int, String>
+        @JvmField var setField: MutableSet<String>
+        @JvmField var enumSetField: MutableSet<Serialization.SomeEnum>
+        @JvmField var enumField: Serialization.SomeEnum
 
 
 
@@ -119,7 +119,7 @@ class Serialization {
     }
 
     class NestedSerializableStruct : Parcelable {
-        var someField: String
+        @JvmField var someField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 class ClassWithStructWithSkipLambdaInPlatform : NativeBase {
 
     class SkipLambdaInPlatform {
-        var intField: Int
+        @JvmField var intField: Int
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipField.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipField.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 
 class SkipField {
-    var field: String
+    @JvmField var field: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 class SkipTypes : NativeBase {
 
     class NotInJava {
-        var fooField: String
+        @JvmField var fooField: String
 
 
 
@@ -27,7 +27,7 @@ class SkipTypes : NativeBase {
     }
 
     class NotInSwift {
-        var fooField: String
+        @JvmField var fooField: String
 
 
 
@@ -42,7 +42,7 @@ class SkipTypes : NativeBase {
     }
 
     class NotInDart {
-        var fooField: String
+        @JvmField var fooField: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
@@ -16,8 +16,8 @@ class Structs : NativeBase {
         BAR(1);
     }
     class Point {
-        var x: Double
-        var y: Double
+        @JvmField var x: Double
+        @JvmField var y: Double
 
 
 
@@ -38,8 +38,8 @@ class Structs : NativeBase {
     }
 
     class Line {
-        var a: Structs.Point
-        var b: Structs.Point
+        @JvmField var a: Structs.Point
+        @JvmField var b: Structs.Point
 
 
 
@@ -55,20 +55,20 @@ class Structs : NativeBase {
     }
 
     class AllTypesStruct {
-        val int8Field: Byte
-        val uint8Field: Short
-        val int16Field: Short
-        val uint16Field: Int
-        val int32Field: Int
-        val uint32Field: Long
-        val int64Field: Long
-        val uint64Field: Long
-        val floatField: Float
-        val doubleField: Double
-        val stringField: String
-        val booleanField: Boolean
-        val bytesField: ByteArray
-        val pointField: Structs.Point
+        @JvmField val int8Field: Byte
+        @JvmField val uint8Field: Short
+        @JvmField val int16Field: Short
+        @JvmField val uint16Field: Int
+        @JvmField val int32Field: Int
+        @JvmField val uint32Field: Long
+        @JvmField val int64Field: Long
+        @JvmField val uint64Field: Long
+        @JvmField val floatField: Float
+        @JvmField val doubleField: Double
+        @JvmField val stringField: String
+        @JvmField val booleanField: Boolean
+        @JvmField val bytesField: ByteArray
+        @JvmField val pointField: Structs.Point
 
 
 
@@ -96,7 +96,7 @@ class Structs : NativeBase {
     }
 
     class NestingImmutableStruct {
-        var structField: Structs.AllTypesStruct
+        @JvmField var structField: Structs.AllTypesStruct
 
 
 
@@ -111,7 +111,7 @@ class Structs : NativeBase {
     }
 
     class DoubleNestingImmutableStruct {
-        var nestingStructField: Structs.NestingImmutableStruct
+        @JvmField var nestingStructField: Structs.NestingImmutableStruct
 
 
 
@@ -126,7 +126,7 @@ class Structs : NativeBase {
     }
 
     class StructWithArrayOfImmutable {
-        var arrayField: MutableList<Structs.AllTypesStruct>
+        @JvmField var arrayField: MutableList<Structs.AllTypesStruct>
 
 
 
@@ -141,11 +141,11 @@ class Structs : NativeBase {
     }
 
     class ImmutableStructWithCppAccessors {
-        val trivialIntField: Int
-        val trivialDoubleField: Double
-        val nontrivialStringField: String
-        val nontrivialPointField: Structs.Point
-        val nontrivialOptionalPoint: Structs.Point?
+        @JvmField val trivialIntField: Int
+        @JvmField val trivialDoubleField: Double
+        @JvmField val nontrivialStringField: String
+        @JvmField val nontrivialPointField: Structs.Point
+        @JvmField val nontrivialOptionalPoint: Structs.Point?
 
 
 
@@ -171,11 +171,11 @@ class Structs : NativeBase {
     }
 
     class MutableStructWithCppAccessors {
-        var trivialIntField: Int
-        var trivialDoubleField: Double
-        var nontrivialStringField: String
-        var nontrivialPointField: Structs.Point
-        var nontrivialOptionalPoint: Structs.Point?
+        @JvmField var trivialIntField: Int
+        @JvmField var trivialDoubleField: Double
+        @JvmField var nontrivialStringField: String
+        @JvmField var nontrivialPointField: Structs.Point
+        @JvmField var nontrivialOptionalPoint: Structs.Point?
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstants.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstants.kt
@@ -26,8 +26,8 @@ class StructsWithConstants {
 
 
         companion object {
-            val DEFAULT_DESCRIPTION: String = "Nonsense"
-            val DEFAULT_TYPE: RouteUtils.RouteType = RouteUtils.RouteType.EQUESTRIAN
+            @JvmField final val DEFAULT_DESCRIPTION: String = "Nonsense"
+            @JvmField final val DEFAULT_TYPE: RouteUtils.RouteType = RouteUtils.RouteType.EQUESTRIAN
         }
     }
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstants.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstants.kt
@@ -11,8 +11,8 @@ package com.example.smoke
 class StructsWithConstants {
 
     class Route {
-        var description: String
-        var type: RouteUtils.RouteType
+        @JvmField var description: String
+        @JvmField var type: RouteUtils.RouteType
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
@@ -27,8 +27,8 @@ class StructsWithConstantsInterface : NativeBase {
 
 
         companion object {
-            val DEFAULT_DESCRIPTION: String = "Foo"
-            val DEFAULT_TYPE: RouteUtils.RouteType = RouteUtils.RouteType.NONE
+            @JvmField final val DEFAULT_DESCRIPTION: String = "Foo"
+            @JvmField final val DEFAULT_TYPE: RouteUtils.RouteType = RouteUtils.RouteType.NONE
         }
     }
 
@@ -42,7 +42,7 @@ class StructsWithConstantsInterface : NativeBase {
 
 
         companion object {
-            val DEFAULT_DESCRIPTION: String = "Foo"
+            @JvmField final val DEFAULT_DESCRIPTION: String = "Foo"
         }
     }
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
@@ -12,8 +12,8 @@ import com.example.NativeBase
 class StructsWithConstantsInterface : NativeBase {
 
     class MultiRoute {
-        var descriptions: MutableList<String>
-        var type: RouteUtils.RouteType
+        @JvmField var descriptions: MutableList<String>
+        @JvmField var type: RouteUtils.RouteType
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
@@ -11,8 +11,8 @@ package com.example.smoke
 class StructsWithMethods {
 
     class Vector {
-        var x: Double
-        var y: Double
+        @JvmField var x: Double
+        @JvmField var y: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -12,9 +12,9 @@ import com.example.NativeBase
 class StructsWithMethodsInterface : NativeBase {
 
     class Vector3 {
-        var x: Double
-        var y: Double
-        var z: Double
+        @JvmField var x: Double
+        @JvmField var y: Double
+        @JvmField var z: Double
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/TypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/TypeCollection.kt
@@ -11,8 +11,8 @@ package com.example.smoke
 class TypeCollection {
 
     class Point {
-        var x: Double
-        var y: Double
+        @JvmField var x: Double
+        @JvmField var y: Double
 
 
 
@@ -28,8 +28,8 @@ class TypeCollection {
     }
 
     class Line {
-        var a: TypeCollection.Point
-        var b: TypeCollection.Point
+        @JvmField var a: TypeCollection.Point
+        @JvmField var b: TypeCollection.Point
 
 
 
@@ -45,20 +45,20 @@ class TypeCollection {
     }
 
     class AllTypesStruct {
-        var int8Field: Byte
-        var uint8Field: Short
-        var int16Field: Short
-        var uint16Field: Int
-        var int32Field: Int
-        var uint32Field: Long
-        var int64Field: Long
-        var uint64Field: Long
-        var floatField: Float
-        var doubleField: Double
-        var stringField: String
-        var booleanField: Boolean
-        var bytesField: ByteArray
-        var pointField: TypeCollection.Point
+        @JvmField var int8Field: Byte
+        @JvmField var uint8Field: Short
+        @JvmField var int16Field: Short
+        @JvmField var uint16Field: Int
+        @JvmField var int32Field: Int
+        @JvmField var uint32Field: Long
+        @JvmField var int64Field: Long
+        @JvmField var uint64Field: Long
+        @JvmField var floatField: Float
+        @JvmField var doubleField: Double
+        @JvmField var stringField: String
+        @JvmField var booleanField: Boolean
+        @JvmField var bytesField: ByteArray
+        @JvmField var pointField: TypeCollection.Point
 
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
@@ -11,8 +11,8 @@ package com.example.smoke
 class TypeCollection {
 
     class Point {
-        var x: Double
-        var y: Double
+        @JvmField var x: Double
+        @JvmField var y: Double
 
 
 
@@ -28,7 +28,7 @@ class TypeCollection {
     }
 
     class StructHavingAliasFieldDefinedBelow {
-        var field: Long
+        @JvmField var field: Long
 
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
@@ -50,7 +50,7 @@ class TypeCollection {
 
 
     companion object {
-        val INVALID_STORAGE_ID: Long = 0L
+        @JvmField final val INVALID_STORAGE_ID: Long = 0L
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 class TypeDefs : NativeBase {
 
     class StructHavingAliasFieldDefinedBelow {
-        var field: Double
+        @JvmField var field: Double
 
 
 
@@ -27,7 +27,7 @@ class TypeDefs : NativeBase {
     }
 
     class TestStruct {
-        var something: String
+        @JvmField var something: String
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
@@ -16,7 +16,7 @@ class PublicClass : NativeBase {
         BAR(1);
     }
     internal class InternalStruct {
-        var stringField: String
+        @JvmField var stringField: String
 
 
 
@@ -31,7 +31,7 @@ class PublicClass : NativeBase {
     }
 
     class PublicStruct {
-        internal var internalField: PublicClass.InternalStruct
+        @JvmField internal var internalField: PublicClass.InternalStruct
 
 
 
@@ -46,8 +46,8 @@ class PublicClass : NativeBase {
     }
 
     class PublicStructWithInternalDefaults {
-        internal var internalField: String
-        var publicField: Float
+        @JvmField internal var internalField: String
+        @JvmField var publicField: Float
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicInterface.kt
@@ -10,7 +10,7 @@ package com.example.smoke
 
 interface PublicInterface {
     class InternalStruct {
-        internal var fieldOfInternalType: PublicClass.InternalStruct
+        @JvmField internal var fieldOfInternalType: PublicClass.InternalStruct
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithInternalConstructors.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithInternalConstructors.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 
 class PublicStructWithInternalConstructors {
-    var someVar: Int
+    @JvmField var someVar: Int
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithNonDefaultInternalField.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithNonDefaultInternalField.kt
@@ -9,9 +9,9 @@ package com.example.smoke
 
 
 class PublicStructWithNonDefaultInternalField {
-    var defaultedField: Int
-    internal var internalField: String
-    var publicField: Boolean
+    @JvmField var defaultedField: Int
+    @JvmField internal var internalField: String
+    @JvmField var publicField: Boolean
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicTypeCollection.kt
@@ -11,7 +11,7 @@ package com.example.smoke
 class PublicTypeCollection {
 
     internal class InternalStruct {
-        internal var stringField: String
+        @JvmField internal var stringField: String
 
 
 


### PR DESCRIPTION
This annotation is needed to access the constants from companion
objects and fields of structs in natural way when utilizing the generated Kotlin
code from Java. Without the annotation the get/set methods would need to
be used on companion and fields.

Note: this PR adjusts generation of static properties for interfaces.  Sadly, `JvmField`
used in companion object of interface requires all properties to be `public final val`.
This restriction applies only to interface -- it does not apply to classes.
Therefore, the implementation of static properties has been changed -- instead of
declaring val property it is replaced with getter/setter functions.