### PR TITLE
functional/LambdasTest.kt: align names with Java generated code

### DIFF
--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/LambdasTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/LambdasTest.kt
@@ -122,21 +122,21 @@ class LambdasTest {
 
     @org.junit.Test
     fun callCppNullableLambdaInJavaWithValue() {
-        val result: StandaloneProducer? = Lambdas.getNullableConfuser().apply("foo")
+        val result: StandaloneProducer? = Lambdas.getNullableConfuser().confuse("foo")
 
         assertEquals("foo", result?.apply())
     }
 
     @org.junit.Test
     fun callCppNullableLambdaInJavaWithNull() {
-        val result: StandaloneProducer? = Lambdas.getNullableConfuser().apply(null)
+        val result: StandaloneProducer? = Lambdas.getNullableConfuser().confuse(null)
 
         assertNull(result)
     }
 
     @org.junit.Test
     fun callJavaNullableLambdaInCppWithValue() {
-        val confuser: Lambdas.NullableConfuser = Lambdas.NullableConfuser { s1: String? ->
+        val confuser: Lambdas.NullableConfounder = Lambdas.NullableConfounder { s1: String? ->
             if (s1 != null) {
                 StandaloneProducer { s1 }
             } else null
@@ -148,7 +148,7 @@ class LambdasTest {
 
     @org.junit.Test
     fun callJavaNullableLambdaInCppWithNull() {
-        val confuser: Lambdas.NullableConfuser = Lambdas.NullableConfuser { s1: String? ->
+        val confuser: Lambdas.NullableConfounder = Lambdas.NullableConfounder { s1: String? ->
             if (s1 != null) {
                 StandaloneProducer { s1 }
             } else null

--- a/functional-tests/functional/input/lime/Lambdas.lime
+++ b/functional-tests/functional/input/lime/Lambdas.lime
@@ -21,6 +21,7 @@ class Lambdas {
     lambda Concatenator = (@Java("first") String, @Java("second") String) -> String
     lambda Tricatenator = (String, String, String) -> String
     @Java(Name = "NullableConfounder", FunctionName = "confuse")
+    @Kotlin(Name = "NullableConfounder", FunctionName = "confuse")
     @Swift("NullableConvoluter")
     lambda NullableConfuser = (String?) -> StandaloneProducer?
 


### PR DESCRIPTION
The input LIME file contained Java-specific annotation to rename
some elements. Because of that they had different names in Java
and Kotlin.

This change aligns the names between Java and Kotlin. This is needed
to be able to run Java tests with Kotlin generated code.