### PR TITLE
KotlinNativeBase: add 'propagateCleanupException' flag

### DIFF
--- a/gluecodium/src/main/resources/templates/kotlin/KotlinNativeBase.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinNativeBase.mustache
@@ -93,6 +93,7 @@ public abstract class NativeBase {
     }
 
     companion object {
+        @JvmField public var propagateCleanupException: Boolean = false
         private val LOGGER = Logger.getLogger(NativeBase::class.java.name);
 
         // The set is to keep DisposableReference itself from being garbage-collected.
@@ -113,6 +114,10 @@ public abstract class NativeBase {
                     (reference as DisposableReference).dispose()
                 } catch (t: Throwable) {
                     LOGGER.log(Level.SEVERE, "Error cleaning up after reference.", t);
+
+                    if (propagateCleanupException) {
+                        throw t
+                    }
                 }
 
                 reference = REFERENCE_QUEUE.poll()

--- a/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/NativeBase.kt
+++ b/gluecodium/src/test/resources/smoke/basic_types/output/android-kotlin/com/example/NativeBase.kt
@@ -73,6 +73,7 @@ public abstract class NativeBase {
     }
 
     companion object {
+        @JvmField public var propagateCleanupException: Boolean = false
         private val LOGGER = Logger.getLogger(NativeBase::class.java.name);
 
         // The set is to keep DisposableReference itself from being garbage-collected.
@@ -93,6 +94,10 @@ public abstract class NativeBase {
                     (reference as DisposableReference).dispose()
                 } catch (t: Throwable) {
                     LOGGER.log(Level.SEVERE, "Error cleaning up after reference.", t);
+
+                    if (propagateCleanupException) {
+                        throw t
+                    }
                 }
 
                 reference = REFERENCE_QUEUE.poll()

--- a/gluecodium/src/test/resources/smoke/namespace_basic/output/android-kotlin/com/example/foo/bar/NativeBase.kt
+++ b/gluecodium/src/test/resources/smoke/namespace_basic/output/android-kotlin/com/example/foo/bar/NativeBase.kt
@@ -73,6 +73,7 @@ public abstract class NativeBase {
     }
 
     companion object {
+        @JvmField public var propagateCleanupException: Boolean = false
         private val LOGGER = Logger.getLogger(NativeBase::class.java.name);
 
         // The set is to keep DisposableReference itself from being garbage-collected.
@@ -93,6 +94,10 @@ public abstract class NativeBase {
                     (reference as DisposableReference).dispose()
                 } catch (t: Throwable) {
                     LOGGER.log(Level.SEVERE, "Error cleaning up after reference.", t);
+
+                    if (propagateCleanupException) {
+                        throw t
+                    }
                 }
 
                 reference = REFERENCE_QUEUE.poll()


### PR DESCRIPTION
Such flag is present in Java's version of NativeBase and is
used to control whether exceptions related to removal of
JNI wrappers are propagated to the caller.

This commit adds the flag also to KotlinNativeBase in order
to be able to use the generated Kotlin code to run Java functional
tests.