### PR TITLE
Kotlin generator: temporarily revert usage of internal keyword

### DIFF
--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>kotlin/KotlinDocComment}}
-{{resolveName "visibility"}}{{#if this.isOpen}}open {{/if}}class {{resolveName}} : {{!!
+{{#if this.isOpen}}open {{/if}}class {{resolveName}} : {{!!
 }}{{#if this.parentClass}}{{resolveName this.parentClass "" "ref"}}{{/if}}{{!!
 }}{{#unless this.parentClass}}NativeBase{{/unless}}{{!!
 }}{{#if this.parentInterfaces}}, {{#this.parentInterfaces}}{{!!
@@ -31,7 +31,7 @@
 {{#set classElement=this}}{{#constructors}}
 {{prefixPartial "kotlin/KotlinMethodComment" "    "}}
     {{>kotlinConstructorThrows}}
-{{resolveName "visibility"}}constructor({{!!
+constructor({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}){{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinEnumeration.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>kotlin/KotlinDocComment}}
-{{resolveName "visibility"}}enum class {{resolveName}}(private val value: Int) {
+enum class {{resolveName}}(private val value: Int) {
 {{joinPartial uniqueEnumerators "kotlin/KotlinEnumerator" ",
 "}}{{#if uniqueEnumerators}};{{/if}}{{#if aliasEnumerators}}
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinFunction.mustache
@@ -21,7 +21,7 @@
 {{#unless this.isConstructor}}{{>kotlin/KotlinMethodComment}}{{/unless}}
 {{#thrownType}}@Throws({{resolveName typeRef}}::class){{/thrownType}}
 {{#if isStatic}}@JvmStatic {{/if}}{{#if override}}override {{/if}}{{!!
-}}{{#unless isInterface}}{{resolveName "visibility"}}external {{/unless}}fun {{resolveName}}({{!!
+}}{{#unless isInterface}}external {{/unless}}fun {{resolveName}}({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}) : {{!!

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinImplClass.mustache
@@ -21,7 +21,7 @@
 /**
  * @suppress
  */
-{{resolveName "visibility"}}class {{resolveName}}Impl : NativeBase, {{resolveName}} {
+class {{resolveName}}Impl : NativeBase, {{resolveName}} {
     protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinInterface.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>kotlin/KotlinDocComment}}
-{{resolveName "visibility"}}interface {{resolveName}} {{!!
+interface {{resolveName}} {{!!
 }}{{#if this.parents}}: {{#parents}}{{resolveName this "" "ref"}}{{#if iter.hasNext}}, {{/if}}{{/parents}} {{/if}}{
 {{>kotlin/KotlinContainerContents}}
 

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinLambda.mustache
@@ -19,7 +19,7 @@
   !
   !}}
 {{>kotlin/KotlinDocComment}}
-{{resolveName "visibility"}}fun interface {{resolveName}} {
+fun interface {{resolveName}} {
 {{#set isInterface=true noAttributes=true}}{{!!
 }}{{#asFunction}}
 {{prefixPartial "kotlin/KotlinFunction" "    "}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinProperty.mustache
@@ -21,7 +21,6 @@
 {{>kotlin/KotlinDocComment}}
 {{#if isStatic}}@JvmStatic {{/if}}{{!!
 }}{{#if override}}override {{/if}}{{!!
-}}{{#unless isInterface}}{{resolveName "visibility"}}{{/unless}}{{!!
 }}{{#if setter}}var{{/if}}{{!!
 }}{{#unless setter}}val{{/unless}}{{!!
 }} {{resolveName}}: {{resolveName typeRef}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinStruct.mustache
@@ -19,15 +19,14 @@
   !
   !}}
 {{>kotlin/KotlinDocComment}}
-{{#unless external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
-}}class {{resolveName}}{{!!
+class {{resolveName}}{{!!
 }}{{#unless external.kotlin.name}}{{!!
 }}{{#if attributes.serializable}} : Parcelable{{/if}}{{!!
 }}{{/unless}} {
 {{#set isImmutable=attributes.immutable}}
 {{#fields}}
 {{prefixPartial "kotlin/KotlinDocComment" "    "}}{{!!
-}}    @JvmField {{resolveName "visibility"}}{{!!
+}}    @JvmField {{!!
 }}{{#unless isImmutable}}var {{/unless}}{{!!
 }}{{#if isImmutable}}val {{/if}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{!!
@@ -45,8 +44,7 @@
 {{prefixPartial "kotlin/KotlinMethodComment" "    "}}
 {{#thrownType}}@Throws({{resolveName typeRef}}::class){{/thrownType}}{{!!
 }}
-    {{#unless self.external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
-}}constructor({{!!
+    constructor({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}) {
@@ -78,9 +76,7 @@
 {{/uninitializedFields}}
      */
 {{/unless}}
-    {{#ifPredicate "hasInternalFreeArgsConstructor"}}{{!!
-}}internal {{!!
-}}{{/ifPredicate}}constructor({{!!
+    constructor({{!!
 }}{{#uninitializedFields}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/uninitializedFields}}) {
@@ -104,9 +100,7 @@
 {{/fields}}
      */
 {{/unless}}
-    {{#ifPredicate "hasInternalAllArgsConstructor"}}{{!!
-}}internal {{!!
-}}{{/ifPredicate}}constructor({{!!
+    constructor({{!!
 }}{{#fields}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/fields}}) {
@@ -135,8 +129,7 @@
 {{/if}}{{/ifPredicate}}
 {{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
 }}
-    {{#unless self.external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
-}}constructor({{!!
+    constructor({{!!
 }}{{#fields}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/fields}}) {
@@ -165,8 +158,7 @@
 {{/instanceOf}}
     {{#if initializedFields}}@JvmOverloads
     {{/if}}{{!!
-    }}{{#unless external.kotlin.converter}}{{resolveName "visibility"}}{{/unless}}{{!!
-}}constructor({{!!
+    }}constructor({{!!
 }}{{#uninitializedFields}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}, {{!!
 }}{{/uninitializedFields}}{{!!

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListener.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-internal interface InternalListener {
+interface InternalListener {
 
     fun onEvent() : Unit
 

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/InternalListenerImpl.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 /**
  * @suppress
  */
-internal class InternalListenerImpl : NativeBase, InternalListener {
+class InternalListenerImpl : NativeBase, InternalListener {
     protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClass.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-internal class InternalClass : NativeBase {
+class InternalClass : NativeBase {
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassInherits.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-internal class InternalClassInherits : NativeBase, InternalInterfaceParent {
+class InternalClassInherits : NativeBase, InternalInterfaceParent {
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithFunctions.kt
@@ -9,8 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-internal class InternalClassWithFunctions : NativeBase {
-
+class InternalClassWithFunctions : NativeBase {
 
     constructor() : this(make(), null as Any?) {
         cacheThisInstance();

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalClassWithStaticProperty.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-internal class InternalClassWithStaticProperty : NativeBase {
+class InternalClassWithStaticProperty : NativeBase {
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterface.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-internal interface InternalInterface {
+interface InternalInterface {
 
     fun fooBar() : Unit
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceImpl.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 /**
  * @suppress
  */
-internal class InternalInterfaceImpl : NativeBase, InternalInterface {
+class InternalInterfaceImpl : NativeBase, InternalInterface {
     protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceParent.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalInterfaceParent.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-internal interface InternalInterfaceParent {
+interface InternalInterfaceParent {
 
     fun fooBar() : Unit
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambda.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambda.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-internal fun interface InternalLambda {
+fun interface InternalLambda {
     fun apply() : Unit
 }
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalLambdaImpl.kt
@@ -12,7 +12,7 @@ import com.example.NativeBase
 /**
  * @suppress
  */
-internal class InternalLambdaImpl : NativeBase, InternalLambda {
+class InternalLambdaImpl : NativeBase, InternalLambda {
     protected constructor(nativeHandle: Long, @Suppress("UNUSED_PARAMETER") tag: Any?)
         : super(nativeHandle, { disposeNativeHandle(it) }) {}
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/InternalPropertyOnly.kt
@@ -25,7 +25,7 @@ class InternalPropertyOnly : NativeBase {
 
 
 
-    internal var foo: String
+    var foo: String
         external get
         external set
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicClass.kt
@@ -11,11 +11,11 @@ import com.example.NativeBase
 
 class PublicClass : NativeBase {
 
-    internal enum class InternalEnum(private val value: Int) {
+    enum class InternalEnum(private val value: Int) {
         FOO(0),
         BAR(1);
     }
-    internal class InternalStruct {
+    class InternalStruct {
         @JvmField var stringField: String
 
 
@@ -31,11 +31,11 @@ class PublicClass : NativeBase {
     }
 
     class PublicStruct {
-        @JvmField internal var internalField: PublicClass.InternalStruct
+        @JvmField var internalField: PublicClass.InternalStruct
 
 
 
-        internal constructor(internalField: PublicClass.InternalStruct) {
+        constructor(internalField: PublicClass.InternalStruct) {
             this.internalField = internalField
         }
 
@@ -46,7 +46,7 @@ class PublicClass : NativeBase {
     }
 
     class PublicStructWithInternalDefaults {
-        @JvmField internal var internalField: String
+        @JvmField var internalField: String
         @JvmField var publicField: Float
 
 
@@ -77,9 +77,9 @@ class PublicClass : NativeBase {
 
 
 
-    internal external fun internalMethod(input: PublicClass.InternalStruct) : PublicClass.InternalStruct
+    external fun internalMethod(input: PublicClass.InternalStruct) : PublicClass.InternalStruct
 
-    internal var internalStructProperty: PublicClass.InternalStruct
+    var internalStructProperty: PublicClass.InternalStruct
         external get
         external set
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicInterface.kt
@@ -10,11 +10,11 @@ package com.example.smoke
 
 interface PublicInterface {
     class InternalStruct {
-        @JvmField internal var fieldOfInternalType: PublicClass.InternalStruct
+        @JvmField var fieldOfInternalType: PublicClass.InternalStruct
 
 
 
-        internal constructor(fieldOfInternalType: PublicClass.InternalStruct) {
+        constructor(fieldOfInternalType: PublicClass.InternalStruct) {
             this.fieldOfInternalType = fieldOfInternalType
         }
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithInternalConstructors.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithInternalConstructors.kt
@@ -13,13 +13,13 @@ class PublicStructWithInternalConstructors {
 
 
 
-    internal constructor() {
+    constructor() {
         val _other = make()
         this.someVar = _other.someVar
     }
 
 
-    internal constructor(someVar: Int) {
+    constructor(someVar: Int) {
         this.someVar = someVar
     }
 
@@ -28,7 +28,7 @@ class PublicStructWithInternalConstructors {
 
 
     companion object {
-        @JvmStatic internal external fun make() : PublicStructWithInternalConstructors
+        @JvmStatic external fun make() : PublicStructWithInternalConstructors
     }
 }
 

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithNonDefaultInternalField.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicStructWithNonDefaultInternalField.kt
@@ -10,12 +10,12 @@ package com.example.smoke
 
 class PublicStructWithNonDefaultInternalField {
     @JvmField var defaultedField: Int
-    @JvmField internal var internalField: String
+    @JvmField var internalField: String
     @JvmField var publicField: Boolean
 
 
 
-    internal constructor(internalField: String, publicField: Boolean) {
+    constructor(internalField: String, publicField: Boolean) {
         this.defaultedField = 42
         this.internalField = internalField
         this.publicField = publicField

--- a/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicTypeCollection.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_attribute/output/android-kotlin/com/example/smoke/PublicTypeCollection.kt
@@ -10,12 +10,12 @@ package com.example.smoke
 
 class PublicTypeCollection {
 
-    internal class InternalStruct {
-        @JvmField internal var stringField: String
+    class InternalStruct {
+        @JvmField var stringField: String
 
 
 
-        internal constructor(stringField: String) {
+        constructor(stringField: String) {
             this.stringField = stringField
         }
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClass.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-internal class KotlinInternalClass : NativeBase {
+class KotlinInternalClass : NativeBase {
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/KotlinInternalClassRev.kt
@@ -9,7 +9,7 @@ package com.example.smoke
 
 import com.example.NativeBase
 
-internal class KotlinInternalClassRev : NativeBase {
+class KotlinInternalClassRev : NativeBase {
 
 
 

--- a/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/PlatformInternalInterface.kt
+++ b/gluecodium/src/test/resources/smoke/visibility_platform/output/android-kotlin/com/example/smoke/PlatformInternalInterface.kt
@@ -8,7 +8,7 @@
 package com.example.smoke
 
 
-internal interface PlatformInternalInterface {
+interface PlatformInternalInterface {
 
 
 


### PR DESCRIPTION
The internal keyword is quite problematic for interoperability with Java and JNI.
The usage of 'internal' forces the compiler to perform additional name mangling.
Such name mangling is not trivial -- therefore, JNI function signatures do not match.

Moreover, when accessed from Java the generated functions and types become public
with additional name suffix. This is problematic.

This change disables generation of 'internal' keyword until correct solution is found.
The usage of 'JvmName()' was tested, but it is not sufficient to cover all cases e.g. interfaces.

So, for the initial release of Kotlin generator the internal keyword support is disabled.