### PR TITLE
smoke tests: add 'dates' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/DateDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/DateDefaults.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+@file:JvmName("DateDefaults")
+
+package com.example.smoke
+
+import java.util.Date
+
+class DateDefaults {
+    @JvmField var dateTime: Date
+    @JvmField var dateTimeUtc: Date
+    @JvmField var beforeEpoch: Date
+    @JvmField var exactlyEpoch: Date
+
+
+
+    constructor() {
+        this.dateTime = Date(1643966117000L)
+        this.dateTimeUtc = Date(1643966117000L)
+        this.beforeEpoch = Date(-1511793883000L)
+        this.exactlyEpoch = Date(0L)
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/DateDefaultsAliased.kt
+++ b/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/DateDefaultsAliased.kt
@@ -1,0 +1,32 @@
+/*
+
+ *
+ */
+
+@file:JvmName("DateDefaultsAliased")
+
+package com.example.smoke
+
+import java.util.Date
+
+class DateDefaultsAliased {
+    @JvmField var dateTime: Date
+    @JvmField var dateTimeUtc: Date
+    @JvmField var beforeEpoch: Date
+    @JvmField var exactlyEpoch: Date
+
+
+
+    constructor() {
+        this.dateTime = Date(1643966117000L)
+        this.dateTimeUtc = Date(1643966117000L)
+        this.beforeEpoch = Date(-1511793883000L)
+        this.exactlyEpoch = Date(0L)
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/Dates.kt
+++ b/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/com/example/smoke/Dates.kt
@@ -1,0 +1,62 @@
+/*
+
+ *
+ */
+
+@file:JvmName("Dates")
+
+package com.example.smoke
+
+import com.example.NativeBase
+import java.util.Date
+
+class Dates : NativeBase {
+
+    class DateStruct {
+        @JvmField var dateField: Date
+        @JvmField var nullableDateField: Date?
+
+
+
+        constructor(dateField: Date) {
+            this.dateField = dateField
+            this.nullableDateField = null
+        }
+
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun dateMethod(input: Date) : Date
+    external fun nullableDateMethod(input: Date?) : Date?
+
+    var dateProperty: Date
+        external get
+        external set
+
+    var dateSet: MutableSet<Date>
+        external get
+        external set
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/jni/com_example_smoke_Dates.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/jni/com_example_smoke_Dates.cpp
@@ -1,0 +1,171 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_Dates.h"
+#include "com_example_smoke_Dates__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jobject
+Java_com_example_smoke_Dates_dateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::std::chrono::system_clock::time_point input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::std::chrono::system_clock::time_point>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->date_method(input);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+jobject
+Java_com_example_smoke_Dates_nullableDateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    std::optional< ::std::chrono::system_clock::time_point > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<std::optional< ::std::chrono::system_clock::time_point >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->nullable_date_method(input);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+jobject
+Java_com_example_smoke_Dates_getDateProperty(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_date_property();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+void
+Java_com_example_smoke_Dates_setDateProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+
+{
+
+
+
+    ::std::chrono::system_clock::time_point value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            ::gluecodium::jni::TypeId<::std::chrono::system_clock::time_point>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->set_date_property(value);
+
+}
+
+
+
+jobject
+Java_com_example_smoke_Dates_getDateSet(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_date_set();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+void
+Java_com_example_smoke_Dates_setDateSet(JNIEnv* _jenv, jobject _jinstance, jobject jvalue)
+
+{
+
+
+
+    ::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > > value = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jvalue),
+            ::gluecodium::jni::TypeId<::std::unordered_set< ::std::chrono::system_clock::time_point, ::gluecodium::hash< ::std::chrono::system_clock::time_point > >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::Dates>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->set_date_set(value);
+
+}
+
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_Dates_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::Dates>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/jni/com_example_smoke_DatesSteady.cpp
+++ b/gluecodium/src/test/resources/smoke/dates/output/android-kotlin/jni/com_example_smoke_DatesSteady.cpp
@@ -1,0 +1,102 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_DatesSteady.h"
+#include "com_example_smoke_DatesSteady__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jobject
+Java_com_example_smoke_DatesSteady_dateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::smoke::DatesSteady::MonotonicDate input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::smoke::DatesSteady::MonotonicDate>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->date_method(input);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+jobject
+Java_com_example_smoke_DatesSteady_nullableDateMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    std::optional< ::smoke::DatesSteady::MonotonicDate > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<std::optional< ::smoke::DatesSteady::MonotonicDate >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->nullable_date_method(input);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+jobject
+Java_com_example_smoke_DatesSteady_dateListMethod(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::smoke::DatesSteady::DateList input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::smoke::DatesSteady::DateList>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->date_list_method(input);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_DatesSteady_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::DatesSteady>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.