### PR TITLE
smoke tests: add 'instances' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleClass.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleClass.kt
@@ -1,0 +1,36 @@
+/*
+
+ *
+ */
+
+@file:JvmName("SimpleClass")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class SimpleClass : NativeBase {
+
+
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
+    external fun getStringValue() : String
+    external fun useSimpleClass(input: SimpleClass) : SimpleClass
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterface.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterface.kt
@@ -1,0 +1,18 @@
+/*
+
+ *
+ */
+
+@file:JvmName("SimpleInterface")
+
+package com.example.smoke
+
+
+interface SimpleInterface {
+
+    fun getStringValue() : String
+    fun useSimpleInterface(input: SimpleInterface) : SimpleInterface
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/SimpleInterfaceImpl.kt
@@ -1,0 +1,30 @@
+/*
+
+ *
+ */
+
+@file:JvmName("SimpleInterfaceImpl")
+
+package com.example.smoke
+
+import com.example.NativeBase
+
+class SimpleInterfaceImpl : NativeBase, SimpleInterface {
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    override external fun getStringValue() : String
+    override external fun useSimpleInterface(input: SimpleInterface) : SimpleInterface
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+    }
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/StructWithClass.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/StructWithClass.kt
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+@file:JvmName("StructWithClass")
+
+package com.example.smoke
+
+
+class StructWithClass {
+    @JvmField var classInstance: SimpleClass
+
+
+
+    constructor(classInstance: SimpleClass) {
+        this.classInstance = classInstance
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/StructWithInterface.kt
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/com/example/smoke/StructWithInterface.kt
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+@file:JvmName("StructWithInterface")
+
+package com.example.smoke
+
+
+class StructWithInterface {
+    @JvmField var interfaceInstance: SimpleInterface
+
+
+
+    constructor(interfaceInstance: SimpleInterface) {
+        this.interfaceInstance = interfaceInstance
+    }
+
+
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleClass.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleClass.cpp
@@ -1,0 +1,71 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_SimpleClass.h"
+#include "com_example_smoke_SimpleClass__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jstring
+Java_com_example_smoke_SimpleClass_getStringValue(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SimpleClass>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_string_value();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+jobject
+Java_com_example_smoke_SimpleClass_useSimpleClass(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::std::shared_ptr< ::smoke::SimpleClass > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::SimpleClass >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SimpleClass>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->use_simple_class(input);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SimpleClass_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SimpleClass>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleClass__Conversion.cpp
@@ -1,0 +1,71 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_SimpleClass__Conversion.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/SimpleClass", com_example_smoke_SimpleClass, ::smoke::SimpleClass)
+
+
+
+std::shared_ptr<::smoke::SimpleClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleClass>>)
+{
+    std::shared_ptr<::smoke::SimpleClass> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::SimpleClass>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleClass>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    auto &javaClass = CachedJavaClass<::smoke::SimpleClass>::java_class;
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::SimpleClass>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleClass__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleClass__Conversion.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/SimpleClass.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::SimpleClass> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleClass>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleClass>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleInterfaceImpl.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleInterfaceImpl.cpp
@@ -1,0 +1,71 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_SimpleInterfaceImpl.h"
+#include "com_example_smoke_SimpleInterface__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniReference.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+
+extern "C" {
+
+jstring
+Java_com_example_smoke_SimpleInterfaceImpl_getStringValue(JNIEnv* _jenv, jobject _jinstance)
+
+{
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SimpleInterface>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->get_string_value();
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+jobject
+Java_com_example_smoke_SimpleInterfaceImpl_useSimpleInterface(JNIEnv* _jenv, jobject _jinstance, jobject jinput)
+
+{
+
+
+
+    ::std::shared_ptr< ::smoke::SimpleInterface > input = ::gluecodium::jni::convert_from_jni(_jenv,
+            ::gluecodium::jni::make_non_releasing_ref(jinput),
+            ::gluecodium::jni::TypeId<::std::shared_ptr< ::smoke::SimpleInterface >>{});
+
+
+
+    auto pInstanceSharedPointer = reinterpret_cast<std::shared_ptr<::smoke::SimpleInterface>*> (
+
+        ::gluecodium::jni::get_class_native_handle(_jenv,_jinstance));
+
+
+
+
+    auto _result = (*pInstanceSharedPointer)->use_simple_interface(input);
+
+    return ::gluecodium::jni::convert_to_jni(_jenv, _result).release();
+}
+
+
+
+JNIEXPORT void JNICALL
+Java_com_example_smoke_SimpleInterfaceImpl_disposeNativeHandle(JNIEnv* _jenv, jobject _jinstance, jlong _jpointerRef)
+{
+    auto p_nobj = reinterpret_cast<std::shared_ptr<::smoke::SimpleInterface>*>(_jpointerRef);
+    ::gluecodium::jni::JniWrapperCache::remove_cached_wrapper(_jenv, *p_nobj);
+    delete p_nobj;
+}
+
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleInterface__Conversion.cpp
@@ -1,0 +1,78 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_SimpleInterface__Conversion.h"
+#include "com_example_smoke_SimpleInterfaceImplCppProxy.h"
+#include "CppProxyBase.h"
+#include "FieldAccessMethods.h"
+#include "JniClassCache.h"
+#include "JniNativeHandle.h"
+#include "JniThrowNewException.h"
+#include "JniWrapperCache.h"
+#include <new>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+REGISTER_JNI_CLASS_CACHE_INHERITANCE("com/example/smoke/SimpleInterfaceImpl", com_example_smoke_SimpleInterface, "smoke_SimpleInterface", ::smoke::SimpleInterface)
+
+template<>
+void createCppProxy(JNIEnv* env, const JniReference<jobject>& obj, ::std::shared_ptr<::smoke::SimpleInterface>& result)
+{
+    CppProxyBase::createProxy<::smoke::SimpleInterface, com_example_smoke_SimpleInterface_CppProxy>(env, obj, "com_example_smoke_SimpleInterface", result);
+}
+
+
+std::shared_ptr<::smoke::SimpleInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleInterface>>)
+{
+    std::shared_ptr<::smoke::SimpleInterface> _nresult{};
+    auto& nativeBaseClass = get_cached_native_base_class();
+    if (_env->IsInstanceOf(_jobj.get(), nativeBaseClass.get()))
+    {
+        if (_jobj != nullptr)
+        {
+            auto long_ptr = get_class_native_handle(_env, _jobj);
+            _nresult = *reinterpret_cast<std::shared_ptr<::smoke::SimpleInterface>*>(long_ptr);
+        }
+    }
+    else
+    {
+        createCppProxy(_env, _jobj, _nresult);
+    }
+    return _nresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleInterface>& _ninput)
+{
+    if ( !_ninput )
+    {
+        return {};
+    }
+
+    auto jResult = ::gluecodium::jni::CppProxyBase::getJavaObject(_jenv, _ninput.get());
+    if (jResult) return jResult;
+
+    jResult = ::gluecodium::jni::JniWrapperCache::get_cached_wrapper(_jenv, _ninput);
+    if (jResult) return jResult;
+
+    const auto& id = ::gluecodium::get_type_repository().get_id(_ninput.get());
+    const auto& javaClass = CachedJavaClass<::smoke::SimpleInterface>::get_java_class(id);
+    auto pInstanceSharedPointer = new (::std::nothrow) std::shared_ptr<::smoke::SimpleInterface>(_ninput);
+    if ( pInstanceSharedPointer == nullptr )
+    {
+        throw_new_out_of_memory_exception(_jenv);
+    }
+    jResult = ::gluecodium::jni::create_instance_object(
+        _jenv, javaClass, reinterpret_cast<jlong>( pInstanceSharedPointer ) );
+    ::gluecodium::jni::JniWrapperCache::cache_wrapper(_jenv, _ninput, jResult);
+
+    return jResult;
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleInterface__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_SimpleInterface__Conversion.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "smoke/SimpleInterface.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::smoke::SimpleInterface> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::smoke::SimpleInterface>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::smoke::SimpleInterface>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_StructWithClass__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_StructWithClass__Conversion.cpp
@@ -1,0 +1,57 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_StructWithClass__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+::smoke::StructWithClass
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::StructWithClass>)
+{
+    ::smoke::StructWithClass _nout{};
+    ::std::shared_ptr< ::smoke::SimpleClass > n_class_instance = convert_from_jni(
+        _jenv,
+        ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "classInstance", "Lcom/example/smoke/SimpleClass;"),
+        TypeId<::std::shared_ptr< ::smoke::SimpleClass >>{} );
+    _nout.class_instance = n_class_instance;
+    return _nout;
+}
+
+std::optional<::smoke::StructWithClass>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::StructWithClass>>)
+{
+    return _jinput
+        ? std::optional<::smoke::StructWithClass>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::StructWithClass>{}))
+        : std::optional<::smoke::StructWithClass>{};
+}
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/StructWithClass", com_example_smoke_StructWithClass, ::smoke::StructWithClass)
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::StructWithClass& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::StructWithClass>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
+    auto jclass_instance = convert_to_jni(_jenv, _ninput.class_instance);
+    ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "classInstance", "Lcom/example/smoke/SimpleClass;", jclass_instance);
+    return _jresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::StructWithClass> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_StructWithInterface__Conversion.cpp
+++ b/gluecodium/src/test/resources/smoke/instances/output/android-kotlin/jni/com_example_smoke_StructWithInterface__Conversion.cpp
@@ -1,0 +1,57 @@
+/*
+
+ *
+ */
+
+#include "com_example_smoke_StructWithInterface__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+#include "JniCallJavaMethod.h"
+#include "JniClassCache.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+::smoke::StructWithInterface
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::smoke::StructWithInterface>)
+{
+    ::smoke::StructWithInterface _nout{};
+    ::std::shared_ptr< ::smoke::SimpleInterface > n_interface_instance = convert_from_jni(
+        _jenv,
+        ::gluecodium::jni::get_object_field_value(_jenv, _jinput, "interfaceInstance", "Lcom/example/smoke/SimpleInterface;"),
+        TypeId<::std::shared_ptr< ::smoke::SimpleInterface >>{} );
+    _nout.interface_instance = n_interface_instance;
+    return _nout;
+}
+
+std::optional<::smoke::StructWithInterface>
+convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::smoke::StructWithInterface>>)
+{
+    return _jinput
+        ? std::optional<::smoke::StructWithInterface>(convert_from_jni(_jenv, _jinput, TypeId<::smoke::StructWithInterface>{}))
+        : std::optional<::smoke::StructWithInterface>{};
+}
+
+REGISTER_JNI_CLASS_CACHE("com/example/smoke/StructWithInterface", com_example_smoke_StructWithInterface, ::smoke::StructWithInterface)
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const ::smoke::StructWithInterface& _ninput)
+{
+    auto& javaClass = CachedJavaClass<::smoke::StructWithInterface>::java_class;
+    auto _jresult = ::gluecodium::jni::alloc_object(_jenv, javaClass);
+
+    auto jinterface_instance = convert_to_jni(_jenv, _ninput.interface_instance);
+    ::gluecodium::jni::set_object_field_value(_jenv, _jresult, "interfaceInstance", "Lcom/example/smoke/SimpleInterface;", jinterface_instance);
+    return _jresult;
+}
+
+JniReference<jobject>
+convert_to_jni(JNIEnv* _jenv, const std::optional<::smoke::StructWithInterface> _ninput)
+{
+    return _ninput ? convert_to_jni(_jenv, *_ninput) : JniReference<jobject>{};
+}
+
+}
+}


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.