### PR TITLE
functional tests: add option to run Java tests with Kotlin code

### DIFF
--- a/functional-tests/build.gradle
+++ b/functional-tests/build.gradle
@@ -36,6 +36,11 @@ ext {
         }
     }
 
+    // Used to run Java tests with the generated Kotlin code.
+    forceJavaTestSources = {
+        return project.hasProperty("force-java-test-sources")
+    }
+
     buildRoot = "${rootProject.projectDir}/build-${getAndroidBuildVariant()}"
     buildNativeRoot = "${buildRoot}/cpp"
     generatedDir = "${buildRoot}/generated"

--- a/functional-tests/functional/CMakeLists.txt
+++ b/functional-tests/functional/CMakeLists.txt
@@ -320,13 +320,22 @@ feature(ExternalTypes cpp android android-kotlin swift dart SOURCES
 
 feature(JavaExternalTypes android SOURCES
     input/src/cpp/JavaExternalTypes.cpp
+    input/src/cpp/VeryBooleanExternalType.cpp
 
     input/lime/JavaExternalTypes.lime
 )
 
-feature(KotlinExternalTypes android-kotlin SOURCES
+set(KOTLIN_EXTERNAL_TYPES_SOURCES
     input/src/cpp/KotlinExternalTypes.cpp
+    input/src/cpp/VeryBooleanExternalType.cpp
+)
 
+if(JAVA_TESTS_CONSUMING_KOTLIN)
+    list(APPEND KOTLIN_EXTERNAL_TYPES_SOURCES input/src/cpp/JavaExternalTypes.cpp)
+endif()
+
+feature(KotlinExternalTypes android-kotlin SOURCES
+    ${KOTLIN_EXTERNAL_TYPES_SOURCES}
     input/lime/KotlinExternalTypes.lime
 )
 
@@ -540,6 +549,12 @@ target_include_directories(functional_bindings PRIVATE "input/src/cpp/")
 
 include(gluecodium/Gluecodium)
 gluecodium_generate(functional_bindings)
+
+set(CUSTOM_GLUECODIUM_TAGS "Lite,ExperimentalFoo")
+if(JAVA_TESTS_CONSUMING_KOTLIN)
+    set(CUSTOM_GLUECODIUM_TAGS "${CUSTOM_GLUECODIUM_TAGS},JavaTestsRunWithKotlin")
+endif()
+
 set_target_properties(functional_bindings PROPERTIES
     GLUECODIUM_JAVA_PACKAGE com.here.android
     GLUECODIUM_JAVA_INTERNAL_PACKAGE lorem.ipsum
@@ -553,7 +568,7 @@ set_target_properties(functional_bindings PROPERTIES
     GLUECODIUM_DART_NAMERULES "${CMAKE_CURRENT_SOURCE_DIR}/../config/dart.properties"
     GLUECODIUM_COPYRIGHT_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/../config/COPYRIGHT"
     GLUECODIUM_DOCS_PLACEHOLDERS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/../config/placeholders.properties"
-    GLUECODIUM_TAGS "Lite,ExperimentalFoo"
+    GLUECODIUM_TAGS "${CUSTOM_GLUECODIUM_TAGS}"
     GLUECODIUM_VERBOSE ON)
 
 gluecodium_get_target_compile_definitions(functional_bindings RESULT_PUBLIC _public_definitions

--- a/functional-tests/functional/build.gradle
+++ b/functional-tests/functional/build.gradle
@@ -23,11 +23,17 @@ apply plugin: 'org.jetbrains.kotlin.android'
 project.buildDir = "${rootProject.buildDir}"
 
 def getCMakeCommonParameters() {
-    return ['-Wno-dev',
+    def params = ['-Wno-dev',
         "-DGLUECODIUM_GENERATORS_DEFAULT=${rootProject.getAndroidBuildVariant()};cpp",
         "-DGLUECODIUM_BASE_OUTPUT_DIR_DEFAULT=${rootProject.generatedDir}",
         "-DGLUECODIUM_VERSION_DEFAULT=${rootProject.useGluecodiumVersion()}",
         '-DGLUECODIUM_ENABLE_INTERNAL_DEBUG_CHECKS_DEFAULT=ON']
+
+    if (rootProject.forceJavaTestSources()) {
+        params.add('-DJAVA_TESTS_CONSUMING_KOTLIN=ON')
+    }
+
+    return params
 }
 
 android {

--- a/functional-tests/functional/build.gradle
+++ b/functional-tests/functional/build.gradle
@@ -72,8 +72,14 @@ android {
                         "${rootProject.generatedDir}/functional_bindings/android-kotlin-cpp/main/android-kotlin"]
             }
 
-            test {
-                kotlin.srcDirs += ["${project.projectDir}/android-kotlin/src/test/kotlin"]
+            if (rootProject.forceJavaTestSources()) {
+                test {
+                    java.srcDirs += ["${project.projectDir}/android/src/test/java"]
+                }
+            } else {
+                test {
+                    kotlin.srcDirs += ["${project.projectDir}/android-kotlin/src/test/kotlin"]
+                }
             }
         } else {
             main {

--- a/functional-tests/functional/input/lime/KotlinExternalTypes.lime
+++ b/functional-tests/functional/input/lime/KotlinExternalTypes.lime
@@ -72,6 +72,18 @@ enum Season {
     AUTUMN
 }
 
+@Kotlin(EnableIf="JavaTestsRunWithKotlin")
+class UseJavaExternalTypes {
+    static fun currencyRoundTrip(input: Currency): Currency
+    static fun timeZoneRoundTrip(input: TimeZone): TimeZone
+    static fun monthRoundTrip(input: Month): Month
+    static fun colorRoundTrip(input: SystemColor): SystemColor
+    static fun seasonRoundTrip(input: Season): Season
+
+    static fun structRoundTrip(input: JavaExternalTypesStruct): JavaExternalTypesStruct
+    static fun veryBooleanUnbox(input: VeryBoolean): Boolean
+}
+
 class UseKotlinExternalTypes {
     static fun currencyRoundTrip(input: Currency): Currency
     static fun timeZoneRoundTrip(input: TimeZone): TimeZone
@@ -81,6 +93,15 @@ class UseKotlinExternalTypes {
 
     static fun structRoundTrip(input: KotlinExternalTypesStruct): KotlinExternalTypesStruct
     static fun veryBooleanUnbox(input: VeryBoolean): Boolean
+}
+
+@Kotlin(EnableIf="JavaTestsRunWithKotlin")
+struct JavaExternalTypesStruct {
+    currency: Currency
+    timeZone: TimeZone
+    month: Month
+    color: SystemColor
+    season: Season
 }
 
 struct KotlinExternalTypesStruct {
@@ -114,6 +135,13 @@ struct VeryBoolean {
 
     value: Boolean
     constructor make(value: Boolean)
+}
+
+@Kotlin(EnableIf="JavaTestsRunWithKotlin")
+struct UseJavaExternalConst {
+    stringField: String
+    @Internal
+    const defaultTruth: VeryBoolean = {true}
 }
 
 struct UseKotlinExternalConst {

--- a/functional-tests/functional/input/lime/PositionalDefaults.lime
+++ b/functional-tests/functional/input/lime/PositionalDefaults.lime
@@ -31,8 +31,8 @@ struct StructWithAllDefaults {
     stringField: String = "\\Jonny \"Magic\" Smith\n"
 }
 
-@Java(PositionalDefaults)
-@Swift(Skip) @Dart(Skip) @Kotlin(Skip)
+@Java(PositionalDefaults) @Kotlin(EnableIf="JavaTestsRunWithKotlin", PositionalDefaults)
+@Swift(Skip) @Dart(Skip)
 struct StructWithJavaPositionalDefaults {
     firstInitField: Int = 42
     firstFreeField: String

--- a/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
+++ b/functional-tests/functional/input/lime/SkipTagsInPlatform.lime
@@ -17,13 +17,13 @@
 
 package test
 
-@Skip(Swift, Dart, Kotlin)
+@Skip(Swift, Dart) @Kotlin(EnableIf="JavaTestsRunWithKotlin")
 interface SkipTagsInJava {
-    @Java(Skip = "Lite")
+    @Java(Skip = "Lite") @Kotlin(Skip = "Lite")
     fun skipTagged()
-    @Java(Skip = "Pro")
+    @Java(Skip = "Pro") @Kotlin(Skip = "Pro")
     fun dontSkipTagged()
-    @Java(Skip = ["Lite", "Pro"])
+    @Java(Skip = ["Lite", "Pro"]) @Kotlin(Skip = ["Lite", "Pro"])
     fun skipTaggedList()
 }
 

--- a/functional-tests/functional/input/src/cpp/JavaExternalTypes.cpp
+++ b/functional-tests/functional/input/src/cpp/JavaExternalTypes.cpp
@@ -57,6 +57,4 @@ UseJavaExternalTypes::struct_round_trip(const JavaExternalTypesStruct& input) {
 bool
 UseJavaExternalTypes::very_boolean_unbox(const VeryBoolean& input) { return input.value; }
 
-VeryBoolean
-VeryBoolean::make(const bool value) { return VeryBoolean{value}; }
 }

--- a/functional-tests/functional/input/src/cpp/VeryBooleanExternalType.cpp
+++ b/functional-tests/functional/input/src/cpp/VeryBooleanExternalType.cpp
@@ -18,43 +18,12 @@
 //
 // -------------------------------------------------------------------------------------------------
 
-#include "test/KotlinExternalTypesStruct.h"
-#include "test/UseKotlinExternalTypes.h"
 #include "test/VeryBoolean.h"
 
 namespace test
 {
-Currency
-UseKotlinExternalTypes::currency_round_trip(const Currency& input) {
-    return input;
-}
 
-TimeZone
-UseKotlinExternalTypes::time_zone_round_trip(const TimeZone& input) {
-    return input;
-}
+VeryBoolean
+VeryBoolean::make(const bool value) { return VeryBoolean{value}; }
 
-Month
-UseKotlinExternalTypes::month_round_trip(const Month input) {
-    return input;
-}
-
-SystemColor
-UseKotlinExternalTypes::color_round_trip(const SystemColor& input) {
-    return input;
-}
-
-Season
-UseKotlinExternalTypes::season_round_trip(const Season input) {
-    return input;
-}
-
-KotlinExternalTypesStruct
-UseKotlinExternalTypes::struct_round_trip(const KotlinExternalTypesStruct& input) {
-    return input;
-}
-
-bool
-UseKotlinExternalTypes::very_boolean_unbox(const VeryBoolean& input) { return input.value; }
-
-}
+} // namespace test

--- a/functional-tests/scripts/build-android-kotlin-functional
+++ b/functional-tests/scripts/build-android-kotlin-functional
@@ -28,6 +28,7 @@ $0 [options]
     --gluecodiumPath [PATH]   Implies --buildGluecodium, path to local gluecodium (default: ${GLUECODIUM_PATH})
     --debug                   Build with debug symbols
     --docs                    Generate docs of tests
+    --forceJavaTestSources    Run Java tests with Kotlin generated code
     --hostOnly                Only build host architecture
     --help                    Print this message
 EOF
@@ -36,6 +37,7 @@ EOF
 CMAKE_BUILD_TYPE=
 BUILD_LOCAL_GLUECODIUM=false
 GENERATE_DOCS=false
+FORCE_JAVA_TEST_SOURCES=
 HOST_ONLY=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -58,6 +60,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --docs)
             GENERATE_DOCS=true
+            shift
+            ;;
+        --forceJavaTestSources)
+            FORCE_JAVA_TEST_SOURCES="-Pforce-java-test-sources"
             shift
             ;;
         --hostOnly)
@@ -87,9 +93,9 @@ INSTALL_AAR_DIR="${ANDROID_DIR}/app/libs/"
 TMP_DIR=$(mktemp -d)
 
 if $HOST_ONLY; then
-    ./gradlew functional:testRelease -Pandroid-kotlin -PhostOnly -PgluecodiumVersion=${GLUECODIUM_VERSION}
+    ./gradlew functional:testRelease -Pandroid-kotlin $FORCE_JAVA_TEST_SOURCES -PhostOnly -PgluecodiumVersion=${GLUECODIUM_VERSION}
 else
-    ./gradlew functional:testRelease -Pandroid-kotlin -PgluecodiumVersion=${GLUECODIUM_VERSION}
+    ./gradlew functional:testRelease -Pandroid-kotlin $FORCE_JAVA_TEST_SOURCES -PgluecodiumVersion=${GLUECODIUM_VERSION}
 fi
 
 if [ "$GENERATE_DOCS" = true ]; then


### PR DESCRIPTION
This change adjusts build scripts of 'android-kotlin' functional
tests. A new parameter called '--forceJavaTestSources' is
added to 'build-android-kotlin-functional' shell script.

Moreover, gradle scripts are adjusted to select proper tests
directory depending on the new flag.