### PR TITLE
KotlinClass.mustache: handle exceptions from after construciton annotation

### DIFF
--- a/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
+++ b/gluecodium/src/main/java/com/here/gluecodium/generator/kotlin/KotlinGeneratorPredicates.kt
@@ -26,6 +26,7 @@ import com.here.gluecodium.model.lime.LimeClass
 import com.here.gluecodium.model.lime.LimeContainer
 import com.here.gluecodium.model.lime.LimeContainerWithInheritance
 import com.here.gluecodium.model.lime.LimeExternalDescriptor
+import com.here.gluecodium.model.lime.LimeFunction
 import com.here.gluecodium.model.lime.LimeLambda
 import com.here.gluecodium.model.lime.LimeStruct
 
@@ -39,6 +40,7 @@ internal object KotlinGeneratorPredicates {
             "hasInternalAllArgsConstructor" to this::hasInternalAllArgsConstructor,
             "hasInternalFreeArgsConstructor" to this::hasInternalFreeArgsConstructor,
             "hasStaticProperties" to this::hasStaticProperties,
+            "isExceptionSameForCtorAndHookFun" to this::isExceptionSameForCtorAndHookFun,
             "needsAllFieldsConstructor" to this::needsAllFieldsConstructor,
         )
 
@@ -101,6 +103,13 @@ internal object KotlinGeneratorPredicates {
                 CommonGeneratorPredicates.isInternal(it, LimeAttributeType.KOTLIN) ||
                     CommonGeneratorPredicates.isInternal(it.typeRef.type, LimeAttributeType.KOTLIN)
             }
+
+    private fun isExceptionSameForCtorAndHookFun(constructor: Any): Boolean {
+        return when (constructor) {
+            is LimeFunction -> CommonGeneratorPredicates.isExceptionSameForCtorAndHookFun(constructor)
+            else -> false
+        }
+    }
 
     private fun needsCompanionObject(element: Any) =
         hasStaticFunctions(element) || hasConstants(element) || needsDisposer(element) ||

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -28,7 +28,7 @@
 {{>kotlin/KotlinContainerContents}}
 
 {{#set classElement=this}}{{#constructors}}
-{{#thrownType}}@Throws ({{resolveName typeRef}}::class){{/thrownType}}{{!!
+{{>kotlinConstructorThrows}}{{!!
 }}    {{resolveName "visibility"}}constructor({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
@@ -126,3 +126,29 @@
     }
 {{/ifPredicate}}
 }
+{{!!
+
+}}{{+kotlinConstructorThrows}}{{!!
+}}{{#set thisConstructor=this}}{{!!
+}}{{#if thrownType}}@Throws ({{>kotlinConstructorExceptions}}){{/if}}{{!!
+}}{{#unless thrownType}}{{!!
+}}{{#attributes.afterconstruction.function}}{{!!
+}}{{#if function.thrownType}}@Throws ({{>kotlinConstructorExceptions}}){{/if}}{{!!
+}}{{/attributes.afterconstruction.function}}{{!!
+}}{{/unless}}{{!!
+}}{{/set}}{{!!
+}}{{/kotlinConstructorThrows}}{{!!
+
+}}{{+kotlinConstructorExceptions}}{{!!
+}}{{#thisConstructor}}{{!!
+}}{{#thrownType}}{{resolveName typeRef}}::class{{/thrownType}}{{!!
+}}{{#unlessPredicate "isExceptionSameForCtorAndHookFun"}}{{!!
+}}{{#if thrownType this.attributes.afterconstruction.function.function.thrownType}}, {{/if}}{{!!
+}}{{#this.attributes.afterconstruction.function}}{{!!
+}}{{#function.thrownType}}{{resolveName typeRef}}::class{{/function.thrownType}}{{!!
+}}{{/this.attributes.afterconstruction.function}}{{!!
+}}{{/unlessPredicate}}{{!!
+}}{{/thisConstructor}}{{!!
+}}{{/kotlinConstructorExceptions}}{{!!
+
+}}

--- a/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
+++ b/gluecodium/src/main/resources/templates/kotlin/KotlinClass.mustache
@@ -28,8 +28,8 @@
 {{>kotlin/KotlinContainerContents}}
 
 {{#set classElement=this}}{{#constructors}}
-{{>kotlinConstructorThrows}}{{!!
-}}    {{resolveName "visibility"}}constructor({{!!
+    {{>kotlinConstructorThrows}}
+{{resolveName "visibility"}}constructor({{!!
 }}{{#parameters}}{{!!
 }}{{resolveName}}: {{resolveName typeRef}}{{#if iter.hasNext}}, {{/if}}{{!!
 }}{{/parameters}}){{!!
@@ -130,10 +130,12 @@
 
 }}{{+kotlinConstructorThrows}}{{!!
 }}{{#set thisConstructor=this}}{{!!
-}}{{#if thrownType}}@Throws ({{>kotlinConstructorExceptions}}){{/if}}{{!!
+}}{{#if thrownType}}@Throws({{>kotlinConstructorExceptions}})
+    {{/if}}{{!!
 }}{{#unless thrownType}}{{!!
 }}{{#attributes.afterconstruction.function}}{{!!
-}}{{#if function.thrownType}}@Throws ({{>kotlinConstructorExceptions}}){{/if}}{{!!
+}}{{#if function.thrownType}}@Throws({{>kotlinConstructorExceptions}})
+    {{/if}}{{!!
 }}{{/attributes.afterconstruction.function}}{{!!
 }}{{/unless}}{{!!
 }}{{/set}}{{!!

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -28,7 +28,8 @@ open class Constructors : NativeBase {
     constructor(foo: String, bar: Long) : this(create(foo, bar), null as Any?) {
         cacheThisInstance();
     }
-@Throws (Constructors.ConstructorExplodedException::class)    constructor(input: String) : this(create(input), null as Any?) {
+    @Throws(Constructors.ConstructorExplodedException::class)
+    constructor(input: String) : this(create(input), null as Any?) {
         cacheThisInstance();
     }
     constructor(input: MutableList<Double>) : this(create(input), null as Any?) {

--- a/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
+++ b/gluecodium/src/test/resources/smoke/constructors/output/android-kotlin/com/example/smoke/Constructors.kt
@@ -64,3 +64,4 @@ open class Constructors : NativeBase {
         @JvmStatic external fun create(input: Long) : Long
     }
 }
+

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -31,15 +31,18 @@ class Thermometer : NativeBase {
         cacheThisInstance();
         notifyObservers(this, observers)
     }
-@Throws (Thermometer.NotificationException::class)    constructor(id: Int, observers: MutableList<TemperatureObserver>) : this(throwingMake(id, observers), null as Any?) {
+    @Throws(Thermometer.NotificationException::class)
+    constructor(id: Int, observers: MutableList<TemperatureObserver>) : this(throwingMake(id, observers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }
-@Throws (Thermometer.NotificationException::class)    constructor(label: String, niceObservers: MutableList<TemperatureObserver>) : this(nothrowMake(label, niceObservers), null as Any?) {
+    @Throws(Thermometer.NotificationException::class)
+    constructor(label: String, niceObservers: MutableList<TemperatureObserver>) : this(nothrowMake(label, niceObservers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, niceObservers)
     }
-@Throws (Thermometer.AnotherNotificationException::class, Thermometer.NotificationException::class)    constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
+    @Throws(Thermometer.AnotherNotificationException::class, Thermometer.NotificationException::class)
+    constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }

--- a/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
+++ b/gluecodium/src/test/resources/smoke/listeners/output/android-kotlin/com/example/smoke/Thermometer.kt
@@ -35,11 +35,11 @@ class Thermometer : NativeBase {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }
-    constructor(label: String, niceObservers: MutableList<TemperatureObserver>) : this(nothrowMake(label, niceObservers), null as Any?) {
+@Throws (Thermometer.NotificationException::class)    constructor(label: String, niceObservers: MutableList<TemperatureObserver>) : this(nothrowMake(label, niceObservers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, niceObservers)
     }
-@Throws (Thermometer.AnotherNotificationException::class)    constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
+@Throws (Thermometer.AnotherNotificationException::class, Thermometer.NotificationException::class)    constructor(dummy: Boolean, observers: MutableList<TemperatureObserver>) : this(anotherThrowingMake(dummy, observers), null as Any?) {
         cacheThisInstance();
         throwingNotifyObservers(this, observers)
     }
@@ -75,3 +75,4 @@ class Thermometer : NativeBase {
         @Throws (Thermometer.NotificationException::class) @JvmStatic external fun throwingNotifyObservers(thermometer: Thermometer, someObservers: MutableList<TemperatureObserver>) : Unit
     }
 }
+


### PR DESCRIPTION
The change, which introduced usage of
throws annotation to indicate possible
exceptions did not take 'after construction'
function into account.
    
This commit adjusts the behavior to correctly
handle throws annotation for after construction
annotation.