### PR TITLE
functional tests: adjust field name for Kotlin external type

### DIFF
--- a/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ExternalTypesTest.kt
+++ b/functional-tests/functional/android-kotlin/src/test/kotlin/com/here/android/test/ExternalTypesTest.kt
@@ -156,7 +156,7 @@ class ExternalTypesTest {
 
         assertNotNull(resultStruct)
         assertTrue(Parcelable::class.java.isInstance(mainStruct))
-        assertEquals(42, resultStruct!!.someStruct.data)
+        assertEquals(42, resultStruct!!.someStruct.mData)
     }
 
     @org.junit.Test

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/AnExternalStruct.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/AnExternalStruct.kt
@@ -22,19 +22,19 @@ import android.os.Parcel
 import android.os.Parcelable
 
 class AnExternalStruct : Parcelable {
-    var data: Int
+    @JvmField var mData: Int
 
     private constructor(parcel: Parcel) {
-        this.data = parcel.readInt()
+        this.mData = parcel.readInt()
     }
 
     constructor(data: Int) {
-        this.data = data
+        this.mData = data
     }
 
     override fun describeContents() = 0
     override fun writeToParcel(parcel: Parcel, flags: Int) {
-        parcel.writeInt(data)
+        parcel.writeInt(mData)
     }
 
     companion object CREATOR : Parcelable.Creator<AnExternalStruct> {

--- a/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ExternalStructMarkedAsSerializableConverter.kt
+++ b/functional-tests/functional/input/src/android-kotlin/kotlin/com/here/android/ExternalStructMarkedAsSerializableConverter.kt
@@ -23,5 +23,5 @@ object ExternalStructMarkedAsSerializableConverter {
     fun convertFromInternal(struct: ExternalMarkedAsSerializable) = AnExternalStruct(struct.field)
 
     @JvmStatic
-    fun convertToInternal(s: com.here.android.test.AnExternalStruct) = ExternalMarkedAsSerializable(s.data)
+    fun convertToInternal(s: com.here.android.test.AnExternalStruct) = ExternalMarkedAsSerializable(s.mData)
 }


### PR DESCRIPTION
This change aligns the name with the corresponding Java type.
It is needed to properly run Java functional tests with Kotlin
generated code.