### PR TITLE
smoke tests: add 'method overloads' test suite for Kotlin

### DIFF
--- a/functional-tests/functional/input/lime/MethodOverloads.lime
+++ b/functional-tests/functional/input/lime/MethodOverloads.lime
@@ -118,7 +118,7 @@ struct StructConstructorOverloads {
     constructor create(input1: String, input2: String)
 }
 
-@Java(Skip) @Dart(Skip)
+@Java(Skip) @Dart(Skip) @Kotlin(Skip)
 class SwiftMethodOverloads {
     @Swift("three")
     fun one(input: String)
@@ -126,7 +126,7 @@ class SwiftMethodOverloads {
     fun two(input: List<String>)
 }
 
-@Swift(Skip) @Dart(Skip)
+@Swift(Skip) @Dart(Skip) @Kotlin(Skip)
 class JavaMethodOverloads {
     @Java("three")
     fun one(input: String)
@@ -134,7 +134,15 @@ class JavaMethodOverloads {
     fun two(input: List<String>)
 }
 
-@Java(Skip) @Swift(Skip)
+@Swift(Skip) @Dart(Skip) @Java(Skip)
+class KotlinMethodOverloads {
+    @Kotlin("three")
+    fun one(input: String)
+    @Kotlin("three")
+    fun two(input: List<String>)
+}
+
+@Java(Skip) @Swift(Skip) @Kotlin(Skip)
 interface SpecialNamesInterface {
     lambda Callback = () -> Void
     @Cpp(Const)

--- a/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
+++ b/gluecodium/src/test/resources/smoke/method_overloads/input/MethodOverloads.lime
@@ -42,9 +42,11 @@ class MethodOverloads {
     ): Boolean
     @Dart("isBooleanStringArray")
     @Java(Name = "isBooleanStringArrayOverload")
+    @Kotlin(Name = "isBooleanStringArrayOverload")
     fun isBoolean(input: StringArray): Boolean
     @Dart("isBooleanIntArray")
     @Java(Name = "isBooleanIntArrayOverload")
+    @Kotlin(Name = "isBooleanIntArrayOverload")
     fun isBoolean(input: IntArray): Boolean
     @Dart("isBooleanConst")
     @Cpp(Const)
@@ -64,7 +66,7 @@ class SpecialNames {
     constructor make(result: String)
 }
 
-@Java(Skip) @Dart(Skip)
+@Java(Skip) @Dart(Skip) @Kotlin(Skip)
 class SwiftMethodOverloads {
     @Swift("three")
     fun one(input: String)
@@ -72,7 +74,7 @@ class SwiftMethodOverloads {
     fun two(input: List<String>)
 }
 
-@Swift(Skip) @Dart(Skip)
+@Swift(Skip) @Dart(Skip) @Kotlin(Skip)
 class JavaMethodOverloads {
     @Java("three")
     fun one(input: String)
@@ -80,7 +82,15 @@ class JavaMethodOverloads {
     fun two(input: List<String>)
 }
 
-@Java(Skip) @Swift(Skip)
+@Swift(Skip) @Dart(Skip) @Java(Skip)
+class KotlinMethodOverloads {
+    @Kotlin("three")
+    fun one(input: String)
+    @Kotlin("three")
+    fun two(input: List<String>)
+}
+
+@Java(Skip) @Swift(Skip) @Kotlin(Skip)
 interface SpecialNamesInterface {
     lambda Callback = () -> Void
     @Cpp(Const)
@@ -93,16 +103,17 @@ class SkippedOverloads {
 
     @Swift(Skip)
     @Java(Skip)
+    @Kotlin(Skip)
     constructor make_for_dart(input: String)
 }
 
-@Java(Skip)
+@Java(Skip) @Kotlin(Skip)
 class NullableOverloads {
     fun foo(input: String)
     fun foo(input: String?)
 }
 
-@Java(Skip) @Dart(Skip)
+@Java(Skip) @Dart(Skip) @Kotlin(Skip)
 class SwiftConstructorOverloads {
     constructor make(input: String)
     constructor make_do(throughput: String)

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/KotlinMethodOverloads.kt
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/KotlinMethodOverloads.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class KotlinMethodOverloads : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun three(input: String) : Unit
+    external fun three(input: MutableList<String>) : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/MethodOverloads.kt
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/MethodOverloads.kt
@@ -1,0 +1,59 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class MethodOverloads : NativeBase {
+
+    class Point {
+        var x: Double
+        var y: Double
+
+
+
+        constructor(x: Double, y: Double) {
+            this.x = x
+            this.y = y
+        }
+
+
+
+
+
+    }
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun isBoolean(input: Boolean) : Boolean
+    external fun isBoolean(input: Byte) : Boolean
+    external fun isBoolean(input: String) : Boolean
+    external fun isBoolean(input: MethodOverloads.Point) : Boolean
+    external fun isBoolean(input1: Boolean, input2: Byte, input3: String, input4: MethodOverloads.Point) : Boolean
+    external fun isBooleanStringArrayOverload(input: MutableList<String>) : Boolean
+    external fun isBooleanIntArrayOverload(input: MutableList<Byte>) : Boolean
+    external fun isBoolean() : Boolean
+    external fun isFloat(input: String) : Boolean
+    external fun isFloat(input: MutableList<Byte>) : Boolean
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/OverloadsWithComments.kt
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/OverloadsWithComments.kt
@@ -1,0 +1,34 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class OverloadsWithComments : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun doStuff() : Unit
+    external fun doStuff(stuff: String) : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/SpecialNames.kt
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/com/example/smoke/SpecialNames.kt
@@ -1,0 +1,41 @@
+/*
+
+ *
+ */
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class SpecialNames : NativeBase {
+
+
+    constructor(result: String) : this(make(result), null as Any?) {
+        cacheThisInstance();
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    private external fun cacheThisInstance()
+
+
+    external fun create() : Unit
+    external fun release() : Unit
+    external fun createProxy() : Unit
+    external fun Uppercase() : Unit
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun make(result: String) : Long
+    }
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_KotlinMethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_KotlinMethodOverloads.cpp
@@ -1,0 +1,75 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_KotlinMethodOverloads.h"
+#include "com_example_smoke_KotlinMethodOverloads__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+void
+Java_com_example_smoke_KotlinMethodOverloads_three__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
+
+{
+
+
+
+    ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::KotlinMethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->one(input);
+
+}
+
+void
+Java_com_example_smoke_KotlinMethodOverloads_three__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::std::vector< ::std::string > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::std::vector< ::std::string >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::KotlinMethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->two(input);
+
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_KotlinMethodOverloads_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::KotlinMethodOverloads>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_KotlinMethodOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_KotlinMethodOverloads.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_KotlinMethodOverloads_three__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_KotlinMethodOverloads_three__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput);
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_MethodOverloads.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_MethodOverloads.cpp
@@ -1,0 +1,282 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_MethodOverloads.h"
+#include "com_example_smoke_MethodOverloads_Point__Conversion.h"
+#include "com_example_smoke_MethodOverloads__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBoolean__Z(JNIEnv* _jenv, jobject _jinstance, jboolean jinput)
+
+{
+
+
+
+    bool input = jinput;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBoolean__B(JNIEnv* _jenv, jobject _jinstance, jbyte jinput)
+
+{
+
+
+
+    int8_t input = jinput;
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBoolean__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
+
+{
+
+
+
+    ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBoolean__Lcom_example_smoke_MethodOverloads_00024Point_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::smoke::MethodOverloads::Point input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::Point>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBoolean__ZBLjava_lang_String_2Lcom_example_smoke_MethodOverloads_00024Point_2(JNIEnv* _jenv, jobject _jinstance, jboolean jinput1, jbyte jinput2, jstring jinput3, jobject jinput4)
+
+{
+
+
+
+    bool input1 = jinput1;
+
+
+
+    int8_t input2 = jinput2;
+
+
+
+    ::std::string input3 = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput3),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    ::smoke::MethodOverloads::Point input4 = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput4),
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::Point>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input1,input2,input3,input4);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBooleanStringArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::smoke::MethodOverloads::StringArray input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::StringArray>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBooleanIntArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::smoke::MethodOverloads::IntArray input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::IntArray>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean(input);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isBoolean__(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_boolean();
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isFloat__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput)
+
+{
+
+
+
+    ::std::string input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_float(input);
+
+    return _result;
+}
+
+jboolean
+Java_com_example_smoke_MethodOverloads_isFloat__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::smoke::MethodOverloads::IntArray input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::smoke::MethodOverloads::IntArray>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->is_float(input);
+
+    return _result;
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_MethodOverloads_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::MethodOverloads>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_MethodOverloads.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_MethodOverloads.h
@@ -1,0 +1,32 @@
+/*
+ *
+
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBoolean__Z(JNIEnv* _jenv, jobject _jinstance, jboolean jinput);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBoolean__B(JNIEnv* _jenv, jobject _jinstance, jbyte jinput);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBoolean__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBoolean__Lcom_example_smoke_MethodOverloads_00024Point_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBoolean__ZBLjava_lang_String_2Lcom_example_smoke_MethodOverloads_00024Point_2(JNIEnv* _jenv, jobject _jinstance, jboolean jinput1, jbyte jinput2, jstring jinput3, jobject jinput4);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBooleanStringArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBooleanIntArrayOverload(JNIEnv* _jenv, jobject _jinstance, jobject jinput);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isBoolean__(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isFloat__Ljava_lang_String_2(JNIEnv* _jenv, jobject _jinstance, jstring jinput);
+JNIEXPORT jboolean JNICALL
+Java_com_example_smoke_MethodOverloads_isFloat__Ljava_util_List_2(JNIEnv* _jenv, jobject _jinstance, jobject jinput);
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_SpecialNames.cpp
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_SpecialNames.cpp
@@ -1,0 +1,135 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_SpecialNames.h"
+#include "com_example_smoke_SpecialNames__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+void
+Java_com_example_smoke_SpecialNames_create(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->create();
+
+}
+
+void
+Java_com_example_smoke_SpecialNames_release(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->release();
+
+}
+
+void
+Java_com_example_smoke_SpecialNames_createProxy(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->create_proxy();
+
+}
+
+void
+Java_com_example_smoke_SpecialNames_Uppercase(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    (*pInstanceSharedPointer)->_uppercase();
+
+}
+
+jlong
+Java_com_example_smoke_SpecialNames_make(JNIEnv* _jenv, jobject _jinstance, jstring jresult)
+
+{
+
+
+
+    ::std::string result = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jresult),
+            ::gluecodium::jni::TypeId<::std::string>{});
+
+
+
+
+
+    auto _result = ::smoke::SpecialNames::make(result);
+
+    auto nSharedPtr = new (::std::nothrow) ::std::shared_ptr< ::smoke::SpecialNames >(_result);
+    if (nSharedPtr == nullptr)
+    {
+        ::gluecodium::jni::throw_new_out_of_memory_exception(_jenv);;
+        return 0;
+    }
+    return reinterpret_cast<jlong>(nSharedPtr);
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_cacheThisInstance(JNIEnv* _jenv, jobject _jinstance)
+{
+    auto jobj = ::gluecodium::jni::make_non_releasing_ref(_jinstance);
+    auto long_ptr = ::gluecodium::jni::get_class_native_handle(_jenv, jobj);
+    auto nobj = *reinterpret_cast<std::shared_ptr<::smoke::SpecialNames>*>(long_ptr);
+
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, nobj, jobj);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_SpecialNames.h
+++ b/gluecodium/src/test/resources/smoke/method_overloads/output/android-kotlin/jni/com_example_smoke_SpecialNames.h
@@ -1,0 +1,21 @@
+/*
+ *
+ */
+#pragma once
+#include <jni.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_create(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_release(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_createProxy(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SpecialNames_Uppercase(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jlong JNICALL
+Java_com_example_smoke_SpecialNames_make(JNIEnv* _jenv, jobject _jinstance, jstring jresult);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.

This change adjusts the LIME file used as input for the
functional tests to match the one used in smoke tests.
This is done to ensure that the generated code compiles
and runs without problems.