### PR TITLE
functional tests: adhere to LIME preconditions in Java tests

### DIFF
--- a/functional-tests/functional/android/src/test/java/com/here/android/test/ArraysTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/ArraysTest.java
@@ -24,6 +24,7 @@ import static junit.framework.Assert.assertTrue;
 
 import android.os.Build;
 import com.here.android.RobolectricApplication;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -410,7 +411,7 @@ public class ArraysTest {
         new Arrays.FancyStruct(
             java.util.Arrays.asList("struct", "3"),
             java.util.Arrays.asList(SHORT_ITEM_4, SHORT_ITEM_4),
-            null);
+            new ArrayList<SimpleInstantiableOne>());
     List<Arrays.FancyStruct> fancyStructList1 = java.util.Arrays.asList(struct1, struct2);
     List<Arrays.FancyStruct> fancyStructList2 = Collections.singletonList(struct3);
 

--- a/functional-tests/functional/android/src/test/java/com/here/android/test/AttributesTest.java
+++ b/functional-tests/functional/android/src/test/java/com/here/android/test/AttributesTest.java
@@ -23,6 +23,7 @@ import static junit.framework.Assert.assertNotNull;
 
 import android.os.Build;
 import com.here.android.RobolectricApplication;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,7 +50,7 @@ public class AttributesTest {
 
   @Test
   public void setGetStructAttribute() {
-    Attributes.ExampleStruct expectedStruct = new Attributes.ExampleStruct(2.71, null);
+    Attributes.ExampleStruct expectedStruct = new Attributes.ExampleStruct(2.71, Arrays.asList(27L));
 
     attributes.setStructAttribute(expectedStruct);
     Attributes.ExampleStruct result = attributes.getStructAttribute();


### PR DESCRIPTION
There were two tests, which explicitly passed 'null' as a parameter
to functions, which are defined as taking non-optional parameters
in LIME files. This was invalid.

When such tests were run with Kotlin generated code then JVM raised
exception -- null passed for explicit non-optional param.

This commit adjusts the mentioned tests and removes the invalid logic.