### PR TITLE
Add JVM annotations to avoid interoperability issues with Java

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGenerator.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGenerator.kt
@@ -203,6 +203,7 @@ internal class KotlinGenerator : Generator {
         val templateData =
             mutableMapOf(
                 "model" to limeElement,
+                "modelName" to limeElement.name,
                 "contentTemplate" to contentTemplateName,
                 "package" to packages,
                 "imports" to imports.distinct().sorted(),
@@ -227,6 +228,7 @@ internal class KotlinGenerator : Generator {
                 else -> imports
             } + importResolver.nativeBaseImport
         templateData["imports"] = implImports.distinct().sorted()
+        templateData["modelName"] = limeElement.name + "Impl"
         templateData["contentTemplate"] = "kotlin/KotlinImplClass"
 
         val implContent =

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -28,7 +28,8 @@
 {{>kotlin/KotlinContainerContents}}
 
 {{#set classElement=this}}{{#constructors}}
-    {{resolveName "visibility"}}constructor({{!!
+{{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
+}}    {{resolveName "visibility"}}constructor({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}){{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinDuration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinDuration.mustache
@@ -74,6 +74,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      * @throws ArithmeticException if the resulting value cannot be represented
      *                             by {@code long} type.
      */
+    @Throws(ArithmeticException::class)
     public fun toNanos(): Long {
         return exactAdd(exactMultiply(mSeconds, NANOS_PER_SECOND), mNanos.toLong());
     }
@@ -96,6 +97,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      * @throws ArithmeticException if the resulting value cannot be represented
      *                             by {@code long} type.
      */
+    @Throws(ArithmeticException::class)
     public fun toMillis(): Long {
         return exactAdd(exactMultiply(mSeconds, MILLIS_PER_SECOND), (mNanos / NANOS_PER_MILLIS).toLong());
     }
@@ -230,7 +232,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
         private val NANOS_PER_MILLIS: Int = 1000000;
         private val MILLIS_PER_SECOND: Long = 1000;
 
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         private fun exactAdd(v1: Long, v2: Long): Long {
             if (v2 < 0 && v1 < (Long.MIN_VALUE - v2)) {
                 throw ArithmeticException("Integer underflow");
@@ -240,7 +242,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
             return v1 + v2;
         }
 
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         private fun exactMultiply(v1: Long, v2: Long): Long {
             if ((v2 == -1L && v1 == Long.MIN_VALUE) || (v1 == -1L && v2 == Long.MIN_VALUE)) {
                 throw ArithmeticException("Integer overflow");
@@ -287,7 +289,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
          * @throws ArithmeticException if the input is outside the range possible to
          *                             represent by a Duration
          */
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         public fun ofDays(days: Long): Duration {
             return ofHours(exactMultiply(days, 24));
         }
@@ -301,7 +303,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
          * @throws ArithmeticException if the input is outside the range possible to
          *                             represent by a Duration
          */
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         public fun ofHours(hours: Long): Duration {
             return ofMinutes(exactMultiply(hours, 60));
         }
@@ -315,7 +317,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
          * @throws ArithmeticException if the input is outside the range possible to
          *                             represent by a Duration
          */
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         public fun ofMinutes(minutes: Long): Duration {
             return ofSeconds(exactMultiply(minutes, 60));
         }

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFile.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFile.mustache
@@ -23,6 +23,8 @@
  *
  */
 
+{{#modelName}}@file:JvmName("{{modelName}}"){{/modelName}}
+
 package {{#package}}{{this}}{{#if iter.hasNext}}.{{/if}}{{/package}}
 
 {{#imports}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
@@ -18,7 +18,8 @@
   ! License-Filename: LICENSE
   !
   !}}
-{{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
+{{#thrownType}}@Throws ({{resolveName typeRef}}::class) {{/thrownType}}{{!!
+}}{{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
 }}{{#unless isInterface}}{{resolveName "visibility"}}external {{/unless}}fun {{resolveName}}({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
@@ -40,6 +40,8 @@
 }}
 {{#set self=this}}
 {{#constructors}}
+{{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
+}}
     {{#unless self.external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
 }}constructor({{!!
 }}{{#parameters}}{{!!
@@ -97,6 +99,8 @@
 
     4. Generate field constructors specified by the user.
 }}{{#set self=this}}{{#fieldConstructors}}
+{{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
+}}
     {{#unless self.external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
 }}constructor({{!!
 }}{{#fields}}{{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
@@ -112,7 +112,9 @@
     5. Generate positional defaults constructor if it is specified and there are no field constructors.
 }}{{#unless fieldConstructors}}{{!!
 }}{{#if attributes.kotlin.positionalDefaults}}
-    {{#unless external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
+    {{#if initializedFields}}@JvmOverloads
+    {{/if}}{{!!
+    }}{{#unless external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
 }}constructor({{!!
 }}{{#uninitializedFields}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}, {{!!

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/smoke/BasicTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("BasicTypes")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,9 @@ class BasicTypes : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/CollectionConstants.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("CollectionConstants")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ class CollectionConstants : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/Constants.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Constants")
+
 package com.example.smoke
 
 
@@ -14,6 +16,11 @@ class Constants {
     }
 
 
+
+
+
+
+
     companion object {
         val BOOL_CONSTANT: Boolean = true
         val INT_CONSTANT: Int = -11
@@ -23,7 +30,5 @@ class Constants {
         val STRING_CONSTANT: String = "Foo bar"
         val ENUM_CONSTANT: Constants.StateEnum = Constants.StateEnum.ON
     }
-
 }
-
 

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/ConstantsInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ConstantsInterface")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -23,6 +25,9 @@ class ConstantsInterface : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
+++ b/gluecodium/src/test/resources/smoke/constants/output/android-kotlin/com/example/smoke/StructConstants.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("StructConstants")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -21,6 +23,9 @@ class StructConstants : NativeBase {
         }
 
 
+
+
+
     }
 
     class NestingStruct {
@@ -31,6 +36,9 @@ class StructConstants : NativeBase {
         constructor(structField: StructConstants.SomeStruct) {
             this.structField = structField
         }
+
+
+
 
 
     }
@@ -45,6 +53,8 @@ class StructConstants : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/ChildConstructors.kt
@@ -3,15 +3,19 @@
  *
  */
 
+@file:JvmName("ChildConstructors")
+
 package com.example.smoke
 
 
 class ChildConstructors : Constructors {
 
 
+
     constructor() : this(createNoArgsChild(), null as Any?) {
         cacheThisInstance();
     }
+
     constructor(other: Constructors) : this(createCopyFromParent(other), null as Any?) {
         cacheThisInstance();
     }
@@ -26,6 +30,8 @@ class ChildConstructors : Constructors {
         : super(nativeHandle, tag) {}
 
     private external fun cacheThisInstance()
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -51,12 +51,13 @@ open class Constructors : NativeBase {
 
 
 
+
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         @JvmStatic external fun create() : Long
         @JvmStatic external fun create(other: Constructors) : Long
         @JvmStatic external fun create(foo: String, bar: Long) : Long
-        @JvmStatic external fun create(input: String) : Long
+        @Throws (Constructors.ConstructorExplodedException::class) @JvmStatic external fun create(input: String) : Long
         @JvmStatic external fun create(input: MutableList<Double>) : Long
         @JvmStatic external fun create(input: Long) : Long
     }

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Constructors")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -26,7 +26,7 @@ open class Constructors : NativeBase {
     constructor(foo: String, bar: Long) : this(create(foo, bar), null as Any?) {
         cacheThisInstance();
     }
-    constructor(input: String) : this(create(input), null as Any?) {
+@Throws (Constructors.ConstructorExplodedException::class)    constructor(input: String) : this(create(input), null as Any?) {
         cacheThisInstance();
     }
     constructor(input: MutableList<Double>) : this(create(input), null as Any?) {

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/BlobDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/BlobDefaults.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("BlobDefaults")
+
 package com.example.smoke
 
 
@@ -16,6 +18,9 @@ class BlobDefaults {
         this.emptyList = byteArrayOf(  )
         this.deadBeef = byteArrayOf( 222.toByte(), 173.toByte(), 190.toByte(), 239.toByte() )
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/DefaultValues.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("DefaultValues")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -30,6 +32,8 @@ class DefaultValues : NativeBase {
 
 
 
+
+
     }
 
     class NullableStructWithDefaults {
@@ -48,6 +52,8 @@ class DefaultValues : NativeBase {
             this.boolField = null
             this.stringField = null
         }
+
+
 
 
 
@@ -74,6 +80,8 @@ class DefaultValues : NativeBase {
 
 
 
+
+
     }
 
     class StructWithEmptyDefaults {
@@ -95,6 +103,8 @@ class DefaultValues : NativeBase {
 
 
 
+
+
     }
 
     class StructWithTypedefDefaults {
@@ -112,6 +122,8 @@ class DefaultValues : NativeBase {
 
 
 
+
+
     }
 
 
@@ -124,6 +136,7 @@ class DefaultValues : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
@@ -15,6 +15,7 @@ class StructWithKotlinPositionalDefaults {
 
 
 
+    @JvmOverloads
     constructor(firstFreeField: String, secondFreeField: Boolean, firstInitField: Int = 42, secondInitField: Float = 7.2f, thirdInitField: String = "\\Jonny \"Magic\" Smith\n") {
         this.firstInitField = firstInitField
         this.firstFreeField = firstFreeField
@@ -22,6 +23,9 @@ class StructWithKotlinPositionalDefaults {
         this.secondFreeField = secondFreeField
         this.thirdInitField = thirdInitField
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/defaults/output/android-kotlin/com/example/smoke/StructWithKotlinPositionalDefaults.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("StructWithKotlinPositionalDefaults")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationDefaults.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("DurationDefaults")
+
 package com.example.smoke
 
 import com.example.time.Duration
@@ -27,6 +29,9 @@ class DurationDefaults {
         this.microz = Duration.ofNanos(665000L)
         this.nanoz = Duration.ofNanos(314635L)
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationMilliseconds.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("DurationMilliseconds")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -20,6 +22,9 @@ class DurationMilliseconds : NativeBase {
         }
 
 
+
+
+
     }
 
 
@@ -34,12 +39,15 @@ class DurationMilliseconds : NativeBase {
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
+
     external fun durationFunction(input: Duration) : Duration
     external fun nullableDurationFunction(input: Duration?) : Duration?
 
     var durationProperty: Duration
         external get
         external set
+
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/smoke/DurationSeconds.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("DurationSeconds")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -20,6 +22,9 @@ class DurationSeconds : NativeBase {
         }
 
 
+
+
+
     }
 
 
@@ -34,12 +39,15 @@ class DurationSeconds : NativeBase {
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
+
     external fun durationFunction(input: Duration) : Duration
     external fun nullableDurationFunction(input: Duration?) : Duration?
 
     var durationProperty: Duration
         external get
         external set
+
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/time/Duration.kt
+++ b/gluecodium/src/test/resources/smoke/durations/output/android-kotlin/com/example/time/Duration.kt
@@ -54,6 +54,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      * @throws ArithmeticException if the resulting value cannot be represented
      *                             by {@code long} type.
      */
+    @Throws(ArithmeticException::class)
     public fun toNanos(): Long {
         return exactAdd(exactMultiply(mSeconds, NANOS_PER_SECOND), mNanos.toLong());
     }
@@ -76,6 +77,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
      * @throws ArithmeticException if the resulting value cannot be represented
      *                             by {@code long} type.
      */
+    @Throws(ArithmeticException::class)
     public fun toMillis(): Long {
         return exactAdd(exactMultiply(mSeconds, MILLIS_PER_SECOND), (mNanos / NANOS_PER_MILLIS).toLong());
     }
@@ -210,7 +212,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
         private val NANOS_PER_MILLIS: Int = 1000000;
         private val MILLIS_PER_SECOND: Long = 1000;
 
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         private fun exactAdd(v1: Long, v2: Long): Long {
             if (v2 < 0 && v1 < (Long.MIN_VALUE - v2)) {
                 throw ArithmeticException("Integer underflow");
@@ -220,7 +222,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
             return v1 + v2;
         }
 
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         private fun exactMultiply(v1: Long, v2: Long): Long {
             if ((v2 == -1L && v1 == Long.MIN_VALUE) || (v1 == -1L && v2 == Long.MIN_VALUE)) {
                 throw ArithmeticException("Integer overflow");
@@ -267,7 +269,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
          * @throws ArithmeticException if the input is outside the range possible to
          *                             represent by a Duration
          */
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         public fun ofDays(days: Long): Duration {
             return ofHours(exactMultiply(days, 24));
         }
@@ -281,7 +283,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
          * @throws ArithmeticException if the input is outside the range possible to
          *                             represent by a Duration
          */
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         public fun ofHours(hours: Long): Duration {
             return ofMinutes(exactMultiply(hours, 60));
         }
@@ -295,7 +297,7 @@ public class Duration private constructor(private var mSeconds: Long, private va
          * @throws ArithmeticException if the input is outside the range possible to
          *                             represent by a Duration
          */
-        @JvmStatic
+        @JvmStatic @Throws(ArithmeticException::class)
         public fun ofMinutes(minutes: Long): Duration {
             return ofSeconds(exactMultiply(minutes, 60));
         }

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumOptionSet.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumOptionSet.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnumOptionSet")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumWithAlias.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnumWithAlias")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/Enums.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Enums")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -31,6 +33,7 @@ class Enums : NativeBase {
 
 
 
+
     }
 
 
@@ -43,6 +46,7 @@ class Enums : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollection.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnumsInTypeCollection")
+
 package com.example.smoke
 
 
@@ -12,6 +14,7 @@ class EnumsInTypeCollection {
         FIRST(0),
         SECOND(1);
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
+++ b/gluecodium/src/test/resources/smoke/enums/output/android-kotlin/com/example/smoke/EnumsInTypeCollectionInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnumsInTypeCollectionInterface")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ class EnumsInTypeCollectionInterface : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/Equatable.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/Equatable.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Equatable")
+
 package com.example.smoke
 
 
@@ -78,6 +80,8 @@ class Equatable {
 
 
 
+
+
     }
 
     class EquatableNullableStruct {
@@ -142,6 +146,8 @@ class Equatable {
 
 
 
+
+
     }
 
     class NestedEquatableStruct {
@@ -174,7 +180,11 @@ class Equatable {
 
 
 
+
+
     }
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EquatableClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -51,6 +53,8 @@ class EquatableClass : NativeBase {
 
 
 
+
+
     }
 
 
@@ -67,6 +71,7 @@ class EquatableClass : NativeBase {
 
     override external fun equals(obj: Any?) : Boolean
     override external fun hashCode(): Int
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/EquatableInterfaceImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EquatableInterfaceImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/SimpleEquatableStruct.kt
+++ b/gluecodium/src/test/resources/smoke/equatable/output/android-kotlin/com/example/smoke/SimpleEquatableStruct.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SimpleEquatableStruct")
+
 package com.example.smoke
 
 
@@ -45,6 +47,8 @@ class SimpleEquatableStruct {
         hash = 31 * hash + (this.nullableInterfaceField?.hashCode() ?: 0)
         return hash
     }
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Errors")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/Errors.kt
@@ -39,12 +39,14 @@ class Errors : NativeBase {
 
 
 
+
+
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
-        @JvmStatic external fun methodWithErrors() : Unit
-        @JvmStatic external fun methodWithExternalErrors() : Unit
-        @JvmStatic external fun methodWithErrorsAndReturnValue() : String
-        @JvmStatic external fun methodWithPayloadError() : Unit
-        @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
+        @Throws (Errors.InternalException::class) @JvmStatic external fun methodWithErrors() : Unit
+        @Throws (Errors.ExternalException::class) @JvmStatic external fun methodWithExternalErrors() : Unit
+        @Throws (Errors.InternalException::class) @JvmStatic external fun methodWithErrorsAndReturnValue() : String
+        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadError() : Unit
+        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
     }
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ErrorsInterface")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterface.kt
@@ -23,18 +23,18 @@ interface ErrorsInterface {
 
 
 
-    fun methodWithErrors() : Unit
-    fun methodWithExternalErrors() : Unit
-    fun methodWithErrorsAndReturnValue() : String
+    @Throws (ErrorsInterface.InternalException::class) fun methodWithErrors() : Unit
+    @Throws (ErrorsInterface.ExternalException::class) fun methodWithExternalErrors() : Unit
+    @Throws (ErrorsInterface.InternalException::class) fun methodWithErrorsAndReturnValue() : String
 
 
     companion object {
         val ERROR_MESSAGE: String = "Some error message constant"
-        @JvmStatic fun methodWithPayloadError() : Unit {
+        @Throws (WithPayloadException::class) @JvmStatic fun methodWithPayloadError() : Unit {
             ErrorsInterfaceImpl.methodWithPayloadError()
         }
 
-        @JvmStatic fun methodWithPayloadErrorAndReturnValue() : String {
+        @Throws (WithPayloadException::class) @JvmStatic fun methodWithPayloadErrorAndReturnValue() : String {
             return ErrorsInterfaceImpl.methodWithPayloadErrorAndReturnValue()
         }
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ErrorsInterfaceImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/ErrorsInterfaceImpl.kt
@@ -17,15 +17,15 @@ class ErrorsInterfaceImpl : NativeBase, ErrorsInterface {
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
-    override external fun methodWithErrors() : Unit
-    override external fun methodWithExternalErrors() : Unit
-    override external fun methodWithErrorsAndReturnValue() : String
+    @Throws (ErrorsInterface.InternalException::class) override external fun methodWithErrors() : Unit
+    @Throws (ErrorsInterface.ExternalException::class) override external fun methodWithExternalErrors() : Unit
+    @Throws (ErrorsInterface.InternalException::class) override external fun methodWithErrorsAndReturnValue() : String
 
 
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
-        @JvmStatic external fun methodWithPayloadError() : Unit
-        @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
+        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadError() : Unit
+        @Throws (WithPayloadException::class) @JvmStatic external fun methodWithPayloadErrorAndReturnValue() : String
     }
 }

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/SomeTypeCollection.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SomeTypeCollection")
+
 package com.example.smoke
 
 
@@ -18,6 +20,9 @@ class SomeTypeCollection {
 
 
 
-}
 
+
+
+
+}
 

--- a/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/WithPayloadException.kt
+++ b/gluecodium/src/test/resources/smoke/errors/output/android-kotlin/com/example/smoke/WithPayloadException.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("WithPayload")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/ExternalMarkedAsSerializable.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/ExternalMarkedAsSerializable.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ExternalMarkedAsSerializable")
+
 package com.example.kotlinsmoke
 
 import android.os.Parcel
@@ -16,6 +18,7 @@ class ExternalMarkedAsSerializable {
     constructor(field: Int) {
         this.field = field
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/KotlinExternalTypesStruct.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/KotlinExternalTypesStruct.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("KotlinExternalTypesStruct")
+
 package com.example.kotlinsmoke
 
 
@@ -22,6 +24,7 @@ class KotlinExternalTypesStruct {
         this.color = color
         this.season = season
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/Season.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/Season.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Season")
+
 package com.example.kotlinsmoke
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SerializableStructWithExternalField.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SerializableStructWithExternalField.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SerializableStructWithExternalField")
+
 package com.example.kotlinsmoke
 
 import android.os.Parcel
@@ -27,6 +29,7 @@ class SerializableStructWithExternalField : Parcelable {
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeParcelable(someStruct, 0)
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SystemColor.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/SystemColor.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SystemColor")
+
 package com.example.kotlinsmoke
 
 
@@ -20,6 +22,7 @@ class SystemColor {
         this.blue = blue
         this.alpha = alpha
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalConst.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalConst.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("UseKotlinExternalConst")
+
 package com.example.kotlinsmoke
 
 
@@ -14,6 +16,7 @@ class UseKotlinExternalConst {
     constructor(stringField: String) {
         this.stringField = stringField
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalTypes.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/UseKotlinExternalTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("UseKotlinExternalTypes")
+
 package com.example.kotlinsmoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ class UseKotlinExternalTypes : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/VeryBoolean.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/kotlinsmoke/VeryBoolean.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("VeryBoolean")
+
 package com.example.kotlinsmoke
 
 
@@ -10,10 +12,12 @@ class VeryBoolean {
     var value: Boolean
 
 
+
     constructor(value: Boolean) {
         val _other = make(value)
         this.value = _other.value
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Enums.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Enums")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -27,6 +29,7 @@ class Enums : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ExternalClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -20,6 +22,7 @@ class ExternalClass : NativeBase {
         constructor(someField: String) {
             this.someField = someField
         }
+
 
 
 
@@ -43,6 +46,7 @@ class ExternalClass : NativeBase {
 
     val someProperty: String
         external get
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ExternalInterface")
+
 package com.example.smoke
 
 
@@ -18,6 +20,7 @@ interface ExternalInterface {
         constructor(someField: String) {
             this.someField = someField
         }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/ExternalInterfaceImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ExternalInterfaceImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/external_types/output/android-kotlin/com/example/smoke/Structs.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Structs")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -27,6 +29,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
     class AnotherExternalStruct {
@@ -37,6 +40,7 @@ class Structs : NativeBase {
         constructor(intField: Byte) {
             this.intField = intField
         }
+
 
 
 
@@ -53,6 +57,7 @@ class Structs : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsAllDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsAllDefaults.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FieldConstructorsAllDefaults")
+
 package com.example.smoke
 
 
@@ -13,26 +15,33 @@ class FieldConstructorsAllDefaults {
 
 
 
+
     constructor() {
         this.stringField = "nonsense"
         this.intField = 42
         this.boolField = true
     }
+
     constructor(intField: Int) {
         this.intField = intField
         this.stringField = "nonsense"
         this.boolField = true
     }
+
     constructor(intField: Int, stringField: String) {
         this.intField = intField
         this.stringField = stringField
         this.boolField = true
     }
+
     constructor(boolField: Boolean, intField: Int, stringField: String) {
         this.boolField = boolField
         this.intField = intField
         this.stringField = stringField
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsPartialDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldConstructorsPartialDefaults.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FieldConstructorsPartialDefaults")
+
 package com.example.smoke
 
 
@@ -13,16 +15,21 @@ class FieldConstructorsPartialDefaults {
 
 
 
+
     constructor(intField: Int, stringField: String) {
         this.intField = intField
         this.stringField = stringField
         this.boolField = true
     }
+
     constructor(boolField: Boolean, intField: Int, stringField: String) {
         this.boolField = boolField
         this.intField = intField
         this.stringField = stringField
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldCustomConstructorsMix.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/FieldCustomConstructorsMix.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FieldCustomConstructorsMix")
+
 package com.example.smoke
 
 
@@ -12,6 +14,7 @@ class FieldCustomConstructorsMix {
     var boolField: Boolean
 
 
+
     constructor(intValue: Int, dummy: Double) {
         val _other = createMe(intValue, dummy)
         this.stringField = _other.stringField
@@ -19,11 +22,15 @@ class FieldCustomConstructorsMix {
         this.boolField = _other.boolField
     }
 
+
     constructor(intField: Int) {
         this.intField = intField
         this.stringField = "nonsense"
         this.boolField = true
     }
+
+
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructNoClash.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructNoClash.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ImmutableStructNoClash")
+
 package com.example.smoke
 
 
@@ -18,11 +20,15 @@ class ImmutableStructNoClash {
         this.intField = intField
         this.boolField = boolField
     }
+
     constructor() {
         this.stringField = "nonsense"
         this.intField = 42
         this.boolField = true
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructWithClash.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/ImmutableStructWithClash.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ImmutableStructWithClash")
+
 package com.example.smoke
 
 
@@ -13,16 +15,21 @@ class ImmutableStructWithClash {
 
 
 
+
     constructor() {
         this.stringField = "nonsense"
         this.intField = 42
         this.boolField = true
     }
+
     constructor(boolField: Boolean, intField: Int, stringField: String) {
         this.boolField = boolField
         this.intField = intField
         this.stringField = stringField
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/MutableStructNoClash.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/MutableStructNoClash.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("MutableStructNoClash")
+
 package com.example.smoke
 
 
@@ -13,11 +15,15 @@ class MutableStructNoClash {
 
 
 
+
     constructor() {
         this.stringField = "nonsense"
         this.intField = 42
         this.boolField = true
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/OuterStructWithFieldConstructor.kt
+++ b/gluecodium/src/test/resources/smoke/field_constructors/output/android-kotlin/com/example/smoke/OuterStructWithFieldConstructor.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("OuterStructWithFieldConstructor")
+
 package com.example.smoke
 
 
@@ -19,13 +21,20 @@ class OuterStructWithFieldConstructor {
         }
 
 
+
+
+
     }
+
 
 
 
     constructor(outerStructField: OuterStructWithFieldConstructor.InnerStructWithDefaults) {
         this.outerStructField = outerStructField
     }
+
+
+
 
 
 }

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/EnumSets.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnumSets")
+
 package com.example.smoke
 
 import java.util.EnumSet
@@ -15,6 +17,7 @@ class EnumSets {
     constructor() {
         this.enumSetField = EnumSet.noneOf(GenericTypesWithCompoundTypes.SomeEnum::class.java)
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithBasicTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("GenericTypesWithBasicTypes")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -21,6 +23,7 @@ class GenericTypesWithBasicTypes : NativeBase {
             this.numbersMap = numbersMap
             this.numbersSet = numbersSet
         }
+
 
 
 
@@ -50,12 +53,16 @@ class GenericTypesWithBasicTypes : NativeBase {
     var listProperty: MutableList<Float>
         external get
         external set
+
     var mapProperty: MutableMap<Float, Double>
         external get
         external set
+
     var setProperty: MutableSet<Float>
         external get
         external set
+
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithCompoundTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("GenericTypesWithCompoundTypes")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -29,6 +31,7 @@ class GenericTypesWithCompoundTypes : NativeBase {
 
 
 
+
     }
 
     class ExternalStruct {
@@ -39,6 +42,7 @@ class GenericTypesWithCompoundTypes : NativeBase {
         constructor(string: String) {
             this.string = string
         }
+
 
 
 
@@ -66,6 +70,7 @@ class GenericTypesWithCompoundTypes : NativeBase {
     external fun methodWithEnumSet(input: MutableSet<GenericTypesWithCompoundTypes.SomeEnum>) : MutableSet<GenericTypesWithCompoundTypes.ExternalEnum>
     external fun methodWithInstancesList(input: MutableList<DummyClass>) : MutableList<DummyInterface>
     external fun methodWithInstancesMap(input: MutableMap<Int, DummyClass>) : MutableMap<Int, DummyInterface>
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/GenericTypesWithGenericTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("GenericTypesWithGenericTypes")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -29,6 +31,7 @@ class GenericTypesWithGenericTypes : NativeBase {
     external fun methodWithListAndSet(input: MutableList<MutableSet<Int>>) : MutableSet<MutableList<Int>>
     external fun methodWithMapAndSet(input: MutableMap<Int, MutableSet<Int>>) : MutableSet<MutableMap<Int, Boolean>>
     external fun methodWithMapGenericKeys(input: MutableMap<MutableSet<Int>, Boolean>) : MutableMap<MutableList<Int>, Boolean>
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedList.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("UseOptimizedList")
+
 package com.example.smoke
 
 import com.example.AbstractNativeList

--- a/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
+++ b/gluecodium/src/test/resources/smoke/generic_types/output/android-kotlin/com/example/smoke/UseOptimizedListStruct.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("UseOptimizedListStruct")
+
 package com.example.smoke
 
 import com.example.AbstractNativeList

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Calculator.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Calculator")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ class Calculator : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListener.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListener.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("CalculatorListener")
+
 package com.example.smoke
 
 
@@ -15,6 +17,7 @@ interface CalculatorListener {
         constructor(result: Double) {
             this.result = result
         }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/CalculatorListenerImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("CalculatorListenerImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStatic.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStatic.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InterfaceWithStatic")
+
 package com.example.smoke
 
 
@@ -13,6 +15,7 @@ interface InterfaceWithStatic {
     var regularProperty: String
         get
         set
+
 
     companion object {
         @JvmStatic fun staticFunction() : String {

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InterfaceWithStaticImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InterfaceWithStaticImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -24,11 +26,13 @@ class InterfaceWithStaticImpl : NativeBase, InterfaceWithStatic {
         external set
 
 
+
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         @JvmStatic external fun staticFunction() : String
         @JvmStatic var staticProperty: String
             external get
             external set
+
     }
 }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalListener")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalListenerImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullable.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullable.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ListenerWithNullable")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithNullableImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ListenerWithNullableImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithProperties.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ListenerWithProperties")
+
 package com.example.smoke
 
 
@@ -19,6 +21,7 @@ interface ListenerWithProperties {
         constructor(result: Double) {
             this.result = result
         }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenerWithPropertiesImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ListenerWithPropertiesImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValues.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ListenersWithReturnValues")
+
 package com.example.smoke
 
 
@@ -19,6 +21,7 @@ interface ListenersWithReturnValues {
         constructor(result: Double) {
             this.result = result
         }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/ListenersWithReturnValuesImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ListenersWithReturnValuesImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/TemperatureObserver.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("TemperatureObserver")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -29,7 +29,7 @@ class Thermometer : NativeBase {
         cacheThisInstance();
         notifyObservers(this, observers)
     }
-    constructor(id: Int, observers: MutableList<TemperatureObserver>) : this(throwingMake(id, observers), null as Any?) {
+@Throws (Thermometer.NotificationException::class)    constructor(id: Int, observers: MutableList<TemperatureObserver>) : this(throwingMake(id, observers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }
@@ -37,7 +37,7 @@ class Thermometer : NativeBase {
         cacheThisInstance();
         throwingNotifyObservers(this, niceObservers)
     }
-    constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
+@Throws (Thermometer.AnotherNotificationException::class)    constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Thermometer")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -66,10 +66,10 @@ class Thermometer : NativeBase {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         @JvmStatic external fun makeWithDuration(interval: Duration, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun makeWithoutDuration(observers: MutableList<TemperatureObserver>) : Long
-        @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
+        @Throws (Thermometer.NotificationException::class) @JvmStatic external fun throwingMake(id: Int, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun nothrowMake(label: String, niceObservers: MutableList<TemperatureObserver>) : Long
-        @JvmStatic external fun anotherThrowingMake(dummy: Boolean, observers: MutableList<TemperatureObserver>) : Long
+        @Throws (Thermometer.AnotherNotificationException::class) @JvmStatic external fun anotherThrowingMake(dummy: Boolean, observers: MutableList<TemperatureObserver>) : Long
         @JvmStatic external fun notifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
-        @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
+        @Throws (Thermometer.NotificationException::class) @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
     }
 }

--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/LocaleDefaults.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/LocaleDefaults.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("LocaleDefaults")
+
 package com.example.smoke
 
 import java.util.Locale
@@ -25,6 +27,7 @@ class LocaleDefaults {
         this.traditionalChineseTaiwan = Locale.forLanguageTag("nan-Hant-TW")
         this.zuerichGerman = Locale.forLanguageTag("gsw-u-sd-chzh")
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
+++ b/gluecodium/src/test/resources/smoke/locales/output/android-kotlin/com/example/smoke/Locales.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Locales")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -18,6 +20,7 @@ class Locales : NativeBase {
         constructor(localeField: Locale) {
             this.localeField = localeField
         }
+
 
 
 
@@ -42,6 +45,7 @@ class Locales : NativeBase {
     var localeProperty: Locale
         external get
         external set
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsClassClass.kt
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsClassClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FirstParentIsClassClass")
+
 package com.example.smoke
 
 
@@ -27,9 +29,12 @@ class FirstParentIsClassClass : ParentClass, ParentNarrowOne {
         external get
         external set
 
+
     override external fun parentFunctionOne() : Unit
     override var parentPropertyOne: String
         external get
         external set
+
+
 
 }

--- a/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsInterfaceInterface.kt
+++ b/gluecodium/src/test/resources/smoke/multiple_inheritance/output/android-kotlin/com/example/smoke/FirstParentIsInterfaceInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FirstParentIsInterfaceInterface")
+
 package com.example.smoke
 
 
@@ -13,6 +15,7 @@ interface FirstParentIsInterfaceInterface : ParentInterface, ParentNarrowOne {
     var childProperty: String
         get
         set
+
 
 }
 

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -30,6 +30,7 @@ class NAME_RULES_KT : NativeBase {
 
 
 
+
     }
 
 
@@ -49,7 +50,7 @@ class NAME_RULES_KT : NativeBase {
     private external fun cacheThisInstance()
 
 
-    external fun some_method(someArgument: NAME_RULES_KT.EXAMPLE_STRUCT_KT) : Double
+    @Throws (NAME_RULES_KT.ExampleException::class) external fun some_method(someArgument: NAME_RULES_KT.EXAMPLE_STRUCT_KT) : Double
 
     var intProperty: Long
         external get
@@ -62,6 +63,7 @@ class NAME_RULES_KT : NativeBase {
     var structProperty: NAME_RULES_KT.EXAMPLE_STRUCT_KT
         external get
         external set
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
+++ b/gluecodium/src/test/resources/smoke/name_rules/output/android-kotlin/com/example/namerules/NAME_RULES_KT.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("NameRules")
+
 package com.example.namerules
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeEnum.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeEnum.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FreeEnum")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeException.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeException.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Free")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeLambda.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreeLambda.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FreeLambda")
+
 package com.example.smoke
 
 import java.util.Date

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/FreePoint.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("FreePoint")
+
 package com.example.smoke
 
 
@@ -20,6 +22,7 @@ class FreePoint {
 
 
     external fun flip() : FreePoint
+
 
     companion object {
         val A_BAR: FreeEnum = FreeEnum.BAR

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/LevelOne.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("LevelOne")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -24,6 +26,7 @@ class LevelOne : NativeBase {
                 constructor(stringField: String) {
                     this.stringField = stringField
                 }
+
 
 
 
@@ -51,6 +54,7 @@ class LevelOne : NativeBase {
 
 
 
+
             companion object {
                 @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
             }
@@ -71,6 +75,7 @@ class LevelOne : NativeBase {
 
 
 
+
         companion object {
             @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)
         }
@@ -85,6 +90,7 @@ class LevelOne : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/NestedReferences.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("NestedReferences")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -17,6 +19,7 @@ class NestedReferences : NativeBase {
         constructor(stringField: String) {
             this.stringField = stringField
         }
+
 
 
 
@@ -37,6 +40,7 @@ class NestedReferences : NativeBase {
 
 
     external fun insideOut(struct1: NestedReferences.NestedReferences, struct2: NestedReferences.NestedReferences) : NestedReferences
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("OuterClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -25,6 +27,7 @@ class OuterClass : NativeBase {
 
 
         external fun foo(input: String) : String
+
 
 
 
@@ -71,6 +74,7 @@ class OuterClass : NativeBase {
 
 
     external fun foo(input: String) : String
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterClassWithInheritance.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("OuterClassWithInheritance")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -25,6 +27,7 @@ class OuterClassWithInheritance : ParentClass {
 
 
         external fun bar(input: String) : String
+
 
 
 
@@ -71,6 +74,7 @@ class OuterClassWithInheritance : ParentClass {
 
 
     external fun foo(input: String) : String
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("OuterInterface")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -24,6 +26,7 @@ interface OuterInterface {
 
 
         external fun foo(input: String) : String
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("OuterStruct")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -60,6 +62,7 @@ class OuterStruct {
         }
     }
     class Builder : NativeBase {
+
 
 
         constructor() : this(create(), null as Any?) {

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/OuterStruct.kt
@@ -32,6 +32,7 @@ class OuterStruct {
 
         external fun doSomething() : Unit
 
+
     }
 
     class InnerClass : NativeBase {
@@ -50,6 +51,7 @@ class OuterStruct {
 
 
         external fun fooBar() : MutableSet<Locale>
+
 
 
 
@@ -78,6 +80,7 @@ class OuterStruct {
 
         external fun field(value: String) : OuterStruct.Builder
         external fun build() : OuterStruct
+
 
 
 
@@ -141,7 +144,8 @@ class OuterStruct {
 
 
 
-    external fun doNothing() : Unit
+    @Throws (OuterStruct.InstantiationException::class) external fun doNothing() : Unit
+
 
 }
 

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("UseFreeTypes")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
+++ b/gluecodium/src/test/resources/smoke/nesting/output/android-kotlin/com/example/smoke/UseFreeTypes.kt
@@ -23,7 +23,8 @@ class UseFreeTypes : NativeBase {
 
 
 
-    external fun doStuff(point: FreePoint, mode: FreeEnum) : Date
+    @Throws (FreeException::class) external fun doStuff(point: FreePoint, mode: FreeEnum) : Date
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
+++ b/gluecodium/src/test/resources/smoke/no_cache/output/android-kotlin/com/example/smoke/NoCacheClass.kt
@@ -3,11 +3,14 @@
  *
  */
 
+@file:JvmName("NoCacheClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
 
 class NoCacheClass : NativeBase {
+
 
 
     constructor() : this(make(), null as Any?) {
@@ -23,7 +26,9 @@ class NoCacheClass : NativeBase {
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
+
     external fun foo() : Unit
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/Nullable.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Nullable")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -21,6 +23,7 @@ class Nullable : NativeBase {
         constructor(stringField: String) {
             this.stringField = stringField
         }
+
 
 
 
@@ -55,6 +58,7 @@ class Nullable : NativeBase {
 
 
 
+
     }
 
     class NullableIntsStruct {
@@ -79,6 +83,7 @@ class Nullable : NativeBase {
             this.uint32Field = null
             this.uint64Field = null
         }
+
 
 
 
@@ -112,33 +117,44 @@ class Nullable : NativeBase {
     var stringProperty: String?
         external get
         external set
+
     var isBoolProperty: Boolean?
         external get
         external set
+
     var doubleProperty: Double?
         external get
         external set
+
     var intProperty: Long?
         external get
         external set
+
     var structProperty: Nullable.SomeStruct?
         external get
         external set
+
     var enumProperty: Nullable.SomeEnum?
         external get
         external set
+
     var arrayProperty: MutableList<String>?
         external get
         external set
+
     var inlineArrayProperty: MutableList<String>?
         external get
         external set
+
     var mapProperty: MutableMap<Long, String>?
         external get
         external set
+
     var instanceProperty: SomeInterface?
         external get
         external set
+
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/NullableCollectionsStruct.kt
+++ b/gluecodium/src/test/resources/smoke/nullable/output/android-kotlin/com/example/smoke/NullableCollectionsStruct.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("NullableCollectionsStruct")
+
 package com.example.smoke
 
 import java.util.Date
@@ -17,6 +19,7 @@ class NullableCollectionsStruct {
         this.dates = dates
         this.structs = structs
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smoke/off/NestedPackages.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("NestedPackages")
+
 package com.example.smoke.off
 
 import com.example.NativeBase
@@ -21,6 +23,7 @@ class NestedPackages : NativeBase {
 
 
 
+
     }
 
 
@@ -33,6 +36,7 @@ class NestedPackages : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
+++ b/gluecodium/src/test/resources/smoke/packages/output/android-kotlin/com/example/smokeoff/UnderscorePackage.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("UnderscorePackage")
+
 package com.example.smokeoff
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ class UnderscorePackage : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PlatformNamesInterface")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -10,6 +12,7 @@ import com.example.smoke.dodoInterface
 import com.example.smoke.dodoTypes
 
 class dodoInterface : NativeBase {
+
 
 
     constructor(makeParameter: String) : this(make(makeParameter), null as Any?) {
@@ -27,11 +30,14 @@ class dodoInterface : NativeBase {
 
     private external fun cacheThisInstance()
 
+
     external fun DodoMethod(DodoParameter: String) : dodoTypes.dodoStruct
 
     var DODO_PROPERTY: Long
         external get
         external set
+
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoListenerImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PlatformNamesListenerImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
+++ b/gluecodium/src/test/resources/smoke/platform_names/output/android-kotlin/com/example/smoke/dodoTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PlatformNames")
+
 package com.example.smoke
 
 import com.example.smoke.dodoTypes
@@ -16,6 +18,7 @@ class dodoTypes {
         var DODO_FIELD: String
 
 
+
         constructor(DodoParameter: String) {
             val _other = DodoCreate(DodoParameter)
             this.DODO_FIELD = _other.DODO_FIELD
@@ -25,10 +28,12 @@ class dodoTypes {
 
 
 
+
         companion object {
             @JvmStatic external fun DodoCreate(DodoParameter: String) : dodoStruct
         }
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/CachedProperties.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("CachedProperties")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -36,6 +38,7 @@ class CachedProperties : NativeBase {
     private var is_cached_cachedProperty = false
     private var cache_cachedProperty: MutableList<String>? = null
     external private fun getCachedProperty_private() : MutableList<String>
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/Properties.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Properties")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -21,6 +23,8 @@ class Properties : NativeBase {
         constructor(value: Double) {
             this.value = value
         }
+
+
 
 
 
@@ -43,26 +47,35 @@ class Properties : NativeBase {
     var builtInTypeProperty: Long
         external get
         external set
+
     val readonlyProperty: Float
         external get
+
     var structProperty: Properties.ExampleStruct
         external get
         external set
+
     var arrayProperty: MutableList<String>
         external get
         external set
+
     var complexTypeProperty: Properties.InternalErrorCode
         external get
         external set
+
     var byteBufferProperty: ByteArray
         external get
         external set
+
     var instanceProperty: PropertiesInterface
         external get
         external set
+
     var isBooleanProperty: Boolean
         external get
         external set
+
+
 
 
     companion object {
@@ -70,7 +83,9 @@ class Properties : NativeBase {
         @JvmStatic var staticProperty: String
             external get
             external set
+
         @JvmStatic val staticReadonlyProperty: Properties.ExampleStruct
             external get
+
     }
 }

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterface.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PropertiesInterface")
+
 package com.example.smoke
 
 
@@ -15,6 +17,7 @@ interface PropertiesInterface {
         constructor(value: Double) {
             this.value = value
         }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/properties/output/android-kotlin/com/example/smoke/PropertiesInterfaceImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PropertiesInterfaceImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
+++ b/gluecodium/src/test/resources/smoke/serialization/output/android-kotlin/com/example/smoke/Serialization.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Serialization")
+
 package com.example.smoke
 
 import android.os.Parcel
@@ -105,6 +107,7 @@ class Serialization {
 
 
 
+
         companion object {
             @JvmField
             val CREATOR = object : Parcelable.Creator<SerializableStruct> {
@@ -138,6 +141,7 @@ class Serialization {
 
 
 
+
         companion object {
             @JvmField
             val CREATOR = object : Parcelable.Creator<NestedSerializableStruct> {
@@ -147,6 +151,7 @@ class Serialization {
 
         }
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/ClassWithStructWithSkipLambdaInPlatform.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("ClassWithStructWithSkipLambdaInPlatform")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -21,6 +23,7 @@ class ClassWithStructWithSkipLambdaInPlatform : NativeBase {
 
 
 
+
     }
 
 
@@ -33,6 +36,7 @@ class ClassWithStructWithSkipLambdaInPlatform : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfEnabled.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnableIfEnabled")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,8 @@ class EnableIfEnabled : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableIfSkipped.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnableIfSkipped")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,8 @@ class EnableIfSkipped : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableTagsInKotlin.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/EnableTagsInKotlin.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("EnableTagsInKotlin")
+
 package com.example.smoke
 
 
@@ -10,6 +12,7 @@ interface EnableTagsInKotlin {
 
     fun enableTagged() : Unit
     fun enableTaggedList() : Unit
+
 
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/InheritFromSkippedImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InheritFromSkippedImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -25,12 +27,15 @@ class InheritFromSkippedImpl : NativeBase, InheritFromSkipped {
     override var skippedInJava: String
         external get
         external set
+
     override var isSkippedInSwift: Boolean
         external get
         external set
+
     override var skippedInDart: Float
         external get
         external set
+
 
     companion object {
         @JvmStatic private external fun disposeNativeHandle(nativeHandle: Long)

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorAutoTag.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorAutoTag.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipEnumeratorAutoTag")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorExplicitTag.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipEnumeratorExplicitTag.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipEnumeratorExplicitTag")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipField.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipField.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipField")
+
 package com.example.smoke
 
 
@@ -14,6 +16,7 @@ class SkipField {
     constructor(field: String) {
         this.field = field
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipFunctions.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipFunctions")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,8 @@ class SkipFunctions : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipProxy.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipProxy.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipProxy")
+
 package com.example.smoke
 
 
@@ -15,11 +17,15 @@ interface SkipProxy {
     var skippedInJava: String
         get
         set
+
     var isSkippedInSwift: Boolean
         get
         set
+
     var skippedInDart: Float
         get
         set
+
+
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipSetter.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipSetter.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipSetter")
+
 package com.example.smoke
 
 
@@ -11,5 +13,7 @@ interface SkipSetter {
 
     val foo: String
         get
+
+
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsInKotlin.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsInKotlin.kt
@@ -3,12 +3,15 @@
  *
  */
 
+@file:JvmName("SkipTagsInKotlin")
+
 package com.example.smoke
 
 
 interface SkipTagsInKotlin {
 
     fun dontSkipTagged() : Unit
+
 
 }
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTagsOnly.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipTagsOnly")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,8 @@ class SkipTagsOnly : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SkipTypes.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SkipTypes")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -21,6 +23,7 @@ class SkipTypes : NativeBase {
 
 
 
+
     }
 
     class NotInSwift {
@@ -31,6 +34,7 @@ class SkipTypes : NativeBase {
         constructor(fooField: String) {
             this.fooField = fooField
         }
+
 
 
 
@@ -49,6 +53,7 @@ class SkipTypes : NativeBase {
 
 
 
+
     }
 
 
@@ -61,6 +66,7 @@ class SkipTypes : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
+++ b/gluecodium/src/test/resources/smoke/skip/output/android-kotlin/com/example/smoke/SomeSkippedClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("SomeSkippedClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -22,7 +24,9 @@ class SomeSkippedClass : NativeBase {
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 
 
+
     external fun doFoo() : DontSmokeEnum
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/Structs.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("Structs")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -18,11 +20,13 @@ class Structs : NativeBase {
         var y: Double
 
 
+
         constructor(phi: Double, r: Double) {
             val _other = fromPolar(phi, r)
             this.x = _other.x
             this.y = _other.y
         }
+
 
 
 
@@ -43,6 +47,7 @@ class Structs : NativeBase {
             this.a = a
             this.b = b
         }
+
 
 
 
@@ -87,6 +92,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
     class NestingImmutableStruct {
@@ -97,6 +103,7 @@ class Structs : NativeBase {
         constructor(structField: Structs.AllTypesStruct) {
             this.structField = structField
         }
+
 
 
 
@@ -115,6 +122,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
     class StructWithArrayOfImmutable {
@@ -125,6 +133,7 @@ class Structs : NativeBase {
         constructor(arrayField: MutableList<Structs.AllTypesStruct>) {
             this.arrayField = arrayField
         }
+
 
 
 
@@ -158,6 +167,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
     class MutableStructWithCppAccessors {
@@ -180,6 +190,7 @@ class Structs : NativeBase {
 
 
 
+
     }
 
 
@@ -192,6 +203,7 @@ class Structs : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstants.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstants.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("StructsWithConstants")
+
 package com.example.smoke
 
 
@@ -20,11 +22,17 @@ class StructsWithConstants {
         }
 
 
+
+
+
         companion object {
             val DEFAULT_DESCRIPTION: String = "Nonsense"
             val DEFAULT_TYPE: RouteUtils.RouteType = RouteUtils.RouteType.EQUESTRIAN
         }
     }
+
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithConstantsInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("StructsWithConstantsInterface")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -22,6 +24,8 @@ class StructsWithConstantsInterface : NativeBase {
 
 
 
+
+
         companion object {
             val DEFAULT_DESCRIPTION: String = "Foo"
             val DEFAULT_TYPE: RouteUtils.RouteType = RouteUtils.RouteType.NONE
@@ -29,6 +33,8 @@ class StructsWithConstantsInterface : NativeBase {
     }
 
     class StructWithConstantsOnly {
+
+
 
 
 
@@ -50,6 +56,7 @@ class StructsWithConstantsInterface : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
@@ -30,12 +30,14 @@ class StructsWithMethods {
         external fun distanceTo(other: StructsWithMethods.Vector) : Double
         external fun add(other: StructsWithMethods.Vector) : StructsWithMethods.Vector
 
+
         companion object {
             @JvmStatic external fun validate(x: Double, y: Double) : Boolean
             @JvmStatic external fun create(x: Double, y: Double) : Vector
-            @JvmStatic external fun create(other: StructsWithMethods.Vector) : Vector
+            @Throws (ValidationUtils.ValidationException::class) @JvmStatic external fun create(other: StructsWithMethods.Vector) : Vector
         }
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
@@ -18,6 +18,7 @@ class StructsWithMethods {
             this.x = _other.x
             this.y = _other.y
         }
+    @Throws (ValidationUtils.ValidationException::class)
         constructor(other: StructsWithMethods.Vector) {
             val _other = create(other)
             this.x = _other.x

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethods.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("StructsWithMethods")
+
 package com.example.smoke
 
 
@@ -11,6 +13,7 @@ class StructsWithMethods {
     class Vector {
         var x: Double
         var y: Double
+
 
 
         constructor(x: Double, y: Double) {

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -34,14 +34,16 @@ class StructsWithMethodsInterface : NativeBase {
         external fun distanceTo(other: StructsWithMethodsInterface.Vector3) : Double
         external fun add(other: StructsWithMethodsInterface.Vector3) : StructsWithMethodsInterface.Vector3
 
+
         companion object {
             @JvmStatic external fun validate(x: Double, y: Double, z: Double) : Boolean
             @JvmStatic external fun create(input: String) : Vector3
-            @JvmStatic external fun create(other: StructsWithMethodsInterface.Vector3) : Vector3
+            @Throws (ValidationUtils.ValidationException::class) @JvmStatic external fun create(other: StructsWithMethodsInterface.Vector3) : Vector3
         }
     }
 
     class StructWithStaticMethodsOnly {
+
 
 
 
@@ -64,6 +66,7 @@ class StructsWithMethodsInterface : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -21,6 +21,7 @@ class StructsWithMethodsInterface : NativeBase {
             this.y = _other.y
             this.z = _other.z
         }
+    @Throws (ValidationUtils.ValidationException::class)
         constructor(other: StructsWithMethodsInterface.Vector3) {
             val _other = create(other)
             this.x = _other.x

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/StructsWithMethodsInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("StructsWithMethodsInterface")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -13,6 +15,7 @@ class StructsWithMethodsInterface : NativeBase {
         var x: Double
         var y: Double
         var z: Double
+
 
 
         constructor(input: String) {

--- a/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/TypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/structs/output/android-kotlin/com/example/smoke/TypeCollection.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("TypeCollection")
+
 package com.example.smoke
 
 
@@ -20,6 +22,9 @@ class TypeCollection {
         }
 
 
+
+
+
     }
 
     class Line {
@@ -32,6 +37,9 @@ class TypeCollection {
             this.a = a
             this.b = b
         }
+
+
+
 
 
     }
@@ -72,7 +80,13 @@ class TypeCollection {
         }
 
 
+
+
+
     }
+
+
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalListTypeDef.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalListTypeDef.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("GlobalListTypeDef")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalMapTypeDef.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/GlobalMapTypeDef.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("GlobalMapTypeDef")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeCollection.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("TypeCollection")
+
 package com.example.smoke
 
 
@@ -22,6 +24,7 @@ class TypeCollection {
 
 
 
+
     }
 
     class StructHavingAliasFieldDefinedBelow {
@@ -36,7 +39,9 @@ class TypeCollection {
 
 
 
+
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
+++ b/gluecodium/src/test/resources/smoke/typedefs/output/android-kotlin/com/example/smoke/TypeDefs.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("TypeDefs")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -21,6 +23,7 @@ class TypeDefs : NativeBase {
 
 
 
+
     }
 
     class TestStruct {
@@ -31,6 +34,7 @@ class TypeDefs : NativeBase {
         constructor(something: String) {
             this.something = something
         }
+
 
 
 
@@ -54,6 +58,8 @@ class TypeDefs : NativeBase {
     var primitiveTypeProperty: MutableList<Double>
         external get
         external set
+
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -23,6 +25,7 @@ internal class InternalClass : NativeBase {
 
 
     external fun fooBar() : Unit
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalClassInherits")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -28,6 +30,7 @@ internal class InternalClassInherits : NativeBase, InternalInterfaceParent {
     override var prop: String
         external get
         external set
+
 
 
     companion object {

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalClassWithFunctions")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -10,9 +12,11 @@ import com.example.NativeBase
 internal class InternalClassWithFunctions : NativeBase {
 
 
+
     constructor() : this(make(), null as Any?) {
         cacheThisInstance();
     }
+
     constructor(foo: String) : this(make(foo), null as Any?) {
         cacheThisInstance();
     }
@@ -30,6 +34,7 @@ internal class InternalClassWithFunctions : NativeBase {
 
 
     external fun fooBar() : Unit
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalClassWithStaticProperty")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ internal class InternalClassWithStaticProperty : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalInterface")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalInterfaceImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceParent.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceParent.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalInterfaceParent")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambda.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambda.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalLambda")
+
 package com.example.smoke
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalLambdaImpl")
+
 package com.example.smoke
 
 import com.example.NativeBase

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("InternalPropertyOnly")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -26,6 +28,7 @@ class InternalPropertyOnly : NativeBase {
     internal var foo: String
         external get
         external set
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PublicClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -25,6 +27,7 @@ class PublicClass : NativeBase {
 
 
 
+
     }
 
     class PublicStruct {
@@ -35,6 +38,7 @@ class PublicClass : NativeBase {
         internal constructor(internalField: PublicClass.InternalStruct) {
             this.internalField = internalField
         }
+
 
 
 
@@ -51,6 +55,7 @@ class PublicClass : NativeBase {
             this.internalField = "foo"
             this.publicField = publicField
         }
+
 
 
 
@@ -75,6 +80,7 @@ class PublicClass : NativeBase {
     internal var internalStructProperty: PublicClass.InternalStruct
         external get
         external set
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PublicInterface")
+
 package com.example.smoke
 
 
@@ -15,6 +17,7 @@ interface PublicInterface {
         internal constructor(fieldOfInternalType: PublicClass.InternalStruct) {
             this.fieldOfInternalType = fieldOfInternalType
         }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithInternalConstructors.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithInternalConstructors.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PublicStructWithInternalConstructors")
+
 package com.example.smoke
 
 
@@ -10,14 +12,17 @@ class PublicStructWithInternalConstructors {
     var someVar: Int
 
 
+
     internal constructor() {
         val _other = make()
         this.someVar = _other.someVar
     }
 
+
     internal constructor(someVar: Int) {
         this.someVar = someVar
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithNonDefaultInternalField.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithNonDefaultInternalField.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PublicStructWithNonDefaultInternalField")
+
 package com.example.smoke
 
 
@@ -18,6 +20,7 @@ class PublicStructWithNonDefaultInternalField {
         this.internalField = internalField
         this.publicField = publicField
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicTypeCollection.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PublicTypeCollection")
+
 package com.example.smoke
 
 
@@ -21,7 +23,9 @@ class PublicTypeCollection {
 
         external fun fooBar() : Unit
 
+
     }
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("KotlinInternalClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ internal class KotlinInternalClass : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("KotlinInternalClassRev")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ internal class KotlinInternalClassRev : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinPublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinPublicClass.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("KotlinPublicClass")
+
 package com.example.smoke
 
 import com.example.NativeBase
@@ -19,6 +21,7 @@ class KotlinPublicClass : NativeBase {
      */
     protected constructor(nativeHandle: Long, tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
+
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/PlatformInternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/PlatformInternalInterface.kt
@@ -3,6 +3,8 @@
  *
  */
 
+@file:JvmName("PlatformInternalInterface")
+
 package com.example.smoke
 
 


### PR DESCRIPTION
------------------- Motivation -------------------
Java and Kotlin can be called from each other.
To avoid the interoperability problems withs Java and to consume the Kotlin code from Java application(JVM), certain annotations need to be used. Idea here is to add the required annotations for operation.

------------------- Implemented solution -------------------
Following annotations are added to ensure proper operation.
1. `@Throws` - To indicate a constructor/structure/functions throws a java checked exception.
2. `@file:JvmName()` - To give appropriate name for Kotlin top level elements in Java
3. `@JvmOverloads` - To indicate functions with default values