### PR TITLE
smoke tests: add 'escaped names' test suite for Kotlin

### DIFF
--- a/gluecodium/src/test/resources/smoke/escaped_names/input/KeywordNames.lime
+++ b/gluecodium/src/test/resources/smoke/escaped_names/input/KeywordNames.lime
@@ -20,6 +20,7 @@ package `package`
 struct `types` {
 
     struct `struct` {
+        @Kotlin("Null")
         `null`: `enum` = `enum`.`NaN`
     }
 
@@ -37,12 +38,15 @@ struct `types` {
 
 class `class`: `interface` {
 
+    @Kotlin("Constructor")
     constructor `constructor`()
 
+    @Kotlin("Fun")
     fun `fun`(
         `Double`: `types`.`ULong`
     ): `types`.`struct` throws `types`.`exception`
 
+    @Kotlin("Property")
     property `property`: `types`.`enum`
 }
 

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Class.kt
@@ -1,0 +1,44 @@
+/*
+
+ *
+ */
+
+@file:JvmName("class")
+
+package com.example.package
+
+import com.example.NativeBase
+
+class Class : NativeBase, Interface {
+
+
+    constructor() : this(Constructor(), null as Any?) {
+        cacheThisInstance();
+    }
+
+    /*
+     * For internal use only.
+     * @hidden
+     * @param nativeHandle The handle to resources on C++ side.
+     * @param tag Tag used by callers to avoid overload resolution problems.
+     */
+    protected constructor(nativeHandle: Long, tag: Any?)
+        : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+    private external fun cacheThisInstance()
+
+
+    @Throws (Types.ExceptionException::class) external fun Fun(double: MutableList<Types.Struct>) : Types.Struct
+
+    var Property: Types.Enum
+        external get
+        external set
+
+
+
+
+    companion object {
+        @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
+        @JvmStatic external fun Constructor() : Long
+    }
+}

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Interface.kt
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Interface.kt
@@ -1,0 +1,16 @@
+/*
+
+ *
+ */
+
+@file:JvmName("interface")
+
+package com.example.package
+
+
+interface Interface {
+
+
+
+}
+

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Types.kt
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/com/example/package/Types.kt
@@ -1,0 +1,45 @@
+/*
+
+ *
+ */
+
+@file:JvmName("types")
+
+package com.example.package
+
+
+class Types {
+
+    enum class Enum(private val value: Int) {
+        NA_N(0);
+    }
+    class ExceptionException(@JvmField val error: Types.Enum) : Exception(error.toString())
+
+
+    class Struct {
+        @JvmField var Null: Types.Enum
+
+
+
+        constructor() {
+            this.Null = Types.Enum.NA_N
+        }
+
+
+
+
+
+    }
+
+
+
+
+
+
+
+
+    companion object {
+        @JvmField final val CONST: Types.Enum = Types.Enum.NA_N
+    }
+}
+

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Class.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Class.h
@@ -1,0 +1,30 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include <jni.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+JNIEXPORT jlong JNICALL
+Java_com_example_package_Class_Constructor(JNIEnv* _jenv, jobject _jinstance);
+JNIEXPORT jobject JNICALL
+Java_com_example_package_Class_Fun(JNIEnv* _jenv, jobject _jinstance, jobject jdouble);
+
+JNIEXPORT jobject JNICALL
+Java_com_example_package_Class_getProperty(JNIEnv* _jenv, jobject _jinstance);
+
+JNIEXPORT void JNICALL
+Java_com_example_package_Class_setProperty(JNIEnv* _jenv, jobject _jinstance, jobject jvalue);
+
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Class__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Class__Conversion.h
@@ -1,0 +1,25 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "package/Class.h"
+#include "com_example_package_Types_Enum__Conversion.h"
+#include "com_example_package_Types_Struct__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <memory>
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+
+JNIEXPORT std::shared_ptr<::package::Class> convert_from_jni(JNIEnv* _env, const JniReference<jobject>& _jobj, TypeId<std::shared_ptr<::package::Class>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::shared_ptr<::package::Class>& _ninput);
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_InterfaceImplCppProxy.cpp
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_InterfaceImplCppProxy.cpp
@@ -1,0 +1,21 @@
+/*
+
+ *
+ */
+
+#include "com_example_package_InterfaceImplCppProxy.h"
+#include "com_example_package_Interface__Conversion.h"
+#include "ArrayConversionUtils.h"
+#include "FieldAccessMethods.h"
+
+namespace gluecodium
+{
+namespace jni
+{
+
+com_example_package_Interface_CppProxy::com_example_package_Interface_CppProxy(JniReference<jobject> globalRef, jint _jHashCode) noexcept
+    : CppProxyBase(std::move(globalRef), _jHashCode, "com_example_package_Interface") {
+}
+
+}
+}

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Types_Enum__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Types_Enum__Conversion.h
@@ -1,0 +1,22 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "package/Types.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::package::Types::Enum convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::package::Types::Enum>);
+JNIEXPORT std::optional<::package::Types::Enum> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::package::Types::Enum>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::package::Types::Enum _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::package::Types::Enum> _ninput);
+}
+}

--- a/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Types_Struct__Conversion.h
+++ b/gluecodium/src/test/resources/smoke/escaped_names/output/android-kotlin/jni/com_example_package_Types_Struct__Conversion.h
@@ -1,0 +1,23 @@
+/*
+
+ *
+ */
+
+#pragma once
+
+#include "package/Types.h"
+#include "com_example_package_Types_Enum__Conversion.h"
+#include "JniReference.h"
+#include "JniTypeId.h"
+#include <optional>
+
+namespace gluecodium
+{
+namespace jni
+{
+JNIEXPORT ::package::Types::Struct convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<::package::Types::Struct>);
+JNIEXPORT std::optional<::package::Types::Struct> convert_from_jni(JNIEnv* _jenv, const JniReference<jobject>& _jinput, TypeId<std::optional<::package::Types::Struct>>);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const ::package::Types::Struct& _ninput);
+JNIEXPORT JniReference<jobject> convert_to_jni(JNIEnv* _jenv, const std::optional<::package::Types::Struct> _ninput);
+}
+}


### PR DESCRIPTION
This change introduces the expected output
for smoke tests, which is aligned with the
same test suite for Java generator to ensure
that the level of support in Kotlin is the same.